### PR TITLE
fix: validate container env var names in PodCliqueSet webhook

### DIFF
--- a/operator/internal/webhook/admission/pcs/validation/podcliqueset.go
+++ b/operator/internal/webhook/admission/pcs/validation/podcliqueset.go
@@ -31,6 +31,7 @@ import (
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/util/sets"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -135,8 +136,8 @@ func (v *pcsValidator) validatePodCliqueTemplates(fldPath *field.Path) ([]string
 		schedulerNames = append(schedulerNames, cliqueTemplateSpec.Spec.PodSpec.SchedulerName)
 	}
 
-	allErrs = append(allErrs, sliceMustHaveUniqueElements(cliqueNames, fldPath.Child("name"), "cliqueTemplateSpec names must be unique")...)
-	allErrs = append(allErrs, sliceMustHaveUniqueElements(cliqueRoles, fldPath.Child("roleName"), "cliqueTemplateSpec.Spec roleNames must be unique")...)
+	allErrs = append(allErrs, sliceMustHaveUniqueElements(cliqueNames, fldPath.Child("name"))...)
+	allErrs = append(allErrs, sliceMustHaveUniqueElements(cliqueRoles, fldPath.Child("roleName"))...)
 
 	uniqueSchedulerNames := lo.Uniq(lo.Map(schedulerNames, func(item string, _ int) string {
 		if item == "" {
@@ -233,9 +234,9 @@ func (v *pcsValidator) validatePodCliqueScalingGroupConfigs(fldPath *field.Path)
 	}
 
 	// validate that the scaling group names are unique
-	allErrs = append(allErrs, sliceMustHaveUniqueElements(pclqScalingGroupNames, fldPath.Child("name"), "PodCliqueScalingGroupConfig names must be unique")...)
+	allErrs = append(allErrs, sliceMustHaveUniqueElements(pclqScalingGroupNames, fldPath.Child("name"))...)
 	// validate that there should not be any overlapping clique names across scaling groups.
-	allErrs = append(allErrs, sliceMustHaveUniqueElements(cliqueNamesAcrossAllScalingGroups, fldPath.Child("cliqueNames"), "clique names must not overlap across scaling groups, every scaling group should have unique clique names")...)
+	allErrs = append(allErrs, sliceMustHaveUniqueElements(cliqueNamesAcrossAllScalingGroups, fldPath.Child("cliqueNames"))...)
 
 	// validate that for all pod cliques that are part of defined scaling groups, separate AutoScalingConfig is not defined for them.
 	scalingGroupCliqueNames := lo.Uniq(cliqueNamesAcrossAllScalingGroups)
@@ -372,7 +373,7 @@ func (v *pcsValidator) validatePodCliqueSpec(name string, cliqueSpec grovecorev1
 				allErrs = append(allErrs, field.Invalid(fldPath.Child("startsAfter"), dep, "clique dependency cannot refer to itself"))
 			}
 		}
-		allErrs = append(allErrs, sliceMustHaveUniqueElements(cliqueSpec.StartsAfter, fldPath.Child("startsAfter"), "clique dependencies must be unique")...)
+		allErrs = append(allErrs, sliceMustHaveUniqueElements(cliqueSpec.StartsAfter, fldPath.Child("startsAfter"))...)
 	}
 
 	if cliqueSpec.ScaleConfig != nil {
@@ -431,7 +432,35 @@ func (v *pcsValidator) validatePodSpec(spec corev1.PodSpec, fldPath *field.Path)
 		}
 	}
 
+	for i, container := range spec.Containers {
+		allErrs = append(allErrs, validateContainer(container, specFldPath.Child("containers").Index(i))...)
+	}
+	for i, container := range spec.InitContainers {
+		allErrs = append(allErrs, validateContainer(container, specFldPath.Child("initContainers").Index(i))...)
+	}
+
 	return warnings, allErrs
+}
+
+// validateContainer validates a single container's fields.
+func validateContainer(container corev1.Container, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	allErrs = append(allErrs, validateContainerEnvVars(container.Env, fldPath.Child("env"))...)
+	return allErrs
+}
+
+// validateContainerEnvVars validates environment variable names, checking for invalid names and duplicates.
+func validateContainerEnvVars(envVars []corev1.EnvVar, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	envNames := make([]string, 0, len(envVars))
+	for j, envVar := range envVars {
+		if errs := k8svalidation.IsEnvVarName(envVar.Name); len(errs) > 0 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Index(j).Child("name"), envVar.Name, strings.Join(errs, "; ")))
+		}
+		envNames = append(envNames, envVar.Name)
+	}
+	allErrs = append(allErrs, sliceMustHaveUniqueElements(envNames, fldPath)...)
+	return allErrs
 }
 
 // ---------------------------- validate update of PodCliqueSet -----------------------------------------------

