### PR TITLE
Added ServiceAccount, Role and RoleBinding components

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -95,7 +95,7 @@ deploy-local: $(SKAFFOLD)
 .PHONY: deploy-local-dev
 deploy-local-dev: $(SKAFFOLD)
 	@$(HACK_DIR)/prepare-local-deploy.sh $(NAMESPACE) $(CERT_EXPIRY)
-	@$(HACK_DIR)/deploy-local.sh dev --cleanup=false -m grove-operator --trigger='manual' -n $(NAMESPACE)
+	@$(HACK_DIR)/deploy-local.sh dev --cleanup=false --keep-running-on-failure -m grove-operator --trigger='manual' -n $(NAMESPACE)
 
 # Deploys grove-operator to a local k8s cluster using skaffold in debug mode.
 .PHONY: deploy-local-debug

--- a/operator/api/core/v1alpha1/constants.go
+++ b/operator/api/core/v1alpha1/constants.go
@@ -20,10 +20,10 @@ const (
 const (
 	// FinalizerPodGangSet is the finalizer for PodGangSet that is added to `.metadata.finalizers[]` slice. This will be placed on all PodGangSet resources
 	// during reconciliation. This finalizer is used to clean up resources that are created for a PodGangSet when it is deleted.
-	FinalizerPodGangSet = "podgangset.grove.io"
+	FinalizerPodGangSet = "grove.io/podgangset.grove.io"
 	// FinalizerPodClique is the finalizer for PodClique that is added to `.metadata.finalizers[]` slice. This will be placed on all PodClique resources
 	// during reconciliation. This finalizer is used to clean up resources that are created for a PodClique when it is deleted.
-	FinalizerPodClique = "podclique.grove.io"
+	FinalizerPodClique = "grove.io/podclique.grove.io"
 )
 
 // Constants for events.

--- a/operator/charts/templates/clusterrole.yaml
+++ b/operator/charts/templates/clusterrole.yaml
@@ -33,6 +33,7 @@ rules:
   - ""
   resources:
   - pods
+  - serviceaccounts
   verbs:
   - create
   - get
@@ -64,3 +65,15 @@ rules:
   - list
   - watch
   - patch
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
+    - roles
+    - rolebindings
+  verbs:
+    - create
+    - get
+    - list
+    - watch
+    - delete
+

--- a/operator/internal/component/namegen.go
+++ b/operator/internal/component/namegen.go
@@ -1,0 +1,28 @@
+package component
+
+import (
+	"fmt"
+	"github.com/NVIDIA/grove/operator/api/core/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GeneratePodGangName generates a PodGang name based on the PodGangSet name and the replica index.
+func GeneratePodGangName(pgsName string, replicaIndex int32) string {
+	return fmt.Sprintf("%s-%d", pgsName, replicaIndex)
+}
+
+// GeneratePodRoleName generates a Pod role name based on the PodGangSet object metadata.
+// This role will be associated to all Pods within a PodGangSet.
+func GeneratePodRoleName(pgsObjMeta metav1.ObjectMeta) string {
+	return fmt.Sprintf("%s:pgs:%s", v1alpha1.SchemeGroupVersion.Group, pgsObjMeta.Name)
+}
+
+// GeneratePodRoleBindingName generates a Pod role binding name based on the PodGangSet object metadata.
+func GeneratePodRoleBindingName(pgsObjMeta metav1.ObjectMeta) string {
+	return fmt.Sprintf("%s:pgs:%s", v1alpha1.SchemeGroupVersion.Group, pgsObjMeta.Name)
+}
+
+// GeneratePodServiceAccountName generates a Pod service account used by all the Pods within a PodGangSet.
+func GeneratePodServiceAccountName(pgsObjMeta metav1.ObjectMeta) string {
+	return pgsObjMeta.Name
+}

--- a/operator/internal/component/pclq/pod/pod.go
+++ b/operator/internal/component/pclq/pod/pod.go
@@ -42,6 +42,11 @@ func New(client client.Client, scheme *runtime.Scheme) component.Operator[v1alph
 	}
 }
 
+func (r _resource) GetExistingResourceNames(ctx context.Context, logger logr.Logger, pclq *v1alpha1.PodClique) ([]string, error) {
+	//TODO Implement me
+	return nil, nil
+}
+
 func (r _resource) Sync(ctx context.Context, logger logr.Logger, pclq *v1alpha1.PodClique) error {
 	info, err := r.listPods(ctx, logger, pclq.Name, pclq.Namespace)
 	if err != nil {

--- a/operator/internal/component/pgs/registry.go
+++ b/operator/internal/component/pgs/registry.go
@@ -4,7 +4,10 @@ import (
 	"github.com/NVIDIA/grove/operator/api/core/v1alpha1"
 	"github.com/NVIDIA/grove/operator/internal/component"
 	"github.com/NVIDIA/grove/operator/internal/component/pgs/podclique"
+	"github.com/NVIDIA/grove/operator/internal/component/pgs/role"
+	"github.com/NVIDIA/grove/operator/internal/component/pgs/rolebinding"
 	"github.com/NVIDIA/grove/operator/internal/component/pgs/service"
+	"github.com/NVIDIA/grove/operator/internal/component/pgs/serviceaccount"
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -15,5 +18,8 @@ func CreateOperatorRegistry(mgr manager.Manager) component.OperatorRegistry[v1al
 	reg := component.NewOperatorRegistry[v1alpha1.PodGangSet]()
 	reg.Register(component.KindPodClique, podclique.New(cl, mgr.GetScheme()))
 	reg.Register(component.KindHeadlessService, service.New(cl, mgr.GetScheme()))
+	reg.Register(component.KindRole, role.New(cl, mgr.GetScheme()))
+	reg.Register(component.KindRoleBinding, rolebinding.New(cl, mgr.GetScheme()))
+	reg.Register(component.KindServiceAccount, serviceaccount.New(cl, mgr.GetScheme()))
 	return reg
 }

--- a/operator/internal/component/pgs/rolebinding/rolebinding.go
+++ b/operator/internal/component/pgs/rolebinding/rolebinding.go
@@ -1,0 +1,147 @@
+package rolebinding
+
+import (
+	"context"
+	"fmt"
+	"github.com/NVIDIA/grove/operator/api/core/v1alpha1"
+	"github.com/NVIDIA/grove/operator/internal/component"
+	groveerr "github.com/NVIDIA/grove/operator/internal/errors"
+	k8sutils "github.com/NVIDIA/grove/operator/internal/utils/kubernetes"
+	"github.com/go-logr/logr"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"strings"
+)
+
+const (
+	errGetRoleBinding    v1alpha1.ErrorCode = "ERR_GET_ROLEBINDING"
+	errSyncRoleBinding   v1alpha1.ErrorCode = "ERR_SYNC_ROLEBINDING"
+	errDeleteRoleBinding v1alpha1.ErrorCode = "ERR_DELETE_ROLEBINDING"
+)
+
+type _resource struct {
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+func New(client client.Client, scheme *runtime.Scheme) component.Operator[v1alpha1.PodGangSet] {
+	return &_resource{
+		client: client,
+		scheme: scheme,
+	}
+}
+
+func (r _resource) GetExistingResourceNames(ctx context.Context, logger logr.Logger, pgs *v1alpha1.PodGangSet) ([]string, error) {
+	roleBindingNames := make([]string, 0, 1)
+	objectKey := getObjectKey(pgs.ObjectMeta)
+	objMeta := &metav1.PartialObjectMetadata{}
+	objMeta.SetGroupVersionKind(rbacv1.SchemeGroupVersion.WithKind("RoleBinding"))
+	if err := r.client.Get(ctx, objectKey, objMeta); err != nil {
+		if errors.IsNotFound(err) {
+			return roleBindingNames, nil
+		}
+		return roleBindingNames, groveerr.WrapError(err,
+			errGetRoleBinding,
+			component.OperationGetExistingResourceNames,
+			fmt.Sprintf("Error getting RoleBinding: %v for PodGangSet: %v", objectKey, client.ObjectKeyFromObject(pgs)),
+		)
+	}
+	if metav1.IsControlledBy(objMeta, &pgs.ObjectMeta) {
+		roleBindingNames = append(roleBindingNames, objMeta.Name)
+	}
+	return roleBindingNames, nil
+}
+
+func (r _resource) Sync(ctx context.Context, logger logr.Logger, pgs *v1alpha1.PodGangSet) error {
+	objectKey := getObjectKey(pgs.ObjectMeta)
+	role := emptyRoleBinding(objectKey)
+	logger.Info("Running CreateOrUpdate RoleBinding", "objectKey", objectKey)
+	opResult, err := controllerutil.CreateOrPatch(ctx, r.client, role, func() error {
+		return r.buildResource(pgs, role)
+	})
+	if err != nil {
+		return groveerr.WrapError(err,
+			errSyncRoleBinding,
+			component.OperationSync,
+			fmt.Sprintf("Error syncing RoleBinding: %v for PodGangSet: %v", objectKey, client.ObjectKeyFromObject(pgs)),
+		)
+	}
+	logger.Info("triggered create or update of RoleBinding", "objectKey", objectKey, "result", opResult)
+	return nil
+}
+
+func (r _resource) Delete(ctx context.Context, logger logr.Logger, pgsObjMeta metav1.ObjectMeta) error {
+	objectKey := getObjectKey(pgsObjMeta)
+	logger.Info("Triggering delete of RoleBinding", "objectKey", objectKey)
+	if err := r.client.Delete(ctx, emptyRoleBinding(objectKey)); err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("RoleBinding not found, deletion is a no-op", "objectKey", objectKey)
+			return nil
+		}
+		return groveerr.WrapError(err,
+			errDeleteRoleBinding,
+			component.OperationDelete,
+			fmt.Sprintf("Error deleting RoleBinding: %v for PodGangSet: %v", objectKey, pgsObjMeta),
+		)
+	}
+	logger.Info("deleted RoleBinding", "objectKey", objectKey)
+	return nil
+}
+
+func (r _resource) buildResource(pgs *v1alpha1.PodGangSet, roleBinding *rbacv1.RoleBinding) error {
+	roleBinding.Labels = getLabels(pgs.ObjectMeta)
+	if err := controllerutil.SetControllerReference(pgs, roleBinding, r.scheme); err != nil {
+		return groveerr.WrapError(err,
+			errSyncRoleBinding,
+			component.OperationSync,
+			fmt.Sprintf("Error setting controller reference for RoleBinding: %v", client.ObjectKeyFromObject(roleBinding)),
+		)
+	}
+	roleBinding.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.SchemeGroupVersion.Group,
+		Kind:     "Role",
+		Name:     component.GeneratePodRoleName(pgs.ObjectMeta),
+	}
+	roleBinding.Subjects = []rbacv1.Subject{
+		{
+			APIGroup:  corev1.SchemeGroupVersion.Group,
+			Kind:      "ServiceAccount",
+			Name:      component.GeneratePodServiceAccountName(pgs.ObjectMeta),
+			Namespace: pgs.Namespace,
+		},
+	}
+	return nil
+}
+
+func getLabels(pgsObjMeta metav1.ObjectMeta) map[string]string {
+	roleLabels := map[string]string{
+		v1alpha1.LabelComponentKey: component.NamePodRoleBinding,
+		v1alpha1.LabelAppNameKey:   strings.ReplaceAll(component.GeneratePodRoleBindingName(pgsObjMeta), ":", "-"),
+	}
+	return lo.Assign(
+		k8sutils.GetDefaultLabelsForPodGangSetManagedResources(pgsObjMeta.Name),
+		roleLabels,
+	)
+}
+
+func getObjectKey(pgsObjMeta metav1.ObjectMeta) client.ObjectKey {
+	return client.ObjectKey{
+		Name:      component.GeneratePodRoleBindingName(pgsObjMeta),
+		Namespace: pgsObjMeta.Namespace,
+	}
+}
+
+func emptyRoleBinding(objKey client.ObjectKey) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      objKey.Name,
+			Namespace: objKey.Namespace,
+		},
+	}
+}

