### PR TITLE
fix: add podCliqueScalingGroup concurrentSyncs to Helm chart

### DIFF
--- a/operator/charts/templates/_helpers.tpl
+++ b/operator/charts/templates/_helpers.tpl
@@ -28,6 +28,8 @@ config.yaml: |
       concurrentSyncs: {{ .Values.config.controllers.podCliqueSet.concurrentSyncs }}
     podClique:
       concurrentSyncs: {{ .Values.config.controllers.podClique.concurrentSyncs }}
+    podCliqueScalingGroup:
+      concurrentSyncs: {{ .Values.config.controllers.podCliqueScalingGroup.concurrentSyncs }}
   {{- if .Values.config.debugging }}
   debugging:
     enableProfiling: {{ .Values.config.debugging.enableProfiling }}

--- a/operator/charts/values.yaml
+++ b/operator/charts/values.yaml
@@ -81,6 +81,8 @@ config:
       concurrentSyncs: 3
     podClique:
       concurrentSyncs: 3
+    podCliqueScalingGroup:
+      concurrentSyncs: 3
   logLevel: info
   logFormat: json
   topologyAwareScheduling:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The Helm chart template (`_helpers.tpl`) and `values.yaml` only configure `concurrentSyncs` for `podCliqueSet` and `podClique` controllers, but omit `podCliqueScalingGroup`. The PCSG controller supports this config field, so it should be rendered in the Helm chart.

This PR adds `podCliqueScalingGroup.concurrentSyncs` to both `_helpers.tpl` and `values.yaml` (default: 3, matching the other controllers).

#### Which issue(s) this PR fixes:

Fixes #471

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```