### PR TITLE
prepend a g to the github has in package version to avoid semver issues

### DIFF
--- a/.github/workflows/push-artifacts.yaml
+++ b/.github/workflows/push-artifacts.yaml
@@ -45,10 +45,11 @@ jobs:
       - name: Extract package version from branch commit
         if: startsWith(github.ref, 'refs/heads/')
         run: |
-          PACKAGE_VERSION=v0.0.0-$(git rev-parse --short HEAD)
+          # We add a 'g' prefix to the hash.
+          # This prevents "all-number" hashes starting with 0 from breaking Helm (invalid semver)
+          PACKAGE_VERSION=v0.0.0-g$(git rev-parse --short HEAD)
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
           echo $PACKAGE_VERSION
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
#### What type of PR is this?

Bug

#### What this PR does / why we need it:

During the github build and push workflow we embed the short git SHA in the version after the version with a - in front. Semver rules require that this not start with a zero, otherwise it's invalid and helm will reject it for it's --version parameter. See:

```
Run sed -i "s#repository: grove-operator#repository: $DOCKER_REGISTRY/grove-operator#" operator/charts/values.yaml
  sed -i "s#repository: grove-operator#repository: $DOCKER_REGISTRY/grove-operator#" operator/charts/values.yaml
  sed -i "s#tag:.*#tag: $PACKAGE_VERSION#" operator/charts/values.yaml
  sed -i "s#value: grove-initc#value: $DOCKER_REGISTRY/grove-initc#" operator/charts/values.yaml
  helm package ./operator/charts --app-version $PACKAGE_VERSION --version $PACKAGE_VERSION
  shell: /usr/bin/bash -e {0}
  env:
    PACKAGE_VERSION: v0.0.0-0617444
    DOCKER_REGISTRY: ghcr.io/ai-dynamo/grove
Error: version segment starts with 0
Error: Process completed with exit code 1.
```

See semver.org: 

> A pre-release version MAY be denoted by appending a hyphen and a series of dot separated identifiers immediately following the patch version. Identifiers MUST comprise only ASCII alphanumerics and hyphens [0-9A-Za-z-]. Identifiers MUST NOT be empty. ***Numeric identifiers MUST NOT include leading zeroes***. Pre-release versions have a lower precedence than the associated normal version. A pre-release version indicates that the version is unstable and might not satisfy the intended compatibility requirements as denoted by its associated normal version. Examples: 1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7, 1.0.0-x.7.z.92, 1.0.0-x-y-z.--.

Just add a 'g' in front of the SHA, and this will never happen again.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs

```
