### PR TITLE
Disallow reducing `PodCliqueSetTemplateSpec.PodCliqueScalingGroupConfig.Replicas` to `0`.

### DIFF
--- a/operator/internal/webhook/admission/pcs/validation/handler.go
+++ b/operator/internal/webhook/admission/pcs/validation/handler.go
@@ -60,7 +60,7 @@ func (h *Handler) ValidateCreate(ctx context.Context, obj runtime.Object) (admis
 }
 
 // ValidateUpdate validates a PodCliqueSet update request.
-func (h *Handler) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) (admission.Warnings, error) {
+func (h *Handler) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	h.logValidatorFunctionInvocation(ctx)
 	newPCS, err := castToPodCliqueSet(newObj)
 	if err != nil {

--- a/operator/internal/webhook/admission/pcs/validation/handler_test.go
+++ b/operator/internal/webhook/admission/pcs/validation/handler_test.go
@@ -146,7 +146,7 @@ func TestValidateUpdate(t *testing.T) {
 	}{
 		{
 			name: "valid update passes validation",
-			newObj: testutils.NewPodCliqueSetBuilder("test-pcs", "default", uuid.NewUUID()).
+			oldObj: testutils.NewPodCliqueSetBuilder("test-pcs", "default", uuid.NewUUID()).
 				WithReplicas(2).
 				WithTerminationDelay(4 * time.Hour).
 				WithCliqueStartupType(ptr.To(grovecorev1alpha1.CliqueStartupTypeAnyOrder)).
@@ -157,7 +157,7 @@ func TestValidateUpdate(t *testing.T) {
 						WithMinAvailable(1).
 						Build()).
 				Build(),
-			oldObj: testutils.NewPodCliqueSetBuilder("test-pcs", "default", uuid.NewUUID()).
+			newObj: testutils.NewPodCliqueSetBuilder("test-pcs", "default", uuid.NewUUID()).
 				WithReplicas(1).
 				WithTerminationDelay(4 * time.Hour).
 				WithCliqueStartupType(ptr.To(grovecorev1alpha1.CliqueStartupTypeAnyOrder)).
@@ -172,21 +172,21 @@ func TestValidateUpdate(t *testing.T) {
 		},
 		{
 			name:          "wrong new object type fails validation",
-			newObj:        &corev1.Pod{},
-			oldObj:        createDummyPodCliqueSet("test"),
+			oldObj:        &corev1.Pod{},
+			newObj:        createDummyPodCliqueSet("test"),
 			expectError:   true,
 			errorContains: "failed to cast new object to PodCliqueSet",
 		},
 		{
 			name:          "wrong old object type fails validation",
-			newObj:        createDummyPodCliqueSet("test"),
-			oldObj:        &corev1.Pod{},
+			oldObj:        createDummyPodCliqueSet("test"),
+			newObj:        &corev1.Pod{},
 			expectError:   true,
 			errorContains: "failed to cast old object to PodCliqueSet",
 		},
 		{
 			name: "invalid update with changed startup type fails validation",
-			newObj: testutils.NewPodCliqueSetBuilder("test-pcs", "default", uuid.NewUUID()).
+			oldObj: testutils.NewPodCliqueSetBuilder("test-pcs", "default", uuid.NewUUID()).
 				WithReplicas(1).
 				WithTerminationDelay(4 * time.Hour).
 				WithCliqueStartupType(ptr.To(grovecorev1alpha1.CliqueStartupTypeInOrder)).
@@ -197,7 +197,7 @@ func TestValidateUpdate(t *testing.T) {
 						WithMinAvailable(1).
 						Build()).
 				Build(),
-			oldObj: testutils.NewPodCliqueSetBuilder("test-pcs", "default", uuid.NewUUID()).
+			newObj: testutils.NewPodCliqueSetBuilder("test-pcs", "default", uuid.NewUUID()).
 				WithReplicas(1).
 				WithTerminationDelay(4 * time.Hour).
 				WithCliqueStartupType(ptr.To(grovecorev1alpha1.CliqueStartupTypeAnyOrder)).


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api
-->

#### What this PR does / why we need it:

The order of arguments specified in `Handler.ValidateUpdate` was incorrect.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #255 

#### Special notes for your reviewer:

#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs

```
