### PR TITLE
Fixed helm charts and added default for podclique reconciler

### DIFF
--- a/operator/api/config/v1alpha1/defaults.go
+++ b/operator/api/config/v1alpha1/defaults.go
@@ -100,3 +100,9 @@ func SetDefaults_PodGangSetControllerConfiguration(obj *PodGangSetControllerConf
 		obj.ConcurrentSyncs = ptr.To(1)
 	}
 }
+
+func SetDefaults_PodCliqueControllerConfiguration(obj *PodCliqueControllerConfiguration) {
+	if obj.ConcurrentSyncs == nil {
+		obj.ConcurrentSyncs = ptr.To(1)
+	}
+}

--- a/operator/charts/templates/_helpers.tpl
+++ b/operator/charts/templates/_helpers.tpl
@@ -24,6 +24,8 @@ config.yaml: |
   controllers:
     podGangSet:
       concurrentSyncs: {{ .Values.config.controllers.podGangSet.concurrentSyncs }}
+    podClique:
+      concurrentSyncs: {{ .Values.config.controllers.podClique.concurrentSyncs }}
   {{- if .Values.config.debugging }}
   debugging:
     enableProfiling: {{ .Values.config.debugging.enableProfiling }}

--- a/operator/charts/templates/deployment.yaml
+++ b/operator/charts/templates/deployment.yaml
@@ -45,7 +45,8 @@ spec:
             timeoutSeconds: 5
           {{- end }}
           {{- if .Values.resources }}
-{{- toYaml .Values.resources | nindent 10 }}
+          resources:
+{{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: operator-config

--- a/operator/charts/values.yaml
+++ b/operator/charts/values.yaml
@@ -53,6 +53,8 @@ config:
   controllers:
     podGangSet:
       concurrentSyncs: 3
+    podClique:
+      concurrentSyncs: 3
   logLevel: info
   logFormat: json
   authorizer:

--- a/operator/internal/components/types.go
+++ b/operator/internal/components/types.go
@@ -1,1 +1,0 @@
-package components

--- a/operator/internal/webhook/admission/pgs/authorization/handler.go
+++ b/operator/internal/webhook/admission/pgs/authorization/handler.go
@@ -1,6 +1,7 @@
 package authorization
 
 import (
+	"context"
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -8,4 +9,8 @@ import (
 type Handler struct {
 	Logger  logr.Logger
 	Decoder admission.Decoder
+}
+
+func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	return admission.Response{}
 }


### PR DESCRIPTION
This PR fixes:

- Helm chart for grove deployment
- Fixes nil pointer dereference due to missing defaulting of PodClique reconciler concurrent workers.