--- a/operator/internal/webhook/admission/pcs/validation/podcliqueset_test.go
+++ b/operator/internal/webhook/admission/pcs/validation/podcliqueset_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
@@ -885,6 +886,133 @@ func TestValidateScaleConfig(t *testing.T) {
 				}
 			} else {
 				assert.Empty(t, errs)
+			}
+		})
+	}
+}
+
+func TestEnvVarValidation(t *testing.T) {
+	testCases := []struct {
+		description    string
+		containers     []corev1.Container
+		initContainers []corev1.Container
+		errorMatchers  []testutils.ErrorMatcher
+	}{
+		{
+			description: "Valid env var names",
+			containers: []corev1.Container{
+				{
+					Name:  "main",
+					Image: "test:latest",
+					Env: []corev1.EnvVar{
+						{Name: "MY_VAR"},
+						{Name: "_PRIVATE"},
+						{Name: "Var123"},
+						{Name: "MY-VAR"},
+						{Name: "my.var"},
+					},
+				},
+			},
+		},
+		{
+			description: "Env var name starting with digit",
+			containers: []corev1.Container{
+				{
+					Name:  "main",
+					Image: "test:latest",
+					Env:   []corev1.EnvVar{{Name: "1VAR"}},
+				},
+			},
+			errorMatchers: []testutils.ErrorMatcher{
+				{ErrorType: field.ErrorTypeInvalid, Field: "spec.template.cliques[0].spec.podSpec.spec.containers[0].env[0].name"},
+			},
+		},
+		{
+			description: "Duplicate env var names in same container",
+			containers: []corev1.Container{
+				{
+					Name:  "main",
+					Image: "test:latest",
+					Env: []corev1.EnvVar{
+						{Name: "MY_VAR"},
+						{Name: "MY_VAR"},
+					},
+				},
+			},
+			errorMatchers: []testutils.ErrorMatcher{
+				{ErrorType: field.ErrorTypeDuplicate, Field: "spec.template.cliques[0].spec.podSpec.spec.containers[0].env"},
+			},
+		},
+		{
+			description: "Duplicate env var names in initContainers",
+			initContainers: []corev1.Container{
+				{
+					Name:  "init",
+					Image: "test:latest",
+					Env: []corev1.EnvVar{
+						{Name: "INIT_VAR"},
+						{Name: "INIT_VAR"},
+					},
+				},
+			},
+			errorMatchers: []testutils.ErrorMatcher{
+				{ErrorType: field.ErrorTypeDuplicate, Field: "spec.template.cliques[0].spec.podSpec.spec.initContainers[0].env"},
+			},
+		},
+		{
+			description: "Same env var name in different containers is valid",
+			containers: []corev1.Container{
+				{
+					Name:  "first",
+					Image: "test:latest",
+					Env:   []corev1.EnvVar{{Name: "SHARED_VAR"}},
+				},
+				{
+					Name:  "second",
+					Image: "test:latest",
+					Env:   []corev1.EnvVar{{Name: "SHARED_VAR"}},
+				},
+			},
+		},
+		{
+			description: "Empty env list",
+			containers: []corev1.Container{
+				{
+					Name:  "main",
+					Image: "test:latest",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			clique := testutils.NewPodCliqueTemplateSpecBuilder("worker").
+				WithReplicas(1).
+				WithRoleName("dummy-worker-role").
+				WithMinAvailable(1)
+
+			for _, c := range tc.containers {
+				clique = clique.WithContainer(c)
+			}
+			for _, c := range tc.initContainers {
+				clique = clique.WithInitContainer(c)
+			}
+
+			pcs := testutils.NewPodCliqueSetBuilder("inference", "default", uuid.NewUUID()).
+				WithReplicas(1).
+				WithTerminationDelay(4 * time.Hour).
+				WithCliqueStartupType(ptr.To(grovecorev1alpha1.CliqueStartupTypeAnyOrder)).
+				WithPodCliqueTemplateSpec(clique.Build()).
+				Build()
+
+			validator := newPCSValidator(pcs, admissionv1.Create, defaultTASConfig())
+			_, errs := validator.validate()
+
+			if tc.errorMatchers != nil {
+				testutils.AssertErrorMatches(t, errs, tc.errorMatchers)
+			} else {
+				assert.NoError(t, errs.ToAggregate(), "Expected no validation error for test case: %s", tc.description)
 			}
 		})
 	}

--- a/operator/internal/webhook/admission/pcs/validation/util.go
+++ b/operator/internal/webhook/admission/pcs/validation/util.go
@@ -18,7 +18,6 @@ package validation
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/ai-dynamo/grove/operator/internal/utils"
 
@@ -58,11 +57,11 @@ func validateNonEmptyStringField(value string, fldPath *field.Path) field.ErrorL
 }
 
 // sliceMustHaveUniqueElements validates that all elements in a string slice are unique.
-func sliceMustHaveUniqueElements(s []string, fldPath *field.Path, msg string) field.ErrorList {
+func sliceMustHaveUniqueElements(s []string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	duplicates := lo.FindDuplicates(s)
 	if len(duplicates) > 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath, strings.Join(duplicates, ","), msg))
+		allErrs = append(allErrs, field.Duplicate(fldPath, duplicates))
 	}
 	return allErrs
 }

