### PR TITLE
Update README roadmap with 2026 priorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,18 @@ Refer to all Grove APIs here
 - Rolling Updates ✅
 - Topology-Aware Scheduling ✅
 
-### 2026 Priorities
+### Q1 2026
 
 - Resource-Optimized Rolling Updates
 - Automatic MNNVL Discovery
+- User Guides for All Supported Features
+
+### Q2 2026
+
 - Terminal States for Training and Batch Workloads
 - Scheduler Plugin Architecture (with Support for Third-Party Scheduler Backends)
 - kubectl-grove CLI
 - Advanced Topology Scheduling
-- User Guides for All Supported Features
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ Refer to all Grove APIs here
 
 - Resource-Optimized Rolling Updates
 - Automatic MNNVL Discovery
+- kubectl-grove CLI
 - User Guides for All Supported Features
 
 ### Q2 2026
 
 - Terminal States for Training and Batch Workloads
 - Scheduler Plugin Architecture (with Support for Third-Party Scheduler Backends)
-- kubectl-grove CLI
 - Advanced Topology Scheduling
 
 ## Contributions

--- a/README.md
+++ b/README.md
@@ -78,9 +78,12 @@ Refer to all Grove APIs here
 ### 2026 Priorities
 
 - Resource-Optimized Rolling Updates
-- Topology Spread Constraints
-- Automatic Topology Detection
-- And More!
+- Automatic MNNVL Discovery
+- Terminal States for Training and Batch Workloads
+- Scheduler Plugin Architecture (with Support for Third-Party Scheduler Backends)
+- kubectl-grove CLI
+- Advanced Topology Scheduling
+- User Guides for All Supported Features
 
 ## Contributions
 


### PR DESCRIPTION
Update 2026 roadmap items: Auto-MNNVL, terminal states, scheduler plugin architecture, kubectl-grove CLI, advanced topology scheduling, and user guides.