### PR TITLE
handle clean up failures better

### DIFF
--- a/operator/e2e/tests/setup.go
+++ b/operator/e2e/tests/setup.go
@@ -181,7 +181,12 @@ func prepareTestCluster(ctx context.Context, t *testing.T, requiredWorkerNodes i
 			logger.Error("=== CLEANUP FAILURE - COLLECTING DIAGNOSTICS ===")
 			logger.Error("================================================================================")
 			CollectAllDiagnostics(diagnosticsTc)
-			t.Fatalf("Failed to cleanup workloads: %v", err)
+
+			// Mark cleanup as failed - this will cause all subsequent tests to fail immediately
+			// when they try to prepare the cluster, preventing potentially corrupted test state
+			sharedCluster.MarkCleanupFailed(err)
+
+			t.Fatalf("Failed to cleanup workloads: %v. All subsequent tests will fail.", err)
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

Test Infra

#### What this PR does / why we need it:

We're seeing failures in test cleanup intermittently. This PR:

* increases the timeout for test cleanup to 2 minutes, since tests pass locally, this might help
* if a test cleanup fails, there's no point running the remaining tests, the next test will likely fail (this will also save us E2E test running resources being wasted)


#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs

```
