### PR TITLE
only warn about MTU/PMTU issues

### DIFF
--- a/operator/hack/kind-up.sh
+++ b/operator/hack/kind-up.sh
@@ -98,10 +98,10 @@ function kind::parse_flags() {
   done
 }
 
-function kind::clamp_mss_to_pmtu() {
-  # https://github.com/kubernetes/test-infra/issues/23741
+function kind::warn_mtu_issues() {
   if [[ "$OSTYPE" != "darwin"* ]]; then
-    iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+    echo "NOTE: If you experience network timeouts, you may have MTU/PMTU issues with Docker networking."
+    echo "See: https://github.com/kubernetes/test-infra/issues/23741"
   fi
 }
 
@@ -391,7 +391,7 @@ function kind::setup_fake_nodes() {
 function main() {
   kind::check_prerequisites
   kind::parse_flags "$@"
-  kind::clamp_mss_to_pmtu
+  kind::warn_mtu_issues
   kind::create_cluster
   kind::setup_fake_nodes
   printf "\n\033[0;33m📌 NOTE: To target the newly created kind cluster, please run the following command:\n\n export KUBECONFIG=${KUBECONFIG}\n\033[0m\n"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Changes `kind-up.sh` to warn about potential MTU/PMTU issues with Docker networking on Linux instead of attempting to run the iptables workaround command directly.

Previously, the script attempted to run:
```
iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
```

This approach had several problems:
1. Requires sudo, which causes file ownership issues (e.g., files created during `make kind-up` end up owned by root)
2. Not everyone will encounter MTU/PMTU issues - it depends on their network configuration
3. The iptables rule only needs to be applied once per reboot, not every time the script runs

Now the script simply prints a warning message pointing users to the relevant GitHub issue if they experience network timeouts.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

The original issue (https://github.com/kubernetes/test-infra/issues/23741) was a GKE-specific networking bug from 2021 that has since been resolved. The workaround may still be useful for some nested Docker networking scenarios, but it's not universally needed.

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
