### PR TITLE
fix(charts): correct webhook configuration scope and metadata

### DIFF
--- a/operator/charts/templates/authorizer-webhook-config.yaml
+++ b/operator/charts/templates/authorizer-webhook-config.yaml
@@ -4,7 +4,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: authorizer-webhook
-  namespace: {{ .Release.Namespace }}
   labels:
 {{- include "operator.authorizer.webhook.labels" . | nindent 4 }}
 webhooks:
@@ -36,7 +35,7 @@ webhooks:
           - secrets
           - serviceaccounts
           - services
-        scope: '*'
+        scope: "Namespaced"
       - apiGroups:
           - ""
         apiVersions:
@@ -45,7 +44,7 @@ webhooks:
           - UPDATE
         resources:
           - pods
-        scope: '*'
+        scope: "Namespaced"
       - apiGroups:
           - "rbac.authorization.k8s.io"
         apiVersions:
@@ -56,7 +55,7 @@ webhooks:
         resources:
           - roles
           - rolebindings
-        scope: '*'
+        scope: "Namespaced"
       - apiGroups:
           - "autoscaling"
         apiVersions:
@@ -67,7 +66,7 @@ webhooks:
           - DELETE
         resources:
           - horizontalpodautoscalers
-        scope: '*'
+        scope: "Namespaced"
       - apiGroups:
           - "grove.io"
         apiVersions:
@@ -79,7 +78,7 @@ webhooks:
         resources:
           - podcliques
           - podcliquescalinggroups
-        scope: '*'
+        scope: "Namespaced"
       - apiGroups:
           - "scheduler.grove.io"
         apiVersions:
@@ -90,6 +89,6 @@ webhooks:
           - DELETE
         resources:
           - podgangs
-        scope: '*'
+        scope: "Namespaced"
     timeoutSeconds: 10
 {{- end }}

--- a/operator/charts/templates/pcs-defaulting-webhook-config.yaml
+++ b/operator/charts/templates/pcs-defaulting-webhook-config.yaml
@@ -3,7 +3,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: podcliqueset-defaulting-webhook
-  namespace: {{ .Release.Namespace }}
   labels:
 {{- include "operator.pcs.defaulting.webhook.labels" . | nindent 4 }}
 webhooks:
@@ -29,6 +28,6 @@ webhooks:
           - UPDATE
         resources:
           - podcliquesets
-        scope: '*'
+        scope: "Namespaced"
     sideEffects: None
     timeoutSeconds: 10

--- a/operator/charts/templates/pcs-validating-webhook-config.yaml
+++ b/operator/charts/templates/pcs-validating-webhook-config.yaml
@@ -3,7 +3,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: podcliqueset-validating-webhook
-  namespace: {{ .Release.Namespace }}
   labels:
 {{- include "operator.pcs.validating.webhook.labels" . | nindent 4 }}
 webhooks:
@@ -29,6 +28,6 @@ webhooks:
           - UPDATE
         resources:
           - podcliquesets
-        scope: '*'
+        scope: "Namespaced"
     sideEffects: None
     timeoutSeconds: 10


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

- Remove invalid namespace field from webhook config metadata
- Change scope from '*' to 'Namespaced' for target resources
- Affects PCS validating/defaulting webhooks and authorizer webhook

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a API change?
```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