--- a/operator/internal/component/pgs/serviceaccount/serviceaccount.go
+++ b/operator/internal/component/pgs/serviceaccount/serviceaccount.go
@@ -1,0 +1,134 @@
+package serviceaccount
+
+import (
+	"context"
+	"fmt"
+	"github.com/NVIDIA/grove/operator/api/core/v1alpha1"
+	"github.com/NVIDIA/grove/operator/internal/component"
+	groveerr "github.com/NVIDIA/grove/operator/internal/errors"
+	k8sutils "github.com/NVIDIA/grove/operator/internal/utils/kubernetes"
+	"github.com/go-logr/logr"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	errGetServiceAccount    v1alpha1.ErrorCode = "ERR_GET_SERVICEACCOUNT"
+	errSyncServiceAccount   v1alpha1.ErrorCode = "ERR_SYNC_SERVICEACCOUNT"
+	errDeleteServiceAccount v1alpha1.ErrorCode = "ERR_DELETE_SERVICEACCOUNT"
+)
+
+type _resource struct {
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+func New(client client.Client, scheme *runtime.Scheme) component.Operator[v1alpha1.PodGangSet] {
+	return &_resource{
+		client: client,
+		scheme: scheme,
+	}
+}
+
+func (r _resource) GetExistingResourceNames(ctx context.Context, logger logr.Logger, pgs *v1alpha1.PodGangSet) ([]string, error) {
+	saNames := make([]string, 0, 1)
+	objectKey := getObjectKey(pgs.ObjectMeta)
+	objMeta := &metav1.PartialObjectMetadata{}
+	objMeta.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ServiceAccount"))
+	if err := r.client.Get(ctx, objectKey, objMeta); err != nil {
+		if errors.IsNotFound(err) {
+			return saNames, nil
+		}
+		return saNames, groveerr.WrapError(err,
+			errGetServiceAccount,
+			component.OperationGetExistingResourceNames,
+			fmt.Sprintf("Error getting ServiceAccount: %v for PodGangSet: %v", objectKey, client.ObjectKeyFromObject(pgs)),
+		)
+	}
+	if metav1.IsControlledBy(objMeta, &pgs.ObjectMeta) {
+		saNames = append(saNames, objMeta.Name)
+	}
+	return saNames, nil
+}
+
+func (r _resource) Sync(ctx context.Context, logger logr.Logger, pgs *v1alpha1.PodGangSet) error {
+	objectKey := getObjectKey(pgs.ObjectMeta)
+	sa := emptyServiceAccount(objectKey)
+
+	logger.Info("Running CreateOrUpdate ServiceAccount", "objectKey", objectKey)
+	opResult, err := controllerutil.CreateOrPatch(ctx, r.client, sa, func() error {
+		return r.buildResource(pgs, sa)
+	})
+	if err != nil {
+		return groveerr.WrapError(err,
+			errSyncServiceAccount,
+			component.OperationSync,
+			fmt.Sprintf("Error syncing ServiceAccount: %v for PodGangSet: %v", objectKey, client.ObjectKeyFromObject(pgs)),
+		)
+	}
+	logger.Info("triggered create or update of ServiceAccount", "objectKey", objectKey, "result", opResult)
+	return nil
+}
+
+func (r _resource) Delete(ctx context.Context, logger logr.Logger, pgsObjMeta metav1.ObjectMeta) error {
+	objectKey := getObjectKey(pgsObjMeta)
+	logger.Info("Triggering delete of ServiceAccount", "objectKey", objectKey)
+	if err := r.client.Delete(ctx, emptyServiceAccount(objectKey)); err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("ServiceAccount not found, deletion is a no-op", "objectKey", objectKey)
+			return nil
+		}
+		return groveerr.WrapError(err,
+			errDeleteServiceAccount,
+			component.OperationDelete,
+			fmt.Sprintf("Error deleting ServiceAccount: %v for PodGangSet: %v", objectKey, pgsObjMeta),
+		)
+	}
+	logger.Info("deleted ServiceAccount", "objectKey", objectKey)
+	return nil
+}
+
+func (r _resource) buildResource(pgs *v1alpha1.PodGangSet, sa *corev1.ServiceAccount) error {
+	sa.Labels = getLabels(pgs.ObjectMeta)
+	if err := controllerutil.SetControllerReference(pgs, sa, r.scheme); err != nil {
+		return groveerr.WrapError(err,
+			errSyncServiceAccount,
+			component.OperationSync,
+			fmt.Sprintf("Error setting controller reference for ServiceAccount: %v", client.ObjectKeyFromObject(sa)),
+		)
+	}
+	// TODO: Check if we need to make sa.AutomountServiceAccountToken configurable. This will enable use to use ServiceAccount projected tokens.
+	return nil
+}
+
+func getLabels(pgsObjMeta metav1.ObjectMeta) map[string]string {
+	roleLabels := map[string]string{
+		v1alpha1.LabelComponentKey: component.NamePodServiceAccount,
+		v1alpha1.LabelAppNameKey:   component.GeneratePodServiceAccountName(pgsObjMeta),
+	}
+	return lo.Assign(
+		k8sutils.GetDefaultLabelsForPodGangSetManagedResources(pgsObjMeta.Name),
+		roleLabels,
+	)
+}
+
+func getObjectKey(pgsObjMeta metav1.ObjectMeta) client.ObjectKey {
+	return client.ObjectKey{
+		Name:      component.GeneratePodServiceAccountName(pgsObjMeta),
+		Namespace: pgsObjMeta.Namespace,
+	}
+}
+
+func emptyServiceAccount(objKey client.ObjectKey) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      objKey.Name,
+			Namespace: objKey.Namespace,
+		},
+	}
+}

