### PR TITLE
cancel stale E2E runs

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -21,6 +21,12 @@ on:
     types: [opened, synchronize, reopened, labeled, ready_for_review]
     branches: ["main"]
 
+# Cancel in-progress runs when a new run is triggered for the same PR
+# This prevents stale E2E test runs from consuming resources
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     # Run on non-draft PRs or draft PRs with 'run-e2e' label


### PR DESCRIPTION
#### What type of PR is this?
 Test Infra
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api
-->

#### What this PR does / why we need it:

When a PR get's updated, it fires off new E2E tests. However if old stale E2E tests are queued or running they will continue and use up limited resources.  This PR cancels stale E2E test that are queued or running, freeing up resources for the new runs. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs

```
