### PR TITLE
fix typo in SO1 and SO2 tests

### DIFF
--- a/operator/e2e/tests/startup_ordering_test.go
+++ b/operator/e2e/tests/startup_ordering_test.go
@@ -71,7 +71,7 @@ func Test_SO1_InorderStartupOrderWithFullReplicas(t *testing.T) {
 		DynamicClient: dynamicClient,
 		Namespace:     "default",
 		Timeout:       5 * time.Minute,
-		Interval:      defaultPollTimeout,
+		Interval:      defaultPollInterval,
 		Workload: &WorkloadConfig{
 			Name:         "workload3",
 			YAMLPath:     "../yaml/workload3.yaml",
@@ -129,7 +129,7 @@ func Test_SO2_InorderStartupOrderWithMinReplicas(t *testing.T) {
 		DynamicClient: dynamicClient,
 		Namespace:     "default",
 		Timeout:       5 * time.Minute,
-		Interval:      defaultPollTimeout,
+		Interval:      defaultPollInterval,
 		Workload: &WorkloadConfig{
 			Name:         "workload4",
 			YAMLPath:     "../yaml/workload4.yaml",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a typo in `Test_SO1_InorderStartupOrderWithFullReplicas` and `Test_SO2_InorderStartupOrderWithMinReplicas` where `defaultPollTimeout` (4 minutes) was mistakenly used instead of `defaultPollInterval` (5 seconds) for the polling interval.

This caused the tests to sleep for 4 minutes between poll checks, even when pods were already ready. The tests would pass but take ~4 minutes longer than necessary.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

The fix changes `Interval: defaultPollTimeout` to `Interval: defaultPollInterval` in two test cases. The other startup ordering tests (SO3, SO4) already use the correct value.

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