--- a/operator/internal/webhook/admission/pcs/validation/util_test.go
+++ b/operator/internal/webhook/admission/pcs/validation/util_test.go
@@ -238,8 +238,6 @@ func TestSliceMustHaveUniqueElements(t *testing.T) {
 		name string
 		// slice is the string slice being validated
 		slice []string
-		// msg is the error message to use if validation fails
-		msg string
 		// expectError indicates whether validation should fail
 		expectError bool
 		// expectedDuplicates is the list of duplicate values expected in the error
@@ -248,45 +246,38 @@ func TestSliceMustHaveUniqueElements(t *testing.T) {
 		{
 			name:        "slice with no duplicates passes validation",
 			slice:       []string{"a", "b", "c"},
-			msg:         "must have unique elements",
 			expectError: false,
 		},
 		{
-			name:               "slice with one duplicate returns Invalid error",
+			name:               "slice with one duplicate returns Duplicate error",
 			slice:              []string{"a", "b", "a"},
-			msg:                "must have unique elements",
 			expectError:        true,
 			expectedDuplicates: []string{"a"},
 		},
 		{
-			name:               "slice with multiple duplicates returns Invalid error",
+			name:               "slice with multiple duplicates returns Duplicate error",
 			slice:              []string{"a", "b", "a", "c", "b"},
-			msg:                "must have unique elements",
 			expectError:        true,
 			expectedDuplicates: []string{"a", "b"},
 		},
 		{
 			name:        "empty slice passes validation",
 			slice:       []string{},
-			msg:         "must have unique elements",
 			expectError: false,
 		},
 		{
 			name:        "nil slice passes validation",
 			slice:       nil,
-			msg:         "must have unique elements",
 			expectError: false,
 		},
 		{
 			name:        "slice with single element passes validation",
 			slice:       []string{"a"},
-			msg:         "must have unique elements",
 			expectError: false,
 		},
 		{
-			name:               "slice with all duplicates returns Invalid error",
+			name:               "slice with all duplicates returns Duplicate error",
 			slice:              []string{"a", "a", "a"},
-			msg:                "must have unique elements",
 			expectError:        true,
 			expectedDuplicates: []string{"a"},
 		},
@@ -294,12 +285,16 @@ func TestSliceMustHaveUniqueElements(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errs := sliceMustHaveUniqueElements(tt.slice, fldPath, tt.msg)
+			errs := sliceMustHaveUniqueElements(tt.slice, fldPath)
 			if tt.expectError {
 				assert.NotEmpty(t, errs)
-				assert.Equal(t, field.ErrorTypeInvalid, errs[0].Type)
-				// Verify the error message contains the error detail
-				assert.Contains(t, errs[0].Detail, tt.msg)
+				assert.Equal(t, field.ErrorTypeDuplicate, errs[0].Type)
+				if len(tt.expectedDuplicates) > 0 {
+					badValues, ok := errs[0].BadValue.([]string)
+					if assert.True(t, ok, "expected BadValue to be []string") {
+						assert.ElementsMatch(t, tt.expectedDuplicates, badValues)
+					}
+				}
 			} else {
 				assert.Empty(t, errs)
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Extend the PodCliqueSet admission webhook to catch invalid and duplicate environment variable names at admission time rather than at pod runtime.

Also corrects sliceMustHaveUniqueElements to emit ErrorTypeDuplicate instead of ErrorTypeInvalid.

Tested:
* UT

Fixes #240 