### PR TITLE
bug fix: prevent auto-mnnvl annotation injection on update

### DIFF
--- a/operator/internal/webhook/admission/pcs/defaulting/handler.go
+++ b/operator/internal/webhook/admission/pcs/defaulting/handler.go
@@ -26,6 +26,7 @@ import (
 	k8sutils "github.com/ai-dynamo/grove/operator/internal/utils/kubernetes"
 
 	"github.com/go-logr/logr"
+	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -59,8 +60,10 @@ func (h *Handler) Default(ctx context.Context, obj runtime.Object) error {
 	h.logger.Info("Applying defaults", "PodCliqueSet", k8sutils.CreateObjectKeyForCreateWebhooks(pcs, req))
 	defaultPodCliqueSet(pcs)
 
-	// Apply MNNVL auto-annotation if conditions are met
-	mnnvl.MutateAutoMNNVL(h.logger, pcs, h.networkConfig.AutoMNNVLEnabled)
+	// Apply MNNVL auto-annotation only on creation.
+	if req.Operation == admissionv1.Create {
+		mnnvl.MutateAutoMNNVL(h.logger, pcs, h.networkConfig.AutoMNNVLEnabled)
+	}
 
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The defaulting webhook called MutateAutoMNNVL unconditionally for both CREATE and UPDATE operations. For legacy PCS resources created before the MNNVL feature, this caused a deadlock: the defaulting webhook added the annotation on update, and the validating webhook rejected it as a forbidden post-creation addition — making the resource unmodifiable (e.g., finalizer removal was blocked during deletion).

Gate MutateAutoMNNVL to only run on CREATE operations and add unit tests covering UPDATE operations and the full webhook pipeline for the legacy PCS migration scenario.

Tested
- manually
- add UT

#### Which issue(s) this PR fixes:

Fixes #416 

#### Special notes for your reviewer:

```release-note
NONE
```