--- a/operator/internal/component/types.go
+++ b/operator/internal/component/types.go
@@ -12,6 +12,8 @@ import (
 
 // Constants for common operations that an Operator can perform.
 const (
+	// OperationGetExistingResourceNames represents an operation to get existing resource names.
+	OperationGetExistingResourceNames = "GetExistingResourceNames"
 	// OperationSync represents a sync operation.
 	OperationSync = "Sync"
 	// OperationDelete represents a delete operation.
@@ -27,6 +29,12 @@ const (
 	NamePodClique = "pgs-podclique"
 	// NamePodGangHeadlessService is the value for v1alpha1.LabelComponentKey for a Headless service for a Pod Gang.
 	NamePodGangHeadlessService = "pgs-headless-service"
+	// NamePodRole is the role that is associated to all Pods that are created for a PodGangSet.
+	NamePodRole = "pod-role"
+	// NamePodRoleBinding is the RoleBinding to a Role that is associated to all Pods that are created for a PodGangSet.
+	NamePodRoleBinding = "pod-role-binding"
+	// NamePodServiceAccount is the ServiceAccount that is used by all Pods that are created for a PodGangSet.
+	NamePodServiceAccount = "pod-service-account"
 )
 
 // GroveCustomResourceType defines a type bound for generic types.
@@ -36,6 +44,8 @@ type GroveCustomResourceType interface {
 
 // Operator is a facade that manages one or more resources that are provisioned for a PodGangSet.
 type Operator[T GroveCustomResourceType] interface {
+	// GetExistingResourceNames returns the names of all the existing resources that this Operator manages.
+	GetExistingResourceNames(ctx context.Context, logger logr.Logger, obj *T) ([]string, error)
 	// Sync synchronizes all resources that this Operator manages. If a component does not exist then it will
 	// create it. If there are changes in the owning PodGangSet resource that transpires changes to one or more resources
 	// managed by this Operator then those component(s) will be either be updated or a deletion is triggered.

--- a/operator/internal/controller/podclique/reconciledelete.go
+++ b/operator/internal/controller/podclique/reconciledelete.go
@@ -48,8 +48,7 @@ func (r *Reconciler) deletePodCliqueResources(ctx context.Context, logger logr.L
 }
 
 func (r *Reconciler) verifyNoResourcesAwaitsCleanup(ctx context.Context, logger logr.Logger, pclq *v1alpha1.PodClique) ctrlcommon.ReconcileStepResult {
-	// TODO implement me
-	return ctrlcommon.ContinueReconcile()
+	return ctrlutils.VerifyNoResourceAwaitsCleanup(ctx, logger, r.operatorRegistry, pclq)
 }
 
 func (r *Reconciler) removeFinalizer(ctx context.Context, logger logr.Logger, pclq *v1alpha1.PodClique) ctrlcommon.ReconcileStepResult {

--- a/operator/internal/controller/podgangset/reconciledelete.go
+++ b/operator/internal/controller/podgangset/reconciledelete.go
@@ -56,8 +56,7 @@ func (r *Reconciler) deletePodGangSetResources(ctx context.Context, logger logr.
 }
 
 func (r *Reconciler) verifyNoResourcesAwaitsCleanup(ctx context.Context, logger logr.Logger, pgs *v1alpha1.PodGangSet) ctrlcommon.ReconcileStepResult {
-	// TODO implement me
-	return ctrlcommon.ContinueReconcile()
+	return ctrlutils.VerifyNoResourceAwaitsCleanup(ctx, logger, r.operatorRegistry, pgs)
 }
 
 func (r *Reconciler) removeFinalizer(ctx context.Context, logger logr.Logger, pgs *v1alpha1.PodGangSet) ctrlcommon.ReconcileStepResult {

--- a/operator/internal/controller/podgangset/reconcilespec.go
+++ b/operator/internal/controller/podgangset/reconcilespec.go
@@ -98,5 +98,8 @@ func getOrderedKindsForSync() []component.Kind {
 	return []component.Kind{
 		component.KindPodClique,
 		component.KindHeadlessService,
+		component.KindRole,
+		component.KindRoleBinding,
+		component.KindServiceAccount,
 	}
 }

--- a/operator/internal/utils/names.go
+++ b/operator/internal/utils/names.go
@@ -1,8 +1,0 @@
-package utils
-
-import "fmt"
-
-// GeneratePodGangName generates a PodGang name based on the PodGangSet name and the replica index.
-func GeneratePodGangName(pgsName string, replicaIndex int32) string {
-	return fmt.Sprintf("%s-%d", pgsName, replicaIndex)
-}


### PR DESCRIPTION
This PR introduces the following:

- Adds components for Role, RoleBinding and ServiceAccount that will be used by the pods.
- Changes the finalizer and adds a domain as recommended by k8s.
- Adds a new file to generate names for components.
- Adds `GetExistingResourceNames` method to `Operator`
- Implements `verifyNoResourcesAwaitsCleanup` in the reconcilers
- Harmonizes labels on all managed resources
