### PR TITLE
Correct API documentation in `PodCliqueSet`

### DIFF
--- a/docs/api-reference/operator-api.md
+++ b/docs/api-reference/operator-api.md
@@ -406,7 +406,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `replicas` _integer_ | Replicas is the number of desired replicas of the PodGang. | 0 |  |
+| `replicas` _integer_ | Replicas is the number of desired replicas of the PodCliqueSet. | 0 |  |
 | `template` _[PodCliqueSetTemplateSpec](#podcliquesettemplatespec)_ | Template describes the template spec for PodGangs that will be created in the PodCliqueSet. |  |  |
 
 

--- a/operator/api/core/v1alpha1/crds/grove.io_podcliquesets.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podcliquesets.yaml
@@ -44,7 +44,7 @@ spec:
             properties:
               replicas:
                 default: 0
-                description: Replicas is the number of desired replicas of the PodGang.
+                description: Replicas is the number of desired replicas of the PodCliqueSet.
                 format: int32
                 type: integer
               template:

--- a/operator/api/core/v1alpha1/podcliqueset.go
+++ b/operator/api/core/v1alpha1/podcliqueset.go
@@ -50,7 +50,7 @@ type PodCliqueSetList struct {
 
 // PodCliqueSetSpec defines the specification of a PodCliqueSet.
 type PodCliqueSetSpec struct {
-	// Replicas is the number of desired replicas of the PodGang.
+	// Replicas is the number of desired replicas of the PodCliqueSet.
 	// +kubebuilder:default=0
 	Replicas int32 `json:"replicas,omitempty"`
 	// Template describes the template spec for PodGangs that will be created in the PodCliqueSet.


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api
-->

#### What this PR does / why we need it:

/kind documentation

Related to #431.

`PodCliqueSetSpec.Replicas` is the number of replicas of the `PodCliqueSet`, not the number of `PodGang`s.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This PR is obviously not exhaustive. I spotted this error in the top level of the API, and therefore I raised this PR. Comprehensive rework of the API documentation will happen at some point in the future, but it is not ideal to leave an error in the API documentation until then.

#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
N/A
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
N/A
```
