### PR TITLE
Add mutations webhook for ClusterTopology resource

### DIFF
--- a/operator/charts/templates/_helpers.tpl
+++ b/operator/charts/templates/_helpers.tpl
@@ -145,6 +145,13 @@ release: "{{ .Release.Name }}"
 {{- end }}
 {{- end -}}
 
+{{- define "operator.clustertopology.defaulting.webhook.labels" -}}
+{{- include "common.chart.labels" . }}
+{{- range $key, $val := .Values.webhooks.clusterTopologyDefaultingWebhook.labels }}
+{{ $key }}: {{ $val }}
+{{- end }}
+{{- end -}}
+
 {{- define "operator.server.secret.labels" -}}
 {{- include "common.chart.labels" . }}
 {{- range $key, $val := .Values.webhookServerSecret.labels }}

--- a/operator/charts/templates/clustertopology-defaulting-webhook-config.yaml
+++ b/operator/charts/templates/clustertopology-defaulting-webhook-config.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: clustertopology-defaulting-webhook
+  labels:
+{{- include "operator.clustertopology.defaulting.webhook.labels" . | nindent 4 }}
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: {{ required ".Values.service.name is required" .Values.service.name }}
+        namespace: {{ .Release.Namespace }}
+        path: /webhooks/default-clustertopology
+        port: {{ required ".Values.config.server.webhooks.port" .Values.config.server.webhooks.port }}
+    failurePolicy: Fail
+    matchPolicy: Exact
+    name: clustertopology.defaulting.webhooks.grove.io
+    namespaceSelector: { }
+    rules:
+      - apiGroups:
+          - "grove.io"
+        apiVersions:
+          - "v1alpha1"
+        operations:
+          - CREATE
+        resources:
+          - clustertopologies
+        scope: 'Cluster'
+    sideEffects: None
+    timeoutSeconds: 10
+

--- a/operator/client/go.mod
+++ b/operator/client/go.mod
@@ -28,11 +28,11 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	golang.org/x/net v0.38.0 // indirect
+	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
-	golang.org/x/sys v0.31.0 // indirect
-	golang.org/x/term v0.30.0 // indirect
-	golang.org/x/text v0.23.0 // indirect
+	golang.org/x/sys v0.38.0 // indirect
+	golang.org/x/term v0.37.0 // indirect
+	golang.org/x/text v0.31.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect

--- a/operator/client/go.sum
+++ b/operator/client/go.sum
@@ -98,6 +98,7 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
 golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/net v0.47.0/go.mod h1:/jNxtkgq5yWUGYkaZGqo27cfGZ1c5Nen03aYrrKpVRU=
 golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
 golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -108,12 +109,15 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
 golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
 golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=
+golang.org/x/term v0.37.0/go.mod h1:5pB4lxRNYYVZuTLmy8oR2BH8dflOR+IbTYFD8fi3254=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
 golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
+golang.org/x/text v0.31.0/go.mod h1:tKRAlv61yKIjGGHX/4tP1LTbc13YSec1pxVEWXzfoeM=
 golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
 golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/operator/internal/controller/cert/cert.go
+++ b/operator/internal/controller/cert/cert.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/ai-dynamo/grove/operator/internal/constants"
+	clustertopologydefaultingwebhook "github.com/ai-dynamo/grove/operator/internal/webhook/admission/clustertopology/defaulting"
 	clustertopologyvalidation "github.com/ai-dynamo/grove/operator/internal/webhook/admission/clustertopology/validation"
 	authorizationwebhook "github.com/ai-dynamo/grove/operator/internal/webhook/admission/pcs/authorization"
 	defaultingwebhook "github.com/ai-dynamo/grove/operator/internal/webhook/admission/pcs/defaulting"
