### PR TITLE
add indices in expectation to reserve in-flight indices

### DIFF
--- a/operator/internal/controller/podclique/components/pod/syncflow.go
+++ b/operator/internal/controller/podclique/components/pod/syncflow.go
@@ -40,6 +40,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -409,7 +410,10 @@ func hasPodGangSchedulingGate(pod *corev1.Pod) bool {
 // createPods creates the specified number of new pods for the PodClique with proper indexing and concurrency control
 func (r _resource) createPods(ctx context.Context, logger logr.Logger, sc *syncContext, numPods int) (int, error) {
 	// Pre-calculate all needed indices to avoid race conditions
-	availableIndices, err := index.GetAvailableIndices(logger, sc.existingPCLQPods, numPods)
+	// Indices assigned to in-flight creations (not yet observed in cache) must be reserved so we do not assign them again.
+	reservedIndices := sets.New(r.expectationsStore.GetCreateExpectationIndices(sc.pclqExpectationsStoreKey)...)
+
+	availableIndices, err := index.GetAvailableIndices(logger, sc.existingPCLQPods, reservedIndices, numPods)
 	if err != nil {
 		return 0, groveerr.WrapError(err,
 			errCodeGetAvailablePodHostNameIndices,

--- a/operator/internal/controller/podclique/components/pod/task.go
+++ b/operator/internal/controller/podclique/components/pod/task.go
@@ -58,7 +58,7 @@ func (r _resource) createPodCreationTask(logger logr.Logger, pcs *grovecorev1alp
 				)
 			}
 			logger.Info("Created Pod for PodClique", "podName", pod.Name, "podUID", pod.GetUID())
-			if err := r.expectationsStore.ExpectCreations(logger, pclqExpectationsKey, pod.GetUID()); err != nil {
+			if err := r.expectationsStore.ExpectCreations(logger, pclqExpectationsKey, pod.GetUID(), podHostNameIndex); err != nil {
 				utilruntime.HandleErrorWithLogger(logger, err, "could not record create expectations for Pod", "pclqObjKey", pclqObjKey, "pod", pod.Name)
 			}
 			r.eventRecorder.Eventf(pclq, corev1.EventTypeNormal, constants.ReasonPodCreateSuccessful, "Created Pod: %s", pod.Name)

--- a/operator/internal/expect/expectations.go
+++ b/operator/internal/expect/expectations.go
@@ -61,6 +61,9 @@ type ControlleeExpectations struct {
 	uidsToDelete sets.Set[types.UID]
 	// uidsToAdd are the set of resource UIDs that are expected to be created.
 	uidsToAdd sets.Set[types.UID]
+	// creationIndices maps UID to the index (e.g. hostname index) assigned to that creation. Optional; only set when
+	// ExpectCreations is used so that callers can reserve those indices until the creation is observed.
+	creationIndices map[types.UID]int
 }
 
 // NewExpectationsStore creates a new expectations store.
@@ -70,14 +73,16 @@ func NewExpectationsStore() *ExpectationsStore {
 	}
 }
 
-// ExpectCreations records resource creation expectations for uids for a controlled resource identified by a controlleeKey.
-func (s *ExpectationsStore) ExpectCreations(logger logr.Logger, controlleeKey string, uids ...types.UID) error {
-	return s.createOrRaiseExpectations(logger, controlleeKey, uids, nil)
+// ExpectCreations records a creation expectation with the given index (e.g. hostname index) so that
+// GetCreateExpectationIndices can return it. Call this when the created resource is assigned a specific index
+// that must be reserved until the creation is observed (e.g. to avoid assigning the same index to another resource).
+func (s *ExpectationsStore) ExpectCreations(logger logr.Logger, controlleeKey string, uid types.UID, index int) error {
+	return s.createOrRaiseExpectations(logger, controlleeKey, []types.UID{uid}, nil, map[types.UID]int{uid: index})
 }
 
 // ExpectDeletions records resource deletion expectations for uids for a controlled resource identified by a controlleeKey.
 func (s *ExpectationsStore) ExpectDeletions(logger logr.Logger, controlleeKey string, uids ...types.UID) error {
-	return s.createOrRaiseExpectations(logger, controlleeKey, nil, uids)
+	return s.createOrRaiseExpectations(logger, controlleeKey, nil, uids, nil)
 }
 
 // ObserveDeletions lowers the delete expectations removing the uids passed.
@@ -123,6 +128,9 @@ func (s *ExpectationsStore) SyncExpectations(controlleeKey string, existingNonTe
 		// Remove the UIDs from `uidsToAdd` if the informer cache is already up-to-date and certain events have
 		// been missed/dropped by the watch resulting in missed calls to `CreationObserved`.
 		exp.uidsToAdd.Delete(existingNonTerminatingUIDs...)
+		for _, uid := range existingNonTerminatingUIDs {
+			delete(exp.creationIndices, uid)
+		}
 		// Remove stale entries in `uidsToDelete` if the `existingUIDS` no longer has those UIDs.
 		staleUIDs := exp.uidsToDelete.Difference(sets.New(existingNonTerminatingUIDs...))
 		exp.uidsToDelete.Delete(staleUIDs.UnsortedList()...)
@@ -144,6 +152,22 @@ func (s *ExpectationsStore) GetCreateExpectations(controlleeKey string) []types.
 	return nil
 }
 
+// GetCreateExpectationIndices returns the set of indices (e.g. hostname indices) for creations that have not yet been
+// synced, when those were recorded via ExpectCreations. Returns nil if none or if no indices were recorded.
+func (s *ExpectationsStore) GetCreateExpectationIndices(controlleeKey string) []int {
+	exp, exists, _ := s.GetExpectations(controlleeKey)
+	if !exists || exp.creationIndices == nil {
+		return nil
+	}
+	var out []int
+	for uid := range exp.uidsToAdd {
+		if idx, ok := exp.creationIndices[uid]; ok {
+			out = append(out, idx)
+		}
+	}
+	return out
+}
+
 // GetDeleteExpectations is a convenience method which gives a slice of resource UIDs for which deletion has not yet been synced
 // in the informer cache.
 func (s *ExpectationsStore) GetDeleteExpectations(controlleeKey string) []types.UID {
@@ -162,7 +186,9 @@ func (s *ExpectationsStore) HasDeleteExpectation(controlleeKey string, uid types
 }
 
 // createOrRaiseExpectations creates or raises create/delete expectations for the given controlleeKey.
-func (s *ExpectationsStore) createOrRaiseExpectations(logger logr.Logger, controlleeKey string, uidsToAdd, uidsToDelete []types.UID) error {
+// creationIndexByUID is optional: when non-nil, each uid in uidsToAdd that has an entry will have that index stored
+// for GetCreateExpectationIndices (e.g. hostname index to reserve until the creation is observed).
+func (s *ExpectationsStore) createOrRaiseExpectations(logger logr.Logger, controlleeKey string, uidsToAdd, uidsToDelete []types.UID, creationIndexByUID map[types.UID]int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	exp, exists, err := s.GetExpectations(controlleeKey)
@@ -175,12 +201,33 @@ func (s *ExpectationsStore) createOrRaiseExpectations(logger logr.Logger, contro
 			uidsToAdd:    sets.New(uidsToAdd...),
 			uidsToDelete: sets.New(uidsToDelete...),
 		}
+		if len(creationIndexByUID) > 0 {
+			exp.creationIndices = make(map[types.UID]int)
+			for _, uid := range uidsToAdd {
+				if idx, ok := creationIndexByUID[uid]; ok {
+					exp.creationIndices[uid] = idx
+				}
+			}
+		}
 		logger.Info("created expectations for controller resource", "controlleeKey", controlleeKey, "uidsToAdd", uidsToAdd, "uidsToDelete", uidsToDelete)
 	} else {
 		exp.uidsToAdd.Insert(uidsToAdd...)
+		if len(creationIndexByUID) > 0 {
+			if exp.creationIndices == nil {
+				exp.creationIndices = make(map[types.UID]int)
+			}
+			for _, uid := range uidsToAdd {
+				if idx, ok := creationIndexByUID[uid]; ok {
+					exp.creationIndices[uid] = idx
+				}
+			}
+		}
 		// If there are UIDs in uidsToDelete that also have a presence in uidsToAdd then remove these UIDs from uidsToAdd
 		// as those add expectations are now no longer valid.
 		exp.uidsToAdd.Delete(uidsToDelete...)
+		for _, uid := range uidsToDelete {
+			delete(exp.creationIndices, uid)
+		}
 		exp.uidsToDelete.Insert(uidsToDelete...)
 		logger.Info("raised expectations for controller resource", "controlleeKey", controlleeKey, "uidsToAdd", uidsToAdd, "uidsToDelete", uidsToDelete)
 	}
@@ -194,6 +241,9 @@ func (s *ExpectationsStore) lowerExpectations(logger logr.Logger, controlleeKey 
 	if exp, exists, _ := s.GetExpectations(controlleeKey); exists {
 		exp.uidsToAdd.Delete(addUIDs...)
 		exp.uidsToAdd.Delete(deleteUIDs...)
+		for _, uid := range addUIDs {
+			delete(exp.creationIndices, uid)
+		}
 		exp.uidsToDelete.Delete(deleteUIDs...)
 		logger.Info("lowered expectations for controlled resource", "controlleeKey", controlleeKey, "addUIDs", addUIDs, "deleteUIDs", deleteUIDs)
 	}

--- a/operator/internal/expect/expectations_test.go
+++ b/operator/internal/expect/expectations_test.go
@@ -17,6 +17,7 @@
 package expect
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 
@@ -55,18 +56,9 @@ func TestExpectCreations(t *testing.T) {
 			if tc.existingUIDs != nil {
 				assert.NoError(t, initializeControlleeExpectations(expStore, controlleeKey, tc.existingUIDs, nil))
 			}
-			// test the method
-			wg := sync.WaitGroup{}
-			wg.Add(len(tc.newUIDs))
-			for _, uid := range tc.newUIDs {
-				go func() {
-					defer wg.Done()
-					err := expStore.ExpectCreations(logr.Discard(), controlleeKey, uid)
-					assert.NoError(t, err)
-				}()
+			for i, uid := range tc.newUIDs {
+				assert.NoError(t, expStore.ExpectCreations(logr.Discard(), controlleeKey, uid, i))
 			}
-			wg.Wait()
-			// compare the expected with actual
 			assert.ElementsMatch(t, tc.expectedCreateExpectationUIDs, expStore.GetCreateExpectations(controlleeKey))
 		})
 	}
@@ -231,6 +223,239 @@ func TestSyncExpectations(t *testing.T) {
 			assert.ElementsMatch(t, tc.deleteExpectationUIDsPostSync, expStore.GetDeleteExpectations(tc.controlleeKey))
 		})
 	}
+}
+
+func TestExpectCreations_with_GetCreateExpectationIndices(t *testing.T) {
+	expStore := NewExpectationsStore()
+	assert.NoError(t, expStore.ExpectCreations(logr.Discard(), controlleeKey, types.UID("uid-1"), 2))
+	assert.NoError(t, expStore.ExpectCreations(logr.Discard(), controlleeKey, types.UID("uid-2"), 3))
+
+	assert.ElementsMatch(t, []types.UID{"uid-1", "uid-2"}, expStore.GetCreateExpectations(controlleeKey))
+	indices := expStore.GetCreateExpectationIndices(controlleeKey)
+	assert.Len(t, indices, 2)
+	assert.ElementsMatch(t, []int{2, 3}, indices)
+
+	// After sync (observe uid-1), only uid-2's index remains reserved
+	expStore.SyncExpectations(controlleeKey, []types.UID{"uid-1"}, nil)
+	assert.ElementsMatch(t, []int{3}, expStore.GetCreateExpectationIndices(controlleeKey))
+}
+
+func TestGetCreateExpectationIndices_NilIndices(t *testing.T) {
+	// When expectations exist but no indices were recorded (e.g. via initializeControlleeExpectations),
+	// GetCreateExpectationIndices should return nil.
+	expStore := NewExpectationsStore()
+	assert.NoError(t, initializeControlleeExpectations(expStore, controlleeKey, []types.UID{"uid-1", "uid-2"}, nil))
+
+	indices := expStore.GetCreateExpectationIndices(controlleeKey)
+	assert.Nil(t, indices)
+}
+
+func TestGetCreateExpectationIndices_NoExpectations(t *testing.T) {
+	expStore := NewExpectationsStore()
+	indices := expStore.GetCreateExpectationIndices("nonexistent-key")
+	assert.Nil(t, indices)
+}
+
+func TestLowerExpectations_CleansCreationIndices(t *testing.T) {
+	// Verify that when CreationObserved is called (via lowerExpectations/ObserveDeletions path for add UIDs),
+	// the corresponding creationIndices entries are removed.
+	expStore := NewExpectationsStore()
+	assert.NoError(t, expStore.ExpectCreations(logr.Discard(), controlleeKey, types.UID("uid-1"), 10))
+	assert.NoError(t, expStore.ExpectCreations(logr.Discard(), controlleeKey, types.UID("uid-2"), 20))
+	assert.NoError(t, expStore.ExpectCreations(logr.Discard(), controlleeKey, types.UID("uid-3"), 30))
+
+	// Verify all 3 indices are present
+	assert.ElementsMatch(t, []int{10, 20, 30}, expStore.GetCreateExpectationIndices(controlleeKey))
+
+	// Sync with uid-1 observed (it appears in non-terminating UIDs)
+	expStore.SyncExpectations(controlleeKey, []types.UID{"uid-1"}, nil)
+
+	// uid-1's index (10) should be gone
+	assert.ElementsMatch(t, []int{20, 30}, expStore.GetCreateExpectationIndices(controlleeKey))
+	assert.ElementsMatch(t, []types.UID{"uid-2", "uid-3"}, expStore.GetCreateExpectations(controlleeKey))
+}
+
+func TestExpectCreations_OverwriteIndex(t *testing.T) {
+	// If the same UID is registered again with a different index, the new index should overwrite.
+	expStore := NewExpectationsStore()
+	assert.NoError(t, expStore.ExpectCreations(logr.Discard(), controlleeKey, types.UID("uid-1"), 5))
+	assert.ElementsMatch(t, []int{5}, expStore.GetCreateExpectationIndices(controlleeKey))
+
+	// Re-register same UID with different index
+	assert.NoError(t, expStore.ExpectCreations(logr.Discard(), controlleeKey, types.UID("uid-1"), 99))
+	indices := expStore.GetCreateExpectationIndices(controlleeKey)
+	assert.Len(t, indices, 1)
+	assert.Equal(t, 99, indices[0])
+}
+
+func TestExpectCreationsAndDeletions_Interleaved(t *testing.T) {
+	// Test the scenario where a UID is added and then deleted in the same expectations set.
+	// The delete should remove the UID from uidsToAdd and clean up its creationIndex.
+	expStore := NewExpectationsStore()
+
+	// Create expectations with indices
+	assert.NoError(t, expStore.ExpectCreations(logr.Discard(), controlleeKey, types.UID("uid-1"), 10))
+	assert.NoError(t, expStore.ExpectCreations(logr.Discard(), controlleeKey, types.UID("uid-2"), 20))
+
+	// Now expect deletion of uid-1 (this removes uid-1 from uidsToAdd)
+	assert.NoError(t, expStore.ExpectDeletions(logr.Discard(), controlleeKey, types.UID("uid-1")))
+
+	// uid-1 should be removed from create expectations and its index cleaned up
+	assert.ElementsMatch(t, []types.UID{"uid-2"}, expStore.GetCreateExpectations(controlleeKey))
+	assert.ElementsMatch(t, []int{20}, expStore.GetCreateExpectationIndices(controlleeKey))
+}
+
+func TestFullLifecycle_CreateExpectation_GetIndices_Observe_Cleanup(t *testing.T) {
+	// Integration-style test: full lifecycle
+	expStore := NewExpectationsStore()
+
+	// Step 1: Reconciler creates 3 pods with indices 0, 1, 2
+	assert.NoError(t, expStore.ExpectCreations(logr.Discard(), controlleeKey, types.UID("pod-uid-a"), 0))
+	assert.NoError(t, expStore.ExpectCreations(logr.Discard(), controlleeKey, types.UID("pod-uid-b"), 1))
+	assert.NoError(t, expStore.ExpectCreations(logr.Discard(), controlleeKey, types.UID("pod-uid-c"), 2))
+
+	// Step 2: Next reconcile starts, informer cache has pod-uid-a but not b and c yet
+	// GetCreateExpectationIndices should return all 3 indices as reserved
+	allIndices := expStore.GetCreateExpectationIndices(controlleeKey)
+	assert.Len(t, allIndices, 3)
+	assert.ElementsMatch(t, []int{0, 1, 2}, allIndices)
+
+	// Step 3: SyncExpectations sees pod-uid-a in cache
+	expStore.SyncExpectations(controlleeKey, []types.UID{"pod-uid-a"}, nil)
+
+	// Step 4: Now only indices 1, 2 should be reserved
+	reservedIndices := expStore.GetCreateExpectationIndices(controlleeKey)
+	assert.Len(t, reservedIndices, 2)
+	assert.ElementsMatch(t, []int{1, 2}, reservedIndices)
+
+	// Step 5: pod-uid-b and pod-uid-c appear in cache
+	expStore.SyncExpectations(controlleeKey, []types.UID{"pod-uid-b", "pod-uid-c"}, nil)
+
+	// Step 6: No more reserved indices
+	finalIndices := expStore.GetCreateExpectationIndices(controlleeKey)
+	assert.Nil(t, finalIndices)
+	assert.Empty(t, expStore.GetCreateExpectations(controlleeKey))
+}
+
+func TestConcurrentExpectCreations(t *testing.T) {
+	// Verify that concurrent ExpectCreations calls are safe (race detector will catch issues)
+	expStore := NewExpectationsStore()
+	const numGoroutines = 50
+
+	wg := sync.WaitGroup{}
+	wg.Add(numGoroutines)
+	for i := range numGoroutines {
+		go func(idx int) {
+			defer wg.Done()
+			uid := types.UID(fmt.Sprintf("uid-%d", idx))
+			_ = expStore.ExpectCreations(logr.Discard(), controlleeKey, uid, idx)
+		}(i)
+	}
+	wg.Wait()
+
+	// All 50 UIDs should be present
+	createExps := expStore.GetCreateExpectations(controlleeKey)
+	assert.Len(t, createExps, numGoroutines)
+
+	// All 50 indices should be present
+	indices := expStore.GetCreateExpectationIndices(controlleeKey)
+	assert.Len(t, indices, numGoroutines)
+}
+
+func TestConcurrentWriteOperations(t *testing.T) {
+	// Verify concurrent write operations (ExpectCreations, SyncExpectations, ExpectDeletions) are safe.
+	// Note: read methods are intentionally lock-free by design — controller-runtime work queue serializes
+	// reconciles for the same key, so reads and writes for the same controlleeKey never overlap.
+	// Write methods DO need locking because RunConcurrentlyWithSlowStart spawns goroutines that
+	// concurrently call ExpectCreations for the same controlleeKey.
+	expStore := NewExpectationsStore()
+	const numCreates = 30
+
+	// Pre-create some expectations
+	for i := range numCreates {
+		uid := types.UID(fmt.Sprintf("uid-%d", i))
+		assert.NoError(t, expStore.ExpectCreations(logr.Discard(), controlleeKey, uid, i))
+	}
+
+	wg := sync.WaitGroup{}
+
+	// Concurrently sync with some UIDs observed (write)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		observedUIDs := make([]types.UID, 0, 10)
+		for i := range 10 {
+			observedUIDs = append(observedUIDs, types.UID(fmt.Sprintf("uid-%d", i)))
+		}
+		expStore.SyncExpectations(controlleeKey, observedUIDs, nil)
+	}()
+
+	// Concurrently add more expectations (write)
+	wg.Add(10)
+	for i := numCreates; i < numCreates+10; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			uid := types.UID(fmt.Sprintf("uid-%d", idx))
+			_ = expStore.ExpectCreations(logr.Discard(), controlleeKey, uid, idx)
+		}(i)
+	}
+
+	wg.Wait()
+	// No panic or race = success
+}
+
+func TestSyncExpectations_WithCreationIndices(t *testing.T) {
+	// Verify that SyncExpectations removes creationIndices entries for UIDs that appear as non-terminating.
+	expStore := NewExpectationsStore()
+	key := "test-ns/indices-sync"
+	assert.NoError(t, expStore.ExpectCreations(logr.Discard(), key, types.UID("uid-1"), 10))
+	assert.NoError(t, expStore.ExpectCreations(logr.Discard(), key, types.UID("uid-2"), 20))
+	assert.NoError(t, expStore.ExpectCreations(logr.Discard(), key, types.UID("uid-3"), 30))
+
+	// Sync: uid-1 is now visible as non-terminating
+	expStore.SyncExpectations(key, []types.UID{"uid-1"}, nil)
+
+	// uid-1's index must be gone; uid-2, uid-3 still reserved
+	assert.ElementsMatch(t, []int{20, 30}, expStore.GetCreateExpectationIndices(key))
+	assert.ElementsMatch(t, []types.UID{"uid-2", "uid-3"}, expStore.GetCreateExpectations(key))
+}
+
+func TestSyncExpectations_PodDeletedBeforeAppearingNonTerminating(t *testing.T) {
+	// Documents a known limitation: if a pod is created (uid recorded), then goes terminating and is
+	// fully deleted before the next SyncExpectations observes it as non-terminating, its index remains
+	// reserved until the expectations are deleted or the controller restarts.
+	// This is acceptable because such rapid pod churn is rare, and the lease is short-lived (next
+	// reconcile will see the pod gone from terminating→deleted and the expectation count mismatch
+	// will trigger re-evaluation).
+	expStore := NewExpectationsStore()
+	key := "test-ns/vanished-pod"
+	assert.NoError(t, expStore.ExpectCreations(logr.Discard(), key, types.UID("uid-vanished"), 5))
+
+	// Step 1: pod appears as terminating (we see it going away)
+	expStore.SyncExpectations(key, nil, []types.UID{"uid-vanished"})
+	// Still reserved — pod hasn't gone fully yet
+	assert.ElementsMatch(t, []int{5}, expStore.GetCreateExpectationIndices(key))
+
+	// Step 2: pod is now fully gone from both lists (delete completed)
+	expStore.SyncExpectations(key, nil, nil)
+	// Known limitation: uid-vanished is still in uidsToAdd because SyncExpectations cannot
+	// distinguish "in-flight pod not yet in cache" from "pod was deleted before it was ever
+	// observed non-terminating". Index 5 remains reserved until expectations are deleted.
+	assert.ElementsMatch(t, []int{5}, expStore.GetCreateExpectationIndices(key),
+		"index is still reserved (known limitation: cannot distinguish in-flight from vanished)")
+}
+
+func TestDeleteExpectations_CleansIndices(t *testing.T) {
+	expStore := NewExpectationsStore()
+	assert.NoError(t, expStore.ExpectCreations(logr.Discard(), controlleeKey, types.UID("uid-1"), 5))
+	assert.NoError(t, expStore.ExpectCreations(logr.Discard(), controlleeKey, types.UID("uid-2"), 10))
+
+	// Delete all expectations
+	assert.NoError(t, expStore.DeleteExpectations(logr.Discard(), controlleeKey))
+
+	// Everything should be gone
+	assert.Nil(t, expStore.GetCreateExpectationIndices(controlleeKey))
+	assert.Nil(t, expStore.GetCreateExpectations(controlleeKey))
 }
 
 func initializeControlleeExpectations(expStore *ExpectationsStore, controlleeKey string, uidsToAdd, uidsToDelete []types.UID) error {

--- a/operator/internal/index/tracker_test.go
+++ b/operator/internal/index/tracker_test.go
@@ -31,7 +31,7 @@ import (
 // ==================== GetAvailableIndices Tests ====================
 
 func TestGetNextAvailableIndices_EmptyPods(t *testing.T) {
-	indices, err := GetAvailableIndices(logr.Logger{}, []*corev1.Pod{}, 3)
+	indices, err := GetAvailableIndices(logr.Logger{}, []*corev1.Pod{}, nil, 3)
 
 	assert.NoError(t, err)
 	assert.Equal(t, []int{0, 1, 2}, indices)
@@ -45,7 +45,7 @@ func TestGetNextAvailableIndices_WithExistingPods(t *testing.T) {
 		createTestPod("pod-c", "test-clique-4"),
 	}
 
-	indices, err := GetAvailableIndices(logr.Logger{}, pods, 3)
+	indices, err := GetAvailableIndices(logr.Logger{}, pods, nil, 3)
 
 	assert.NoError(t, err)
 	// Should fill holes: 1, 3, 5
@@ -59,7 +59,7 @@ func TestGetNextAvailableIndices_Sequential(t *testing.T) {
 		createTestPod("pod-c", "test-clique-2"),
 	}
 
-	indices, err := GetAvailableIndices(logr.Logger{}, pods, 2)
+	indices, err := GetAvailableIndices(logr.Logger{}, pods, nil, 2)
 
 	assert.NoError(t, err)
 	// Should continue sequence: 3, 4
@@ -74,11 +74,42 @@ func TestGetNextAvailableIndices_InvalidHostnames(t *testing.T) {
 		createTestPod("pod-valid2", "test-clique-2"),
 	}
 
-	indices, err := GetAvailableIndices(logr.Logger{}, pods, 3)
+	indices, err := GetAvailableIndices(logr.Logger{}, pods, nil, 3)
 
 	// Should return error for invalid hostname
 	assert.Error(t, err)
 	assert.Nil(t, indices)
+}
+
+func TestGetAvailableIndices_WithReservedIndices(t *testing.T) {
+	// Existing pods have indices 0, 1. Reserved (in-flight) has 2, 3. So available for 2 new pods should be 4, 5.
+	pods := []*corev1.Pod{
+		createTestPod("pod-a", "test-clique-0"),
+		createTestPod("pod-b", "test-clique-1"),
+	}
+	reserved := sets.New[int](2, 3)
+
+	indices, err := GetAvailableIndices(logr.Logger{}, pods, reserved, 2)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []int{4, 5}, indices)
+}
+
+func TestGetAvailableIndices_ReservedOverlapsWithPods(t *testing.T) {
+	// Pod already uses index 3; reservedIndices contains 3 and 5.
+	// Union should deduplicate so index 3 is not double-counted.
+	// With pods at 0,1,3 and reserved {3,5}, available should be 2,4.
+	pods := []*corev1.Pod{
+		createTestPod("pod-a", "test-clique-0"),
+		createTestPod("pod-b", "test-clique-1"),
+		createTestPod("pod-c", "test-clique-3"),
+	}
+	reserved := sets.New[int](3, 5)
+
+	indices, err := GetAvailableIndices(logr.Logger{}, pods, reserved, 2)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []int{2, 4}, indices)
 }
 
 // ==================== extractUsedIndices Tests ====================


### PR DESCRIPTION
#### What type of PR is this?
Resolve indices conflict issue.
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api
-->

#### What this PR does / why we need it:
Hostname indices could be re-used however grove doesn't noticed that

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #462 

#### Special notes for your reviewer:

#### Does this PR introduce a API change?
Add a creationInidices in Expectations
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
type ControlleeExpectations struct {
	// key is the unique identifier for the resource for which expectations are captured.
	key string
	// uidsToDelete are the set of resource UIDs that are expected to be deleted.
	uidsToDelete sets.Set[types.UID]
	// uidsToAdd are the set of resource UIDs that are expected to be created.
	uidsToAdd sets.Set[types.UID]
	// creationIndices maps UID to the index (e.g. hostname index) assigned to that creation. Optional; only set when
	// ExpectCreations is used so that callers can reserve those indices until the creation is observed.
	creationIndices map[types.UID]int
}

```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs

```
