### PR TITLE
GREP-373: kubectl-grove CLI Plugin

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,19 +23,29 @@ All grove operator Make targets are located in [Operator Makefile](../operator/M
 
 In case you wish to develop Grove using a local kind cluster, please do the following:
 
-- To set up a KIND cluster with local docker registry run the following command:
+- **Navigate to the operator directory:**
+
+  ```bash
+  cd operator
+  ```
+
+- **Set up a KIND cluster with local docker registry:**
 
   ```bash
   make kind-up
   ```
 
-- Specify the `KUBECONFIG` environment variable in your shell session to the path printed out at the end of the previous step:
+- **Export the kubeconfig** for the kind cluster:
 
   ```bash
-  # You would see something like `export KUBECONFIG=/path-to-your-grove-clone/grove/operator/hack/kind/kubeconfig` printed.
-  # If you are already in `/path-to-your-grove-clone/grove/operator`, then you can simply:
-  export KUBECONFIG=./hack/kind/kubeconfig
+  # Create the kubeconfig file in the expected location
+  kind get kubeconfig --name grove-test-cluster > hack/kind/kubeconfig
+
+  # Set the KUBECONFIG environment variable
+  export KUBECONFIG=$(pwd)/hack/kind/kubeconfig
   ```
+
+  > **Note:** Keep this terminal session open, or re-export `KUBECONFIG` in new terminal sessions.
 
 #### Remote cluster set-up
 
@@ -57,10 +67,16 @@ If you wish to use your own Kubernetes cluster instead of the KIND cluster, foll
 
 ### Installation using make targets
 
+> **Important:** All commands in this section must be run from the `operator/` directory.
+
 ```bash
-# If you wish to deploy all Grove Operator resources in a custom namespace then set the `NAMESPACE` environment variable
+# Navigate to the operator directory (if not already there)
+cd operator
+
+# Optional: Deploy to a custom namespace
 export NAMESPACE=custom-ns
-# if `NAMESPACE` environment variable is set then `make deploy` target will use this namespace to deploy all Grove operator resources
+
+# Deploy Grove operator and all resources
 make deploy
 ```
 
@@ -75,6 +91,8 @@ This make target leverages Grove [Helm](https://helm.sh/) charts and [Skaffold](
 - All Grove operator resources defined as a part of [Grove Helm chart templates](../operator/charts/templates).
 
 ## Deploy a `PodCliqueSet`
+
+> **Important:** Ensure you're in the `operator/` directory for the relative path to work.
 
 - Deploy one of the samples present in the [samples](../operator/samples/simple) directory.
 
@@ -127,7 +145,7 @@ As specified in the [README.md](../README.md) and the [docs](../docs), there are
 - Let's try scaling the `PodCliqueScalingGroup` from 1 to 2 replicas:
 
   ```bash
-  kubectl scale pcsg simple1-0-pcsg --replicas=2
+  kubectl scale pcsg simple1-0-sga --replicas=2
   ```
 
   This will create new pods that associate with cliques that belong to this scaling group, and their associated `PodGang`s.
@@ -176,7 +194,7 @@ As specified in the [README.md](../README.md) and the [docs](../docs), there are
   Similarly, the `PodCliqueScalingGroup` can be scaled back in to 1 replicas like so:
 
   ```bash
-  kubectl scale pcsg simple1-0-pcsg --replicas=1
+  kubectl scale pcsg simple1-0-sga --replicas=1
   ```
 
 - Scaling can also be triggered at the `PodCliqueSet` level, as can be seen here:
@@ -235,6 +253,94 @@ As specified in the [README.md](../README.md) and the [docs](../docs), there are
   ```bash
   kubectl scale pcs simple1 --replicas=1
   ```
+
+## Troubleshooting
+
+### Deployment Issues
+
+#### `make deploy` fails with "No rule to make target 'deploy'"
+
+**Cause:** You're running the command from the wrong directory.
+
+**Solution:** Ensure you're in the `operator/` directory:
+```bash
+cd operator
+make deploy
+```
+
+#### `make deploy` fails with "unable to connect to Kubernetes"
+
+**Cause:** The `KUBECONFIG` environment variable is not set correctly.
+
+**Solution:** Export the kubeconfig for your kind cluster:
+```bash
+kind get kubeconfig --name grove-test-cluster > hack/kind/kubeconfig
+export KUBECONFIG=$(pwd)/hack/kind/kubeconfig
+make deploy
+```
+
+#### Grove operator pod is in `CrashLoopBackOff`
+
+**Cause:** Check the operator logs for specific errors.
+
+**Solution:**
+```bash
+kubectl logs -l app.kubernetes.io/name=grove-operator
+```
+
+### Runtime Issues
+
+#### Pods stuck in `Pending` state
+
+**Cause:** Gang scheduling requirements might not be met, or there aren't enough resources.
+
+**Solution:**
+1. Check PodGang status:
+   ```bash
+   kubectl get pg -o yaml
+   ```
+2. Check if MinAvailable requirements can be satisfied by your cluster resources
+3. Check node resources:
+   ```bash
+   kubectl describe nodes
+   ```
+
+#### `kubectl scale` command fails with "not found"
+
+**Cause:** The resource name might be incorrect.
+
+**Solution:** List the actual resource names first:
+```bash
+# For PodCliqueScalingGroups
+kubectl get pcsg
+
+# For PodCliqueSets
+kubectl get pcs
+```
+
+Then use the exact name from the output.
+
+#### PodCliqueScalingGroup not auto-scaling
+
+**Cause:** HPA might not be created or metrics-server might be missing.
+
+**Solution:**
+1. Verify HPA exists:
+   ```bash
+   kubectl get hpa
+   ```
+2. Check if metrics-server is running (required for HPA):
+   ```bash
+   kubectl get deployment metrics-server -n kube-system
+   ```
+3. For kind clusters, you may need to install metrics-server separately.
+
+### Getting Help
+
+If you encounter issues not covered here:
+1. Check the [GitHub Issues](https://github.com/NVIDIA/grove/issues) for similar problems
+2. Join the [Grove mailing list](https://groups.google.com/g/grove-k8s)
+3. Start a [discussion thread](https://github.com/NVIDIA/grove/discussions)
 
 ## Supported Schedulers
 

--- a/docs/proposals/373-kubectl-grove-cli/README.md
+++ b/docs/proposals/373-kubectl-grove-cli/README.md
@@ -1,0 +1,346 @@
+# GREP-373: kubectl-grove CLI Plugin
+
+<!-- toc -->
+<!-- /toc -->
+
+## Summary
+
+This GREP proposes `kubectl-grove`, a kubectl plugin that provides a rich interaction layer for Grove workloads on Kubernetes. The CLI bridges the gap between raw `kubectl` commands and the complex, hierarchical nature of Grove resources (PodCliqueSets, PodGangs, PodCliques, Pods), offering both command-line tools and an interactive Terminal User Interface (TUI) called **Arborist**.
+
+## Motivation
+
+Managing distributed AI/ML workloads with Grove involves understanding complex resource hierarchies and placement topologies. Users currently need to:
+
+1. Run multiple `kubectl get` commands to understand the state of their deployment
+2. Manually correlate PodCliqueSets → PodGangs → PodCliques → Pods relationships
+3. Lack visibility into GPU allocation, topology placement, and fragmentation
+4. Have no intuitive way to visualize how pods are distributed across racks and nodes
+
+A purpose-built CLI solves these problems by providing Grove-aware commands and visualizations that understand the resource model.
+
+### Goals
+
+1. **Unified visibility**: Single interface to view the entire Grove resource hierarchy
+2. **Topology-first visualization**: Rich visual representation of pod placement across racks, nodes, and GPUs
+3. **Interactive exploration**: TUI for real-time hierarchical navigation and event monitoring
+4. **Grove-aware operations**: Commands that understand placement scores, roles, and workload topology
+5. **Operational tooling**: Status, health, metrics, diagnostics, and lifecycle management
+
+### Non-Goals
+
+1. Replacing `kubectl` for general Kubernetes operations
+2. Direct model serving or workload execution
+3. Multi-cluster federation (initial version)
+
+## Proposal
+
+### Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        kubectl-grove                            │
+├─────────────────────────────────────────────────────────────────┤
+│  Commands Layer                                                 │
+│  ┌─────────┐ ┌─────────┐ ┌──────────┐ ┌─────────┐ ┌──────────┐  │
+│  │ status  │ │topology │ │  health  │ │ metrics │ │   tui    │  │
+│  └─────────┘ └─────────┘ └──────────┘ └─────────┘ └──────────┘  │
+│  ┌─────────┐ ┌──────────┐ ┌─────────┐                           │
+│  │  plan   │ │ rollout  │ │  diag   │                           │
+│  └─────────┘ └──────────┘ └─────────┘                           │
+├─────────────────────────────────────────────────────────────────┤
+│  Kubernetes Client Layer (dynamic + typed clients)             │
+├─────────────────────────────────────────────────────────────────┤
+│  Grove CRDs: PodCliqueSet, PodClique, PodGang, ClusterTopology │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Resource Hierarchy
+
+kubectl-grove operates on Grove's hierarchical resource model:
+
+```
+PodCliqueSet (deployment unit)
+  └── PodCliqueSetReplica (revision/instance)
+        └── PodGang (scheduling unit - all-or-nothing)
+              └── PodClique (role group)
+                    └── Pod (actual workload)
+```
+
+### User Stories
+
+#### Story 1: Visualizing Topology Placement
+
+As a platform engineer, I want to see how my pods are distributed across racks and nodes so I can identify fragmentation issues and optimize placement.
+
+```bash
+$ kubectl grove topology my-workload -n prod
+```
+
+#### Story 2: Interactive Debugging
+
+As an operator, I want to interactively navigate the Grove resource hierarchy to understand the state of my deployment and correlate events with specific pods.
+
+```bash
+$ kubectl grove tui -n prod
+```
+
+### Limitations/Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| TUI complexity may be difficult to maintain | Use established TUI library (tview) with modular view components |
+| kubectl plugin discovery requires PATH setup | Provide installation script and documentation |
+| Real-time updates may cause API server load | Configurable refresh intervals with sensible defaults |
+
+## Design Details
+
+### Command Reference
+
+#### Phase 1: Core Visibility (MVP)
+
+##### `kubectl grove status`
+
+Display PodCliqueSet status with progress visualization.
+
+```bash
+kubectl grove status my-workload -n prod
+kubectl grove status -A  # all namespaces
+```
+
+**Output:**
+```
+PodCliqueSet: my-workload    Namespace: prod
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  Clique          Ready    Status       Progress
+  ──────          ─────    ──────       ────────
+  prefill         4/4      Running      [████████████████] 100%
+  decode          7/8      Scaling      [██████████████░░]  88%
+
+  PlacementScore: 0.94    Phase: Running    Age: 2h34m
+```
+
+##### `kubectl grove topology`
+
+Visualize pod placement across the cluster topology hierarchy.
+
+```bash
+kubectl grove topology my-workload -n prod
+kubectl grove topology my-workload -n prod -w  # watch mode
+```
+
+**Output:**
+```
+╭─ ClusterTopology: grove-topology ─────────────────────────────────╮
+│ Hierarchy: rack → host → pod                                      │
+│ PlacementScore: 0.94 [█████████░]                                 │
+╰───────────────────────────────────────────────────────────────────╯
+
+PodCliqueSet: my-workload    PlacementScore: 0.94
+
+Rack: rack-1 [optimal]  (24/32 GPUs allocated)
+  │
+  ├── node-gpu-01: [████████████░░░░] (6/8 GPUs)
+  │     ├── [P] my-workload-prefill-0     Running   gpu:2
+  │     ├── [P] my-workload-prefill-1     Running   gpu:2
+  │     └── [D] my-workload-decode-0      Running   gpu:2
+  │
+  ├── node-gpu-02: [████████████████] (8/8 GPUs)
+  │     ├── [D] my-workload-decode-1      Running   gpu:2
+  │     ├── [D] my-workload-decode-2      Running   gpu:2
+  │     ├── [D] my-workload-decode-3      Running   gpu:2
+  │     └── [D] my-workload-decode-4      Running   gpu:2
+  │
+  └── node-gpu-03: [████████████░░░░] (6/8 GPUs)
+        ├── [P] my-workload-prefill-2     Running   gpu:2
+        ├── [P] my-workload-prefill-3     Running   gpu:2
+        └── [D] my-workload-decode-5      Running   gpu:2
+
+Rack: rack-2 [suboptimal]  (2/32 GPUs allocated)
+  │
+  └── node-gpu-04: [██░░░░░░░░░░░░░░] (2/8 GPUs)
+        └── [D] my-workload-decode-6      Running   gpu:2
+
+⚠ Warning: Pods fragmented across 2 racks
+  → 1 decode pod in rack-2 may experience higher latency
+```
+
+##### `kubectl grove health`
+
+Gang-aware health dashboard.
+
+```bash
+kubectl grove health my-workload -n prod
+kubectl grove health -A -w  # all namespaces, watch mode
+```
+
+##### `kubectl grove diagnostics`
+
+Collect comprehensive diagnostic data for troubleshooting.
+
+```bash
+kubectl grove diagnostics -n prod -o ./diag-output
+```
+
+**Collects:**
+- All Grove CRs (PodCliqueSet, PodClique, PodGang, etc.)
+- Pod logs and status
+- Events filtered by namespace
+- Operator logs
+- Node information for placed pods
+
+#### Phase 2: Interactive TUI (Arborist)
+
+##### `kubectl grove tui`
+
+Launch the **Arborist** interactive terminal user interface.
+
+```bash
+kubectl grove tui -n prod
+```
+
+**Layout:**
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│          Arborist | Grove Operator | Hierarchical Resource Viewer   │
+├─────────────────────────────────────────────────────────────────────┤
+│ > Forest > my-workload > gang-0 > prefill                           │
+├───────────────────────────────────────────┬─────────────────────────┤
+│ Resources                                 │ Events                  │
+│ ─────────                                 │ ──────                  │
+│ ► prefill-0     Running    gpu:2   node-1│ 2m  Pod scheduled       │
+│   prefill-1     Running    gpu:2   node-1│ 2m  Pod started         │
+│   prefill-2     Running    gpu:2   node-3│ 1m  Health check passed │
+│   prefill-3     Running    gpu:2   node-3│ 30s Metrics available   │
+│                                           │                         │
+├───────────────────────────────────────────┴─────────────────────────┤
+│ Enter: Drill down | Esc: Back | Tab: Switch pane | t: Topology | q  │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+**Navigation Hierarchy:**
+```
+ViewForest (all PodCliqueSets)
+  └── ViewPodCliqueSet (PodGangs in selected PCS)
+        └── ViewPodGang (PodCliques in selected Gang)
+              └── ViewPodClique (Pods in selected Clique)
+                    └── ViewPod (YAML detail view)
+```
+
+**Keybindings:**
+| Key | Action |
+|-----|--------|
+| `Enter` | Drill down into selected resource |
+| `Esc` | Navigate back up the hierarchy |
+| `Tab` | Switch focus between Resources and Events panes |
+| `t` | Toggle topology visualization view |
+| `↑/↓` | Navigate items |
+| `q` / `Ctrl+Q` | Quit |
+
+#### Phase 3: Lifecycle Management
+
+| Command | Description |
+|---------|-------------|
+| `kubectl grove rollout` | Manage rolling updates |
+| `kubectl grove scale` | Scale workers by role with placement analysis |
+| `kubectl grove update` | High-level updates with dry-run preview |
+| `kubectl grove restart` | Rolling restart without spec changes |
+| `kubectl grove apply` | Apply config with diff and plan comparison |
+
+#### Phase 4: Metrics
+
+##### `kubectl grove metrics`
+
+Live metrics from pod endpoints.
+
+```bash
+kubectl grove metrics my-workload -n prod
+kubectl grove metrics my-workload -n prod --role prefill
+kubectl grove metrics my-workload -n prod -w --json
+```
+
+### Monitoring
+
+The CLI itself does not emit metrics but surfaces metrics from:
+- Pod-level Prometheus endpoints (GPU utilization, memory)
+- Grove operator metrics (placement scores, reconciliation)
+- Kubernetes events related to Grove resources
+
+### Test Plan
+
+- Unit tests for each command's output formatting and data transformation
+- Integration tests against a kind cluster with Grove CRDs installed
+- E2E tests for TUI navigation flows
+
+### Graduation Criteria
+
+#### Alpha
+- Core commands implemented: `status`, `topology`, `health`, `diagnostics`
+- Basic TUI with hierarchical navigation
+- Installation via `kubectl krew`
+
+#### Beta
+- TUI topology view embedded
+- Lifecycle commands: `rollout`, `scale`
+- Watch mode for all applicable commands
+
+#### GA
+- Full lifecycle command suite
+- Metrics integration
+- Comprehensive documentation and tutorials
+
+## Implementation History
+
+- 2026-01-27: GREP proposed
+
+## Alternatives
+
+### Alternative 1: Web Dashboard
+
+A web-based UI was considered but rejected for initial implementation because:
+- Requires additional infrastructure (ingress, auth)
+- kubectl plugin provides zero-infrastructure solution
+- TUI works in SSH sessions and constrained environments
+
+### Alternative 2: Extend kubectl with custom columns
+
+Using `kubectl get -o custom-columns` was considered but:
+- Cannot represent hierarchical relationships
+- No interactive capabilities
+- Limited visualization options
+
+## Appendix
+
+### Example Session
+
+```bash
+# Deploy workload
+$ kubectl apply -f my-workload-pcs.yaml
+
+# Check deployment status
+$ kubectl grove status my-workload -n prod
+PodCliqueSet: my-workload    Phase: Scaling    Progress: [██████████░░░░░░] 62%
+
+# Visualize topology placement
+$ kubectl grove topology my-workload -n prod
+rack-1 (16/32 GPUs)
+  ├── node-01 [████████░░░░░░░░] (4/8)
+  │     [P] prefill-0  [P] prefill-1
+  └── node-02 [████████░░░░░░░░] (4/8)
+        [D] decode-0  [D] decode-1
+
+⚠ Warning: Only 50% of target pods scheduled
+
+# Launch TUI for interactive exploration
+$ kubectl grove tui -n prod
+# (Interactive TUI opens - press 't' for topology view)
+
+# Collect diagnostics if issues arise
+$ kubectl grove diagnostics -n prod -o ./debug
+Collecting PodCliqueSets... done
+Collecting PodCliques... done
+Collecting PodGangs... done
+Collecting Pod logs... done
+Collecting Events... done
+Output written to ./debug/
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,220 @@
+# Quickstart: Deploy Your First Workload with Grove
+
+This guide will walk you through deploying a simple disaggregated AI workload using Grove in about 10 minutes.
+
+## What You'll Learn
+
+By the end of this quickstart, you'll understand how to:
+- Deploy a multi-component workload with Grove
+- Scale components independently or as a group
+- Observe gang scheduling in action
+
+## Prerequisites
+
+- A Kubernetes cluster (we'll use kind for local testing)
+- `kubectl` installed and configured
+- Docker Desktop running (for kind)
+- 10-15 minutes
+
+## Understanding the Example Workload
+
+We'll deploy a simple workload that mimics a disaggregated inference setup with four components:
+
+- **Role A (pca)**: Auto-scaling component (e.g., routing layer) - scales based on CPU
+- **Role B (pcb)** and **Role C (pcc)**: Tightly-coupled components (e.g., prefill + decode) - must scale together as a group
+- **Role D (pcd)**: Fixed-size component (e.g., model cache) - doesn't auto-scale
+
+This demonstrates Grove's key capabilities: individual auto-scaling, grouped scaling, and gang scheduling.
+
+## Step 1: Set Up Your Local Environment
+
+### Install Grove Operator
+
+Follow the [installation guide](installation.md) to:
+1. Create a kind cluster with `make kind-up`
+2. Export the KUBECONFIG
+3. Deploy Grove with `make deploy`
+
+**Quick check:** Verify Grove operator is running:
+```bash
+kubectl get pods -l app.kubernetes.io/name=grove-operator
+```
+
+You should see a pod in `Running` status.
+
+## Step 2: Deploy Your First PodCliqueSet
+
+Create a PodCliqueSet that defines all four components:
+
+```bash
+cd operator
+kubectl apply -f samples/simple/simple1.yaml
+```
+
+**What just happened?** Grove created:
+- 1 `PodCliqueSet` (the top-level resource)
+- 4 `PodCliques` (one for each component role)
+- 1 `PodCliqueScalingGroup` (grouping pcb and pcc)
+- 1 `PodGang` (for gang scheduling)
+- 9 `Pods` (3 for pca, 2 each for pcb/pcc/pcd)
+
+## Step 3: Observe the Resources
+
+Watch as Grove creates and schedules all resources:
+
+```bash
+kubectl get pcs,pclq,pcsg,pg,pod -owide
+```
+
+Expected output:
+```
+NAME                            AGE
+podcliqueset.grove.io/simple1   34s
+
+NAME                                     AGE
+podclique.grove.io/simple1-0-pca         33s
+podclique.grove.io/simple1-0-pcd         33s
+podclique.grove.io/simple1-0-sga-0-pcb   33s
+podclique.grove.io/simple1-0-sga-0-pcc   33s
+
+NAME                                           AGE
+podcliquescalinggroup.grove.io/simple1-0-sga   33s
+
+NAME                                   AGE
+podgang.scheduler.grove.io/simple1-0   33s
+
+NAME                                  READY   STATUS    RESTARTS   AGE
+pod/grove-operator-699c77979f-7x2zc   1/1     Running   0          51s
+pod/simple1-0-pca-pkl2b               1/1     Running   0          33s
+pod/simple1-0-pca-s7dz2               1/1     Running   0          33s
+pod/simple1-0-pca-wjfqz               1/1     Running   0          33s
+pod/simple1-0-pcd-l4vnk               1/1     Running   0          33s
+pod/simple1-0-pcd-s7687               1/1     Running   0          33s
+pod/simple1-0-sga-0-pcb-m9shj         1/1     Running   0          33s
+pod/simple1-0-sga-0-pcb-vnrqw         1/1     Running   0          33s
+pod/simple1-0-sga-0-pcc-g8rg8         1/1     Running   0          33s
+pod/simple1-0-sga-0-pcc-hx4zn         1/1     Running   0          33s
+```
+
+**Key observation:** Notice all pods reached `Running` state together - that's gang scheduling! Grove ensured all pods were scheduled before starting any of them.
+
+## Step 4: Scale a PodCliqueScalingGroup
+
+Scale the tightly-coupled components (pcb and pcc) as a group:
+
+```bash
+kubectl scale pcsg simple1-0-sga --replicas=2
+```
+
+Observe the new resources:
+```bash
+kubectl get pcs,pclq,pcsg,pg,pod -owide
+```
+
+**What happened?**
+- Grove created a new replica of the scaling group
+- Both `pcb` and `pcc` scaled together from 2 to 4 pods each
+- A new `PodGang` was created for gang scheduling the new replica
+- New `PodCliques` appeared: `simple1-0-sga-1-pcb` and `simple1-0-sga-1-pcc`
+
+Scale back down:
+```bash
+kubectl scale pcsg simple1-0-sga --replicas=1
+```
+
+## Step 5: Scale the Entire PodCliqueSet
+
+Scale the entire workload to create a complete second instance:
+
+```bash
+kubectl scale pcs simple1 --replicas=2
+```
+
+Check the resources:
+```bash
+kubectl get pcs,pclq,pcsg,pg,pod -owide
+```
+
+**What happened?**
+- Grove created a complete duplicate of your workload
+- All new resources have `-1-` in their names (second replica)
+- A new `PodGang` (`simple1-1`) was created
+- All components (pca, pcb, pcc, pcd) were duplicated
+
+Scale back:
+```bash
+kubectl scale pcs simple1 --replicas=1
+```
+
+## Step 6: Understand the Hierarchy
+
+Let's visualize what you just created:
+
+```
+PodCliqueSet (simple1)
+├── Replica 0 (PodGang: simple1-0)
+│   ├── PodClique: pca (3 pods)
+│   ├── PodClique: pcd (2 pods)
+│   └── PodCliqueScalingGroup: sga
+│       ├── PodClique: pcb (2 pods)
+│       └── PodClique: pcc (2 pods)
+└── Replica 1 (when scaled to 2)
+    └── [same structure]
+```
+
+**Scaling behaviors:**
+- `kubectl scale pcs simple1`: Creates/removes complete replicas
+- `kubectl scale pcsg simple1-0-sga`: Scales just the grouped components (pcb + pcc)
+- Auto-scaling (when CPU threshold is met): Automatically scales `pca` or the scaling group
+
+## Step 7: Clean Up
+
+Remove the sample workload:
+
+```bash
+kubectl delete -f samples/simple/simple1.yaml
+```
+
+Verify cleanup:
+```bash
+kubectl get pcs,pclq,pcsg,pg,pod
+```
+
+Only the Grove operator pod should remain.
+
+## What's Next?
+
+Now that you understand the basics, explore:
+
+- **[Installation Guide](installation.md)** - Learn about remote cluster deployment
+- **[API Reference](api-reference/operator-api.md)** - Deep dive into all configuration options
+- **[Samples](../operator/samples/)** - Explore more complex examples
+- **Auto-scaling** - Trigger CPU-based auto-scaling by generating load
+- **Startup Ordering** - Define dependencies between components
+
+## Key Concepts Recap
+
+| Concept | What It Does | When to Use |
+|---------|--------------|-------------|
+| **PodCliqueSet** | Top-level resource defining your workload | Every Grove deployment |
+| **PodClique** | Group of pods with the same role | Each component type in your system |
+| **PodCliqueScalingGroup** | Multiple PodCliques that scale together | Tightly-coupled components (prefill+decode) |
+| **PodGang** | Ensures all components are co-scheduled | Automatically created by Grove |
+
+## Troubleshooting
+
+### Pods stuck in Pending
+- Check PodGang status: `kubectl describe pg simple1-0`
+- Ensure your cluster has enough resources for gang scheduling
+
+### Auto-scaling not working
+- For kind clusters, install metrics-server:
+  ```bash
+  kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+  ```
+- Add `--kubelet-insecure-tls` to metrics-server deployment for kind
+
+### Need help?
+- See the full [Troubleshooting Guide](installation.md#troubleshooting)
+- Join the [Grove mailing list](https://groups.google.com/g/grove-k8s)
+- File an [issue](https://github.com/NVIDIA/grove/issues)


### PR DESCRIPTION
## What type of PR is this?

/kind feature
/kind documentation

## What this PR does / why we need it:

Introduces GREP-373, a proposal for `kubectl-grove` - a kubectl plugin that provides a rich interaction layer for Grove workloads on Kubernetes.

The CLI bridges the gap between raw `kubectl` commands and the complex, hierarchical nature of Grove resources (PodCliqueSets, PodGangs, PodCliques, Pods), offering both command-line tools and an interactive Terminal User Interface (TUI) called **Arborist**.

### Proposed Features

**Critical (Must Have)**
- **Arborist TUI** (`kubectl grove tui`) - Hierarchical navigation with real-time refresh and embedded topology view
- **Topology Command** (`kubectl grove topology`) - Rack → Node → Pod visualization with GPU allocation bars

**High Priority**
- `kubectl grove status` - PodCliqueSet status with progress visualization
- `kubectl grove health` - Gang-aware health dashboard
- `kubectl grove diagnostics` - Comprehensive diagnostic data collection

**Medium Priority**
- Lifecycle commands: `rollout`, `scale`, `update`, `restart`, `apply`
- `kubectl grove metrics` - Live metrics from pod endpoints

## Which issue(s) this PR fixes:

Fixes #373

## Special notes for your reviewer:

This is a proposal document (GREP) following the template from #362. Looking for feedback on:
- Command priorities and phasing
- TUI design and navigation model
- Any missing use cases

## Does this PR introduce an API change?

```release-note
NONE
```

## Additional documentation:

```docs
Adds GREP-373 proposal for kubectl-grove CLI plugin.
```

🤖 Generated with [Claude Code](https://claude.ai/code)