### PR TITLE
docs: add TAS version requirement for KAI-scheduler

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -213,3 +213,4 @@ If you encounter issues not covered here:
 Currently the following schedulers support gang scheduling of `PodGang`s created by the Grove operator:
 
 - [NVIDIA/KAI-scheduler](https://github.com/NVIDIA/KAI-Scheduler)
+  - Topology Aware Scheduling (TAS) requires [v0.13.0-rc1](https://github.com/NVIDIA/KAI-Scheduler/releases/tag/v0.13.0-rc1)+


### PR DESCRIPTION
/kind documentation

#### What this PR does / why we need it:
Adds a note under the KAI-scheduler entry in the Supported Schedulers section that Topology Aware Scheduling (TAS) requires KAI v0.13.0-rc1+.

#### Which issue(s) this PR fixes:
Fixes #441

#### Special notes for your reviewer:

#### Does this PR introduce a API change?
```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:
```docs
Updated docs/installation.md Supported Schedulers section
```