@@ -80,6 +81,10 @@ func WaitTillWebhookCertsReady(logger logr.Logger, certsReady chan struct{}) {
 func getWebhooks(authorizerEnabled bool) []cert.WebhookInfo {
 	// defaulting and validating webhooks are always enabled, and are therefore registered by default.
 	webhooks := []cert.WebhookInfo{
+		{
+			Type: cert.Mutating,
+			Name: clustertopologydefaultingwebhook.Name,
+		},
 		{
 			Type: cert.Mutating,
 			Name: defaultingwebhook.Name,

--- a/operator/internal/webhook/admission/clustertopology/defaulting/clustertopology.go
+++ b/operator/internal/webhook/admission/clustertopology/defaulting/clustertopology.go
@@ -1,0 +1,37 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package defaulting
+
+import (
+	"sort"
+
+	"github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+)
+
+// defaultClusterTopology reorders the topology levels to match the predefined hierarchy.
+// The levels are sorted from broadest to narrowest scope
+func defaultClusterTopology(clusterTopology *v1alpha1.ClusterTopology) {
+	if len(clusterTopology.Spec.Levels) == 1 {
+		// No need to reorder if there's a single level
+		return
+	}
+
+	// Sort levels by their domain order using the Compare method
+	sort.SliceStable(clusterTopology.Spec.Levels, func(i, j int) bool {
+		return clusterTopology.Spec.Levels[i].Compare(clusterTopology.Spec.Levels[j]) < 0
+	})
+}

--- a/operator/internal/webhook/admission/clustertopology/defaulting/clustertopology_test.go
+++ b/operator/internal/webhook/admission/clustertopology/defaulting/clustertopology_test.go
@@ -1,0 +1,104 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package defaulting
+
+import (
+	"testing"
+
+	"github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultClusterTopology(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []v1alpha1.TopologyLevel
+		expected []v1alpha1.TopologyLevel
+	}{
+		{
+			name: "single level remains unchanged",
+			input: []v1alpha1.TopologyLevel{
+				{Domain: v1alpha1.TopologyDomainRack, Key: "topology.kubernetes.io/rack"},
+			},
+			expected: []v1alpha1.TopologyLevel{
+				{Domain: v1alpha1.TopologyDomainRack, Key: "topology.kubernetes.io/rack"},
+			},
+		},
+		{
+			name: "reorder from mixed order",
+			input: []v1alpha1.TopologyLevel{
+				{Domain: v1alpha1.TopologyDomainHost, Key: "kubernetes.io/hostname"},
+				{Domain: v1alpha1.TopologyDomainRegion, Key: "topology.kubernetes.io/region"},
+				{Domain: v1alpha1.TopologyDomainRack, Key: "topology.kubernetes.io/rack"},
+			},
+			expected: []v1alpha1.TopologyLevel{
+				{Domain: v1alpha1.TopologyDomainRegion, Key: "topology.kubernetes.io/region"},
+				{Domain: v1alpha1.TopologyDomainRack, Key: "topology.kubernetes.io/rack"},
+				{Domain: v1alpha1.TopologyDomainHost, Key: "kubernetes.io/hostname"},
+			},
+		},
+		{
+			name: "already ordered levels remain unchanged",
+			input: []v1alpha1.TopologyLevel{
+				{Domain: v1alpha1.TopologyDomainRegion, Key: "topology.kubernetes.io/region"},
+				{Domain: v1alpha1.TopologyDomainZone, Key: "topology.kubernetes.io/zone"},
+				{Domain: v1alpha1.TopologyDomainHost, Key: "kubernetes.io/hostname"},
+			},
+			expected: []v1alpha1.TopologyLevel{
+				{Domain: v1alpha1.TopologyDomainRegion, Key: "topology.kubernetes.io/region"},
+				{Domain: v1alpha1.TopologyDomainZone, Key: "topology.kubernetes.io/zone"},
+				{Domain: v1alpha1.TopologyDomainHost, Key: "kubernetes.io/hostname"},
+			},
+		},
+		{
+			name: "all topology domains reordered correctly",
+			input: []v1alpha1.TopologyLevel{
+				{Domain: v1alpha1.TopologyDomainNuma, Key: "topology.kubernetes.io/numa"},
+				{Domain: v1alpha1.TopologyDomainHost, Key: "kubernetes.io/hostname"},
+				{Domain: v1alpha1.TopologyDomainRack, Key: "topology.kubernetes.io/rack"},
+				{Domain: v1alpha1.TopologyDomainBlock, Key: "topology.kubernetes.io/block"},
+				{Domain: v1alpha1.TopologyDomainDataCenter, Key: "topology.kubernetes.io/datacenter"},
+				{Domain: v1alpha1.TopologyDomainZone, Key: "topology.kubernetes.io/zone"},
+				{Domain: v1alpha1.TopologyDomainRegion, Key: "topology.kubernetes.io/region"},
+			},
+			expected: []v1alpha1.TopologyLevel{
+				{Domain: v1alpha1.TopologyDomainRegion, Key: "topology.kubernetes.io/region"},
+				{Domain: v1alpha1.TopologyDomainZone, Key: "topology.kubernetes.io/zone"},
+				{Domain: v1alpha1.TopologyDomainDataCenter, Key: "topology.kubernetes.io/datacenter"},
+				{Domain: v1alpha1.TopologyDomainBlock, Key: "topology.kubernetes.io/block"},
+				{Domain: v1alpha1.TopologyDomainRack, Key: "topology.kubernetes.io/rack"},
+				{Domain: v1alpha1.TopologyDomainHost, Key: "kubernetes.io/hostname"},
+				{Domain: v1alpha1.TopologyDomainNuma, Key: "topology.kubernetes.io/numa"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusterTopology := &v1alpha1.ClusterTopology{
+				Spec: v1alpha1.ClusterTopologySpec{
+					Levels: tt.input,
+				},
+			}
+
+			defaultClusterTopology(clusterTopology)
+
+			assert.Equal(t, tt.expected, clusterTopology.Spec.Levels, "levels should be reordered correctly")
+		})
+	}
+}

--- a/operator/internal/webhook/admission/clustertopology/defaulting/handler.go
+++ b/operator/internal/webhook/admission/clustertopology/defaulting/handler.go
@@ -1,0 +1,58 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package defaulting
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	k8sutils "github.com/ai-dynamo/grove/operator/internal/utils/kubernetes"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// Handler sets default values on ClusterTopology resources.
+type Handler struct {
+	logger logr.Logger
+}
+
+// NewHandler returns a new instance of defaulting webhook handler.
+func NewHandler(mgr manager.Manager) *Handler {
+	return &Handler{
+		logger: mgr.GetLogger().WithName("webhook").WithName(Name),
+	}
+}
+
+// Default applies default values to a ClusterTopology object.
+func (h *Handler) Default(ctx context.Context, obj runtime.Object) error {
+	h.logger.Info("Defaulting webhook invoked for ClusterTopology")
+	clusterTopology, ok := obj.(*v1alpha1.ClusterTopology)
+	if !ok {
+		return fmt.Errorf("expected a ClusterTopology object but got %T", obj)
+	}
+	req, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	h.logger.Info("Applying defaults", "ClusterTopology", k8sutils.CreateObjectKeyForCreateWebhooks(clusterTopology, req))
+	defaultClusterTopology(clusterTopology)
+	return nil
+}

--- a/operator/internal/webhook/admission/clustertopology/defaulting/register.go
+++ b/operator/internal/webhook/admission/clustertopology/defaulting/register.go
@@ -1,0 +1,39 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package defaulting
+
+import (
+	"github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	// Name is the name of the default webhook handler for ClusterTopology.
+	Name        = "clustertopology-defaulting-webhook"
+	webhookPath = "/webhooks/default-clustertopology"
+)
+
+// RegisterWithManager registers the webhook with the manager.
+func (h *Handler) RegisterWithManager(mgr manager.Manager) error {
+	webhook := admission.
+		WithCustomDefaulter(mgr.GetScheme(), &v1alpha1.ClusterTopology{}, h).
+		WithRecoverPanic(true)
+	mgr.GetWebhookServer().Register(webhookPath, webhook)
+	return nil
+}

--- a/operator/internal/webhook/register.go
+++ b/operator/internal/webhook/register.go
@@ -23,6 +23,7 @@ import (
 
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	"github.com/ai-dynamo/grove/operator/internal/constants"
+	clustertopologydefaulting "github.com/ai-dynamo/grove/operator/internal/webhook/admission/clustertopology/defaulting"
 	ctvalidation "github.com/ai-dynamo/grove/operator/internal/webhook/admission/clustertopology/validation"
 	"github.com/ai-dynamo/grove/operator/internal/webhook/admission/pcs/authorization"
 	"github.com/ai-dynamo/grove/operator/internal/webhook/admission/pcs/defaulting"
@@ -33,6 +34,11 @@ import (
 
 // RegisterWebhooks registers the webhooks with the controller manager.
 func RegisterWebhooks(mgr manager.Manager, authorizerConfig configv1alpha1.AuthorizerConfig) error {
+	clusterTopologyDefaultingWebhook := clustertopologydefaulting.NewHandler(mgr)
+	slog.Info("Registering webhook with manager", "handler", clustertopologydefaulting.Name)
+	if err := clusterTopologyDefaultingWebhook.RegisterWithManager(mgr); err != nil {
+		return fmt.Errorf("failed adding %s webhook handler: %v", clustertopologydefaulting.Name, err)
+	}
 	defaultingWebhook := defaulting.NewHandler(mgr)
 	slog.Info("Registering webhook with manager", "handler", defaulting.Name)
 	if err := defaultingWebhook.RegisterWithManager(mgr); err != nil {


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
* Implement a mutations webhook that enforces order in the topology domain hierarchy.
* Add UT

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a API change?
```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
Design ref: docs/designs/topology.md
```
