### PR TITLE
document in internal/webooks

### DIFF
--- a/operator/internal/webhook/admission/pcs/defaulting/handler.go
+++ b/operator/internal/webhook/admission/pcs/defaulting/handler.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// Handler struct sets default values on PodCliqueSet CR
+// Handler sets default values on PodCliqueSet resources.
 type Handler struct {
 	logger logr.Logger
 }
@@ -41,7 +41,7 @@ func NewHandler(mgr manager.Manager) *Handler {
 	}
 }
 
-// Default implements webhook.CustomDefaulter
+// Default applies default values to a PodCliqueSet object.
 func (h *Handler) Default(ctx context.Context, obj runtime.Object) error {
 	h.logger.Info("Defaulting webhook invoked for PodCliqueSet")
 	pcs, ok := obj.(*v1alpha1.PodCliqueSet)

--- a/operator/internal/webhook/admission/pcs/defaulting/podcliqueset.go
+++ b/operator/internal/webhook/admission/pcs/defaulting/podcliqueset.go
@@ -41,14 +41,12 @@ func defaultPodCliqueSet(pcs *grovecorev1alpha1.PodCliqueSet) {
 
 // defaultPodCliqueSetSpec adds defaults to the specification of a PodCliqueSet.
 func defaultPodCliqueSetSpec(spec *grovecorev1alpha1.PodCliqueSetSpec) {
-	// default PodCliqueSetTemplateSpec
 	defaultPodCliqueSetTemplateSpec(&spec.Template)
 }
 
+// defaultPodCliqueSetTemplateSpec applies defaults to the template specification including cliques, scaling groups, and service configuration.
 func defaultPodCliqueSetTemplateSpec(spec *grovecorev1alpha1.PodCliqueSetTemplateSpec) {
-	// default PodCliqueTemplateSpecs
 	spec.Cliques = defaultPodCliqueTemplateSpecs(spec.Cliques)
-	// default PodCliqueScalingGroupConfigs
 	spec.PodCliqueScalingGroupConfigs = defaultPodCliqueScalingGroupConfigs(spec.PodCliqueScalingGroupConfigs)
 	if spec.TerminationDelay == nil {
 		spec.TerminationDelay = &metav1.Duration{Duration: defaultTerminationDelay}
@@ -57,6 +55,7 @@ func defaultPodCliqueSetTemplateSpec(spec *grovecorev1alpha1.PodCliqueSetTemplat
 	spec.HeadlessServiceConfig = defaultHeadlessServiceConfig(spec.HeadlessServiceConfig)
 }
 
+// defaultHeadlessServiceConfig applies defaults to the headless service configuration.
 func defaultHeadlessServiceConfig(headlessServiceConfig *grovecorev1alpha1.HeadlessServiceConfig) *grovecorev1alpha1.HeadlessServiceConfig {
 	if headlessServiceConfig == nil {
 		headlessServiceConfig = &grovecorev1alpha1.HeadlessServiceConfig{
@@ -66,6 +65,7 @@ func defaultHeadlessServiceConfig(headlessServiceConfig *grovecorev1alpha1.Headl
 	return headlessServiceConfig
 }
 
+// defaultPodCliqueTemplateSpecs applies defaults to each PodClique template including replicas, minAvailable, and autoscaling configuration.
 func defaultPodCliqueTemplateSpecs(cliqueSpecs []*grovecorev1alpha1.PodCliqueTemplateSpec) []*grovecorev1alpha1.PodCliqueTemplateSpec {
 	defaultedCliqueSpecs := make([]*grovecorev1alpha1.PodCliqueTemplateSpec, 0, len(cliqueSpecs))
 	for _, cliqueSpec := range cliqueSpecs {
@@ -87,6 +87,8 @@ func defaultPodCliqueTemplateSpecs(cliqueSpecs []*grovecorev1alpha1.PodCliqueTem
 	return defaultedCliqueSpecs
 }
 
+// defaultPodCliqueScalingGroupConfigs applies defaults to scaling group configurations.
+// Note: Replicas field is already set by kubebuilder defaults before the webhook runs.
 func defaultPodCliqueScalingGroupConfigs(scalingGroupConfigs []grovecorev1alpha1.PodCliqueScalingGroupConfig) []grovecorev1alpha1.PodCliqueScalingGroupConfig {
 	defaultedScalingGroupConfigs := make([]grovecorev1alpha1.PodCliqueScalingGroupConfig, 0, len(scalingGroupConfigs))
 	for _, scalingGroupConfig := range scalingGroupConfigs {

--- a/operator/internal/webhook/admission/pcs/validation/handler.go
+++ b/operator/internal/webhook/admission/pcs/validation/handler.go
@@ -83,6 +83,7 @@ func (h *Handler) ValidateDelete(_ context.Context, _ runtime.Object) (admission
 	return nil, nil
 }
 
+// castToPodCliqueSet attempts to cast a runtime.Object to a PodCliqueSet.
 func castToPodCliqueSet(obj runtime.Object) (*v1alpha1.PodCliqueSet, error) {
 	pcs, ok := obj.(*v1alpha1.PodCliqueSet)
 	if !ok {
@@ -91,6 +92,7 @@ func castToPodCliqueSet(obj runtime.Object) (*v1alpha1.PodCliqueSet, error) {
 	return pcs, nil
 }
 
+// logValidatorFunctionInvocation logs details about the validation request including user and operation information.
 func (h *Handler) logValidatorFunctionInvocation(ctx context.Context) {
 	req, err := admission.RequestFromContext(ctx)
 	if err != nil {

--- a/operator/internal/webhook/admission/pcs/validation/util.go
+++ b/operator/internal/webhook/admission/pcs/validation/util.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
+// validateEnumType validates that a value is one of the allowed enum values.
 func validateEnumType[T comparable](value *T, allowedValues sets.Set[T], fldPath *field.Path) field.ErrorList {
 	allErrs := validateNonNilField(value, fldPath)
 	if len(allErrs) != 0 {
@@ -38,6 +39,7 @@ func validateEnumType[T comparable](value *T, allowedValues sets.Set[T], fldPath
 	return allErrs
 }
 
+// validateNonNilField validates that a pointer field is not nil.
 func validateNonNilField[T any](value *T, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if value == nil {
@@ -46,6 +48,7 @@ func validateNonNilField[T any](value *T, fldPath *field.Path) field.ErrorList {
 	return allErrs
 }
 
+// validateNonEmptyStringField validates that a string field is not empty.
 func validateNonEmptyStringField(value string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if utils.IsEmptyStringType(value) {
@@ -54,6 +57,7 @@ func validateNonEmptyStringField(value string, fldPath *field.Path) field.ErrorL
 	return allErrs
 }
 
+// sliceMustHaveUniqueElements validates that all elements in a string slice are unique.
 func sliceMustHaveUniqueElements(s []string, fldPath *field.Path, msg string) field.ErrorList {
 	allErrs := field.ErrorList{}
 	duplicates := lo.FindDuplicates(s)


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR increases the documentation of internal/webhooks. 

#### Special notes for your reviewer:

Prompt:

Improve the inline documentation for for all golang files under this directory/package. Here are the rules to follow: 

* Use concise idiomatic go documentation principles.  
* Ensure correctness. 
* Add some minimal inline documentation above complex code blocks when to explain the intent of the code. 
* Don't document code that is clearly self documenting. 
* Blocks of code should only have a comment describing them if it is practical and valuable. 
* Don't change the code or variable names. 
* All functions to should have concise accurate documentation with the exception of command "main" functions which are obviously entry points. 
* Document field structs but don't duplicate the field documentation above. 
* Avoid duplicate documentation, just pick the most appropriate place.
* Large or complex blocks of code that aren't self documenting should be documented. 
* Avoid re-writing any existing documentation unless it's incomplete, or incorrect


Example of documentation that isn't useful and should be avoided: 
  ```// log is the global logger instance configured for the grove init container.
// It uses JSON format at INFO level for structured logging.
var (
 log = logger.MustNewLogger(false, configv1alpha1.InfoLevel, configv1alpha1.LogFormatJSON).WithName("grove-initc")
)```. 

Examples of documentation that doesn't add value: 
```  // Parse the replica count as an integer
  replicas, err := strconv.Atoi(nameAndMinAvailable[1])
  if err != nil {
   return nil, groveerr.WrapError(err, errCodeInvalidInput, operationParseFlag, "failed to convert replicas to int")
  }
```
```
  // Store the PodClique name and its minimum available replicas
  podCliqueDependencies[strings.TrimSpace(nameAndMinAvailable[0])] = replicas
```
```
// Initialize the configuration with empty PodClique list
 config := CLIOptions{
  podCliques: make([]string, 0),
 }
```
```
 // Register all command line flags
 config.RegisterFlags(pflag.CommandLine)
 // Parse the command line arguments
 pflag.Parse()
```

```
 // Get the in-cluster REST configuration
 restConfig, err := rest.InClusterConfig()
```
```
// Get the pod informer from the factory
typedInformer := factory.Core().V1().Pods().Informer()
```

Systematically check every golang file under this directory is documented as per the instructions above. 



#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
