### PR TITLE
fixed the owner name to be lower case nvidia

### DIFF
--- a/.github/workflows/push-artifacts.yaml
+++ b/.github/workflows/push-artifacts.yaml
@@ -28,7 +28,7 @@ permissions:
   packages: write
 
 env:
-  DOCKER_REGISTRY: "ghcr.io/${{ github.repository_owner }}/grove"
+  DOCKER_REGISTRY: "ghcr.io/nvidia/grove"
 
 jobs:
   build-and-push:


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api
-->

/kind bug

#### What this PR does / why we need it:
https://github.com/NVIDIA/grove/pull/219 introduced a bug where it tries to generalize the repo name which is used as part of `DOCKER_REGISTRY: "ghcr.io/${{ github.repository_owner }}/grove"`
The issue is that for the current org `NVIDIA` this is all upper case. This does not work for docker registry urls. It must be lower case. For now this PR only reverts this change and hard codes it to `NVIDIA` but we need to test a generic fix which also lower cases it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs

```
