### PR TITLE
ci: setting up DCO validation for external contributors

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds setup of the CI enforcement of the Contribution License Agreement already in the repo. Once merged I will enable the GitHub app for the repo

#### Which issue(s) this PR fixes:

Fixes #474

#### Special notes for your reviewer:

#### Does this PR introduce a API change?
None


#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

None