### PR TITLE
Pass `PodClique` annotations to `Pod`s during create.

### DIFF
--- a/operator/internal/component/podclique/pod/pod.go
+++ b/operator/internal/component/podclique/pod/pod.go
@@ -158,6 +158,7 @@ func (r _resource) buildResource(pgs *grovecorev1alpha1.PodGangSet, pclq *grovec
 		GenerateName: fmt.Sprintf("%s-", pclq.Name),
 		Namespace:    pclq.Namespace,
 		Labels:       labels,
+		Annotations:  pclq.Annotations,
 	}
 	if err = controllerutil.SetControllerReference(pclq, pod, r.scheme); err != nil {
 		return groveerr.WrapError(err,


### PR DESCRIPTION
* Pass the annotations specified for the `PodClique` in the `PodCliqueTemplateSpec` to all its `Pod`s during create.

This PR partially fixes #128.

A future PR will bring in the Pod annotation updates whenever the `PodCliqueTemplateSpec` is updated with a new set of annotations.
