### PR TITLE
GREP-498: Controller Reconciliation Prometheus Metrics

### DIFF
--- a/docs/proposals/498-controller-reconcile-metrics/README.md
+++ b/docs/proposals/498-controller-reconcile-metrics/README.md
@@ -6,17 +6,22 @@
   - [Goals](#goals)
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
+  - [Overview](#overview)
+  - [Relationship to Built-in Metrics](#relationship-to-built-in-metrics)
   - [User Stories](#user-stories)
     - [Story 1: Diagnosing Slow Deployment at Scale](#story-1-diagnosing-slow-deployment-at-scale)
     - [Story 2: Identifying Cross-Controller Resource Contention](#story-2-identifying-cross-controller-resource-contention)
-    - [Story 3: Capacity Planning for MaxConcurrentReconciles](#story-3-capacity-planning-for-maxconcurrentreconciles)
-  - [Limitations/Risks & Mitigations](#limitationsrisks--mitigations)
+    - [Story 3: Distinguishing Transient vs Persistent Errors](#story-3-distinguishing-transient-vs-persistent-errors)
+  - [Limitations/Risks &amp; Mitigations](#limitationsrisks--mitigations)
 - [Design Details](#design-details)
   - [Metric Definitions](#metric-definitions)
-  - [ObservedReconciler Wrapper](#observedreconciler-wrapper)
-  - [MetricsContext for Sub-Operation Timing](#metricscontext-for-sub-operation-timing)
-  - [Conflict Tracking](#conflict-tracking)
-  - [Built-in controller-runtime Metrics](#built-in-controller-runtime-metrics)
+    - [Sub-Operation Timing](#sub-operation-timing)
+    - [Conflict Tracking](#conflict-tracking)
+    - [Error Categorization](#error-categorization)
+  - [MetricsContext Implementation](#metricscontext-implementation)
+  - [Usage in Controllers](#usage-in-controllers)
+  - [Conflict and Error Tracking](#conflict-and-error-tracking)
+  - [Built-in controller-runtime Metrics Reference](#built-in-controller-runtime-metrics-reference)
   - [File Changes Summary](#file-changes-summary)
   - [Example PromQL Queries](#example-promql-queries)
   - [Monitoring](#monitoring)
@@ -25,6 +30,9 @@
   - [Graduation Criteria](#graduation-criteria)
 - [Implementation History](#implementation-history)
 - [Alternatives](#alternatives)
+  - [Alt 1: Structured Logging Only](#alt-1-structured-logging-only)
+  - [Alt 2: OpenTelemetry Tracing](#alt-2-opentelemetry-tracing)
+  - [Alt 3: ObservedReconciler Wrapper for All Metrics](#alt-3-observedreconciler-wrapper-for-all-metrics)
 - [Appendix](#appendix)
   - [Appendix A: Cross-Controller Conflict Storm Analysis](#appendix-a-cross-controller-conflict-storm-analysis)
   - [Appendix B: Terminology](#appendix-b-terminology)
@@ -32,121 +40,135 @@
 
 ## Summary
 
-The Grove operator currently exposes **zero custom Prometheus metrics**. The three controllers (PodCliqueSet, PodClique, PodCliqueScalingGroup) have no observability into reconciliation performance, sub-operation latency, error categorization, or resource contention. This proposal adds a comprehensive Prometheus metrics framework to all Grove controllers, providing reconcile-level and sub-operation-level visibility. When large numbers of PodCliques and Pods are created — particularly when Grove is used by an upstream operator like Dynamo — reconciliation performance degrades due to high event rates and cross-controller resource contention, but there is currently no way to observe, quantify, or diagnose these issues.
+The Grove operator currently has **no custom Prometheus metrics**. While controller-runtime already provides built-in reconcile-level metrics (`controller_runtime_reconcile_total`, `controller_runtime_reconcile_time_seconds`, `controller_runtime_active_workers`) and workqueue metrics (`workqueue_depth`, `workqueue_queue_duration_seconds`, etc.), these only cover the overall reconcile outcome and duration. They provide no visibility into **which sub-operation within a reconcile is slow**, **how often 409 Conflicts occur on specific resource types**, or **what categories of errors are causing failures**.
+
+This proposal adds three focused custom metrics to all Grove controllers (PodCliqueSet, PodClique, PodCliqueScalingGroup) that complement the existing built-in metrics, filling the observability gaps that cannot be addressed by controller-runtime alone.
 
 ## Motivation
 
 During large-scale inference graph deployments using Grove (via NVIDIA Dynamo), we observed significant reconciliation performance degradation. Deploying an inference graph with 5 services × 10 replicas produces 50+ PodClique Pods, each transitioning through multiple states (Pending → Running → Ready). This generates a high rate of status changes that cascade through the Grove controller hierarchy (PodClique → PodCliqueScalingGroup → PodCliqueSet).
 
-**The fundamental problem**: Grove has no metrics to answer basic operational questions:
+The built-in controller-runtime metrics tell us **that** reconciliation is slow or erroring, but not **why**:
 
-1. **How long do reconciliations take?** There is no duration tracking for any controller's reconcile loop.
-2. **Which sub-operation is the bottleneck?** Each reconcile performs multiple steps (ensureFinalizer, processRollingUpdate, syncResources, updateObservedGeneration, reconcileStatus) but we cannot see which step is slow.
-3. **How often do API calls fail?** Status updates via `r.client.Status().Update()` and `r.client.Status().Patch()` can fail with 409 Conflict when an external controller (e.g., Dynamo's DGD controller) concurrently modifies the same PodClique/PodCliqueSet objects. We cannot see the conflict rate.
-4. **How deep is the work queue?** We have no visibility into per-controller queue depth, queue wait time, or event processing rate.
-5. **What is the reconcile throughput?** We cannot determine if controllers are keeping up with the event rate.
+1. **No sub-operation visibility** — Each reconcile performs multiple steps (ensureFinalizer, processRollingUpdate, syncResources, updateObservedGeneration, reconcileStatus). The built-in `controller_runtime_reconcile_time_seconds` only captures the total duration. We cannot determine which step is the bottleneck.
 
-This lack of observability means that performance issues require ad-hoc debugging via log analysis. Operators cannot set alerts, create dashboards, or make data-driven tuning decisions.
+2. **No conflict attribution** — Status updates via `r.client.Status().Update()` and `r.client.Status().Patch()` can fail with 409 Conflict when an external controller (e.g., Dynamo's DGD controller) concurrently modifies the same PodClique/PodCliqueSet objects. The built-in `controller_runtime_reconcile_total{result="error"}` counts all errors equally — we cannot see the conflict rate or which resource type is affected.
+
+3. **No error categorization** — The built-in metrics only distinguish `success`, `error`, `requeue`, and `requeue_after`. We cannot distinguish a transient 409 Conflict (likely to self-resolve on retry) from a persistent validation error or a timeout, making it impossible to prioritize debugging effort.
 
 ### Goals
 
-* Add Prometheus metrics to all three Grove controllers (PodCliqueSet, PodClique, PodCliqueScalingGroup) with a consistent, general-purpose framework
-* Track reconcile duration, count, error rate, and error categorization per controller
-* Track sub-operation timing within each reconcile loop to identify bottlenecks
-* Track in-flight (concurrent) reconciliation count per controller
-* Track 409 Conflict errors with target-resource attribution to diagnose cross-controller contention
-* Verify and document controller-runtime built-in workqueue and REST client metrics
-* Design the framework as an extensible foundation — controller-specific business metrics can be added incrementally in the future
-* Provide example Grafana dashboard panels and PromQL queries
+* Add three custom Prometheus metrics to fill gaps not covered by controller-runtime built-in metrics
+* Track sub-operation timing within each reconcile loop to identify internal bottlenecks
+* Track 409 Conflict errors with target-resource-kind attribution to diagnose cross-controller contention
+* Track error categorization by Kubernetes error type for targeted debugging
+* Document the full set of available metrics (built-in + custom) for Grove operators
+* Design the framework as extensible — controller-specific business metrics can be added incrementally
 
 ### Non-Goals
 
+* This proposal does NOT duplicate any controller-runtime built-in metrics
 * This proposal does NOT add metrics to the Grove scheduler component (only the operator)
 * This proposal does NOT change reconciliation logic; it is purely additive instrumentation
 * This proposal does NOT define alert thresholds or SLOs (those are deployment-specific)
 * This proposal does NOT add metrics to upstream consumers of Grove (e.g., Dynamo Operator)
-* This proposal does NOT prescribe architectural mitigations for performance issues (e.g., watch predicate throttling); those require separate proposals informed by the data this proposal provides
-* Detailed per-controller business-logic metrics (e.g., rolling update step counts, PodGang recreation rates) are deferred to future incremental additions
+* Architectural mitigations for the conflict storm (e.g., watch predicate throttling, SSA adoption) require separate proposals informed by data this proposal provides
 
 ## Proposal
 
 ### Overview
 
-Introduce a `metrics` package under `operator/internal/controller/metrics/` containing:
+Introduce a lightweight `MetricsContext` mechanism that controllers use to record sub-operation timings, conflict events, and error classifications. The context is injected at the reconcile entry point and propagated via Go's `context.Context`.
 
-1. **`ObservedReconciler`** — A wrapper around any `reconcile.Reconciler` that automatically records total reconcile duration, count, errors, in-flight count, and requeue reasons. All three controllers will be wrapped with this.
-2. **`MetricsContext`** — A struct injected into `context.Context` that controllers can use to record sub-operation timings and conflict events. This is the extension point for future metrics.
-3. **Metric definitions** — All Prometheus metric variables and the `InitMetrics()` registration function.
+New package: `operator/internal/controller/metrics/` containing:
 
-All metrics use the `grove_operator` namespace prefix.
+1. **`metrics.go`** — Three custom Prometheus metric definitions and `InitMetrics()` registration.
+2. **`metrics_context.go`** — `MetricsContext` struct, context helpers, `RecordSubOperation`, `RecordConflict`, and `RecordError`.
+
+No `ObservedReconciler` wrapper is needed — controller-runtime already handles reconcile-level metrics. The `MetricsContext` is created at the beginning of each controller's `Reconcile()` method and used throughout the reconcile flow.
+
+### Relationship to Built-in Metrics
+
+The following metrics are already provided by controller-runtime and should NOT be duplicated:
+
+| Built-in Metric | What It Provides |
+|----------------|-----------------|
+| `controller_runtime_reconcile_time_seconds` | Total reconcile duration per controller (histogram) |
+| `controller_runtime_reconcile_total` | Reconcile count by result: success, error, requeue, requeue_after |
+| `controller_runtime_active_workers` | In-flight reconciliation count per controller |
+| `controller_runtime_max_concurrent_reconciles` | Configured MaxConcurrentReconciles per controller |
+| `workqueue_depth` | Current work queue depth per controller |
+| `workqueue_adds_total` | Total items added to work queue |
+| `workqueue_queue_duration_seconds` | Time items wait in queue before processing |
+| `workqueue_work_duration_seconds` | Time spent processing items |
+| `workqueue_retries_total` | Total retries |
+| `rest_client_requests_total` | API requests by verb and status code |
+| `rest_client_request_duration_seconds` | API request latency by verb and URL |
+
+This proposal adds **only** what the built-in metrics cannot provide.
 
 ### User Stories
 
 #### Story 1: Diagnosing Slow Deployment at Scale
 
-As a platform operator deploying large inference graphs via Grove, I want to see which sub-operation within PodClique reconciliation is slow (e.g., is it `sync_pods`, `reconcile_status`, or `update_observed_generation`?) so that I can file a targeted bug report or tune the system.
+As a platform operator deploying large inference graphs via Grove, I see from `controller_runtime_reconcile_time_seconds` that PodClique reconciliations are taking 5+ seconds. I need to see **which sub-operation** is slow (is it `sync_pods`, `reconcile_status`, or `process_rolling_update`?) so that I can file a targeted bug report or tune the system.
 
 #### Story 2: Identifying Cross-Controller Resource Contention
 
-As a developer integrating Grove with an upstream operator (e.g., Dynamo), I want to see the 409 Conflict rate on PodClique and PodCliqueSet status updates, broken down by target resource kind, so that I can determine if cross-controller contention is the root cause of reconciliation failures.
+As a developer integrating Grove with an upstream operator (e.g., Dynamo), I see from `controller_runtime_reconcile_total{result="error"}` that errors are increasing. I need to know **how many are 409 Conflicts** and **which resource type** (PodClique vs PodCliqueSet) is the contention hotspot, so that I can determine the right mitigation strategy.
 
-#### Story 3: Capacity Planning for MaxConcurrentReconciles
+#### Story 3: Distinguishing Transient vs Persistent Errors
 
-As a cluster administrator, I want to see the in-flight reconciliation count and work queue depth per controller so that I can decide whether to increase `MaxConcurrentReconciles` for the PodClique controller during large-scale deployments.
+As a cluster administrator, I see reconcile errors but cannot tell if they are transient conflicts (self-resolving on retry) or persistent validation errors (requiring manual intervention). I need error categorization by Kubernetes error type.
 
 ### Limitations/Risks & Mitigations
 
 | Risk | Mitigation |
 |------|------------|
-| Label cardinality explosion from `namespace` × `operation` × histogram buckets | `operation` values are bounded and explicitly defined per controller (~5-8 per controller). Estimated total new time series in a 10-namespace cluster: ~3,000-6,000, well within Prometheus capacity. |
-| Performance overhead of metric recording | All metric operations (Inc, Observe) are O(1) atomic operations. Overhead is < 1μs per call. The `MetricsContext` nil-check pattern ensures zero overhead when metrics context is not injected. |
-| `ObservedReconciler` wrapper changes the reconciler type passed to `Complete()` | This is the same pattern used by NVIDIA Dynamo's operator and by controller-runtime's own metrics. Fully compatible with `builder.Complete()`. |
+| Label cardinality from `operation` × histogram buckets | `operation` values are bounded and explicitly defined per controller (~6 per controller). Without `namespace` label, estimated total new time series: ~500-1,000, very low. |
+| Performance overhead of metric recording | All metric operations (Inc, Observe) are O(1) atomic operations. Overhead is < 1μs per call. The `MetricsContext` nil-check pattern ensures zero overhead when not injected. |
 
 ## Design Details
 
 ### Metric Definitions
 
-All metrics are registered with the controller-runtime metrics registry via `InitMetrics()`.
+All custom metrics use the `grove_operator` namespace prefix and are registered with the controller-runtime metrics registry via `InitMetrics()`.
 
-#### Reconcile-Level Metrics (recorded by ObservedReconciler)
-
-| Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
-| `grove_operator_reconcile_duration_seconds` | Histogram | `controller`, `namespace`, `result` | Total duration of each reconciliation loop |
-| `grove_operator_reconcile_total` | Counter | `controller`, `namespace`, `result` | Total number of reconciliations |
-| `grove_operator_reconcile_errors_total` | Counter | `controller`, `namespace`, `error_type` | Total reconciliation errors, categorized by Kubernetes error type |
-| `grove_operator_reconcile_inflight` | Gauge | `controller` | Number of reconciliations currently in progress |
-| `grove_operator_reconcile_requeue_total` | Counter | `controller`, `namespace`, `reason` | Count of requeue events with categorized reasons |
-
-**Label values:**
-- `controller`: `PodCliqueSet`, `PodClique`, `PodCliqueScalingGroup`
-- `result`: `success`, `error`, `requeue`
-- `error_type`: `not_found`, `conflict`, `already_exists`, `timeout`, `forbidden`, `invalid`, `internal`
-- `reason`: `explicit_requeue`, `conflict`, `timeout`, `internal`, etc.
-
-#### Sub-Operation Metrics (recorded by controllers via MetricsContext)
+#### Sub-Operation Timing
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `grove_operator_reconcile_sub_operation_duration_seconds` | Histogram | `controller`, `namespace`, `operation` | Duration of individual sub-operations within a reconcile loop |
+| `grove_operator_reconcile_sub_operation_duration_seconds` | Histogram | `controller`, `operation` | Duration of individual sub-operations within a reconcile loop |
 
 **`operation` label values per controller:**
 
 | Controller | Operations |
 |------------|------------|
-| PodCliqueSet | `get_resource`, `ensure_finalizer`, `process_generation_hash`, `sync_resources`, `update_observed_generation`, `reconcile_status` |
-| PodClique | `get_resource`, `ensure_finalizer`, `process_rolling_update`, `sync_pods`, `update_observed_generation`, `reconcile_status` |
-| PodCliqueScalingGroup | `get_resource`, `ensure_finalizer`, `process_rolling_update`, `sync_resources`, `update_observed_generation`, `reconcile_status` |
+| PodCliqueSet | `ensure_finalizer`, `process_generation_hash`, `sync_resources`, `update_observed_generation`, `reconcile_status` |
+| PodClique | `ensure_finalizer`, `process_rolling_update`, `sync_pods`, `update_observed_generation`, `reconcile_status` |
+| PodCliqueScalingGroup | `ensure_finalizer`, `process_rolling_update`, `sync_resources`, `update_observed_generation`, `reconcile_status` |
 
-#### Conflict Tracking Metrics
+#### Conflict Tracking
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `grove_operator_status_update_conflict_total` | Counter | `controller`, `namespace`, `target_kind` | Count of 409 Conflict errors on Status Update/Patch operations |
+| `grove_operator_status_update_conflict_total` | Counter | `controller`, `target_kind` | Count of 409 Conflict errors on Status Update/Patch operations, attributed to the target resource kind |
 
-This metric captures conflicts that occur when Grove's status updates race against an external controller (e.g., Dynamo scaling PodClique) modifying the same object. The `target_kind` label identifies which object type (PodCliqueSet, PodClique, PodCliqueScalingGroup) experienced the conflict.
+**`target_kind` values:** `PodCliqueSet`, `PodClique`, `PodCliqueScalingGroup`
 
-### ObservedReconciler Wrapper
+This metric answers "which resource type is the contention hotspot?" — a question the built-in `controller_runtime_reconcile_total{result="error"}` cannot answer because it only counts errors at the reconcile level without identifying the target resource.
+
+#### Error Categorization
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `grove_operator_reconcile_errors_total` | Counter | `controller`, `error_type` | Reconciliation errors categorized by Kubernetes error type |
+
+**`error_type` values:** `not_found`, `conflict`, `already_exists`, `timeout`, `forbidden`, `invalid`, `rate_limited`, `internal`
+
+This metric answers "what kinds of errors are occurring?" — the built-in metrics only tell you `result="error"` without further classification.
+
+### MetricsContext Implementation
 
 ```go
 package metrics
@@ -157,56 +179,107 @@ import (
 
     "github.com/prometheus/client_golang/prometheus"
     k8serrors "k8s.io/apimachinery/pkg/api/errors"
-    ctrl "sigs.k8s.io/controller-runtime"
     ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
-    "sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const metricsNamespace = "grove_operator"
 
-type ObservedReconciler struct {
-    reconcile.Reconciler
+var (
+    reconcileSubOpDuration = prometheus.NewHistogramVec(
+        prometheus.HistogramOpts{
+            Namespace: metricsNamespace,
+            Name:      "reconcile_sub_operation_duration_seconds",
+            Help:      "Duration of individual sub-operations within a reconcile loop",
+            Buckets:   []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+        },
+        []string{"controller", "operation"},
+    )
+
+    statusUpdateConflictTotal = prometheus.NewCounterVec(
+        prometheus.CounterOpts{
+            Namespace: metricsNamespace,
+            Name:      "status_update_conflict_total",
+            Help:      "Total 409 Conflict errors on Status Update/Patch, by target resource kind",
+        },
+        []string{"controller", "target_kind"},
+    )
+
+    reconcileErrorsTotal = prometheus.NewCounterVec(
+        prometheus.CounterOpts{
+            Namespace: metricsNamespace,
+            Name:      "reconcile_errors_total",
+            Help:      "Reconciliation errors categorized by Kubernetes error type",
+        },
+        []string{"controller", "error_type"},
+    )
+)
+
+func InitMetrics() {
+    ctrlmetrics.Registry.MustRegister(
+        reconcileSubOpDuration,
+        statusUpdateConflictTotal,
+        reconcileErrorsTotal,
+    )
+}
+```
+
+```go
+package metrics
+
+import (
+    "context"
+    "time"
+
+    k8serrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+type contextKey struct{}
+
+type MetricsContext struct {
     controllerName string
 }
 
-func NewObservedReconciler(r reconcile.Reconciler, controllerName string) *ObservedReconciler {
-    return &ObservedReconciler{Reconciler: r, controllerName: controllerName}
+func NewMetricsContext(controllerName string) *MetricsContext {
+    return &MetricsContext{controllerName: controllerName}
 }
 
-func (m *ObservedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-    reconcileInflight.WithLabelValues(m.controllerName).Inc()
-    defer reconcileInflight.WithLabelValues(m.controllerName).Dec()
-
-    mc := NewMetricsContext(m.controllerName, req.Namespace)
-    ctx = WithMetricsContext(ctx, mc)
-
-    startTime := time.Now()
-    result, err := m.Reconciler.Reconcile(ctx, req)
-    duration := time.Since(startTime)
-
-    requeue := result.Requeue || result.RequeueAfter > 0
-
-    resultLabel := "success"
-    if err != nil {
-        resultLabel = "error"
-        reconcileErrors.WithLabelValues(m.controllerName, req.Namespace, categorizeError(err)).Inc()
-    } else if requeue {
-        resultLabel = "requeue"
-    }
-
-    reconcileDuration.WithLabelValues(m.controllerName, req.Namespace, resultLabel).Observe(duration.Seconds())
-    reconcileTotal.WithLabelValues(m.controllerName, req.Namespace, resultLabel).Inc()
-
-    if err != nil {
-        reconcileRequeueTotal.WithLabelValues(m.controllerName, req.Namespace, categorizeError(err)).Inc()
-    } else if requeue {
-        reconcileRequeueTotal.WithLabelValues(m.controllerName, req.Namespace, "explicit_requeue").Inc()
-    }
-
-    return result, err
+func WithMetricsContext(ctx context.Context, mc *MetricsContext) context.Context {
+    return context.WithValue(ctx, contextKey{}, mc)
 }
 
-func categorizeError(err error) string {
+func MetricsContextFromContext(ctx context.Context) *MetricsContext {
+    mc, _ := ctx.Value(contextKey{}).(*MetricsContext)
+    return mc
+}
+
+func (mc *MetricsContext) RecordSubOperation(operation string, start time.Time) {
+    if mc == nil {
+        return
+    }
+    reconcileSubOpDuration.WithLabelValues(
+        mc.controllerName, operation,
+    ).Observe(time.Since(start).Seconds())
+}
+
+func (mc *MetricsContext) RecordConflict(targetKind string) {
+    if mc == nil {
+        return
+    }
+    statusUpdateConflictTotal.WithLabelValues(
+        mc.controllerName, targetKind,
+    ).Inc()
+}
+
+func (mc *MetricsContext) RecordError(err error) {
+    if mc == nil || err == nil {
+        return
+    }
+    reconcileErrorsTotal.WithLabelValues(
+        mc.controllerName, CategorizeError(err),
+    ).Inc()
+}
+
+func CategorizeError(err error) string {
     switch {
     case k8serrors.IsNotFound(err):
         return "not_found"
@@ -228,136 +301,146 @@ func categorizeError(err error) string {
 }
 ```
 
-### MetricsContext for Sub-Operation Timing
+### Usage in Controllers
+
+No `ObservedReconciler` wrapper is needed. Controllers create a `MetricsContext` at the beginning of their `Reconcile()` method:
 
 ```go
-package metrics
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+    logger := ctrllogger.FromContext(ctx).WithName(controllerName)
 
-import (
-    "context"
-    "time"
-)
+    mc := metrics.NewMetricsContext(controllerName)
+    ctx = metrics.WithMetricsContext(ctx, mc)
 
-type contextKey struct{}
-
-type MetricsContext struct {
-    controllerName string
-    namespace      string
-}
-
-func NewMetricsContext(controllerName, namespace string) *MetricsContext {
-    return &MetricsContext{controllerName: controllerName, namespace: namespace}
-}
-
-func WithMetricsContext(ctx context.Context, mc *MetricsContext) context.Context {
-    return context.WithValue(ctx, contextKey{}, mc)
-}
-
-func MetricsContextFromContext(ctx context.Context) *MetricsContext {
-    mc, _ := ctx.Value(contextKey{}).(*MetricsContext)
-    return mc
-}
-
-func (mc *MetricsContext) RecordSubOperation(operation string, start time.Time) {
-    if mc == nil {
-        return
-    }
-    reconcileSubOpDuration.WithLabelValues(
-        mc.controllerName, mc.namespace, operation,
-    ).Observe(time.Since(start).Seconds())
-}
-
-func (mc *MetricsContext) RecordConflict(targetKind string) {
-    if mc == nil {
-        return
-    }
-    statusUpdateConflictTotal.WithLabelValues(
-        mc.controllerName, mc.namespace, targetKind,
-    ).Inc()
+    // ... existing reconcile logic unchanged ...
 }
 ```
 
-### Conflict Tracking
+Sub-operations are timed at step boundaries in `reconcileSpec` and `reconcileStatus`:
 
-Status update conflicts are recorded at the call sites where `r.client.Status().Update()` or `r.client.Status().Patch()` can return a 409 error. Key locations:
+```go
+func (r *Reconciler) reconcileSpec(ctx context.Context, logger logr.Logger, pclq *grovecorev1alpha1.PodClique) ctrlcommon.ReconcileStepResult {
+    mc := metrics.MetricsContextFromContext(ctx)
 
-**PodCliqueSet controller:**
-- `reconcileStatus` → `r.client.Status().Update(ctx, pcs)` — updates replica counts, conditions
-- `reconcileSpec` → `setGenerationHash` / `initRollingUpdateProgress` → `r.client.Status().Update(ctx, pcs)`
+    start := time.Now()
+    if stepResult := r.ensureFinalizer(ctx, logger, pclq); ctrlcommon.ShortCircuitReconcileFlow(stepResult) {
+        return r.recordIncompleteReconcile(ctx, logger, pclq, &stepResult)
+    }
+    mc.RecordSubOperation("ensure_finalizer", start)
 
-**PodClique controller:**
-- `reconcileStatus` → `r.client.Status().Patch(ctx, pclq, patch)` — updates replicas, readyReplicas, conditions
-- `reconcileSpec` → `initOrResetRollingUpdate` → `r.client.Status().Patch(ctx, pclq, patch)`
+    start = time.Now()
+    if stepResult := r.processRollingUpdate(ctx, logger, pclq); ctrlcommon.ShortCircuitReconcileFlow(stepResult) {
+        return r.recordIncompleteReconcile(ctx, logger, pclq, &stepResult)
+    }
+    mc.RecordSubOperation("process_rolling_update", start)
 
-**PodCliqueScalingGroup controller:**
-- `reconcileStatus` → `r.client.Status().Patch(ctx, pcsg, patch)` — updates replicas, availability
+    start = time.Now()
+    if stepResult := r.syncPCLQResources(ctx, logger, pclq); ctrlcommon.ShortCircuitReconcileFlow(stepResult) {
+        return r.recordIncompleteReconcile(ctx, logger, pclq, &stepResult)
+    }
+    mc.RecordSubOperation("sync_pods", start)
 
-Example instrumentation in PodCliqueSet `reconcileStatus`:
+    start = time.Now()
+    if stepResult := r.updateObservedGeneration(ctx, logger, pclq); ctrlcommon.ShortCircuitReconcileFlow(stepResult) {
+        return r.recordIncompleteReconcile(ctx, logger, pclq, &stepResult)
+    }
+    mc.RecordSubOperation("update_observed_generation", start)
+
+    return ctrlcommon.ContinueReconcile()
+}
+```
+
+### Conflict and Error Tracking
+
+Conflicts and errors are recorded at the call sites where `Status().Update()` or `Status().Patch()` may fail:
 
 ```go
 func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pcs *grovecorev1alpha1.PodCliqueSet) ctrlcommon.ReconcileStepResult {
+    mc := metrics.MetricsContextFromContext(ctx)
+
     // ... existing logic to mutate pcs.Status ...
 
     if err = r.client.Status().Update(ctx, pcs); err != nil {
         if k8serrors.IsConflict(err) {
-            mc := metrics.MetricsContextFromContext(ctx)
             mc.RecordConflict("PodCliqueSet")
         }
+        mc.RecordError(err)
         return ctrlcommon.ReconcileWithErrors("failed to update PodCliqueSet status", err)
     }
     return ctrlcommon.ContinueReconcile()
 }
 ```
 
-### Built-in controller-runtime Metrics
+### Built-in controller-runtime Metrics Reference
 
-controller-runtime (v0.22.4) already exposes the following metrics via the standard workqueue and REST client instrumentation. These require no code changes but should be **verified and documented**:
+The following metrics are already available and should be used for reconcile-level monitoring. They require no code changes:
 
-**Work Queue Metrics** (labeled by controller `name`):
-- `workqueue_depth` — current queue depth
-- `workqueue_adds_total` — total items added
-- `workqueue_queue_duration_seconds` — time items wait in queue before processing
-- `workqueue_work_duration_seconds` — time spent processing items
-- `workqueue_retries_total` — total retries
-- `workqueue_unfinished_work_seconds` — unfinished work duration
-- `workqueue_longest_running_processor_seconds` — longest running processor
-
-**REST Client Metrics**:
-- `rest_client_requests_total` — API requests by verb and status code
-- `rest_client_request_duration_seconds` — request latency by verb and URL
+| Metric | What It Tells You |
+|--------|------------------|
+| `controller_runtime_reconcile_time_seconds{controller="..."}` | How long reconciliations take (P50/P95/P99) |
+| `controller_runtime_reconcile_total{controller="...",result="..."}` | Reconcile count by outcome (success/error/requeue) |
+| `controller_runtime_active_workers{controller="..."}` | Current in-flight reconcile count |
+| `controller_runtime_max_concurrent_reconciles{controller="..."}` | Configured concurrency limit |
+| `workqueue_depth{name="..."}` | Work queue backlog |
+| `workqueue_queue_duration_seconds{name="..."}` | How long items wait in queue |
+| `workqueue_retries_total{name="..."}` | Retry count |
 
 ### File Changes Summary
 
 | File | Change |
 |------|--------|
-| `internal/controller/metrics/metrics.go` | **New**: Prometheus metric variable definitions, `InitMetrics()` registration |
-| `internal/controller/metrics/reconciler_wrapper.go` | **New**: `ObservedReconciler` wrapper with duration, count, error, inflight, requeue tracking |
-| `internal/controller/metrics/metrics_context.go` | **New**: `MetricsContext` struct, context helpers, `RecordSubOperation`, `RecordConflict` |
-| `internal/controller/manager.go` | Add `metrics.InitMetrics()` call after manager creation |
-| `internal/controller/podcliqueset/register.go` | Wrap reconciler with `metrics.NewObservedReconciler(r, "PodCliqueSet")` in `Complete()` |
-| `internal/controller/podclique/register.go` | Wrap reconciler with `metrics.NewObservedReconciler(r, "PodClique")` in `Complete()` |
-| `internal/controller/podcliquescalinggroup/register.go` | Wrap reconciler with `metrics.NewObservedReconciler(r, "PodCliqueScalingGroup")` in `Complete()` |
-| `internal/controller/podcliqueset/reconcilespec.go` | Add `mc.RecordSubOperation()` calls at each step boundary |
-| `internal/controller/podcliqueset/reconcilestatus.go` | Add `mc.RecordSubOperation()` and `mc.RecordConflict()` on 409 |
-| `internal/controller/podclique/reconcilespec.go` | Add `mc.RecordSubOperation()` calls at each step boundary |
-| `internal/controller/podclique/reconcilestatus.go` | Add `mc.RecordSubOperation()` and `mc.RecordConflict()` on 409 |
-| `internal/controller/podcliquescalinggroup/reconcilespec.go` | Add `mc.RecordSubOperation()` calls at each step boundary |
-| `internal/controller/podcliquescalinggroup/reconcilestatus.go` | Add `mc.RecordSubOperation()` and `mc.RecordConflict()` on 409 |
-| `docs/` | Document all new metrics, built-in metrics, and example PromQL queries |
+| `internal/controller/metrics/metrics.go` | **New**: 3 metric definitions + `InitMetrics()` |
+| `internal/controller/metrics/metrics_context.go` | **New**: `MetricsContext` with `RecordSubOperation`, `RecordConflict`, `RecordError` |
+| `internal/controller/manager.go` | Add `metrics.InitMetrics()` call |
+| `internal/controller/podcliqueset/reconciler.go` | Create and inject `MetricsContext` |
+| `internal/controller/podcliqueset/reconcilespec.go` | Add `mc.RecordSubOperation()` at step boundaries |
+| `internal/controller/podcliqueset/reconcilestatus.go` | Add `mc.RecordSubOperation()`, `mc.RecordConflict()`, `mc.RecordError()` |
+| `internal/controller/podclique/reconciler.go` | Create and inject `MetricsContext` |
+| `internal/controller/podclique/reconcilespec.go` | Add `mc.RecordSubOperation()` at step boundaries |
+| `internal/controller/podclique/reconcilestatus.go` | Add `mc.RecordSubOperation()`, `mc.RecordConflict()`, `mc.RecordError()` |
+| `internal/controller/podcliquescalinggroup/reconciler.go` | Create and inject `MetricsContext` |
+| `internal/controller/podcliquescalinggroup/reconcilespec.go` | Add `mc.RecordSubOperation()` at step boundaries |
+| `internal/controller/podcliquescalinggroup/reconcilestatus.go` | Add `mc.RecordSubOperation()`, `mc.RecordConflict()`, `mc.RecordError()` |
 
 ### Example PromQL Queries
 
 ```promql
+# ===== Built-in Metrics (already available) =====
+
 # P95 reconcile duration by controller
 histogram_quantile(0.95,
   sum by (controller, le) (
-    rate(grove_operator_reconcile_duration_seconds_bucket[5m])
+    rate(controller_runtime_reconcile_time_seconds_bucket[5m])
   )
 )
 
-# Reconcile error rate by error type
-sum by (controller, error_type) (
-  rate(grove_operator_reconcile_errors_total[5m])
+# Reconcile rate by result
+sum by (controller, result) (
+  rate(controller_runtime_reconcile_total[5m])
+)
+
+# In-flight reconciliations vs configured max
+controller_runtime_active_workers / controller_runtime_max_concurrent_reconciles
+
+# Work queue depth per controller
+workqueue_depth{name=~"podcliqueset-controller|podclique-controller|podcliquescalinggroup-controller"}
+
+# Work queue wait time P99
+histogram_quantile(0.99,
+  sum by (name, le) (
+    rate(workqueue_queue_duration_seconds_bucket[5m])
+  )
+)
+
+# ===== New Custom Metrics (added by this proposal) =====
+
+# Sub-operation P95 latency for PodClique — where is time spent?
+histogram_quantile(0.95,
+  sum by (operation, le) (
+    rate(grove_operator_reconcile_sub_operation_duration_seconds_bucket{
+      controller="podclique-controller"
+    }[5m])
+  )
 )
 
 # 409 Conflict rate — which resource is the contention hotspot?
@@ -365,50 +448,31 @@ sum by (controller, target_kind) (
   rate(grove_operator_status_update_conflict_total[5m])
 )
 
-# In-flight reconciliations — are controllers saturated?
-grove_operator_reconcile_inflight
-
-# Sub-operation P95 latency for PodClique — where is time spent?
-histogram_quantile(0.95,
-  sum by (operation, le) (
-    rate(grove_operator_reconcile_sub_operation_duration_seconds_bucket{
-      controller="PodClique"
-    }[5m])
-  )
+# Error breakdown by type — transient conflicts vs persistent errors
+sum by (controller, error_type) (
+  rate(grove_operator_reconcile_errors_total[5m])
 )
 
-# Work queue depth per controller (built-in)
-workqueue_depth{name=~"PodCliqueSet|PodClique|PodCliqueScalingGroup"}
-
-# Work queue wait time P99 (built-in)
-histogram_quantile(0.99,
-  sum by (name, le) (
-    rate(workqueue_queue_duration_seconds_bucket{
-      name=~"PodCliqueSet|PodClique|PodCliqueScalingGroup"
-    }[5m])
-  )
-)
-
-# Requeue rate by reason
-sum by (controller, reason) (
-  rate(grove_operator_reconcile_requeue_total[5m])
-)
+# Conflict-to-total-error ratio — what fraction of errors are conflicts?
+sum(rate(grove_operator_reconcile_errors_total{error_type="conflict"}[5m]))
+/
+sum(rate(controller_runtime_reconcile_total{result="error"}[5m]))
 ```
 
 ### Monitoring
 
-The metrics introduced by this proposal provide the following monitoring capabilities:
+The custom metrics introduced by this proposal, combined with the built-in controller-runtime metrics, provide:
 
-1. **Reconciliation Health**: P50/P95/P99 reconcile duration, success/error/requeue rates per controller.
-2. **Sub-Operation Bottleneck Identification**: Per-step latency breakdown (e.g., `sync_pods` vs `reconcile_status` in PodClique controller).
-3. **Conflict Detection**: 409 Conflict rate with target-kind attribution, enabling detection of cross-controller contention.
-4. **Capacity Saturation**: In-flight reconcile count vs MaxConcurrentReconciles, work queue depth and wait time.
-5. **Error Classification**: Errors categorized by Kubernetes error type (not_found, conflict, timeout, etc.) for targeted debugging.
+1. **Sub-Operation Bottleneck Identification**: Per-step latency breakdown to pinpoint slow operations (e.g., `sync_pods` vs `reconcile_status`).
+2. **Conflict Detection and Attribution**: 409 Conflict rate by target resource kind, identifying cross-controller contention hotspots.
+3. **Error Triage**: Errors categorized by Kubernetes error type, distinguishing transient conflicts from persistent failures.
+
+The built-in metrics already provide reconciliation health (duration, throughput, success rate), capacity saturation (active workers, queue depth), and API client performance.
 
 Recommended alert examples (not enforced by this proposal):
-- `grove_operator_reconcile_errors_total{error_type="conflict"}` rate > 1/s → cross-controller contention
-- `workqueue_depth{name="PodClique"}` > 50 for 5m → PodClique controller falling behind
-- `grove_operator_reconcile_inflight{controller="PodClique"}` = MaxConcurrentReconciles for 5m → controller saturated
+- `grove_operator_status_update_conflict_total` rate > 1/s → cross-controller contention
+- `grove_operator_reconcile_errors_total{error_type="timeout"}` rate > 0.1/s → API server pressure
+- `workqueue_depth{name="podclique-controller"}` > 50 for 5m → PodClique controller falling behind
 
 ### Dependencies
 
@@ -419,25 +483,25 @@ No new external dependencies are introduced.
 
 ### Test Plan
 
-1. **Unit tests** for `ObservedReconciler`: Verify that metrics are correctly recorded for success, error, and requeue outcomes. Mock reconciler returning different results.
-2. **Unit tests** for `MetricsContext`: Verify `RecordSubOperation` and `RecordConflict` correctly increment counters and observe histograms.
-3. **Unit tests** for `categorizeError`: Verify error categorization for all Kubernetes error types.
-4. **Integration test**: Deploy Grove with metrics enabled, create a PodCliqueSet, and verify metrics are exposed at the `/metrics` endpoint with correct label values.
-5. **E2E test**: Deploy at scale (multiple PodCliqueSets with many replicas), scrape metrics, and verify sub-operation and conflict metrics are populated.
+1. **Unit tests** for `MetricsContext`: Verify `RecordSubOperation`, `RecordConflict`, and `RecordError` correctly observe histograms and increment counters.
+2. **Unit tests** for `CategorizeError`: Verify error categorization for all Kubernetes error types.
+3. **Integration test**: Deploy Grove, create a PodCliqueSet, and verify custom metrics are exposed at the `/metrics` endpoint alongside the existing built-in metrics.
+4. **E2E test**: Deploy at scale (multiple PodCliqueSets with many replicas), scrape metrics, and verify sub-operation and conflict metrics are populated.
 
 ### Graduation Criteria
 
 **Alpha (this proposal):**
-- All three controllers wrapped with `ObservedReconciler`
+- Three custom metrics registered and recorded in all three controllers
 - Sub-operation timing at major step boundaries
 - Conflict tracking on status update/patch calls
-- Documentation and example PromQL queries
+- Error categorization on reconcile errors
+- Documentation covering both built-in and custom metrics
 - Unit tests for all new code
 
 **Beta (future):**
-- Grafana dashboard JSON included in the chart
+- Grafana dashboard JSON included in the chart (combining built-in and custom metrics)
 - ServiceMonitor template in Helm chart
-- Additional controller-specific business metrics based on alpha data analysis
+- Additional controller-specific metrics based on alpha data analysis
 
 **GA (future):**
 - Metrics stable for 2+ releases
@@ -447,6 +511,8 @@ No new external dependencies are introduced.
 ## Implementation History
 
 - 2026-03-11: Initial GREP draft created
+- 2026-03-24: PR #499 opened
+- 2026-03-30: Updated based on review feedback — removed 4 duplicate metrics, removed namespace label, refocused on 3 genuinely new metrics
 
 ## Alternatives
 
@@ -466,13 +532,13 @@ No new external dependencies are introduced.
 
 **Rejected because:** Tracing is valuable for deep-dive debugging but requires significant infrastructure investment. Prometheus metrics provide the aggregate view needed for dashboards and alerts with minimal overhead. Tracing can be added later.
 
-### Alt 3: Custom client.Client Wrapper
+### Alt 3: ObservedReconciler Wrapper for All Metrics
 
-**Pros:** Automatically instruments all API calls without per-controller changes.
+**Pros:** Single wrapper provides all metrics automatically without per-controller changes.
 
-**Cons:** Loses controller context (which controller triggered the call); complex to implement (must handle all client.Client methods); client-go already provides `rest_client_*` metrics.
+**Cons:** Duplicates controller-runtime built-in metrics (`controller_runtime_reconcile_time_seconds`, `controller_runtime_reconcile_total`, `controller_runtime_active_workers`). Creates confusion with two sources of truth for the same data.
 
-**Rejected because:** The `MetricsContext` approach provides controller attribution while being simpler. Combined with existing client-go metrics, this is sufficient.
+**Rejected because:** controller-runtime already provides reconcile-level metrics. Wrapping the reconciler would duplicate these. The `MetricsContext` approach focuses on what's genuinely missing (sub-operation timing, conflict attribution, error categorization) without duplication.
 
 ## Appendix
 
@@ -498,16 +564,16 @@ Grove Operator
 1. Upstream operator scales PodClique via Scale subresource (Get scale → Update scale).
 2. Between the Get and Update, Grove's PC controller updates PC status (e.g., readyReplicas changes as a Pod becomes Ready).
 3. The upstream operator's Scale Update receives 409 Conflict (resourceVersion mismatch).
-4. Similarly, Grove's PCS `reconcileStatus` calls `r.client.Status().Update(ctx, pcs)`. If the upstream operator concurrently modifies PCS (e.g., spec update via SyncResource), Grove's status update can also conflict.
+4. Similarly, Grove's PCS `reconcileStatus` calls `r.client.Status().Update(ctx, pcs)`. If the upstream operator concurrently modifies PCS, Grove's status update can also conflict.
 
 **Why Grove needs these metrics:**
 
-Without metrics on the Grove side, we can only see the upstream operator's view of the conflict. The `grove_operator_status_update_conflict_total` metric provides the other half: how often Grove's own status updates are failing due to concurrent external writes. Combined with the upstream operator's metrics, this gives a complete picture of the contention and guides architectural decisions (e.g., switching from `Status().Update()` to `Status().Patch()` with optimistic merge, or using Server-Side Apply).
+Without metrics on the Grove side, we can only see the upstream operator's view of the conflict. The `grove_operator_status_update_conflict_total` metric provides the other half: how often Grove's own status updates fail due to concurrent external writes. Combined with the upstream operator's metrics, this gives a complete picture of the contention and guides architectural decisions (e.g., switching from `Status().Update()` to field-level `Status().Patch()`, or using Server-Side Apply).
 
 **Future work enabled by these metrics:**
 
-1. **Status Patch optimization** — If `status_update_conflict_total` is high for PCS, consider switching PCS `reconcileStatus` from `Status().Update()` to field-level `Status().Patch()` to reduce conflict surface.
-2. **Rate limiter tuning** — Use `reconcile_inflight` and `workqueue_depth` data to tune `MaxConcurrentReconciles` per controller.
+1. **Status Patch optimization** — If `status_update_conflict_total` is high for PCS, consider switching `reconcileStatus` from `Status().Update()` to field-level `Status().Patch()` to reduce conflict surface.
+2. **Rate limiter tuning** — Use built-in `controller_runtime_active_workers` and `workqueue_depth` data to tune `MaxConcurrentReconciles` per controller.
 3. **Watch predicate optimization** — Use sub-operation latency data to determine if watch predicates should be tightened to reduce unnecessary reconcile triggers.
 4. **Upstream coordination** — Share conflict data with upstream operator teams to jointly optimize the interaction pattern.
 
@@ -521,6 +587,5 @@ Without metrics on the Grove side, we can only see the upstream operator's view 
 | **Conflict storm** | A pattern where concurrent writes to the same Kubernetes object produce cascading 409 Conflict errors |
 | **Optimistic concurrency** | Kubernetes mechanism where every object has a `resourceVersion`; an Update must match the current version or receive 409 Conflict |
 | **Sub-operation** | A discrete step within a reconciliation loop (e.g., syncResources, reconcileStatus) |
-| **Watch amplification** | The effect of Watch predicates triggering many reconciliations from frequent status changes |
 
 > NOTE: This GREP template has been inspired by [KEP Template](https://github.com/kubernetes/enhancements/blob/f90055d254c356b2c038a1bdf4610bf4acd8d7be/keps/NNNN-kep-template/README.md).

--- a/docs/proposals/498-controller-reconcile-metrics/README.md
+++ b/docs/proposals/498-controller-reconcile-metrics/README.md
@@ -1,0 +1,526 @@
+# GREP-498: Controller Reconciliation Prometheus Metrics
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+    - [Story 1: Diagnosing Slow Deployment at Scale](#story-1-diagnosing-slow-deployment-at-scale)
+    - [Story 2: Identifying Cross-Controller Resource Contention](#story-2-identifying-cross-controller-resource-contention)
+    - [Story 3: Capacity Planning for MaxConcurrentReconciles](#story-3-capacity-planning-for-maxconcurrentreconciles)
+  - [Limitations/Risks & Mitigations](#limitationsrisks--mitigations)
+- [Design Details](#design-details)
+  - [Metric Definitions](#metric-definitions)
+  - [ObservedReconciler Wrapper](#observedreconciler-wrapper)
+  - [MetricsContext for Sub-Operation Timing](#metricscontext-for-sub-operation-timing)
+  - [Conflict Tracking](#conflict-tracking)
+  - [Built-in controller-runtime Metrics](#built-in-controller-runtime-metrics)
+  - [File Changes Summary](#file-changes-summary)
+  - [Example PromQL Queries](#example-promql-queries)
+  - [Monitoring](#monitoring)
+  - [Dependencies](#dependencies)
+  - [Test Plan](#test-plan)
+  - [Graduation Criteria](#graduation-criteria)
+- [Implementation History](#implementation-history)
+- [Alternatives](#alternatives)
+- [Appendix](#appendix)
+  - [Appendix A: Cross-Controller Conflict Storm Analysis](#appendix-a-cross-controller-conflict-storm-analysis)
+  - [Appendix B: Terminology](#appendix-b-terminology)
+<!-- /toc -->
+
+## Summary
+
+The Grove operator currently exposes **zero custom Prometheus metrics**. The three controllers (PodCliqueSet, PodClique, PodCliqueScalingGroup) have no observability into reconciliation performance, sub-operation latency, error categorization, or resource contention. This proposal adds a comprehensive Prometheus metrics framework to all Grove controllers, providing reconcile-level and sub-operation-level visibility. When large numbers of PodCliques and Pods are created — particularly when Grove is used by an upstream operator like Dynamo — reconciliation performance degrades due to high event rates and cross-controller resource contention, but there is currently no way to observe, quantify, or diagnose these issues.
+
+## Motivation
+
+During large-scale inference graph deployments using Grove (via NVIDIA Dynamo), we observed significant reconciliation performance degradation. Deploying an inference graph with 5 services × 10 replicas produces 50+ PodClique Pods, each transitioning through multiple states (Pending → Running → Ready). This generates a high rate of status changes that cascade through the Grove controller hierarchy (PodClique → PodCliqueScalingGroup → PodCliqueSet).
+
+**The fundamental problem**: Grove has no metrics to answer basic operational questions:
+
+1. **How long do reconciliations take?** There is no duration tracking for any controller's reconcile loop.
+2. **Which sub-operation is the bottleneck?** Each reconcile performs multiple steps (ensureFinalizer, processRollingUpdate, syncResources, updateObservedGeneration, reconcileStatus) but we cannot see which step is slow.
+3. **How often do API calls fail?** Status updates via `r.client.Status().Update()` and `r.client.Status().Patch()` can fail with 409 Conflict when an external controller (e.g., Dynamo's DGD controller) concurrently modifies the same PodClique/PodCliqueSet objects. We cannot see the conflict rate.
+4. **How deep is the work queue?** We have no visibility into per-controller queue depth, queue wait time, or event processing rate.
+5. **What is the reconcile throughput?** We cannot determine if controllers are keeping up with the event rate.
+
+This lack of observability means that performance issues require ad-hoc debugging via log analysis. Operators cannot set alerts, create dashboards, or make data-driven tuning decisions.
+
+### Goals
+
+* Add Prometheus metrics to all three Grove controllers (PodCliqueSet, PodClique, PodCliqueScalingGroup) with a consistent, general-purpose framework
+* Track reconcile duration, count, error rate, and error categorization per controller
+* Track sub-operation timing within each reconcile loop to identify bottlenecks
+* Track in-flight (concurrent) reconciliation count per controller
+* Track 409 Conflict errors with target-resource attribution to diagnose cross-controller contention
+* Verify and document controller-runtime built-in workqueue and REST client metrics
+* Design the framework as an extensible foundation — controller-specific business metrics can be added incrementally in the future
+* Provide example Grafana dashboard panels and PromQL queries
+
+### Non-Goals
+
+* This proposal does NOT add metrics to the Grove scheduler component (only the operator)
+* This proposal does NOT change reconciliation logic; it is purely additive instrumentation
+* This proposal does NOT define alert thresholds or SLOs (those are deployment-specific)
+* This proposal does NOT add metrics to upstream consumers of Grove (e.g., Dynamo Operator)
+* This proposal does NOT prescribe architectural mitigations for performance issues (e.g., watch predicate throttling); those require separate proposals informed by the data this proposal provides
+* Detailed per-controller business-logic metrics (e.g., rolling update step counts, PodGang recreation rates) are deferred to future incremental additions
+
+## Proposal
+
+### Overview
+
+Introduce a `metrics` package under `operator/internal/controller/metrics/` containing:
+
+1. **`ObservedReconciler`** — A wrapper around any `reconcile.Reconciler` that automatically records total reconcile duration, count, errors, in-flight count, and requeue reasons. All three controllers will be wrapped with this.
+2. **`MetricsContext`** — A struct injected into `context.Context` that controllers can use to record sub-operation timings and conflict events. This is the extension point for future metrics.
+3. **Metric definitions** — All Prometheus metric variables and the `InitMetrics()` registration function.
+
+All metrics use the `grove_operator` namespace prefix.
+
+### User Stories
+
+#### Story 1: Diagnosing Slow Deployment at Scale
+
+As a platform operator deploying large inference graphs via Grove, I want to see which sub-operation within PodClique reconciliation is slow (e.g., is it `sync_pods`, `reconcile_status`, or `update_observed_generation`?) so that I can file a targeted bug report or tune the system.
+
+#### Story 2: Identifying Cross-Controller Resource Contention
+
+As a developer integrating Grove with an upstream operator (e.g., Dynamo), I want to see the 409 Conflict rate on PodClique and PodCliqueSet status updates, broken down by target resource kind, so that I can determine if cross-controller contention is the root cause of reconciliation failures.
+
+#### Story 3: Capacity Planning for MaxConcurrentReconciles
+
+As a cluster administrator, I want to see the in-flight reconciliation count and work queue depth per controller so that I can decide whether to increase `MaxConcurrentReconciles` for the PodClique controller during large-scale deployments.
+
+### Limitations/Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Label cardinality explosion from `namespace` × `operation` × histogram buckets | `operation` values are bounded and explicitly defined per controller (~5-8 per controller). Estimated total new time series in a 10-namespace cluster: ~3,000-6,000, well within Prometheus capacity. |
+| Performance overhead of metric recording | All metric operations (Inc, Observe) are O(1) atomic operations. Overhead is < 1μs per call. The `MetricsContext` nil-check pattern ensures zero overhead when metrics context is not injected. |
+| `ObservedReconciler` wrapper changes the reconciler type passed to `Complete()` | This is the same pattern used by NVIDIA Dynamo's operator and by controller-runtime's own metrics. Fully compatible with `builder.Complete()`. |
+
+## Design Details
+
+### Metric Definitions
+
+All metrics are registered with the controller-runtime metrics registry via `InitMetrics()`.
+
+#### Reconcile-Level Metrics (recorded by ObservedReconciler)
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `grove_operator_reconcile_duration_seconds` | Histogram | `controller`, `namespace`, `result` | Total duration of each reconciliation loop |
+| `grove_operator_reconcile_total` | Counter | `controller`, `namespace`, `result` | Total number of reconciliations |
+| `grove_operator_reconcile_errors_total` | Counter | `controller`, `namespace`, `error_type` | Total reconciliation errors, categorized by Kubernetes error type |
+| `grove_operator_reconcile_inflight` | Gauge | `controller` | Number of reconciliations currently in progress |
+| `grove_operator_reconcile_requeue_total` | Counter | `controller`, `namespace`, `reason` | Count of requeue events with categorized reasons |
+
+**Label values:**
+- `controller`: `PodCliqueSet`, `PodClique`, `PodCliqueScalingGroup`
+- `result`: `success`, `error`, `requeue`
+- `error_type`: `not_found`, `conflict`, `already_exists`, `timeout`, `forbidden`, `invalid`, `internal`
+- `reason`: `explicit_requeue`, `conflict`, `timeout`, `internal`, etc.
+
+#### Sub-Operation Metrics (recorded by controllers via MetricsContext)
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `grove_operator_reconcile_sub_operation_duration_seconds` | Histogram | `controller`, `namespace`, `operation` | Duration of individual sub-operations within a reconcile loop |
+
+**`operation` label values per controller:**
+
+| Controller | Operations |
+|------------|------------|
+| PodCliqueSet | `get_resource`, `ensure_finalizer`, `process_generation_hash`, `sync_resources`, `update_observed_generation`, `reconcile_status` |
+| PodClique | `get_resource`, `ensure_finalizer`, `process_rolling_update`, `sync_pods`, `update_observed_generation`, `reconcile_status` |
+| PodCliqueScalingGroup | `get_resource`, `ensure_finalizer`, `process_rolling_update`, `sync_resources`, `update_observed_generation`, `reconcile_status` |
+
+#### Conflict Tracking Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `grove_operator_status_update_conflict_total` | Counter | `controller`, `namespace`, `target_kind` | Count of 409 Conflict errors on Status Update/Patch operations |
+
+This metric captures conflicts that occur when Grove's status updates race against an external controller (e.g., Dynamo scaling PodClique) modifying the same object. The `target_kind` label identifies which object type (PodCliqueSet, PodClique, PodCliqueScalingGroup) experienced the conflict.
+
+### ObservedReconciler Wrapper
+
+```go
+package metrics
+
+import (
+    "context"
+    "time"
+
+    "github.com/prometheus/client_golang/prometheus"
+    k8serrors "k8s.io/apimachinery/pkg/api/errors"
+    ctrl "sigs.k8s.io/controller-runtime"
+    ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+    "sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const metricsNamespace = "grove_operator"
+
+type ObservedReconciler struct {
+    reconcile.Reconciler
+    controllerName string
+}
+
+func NewObservedReconciler(r reconcile.Reconciler, controllerName string) *ObservedReconciler {
+    return &ObservedReconciler{Reconciler: r, controllerName: controllerName}
+}
+
+func (m *ObservedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+    reconcileInflight.WithLabelValues(m.controllerName).Inc()
+    defer reconcileInflight.WithLabelValues(m.controllerName).Dec()
+
+    mc := NewMetricsContext(m.controllerName, req.Namespace)
+    ctx = WithMetricsContext(ctx, mc)
+
+    startTime := time.Now()
+    result, err := m.Reconciler.Reconcile(ctx, req)
+    duration := time.Since(startTime)
+
+    requeue := result.Requeue || result.RequeueAfter > 0
+
+    resultLabel := "success"
+    if err != nil {
+        resultLabel = "error"
+        reconcileErrors.WithLabelValues(m.controllerName, req.Namespace, categorizeError(err)).Inc()
+    } else if requeue {
+        resultLabel = "requeue"
+    }
+
+    reconcileDuration.WithLabelValues(m.controllerName, req.Namespace, resultLabel).Observe(duration.Seconds())
+    reconcileTotal.WithLabelValues(m.controllerName, req.Namespace, resultLabel).Inc()
+
+    if err != nil {
+        reconcileRequeueTotal.WithLabelValues(m.controllerName, req.Namespace, categorizeError(err)).Inc()
+    } else if requeue {
+        reconcileRequeueTotal.WithLabelValues(m.controllerName, req.Namespace, "explicit_requeue").Inc()
+    }
+
+    return result, err
+}
+
+func categorizeError(err error) string {
+    switch {
+    case k8serrors.IsNotFound(err):
+        return "not_found"
+    case k8serrors.IsConflict(err):
+        return "conflict"
+    case k8serrors.IsAlreadyExists(err):
+        return "already_exists"
+    case k8serrors.IsTimeout(err), k8serrors.IsServerTimeout(err):
+        return "timeout"
+    case k8serrors.IsForbidden(err):
+        return "forbidden"
+    case k8serrors.IsInvalid(err):
+        return "invalid"
+    case k8serrors.IsTooManyRequests(err):
+        return "rate_limited"
+    default:
+        return "internal"
+    }
+}
+```
+
+### MetricsContext for Sub-Operation Timing
+
+```go
+package metrics
+
+import (
+    "context"
+    "time"
+)
+
+type contextKey struct{}
+
+type MetricsContext struct {
+    controllerName string
+    namespace      string
+}
+
+func NewMetricsContext(controllerName, namespace string) *MetricsContext {
+    return &MetricsContext{controllerName: controllerName, namespace: namespace}
+}
+
+func WithMetricsContext(ctx context.Context, mc *MetricsContext) context.Context {
+    return context.WithValue(ctx, contextKey{}, mc)
+}
+
+func MetricsContextFromContext(ctx context.Context) *MetricsContext {
+    mc, _ := ctx.Value(contextKey{}).(*MetricsContext)
+    return mc
+}
+
+func (mc *MetricsContext) RecordSubOperation(operation string, start time.Time) {
+    if mc == nil {
+        return
+    }
+    reconcileSubOpDuration.WithLabelValues(
+        mc.controllerName, mc.namespace, operation,
+    ).Observe(time.Since(start).Seconds())
+}
+
+func (mc *MetricsContext) RecordConflict(targetKind string) {
+    if mc == nil {
+        return
+    }
+    statusUpdateConflictTotal.WithLabelValues(
+        mc.controllerName, mc.namespace, targetKind,
+    ).Inc()
+}
+```
+
+### Conflict Tracking
+
+Status update conflicts are recorded at the call sites where `r.client.Status().Update()` or `r.client.Status().Patch()` can return a 409 error. Key locations:
+
+**PodCliqueSet controller:**
+- `reconcileStatus` → `r.client.Status().Update(ctx, pcs)` — updates replica counts, conditions
+- `reconcileSpec` → `setGenerationHash` / `initRollingUpdateProgress` → `r.client.Status().Update(ctx, pcs)`
+
+**PodClique controller:**
+- `reconcileStatus` → `r.client.Status().Patch(ctx, pclq, patch)` — updates replicas, readyReplicas, conditions
+- `reconcileSpec` → `initOrResetRollingUpdate` → `r.client.Status().Patch(ctx, pclq, patch)`
+
+**PodCliqueScalingGroup controller:**
+- `reconcileStatus` → `r.client.Status().Patch(ctx, pcsg, patch)` — updates replicas, availability
+
+Example instrumentation in PodCliqueSet `reconcileStatus`:
+
+```go
+func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pcs *grovecorev1alpha1.PodCliqueSet) ctrlcommon.ReconcileStepResult {
+    // ... existing logic to mutate pcs.Status ...
+
+    if err = r.client.Status().Update(ctx, pcs); err != nil {
+        if k8serrors.IsConflict(err) {
+            mc := metrics.MetricsContextFromContext(ctx)
+            mc.RecordConflict("PodCliqueSet")
+        }
+        return ctrlcommon.ReconcileWithErrors("failed to update PodCliqueSet status", err)
+    }
+    return ctrlcommon.ContinueReconcile()
+}
+```
+
+### Built-in controller-runtime Metrics
+
+controller-runtime (v0.22.4) already exposes the following metrics via the standard workqueue and REST client instrumentation. These require no code changes but should be **verified and documented**:
+
+**Work Queue Metrics** (labeled by controller `name`):
+- `workqueue_depth` — current queue depth
+- `workqueue_adds_total` — total items added
+- `workqueue_queue_duration_seconds` — time items wait in queue before processing
+- `workqueue_work_duration_seconds` — time spent processing items
+- `workqueue_retries_total` — total retries
+- `workqueue_unfinished_work_seconds` — unfinished work duration
+- `workqueue_longest_running_processor_seconds` — longest running processor
+
+**REST Client Metrics**:
+- `rest_client_requests_total` — API requests by verb and status code
+- `rest_client_request_duration_seconds` — request latency by verb and URL
+
+### File Changes Summary
+
+| File | Change |
+|------|--------|
+| `internal/controller/metrics/metrics.go` | **New**: Prometheus metric variable definitions, `InitMetrics()` registration |
+| `internal/controller/metrics/reconciler_wrapper.go` | **New**: `ObservedReconciler` wrapper with duration, count, error, inflight, requeue tracking |
+| `internal/controller/metrics/metrics_context.go` | **New**: `MetricsContext` struct, context helpers, `RecordSubOperation`, `RecordConflict` |
+| `internal/controller/manager.go` | Add `metrics.InitMetrics()` call after manager creation |
+| `internal/controller/podcliqueset/register.go` | Wrap reconciler with `metrics.NewObservedReconciler(r, "PodCliqueSet")` in `Complete()` |
+| `internal/controller/podclique/register.go` | Wrap reconciler with `metrics.NewObservedReconciler(r, "PodClique")` in `Complete()` |
+| `internal/controller/podcliquescalinggroup/register.go` | Wrap reconciler with `metrics.NewObservedReconciler(r, "PodCliqueScalingGroup")` in `Complete()` |
+| `internal/controller/podcliqueset/reconcilespec.go` | Add `mc.RecordSubOperation()` calls at each step boundary |
+| `internal/controller/podcliqueset/reconcilestatus.go` | Add `mc.RecordSubOperation()` and `mc.RecordConflict()` on 409 |
+| `internal/controller/podclique/reconcilespec.go` | Add `mc.RecordSubOperation()` calls at each step boundary |
+| `internal/controller/podclique/reconcilestatus.go` | Add `mc.RecordSubOperation()` and `mc.RecordConflict()` on 409 |
+| `internal/controller/podcliquescalinggroup/reconcilespec.go` | Add `mc.RecordSubOperation()` calls at each step boundary |
+| `internal/controller/podcliquescalinggroup/reconcilestatus.go` | Add `mc.RecordSubOperation()` and `mc.RecordConflict()` on 409 |
+| `docs/` | Document all new metrics, built-in metrics, and example PromQL queries |
+
+### Example PromQL Queries
+
+```promql
+# P95 reconcile duration by controller
+histogram_quantile(0.95,
+  sum by (controller, le) (
+    rate(grove_operator_reconcile_duration_seconds_bucket[5m])
+  )
+)
+
+# Reconcile error rate by error type
+sum by (controller, error_type) (
+  rate(grove_operator_reconcile_errors_total[5m])
+)
+
+# 409 Conflict rate — which resource is the contention hotspot?
+sum by (controller, target_kind) (
+  rate(grove_operator_status_update_conflict_total[5m])
+)
+
+# In-flight reconciliations — are controllers saturated?
+grove_operator_reconcile_inflight
+
+# Sub-operation P95 latency for PodClique — where is time spent?
+histogram_quantile(0.95,
+  sum by (operation, le) (
+    rate(grove_operator_reconcile_sub_operation_duration_seconds_bucket{
+      controller="PodClique"
+    }[5m])
+  )
+)
+
+# Work queue depth per controller (built-in)
+workqueue_depth{name=~"PodCliqueSet|PodClique|PodCliqueScalingGroup"}
+
+# Work queue wait time P99 (built-in)
+histogram_quantile(0.99,
+  sum by (name, le) (
+    rate(workqueue_queue_duration_seconds_bucket{
+      name=~"PodCliqueSet|PodClique|PodCliqueScalingGroup"
+    }[5m])
+  )
+)
+
+# Requeue rate by reason
+sum by (controller, reason) (
+  rate(grove_operator_reconcile_requeue_total[5m])
+)
+```
+
+### Monitoring
+
+The metrics introduced by this proposal provide the following monitoring capabilities:
+
+1. **Reconciliation Health**: P50/P95/P99 reconcile duration, success/error/requeue rates per controller.
+2. **Sub-Operation Bottleneck Identification**: Per-step latency breakdown (e.g., `sync_pods` vs `reconcile_status` in PodClique controller).
+3. **Conflict Detection**: 409 Conflict rate with target-kind attribution, enabling detection of cross-controller contention.
+4. **Capacity Saturation**: In-flight reconcile count vs MaxConcurrentReconciles, work queue depth and wait time.
+5. **Error Classification**: Errors categorized by Kubernetes error type (not_found, conflict, timeout, etc.) for targeted debugging.
+
+Recommended alert examples (not enforced by this proposal):
+- `grove_operator_reconcile_errors_total{error_type="conflict"}` rate > 1/s → cross-controller contention
+- `workqueue_depth{name="PodClique"}` > 50 for 5m → PodClique controller falling behind
+- `grove_operator_reconcile_inflight{controller="PodClique"}` = MaxConcurrentReconciles for 5m → controller saturated
+
+### Dependencies
+
+- `github.com/prometheus/client_golang` — already an indirect dependency via controller-runtime
+- `sigs.k8s.io/controller-runtime/pkg/metrics` — already used for the metrics server endpoint
+
+No new external dependencies are introduced.
+
+### Test Plan
+
+1. **Unit tests** for `ObservedReconciler`: Verify that metrics are correctly recorded for success, error, and requeue outcomes. Mock reconciler returning different results.
+2. **Unit tests** for `MetricsContext`: Verify `RecordSubOperation` and `RecordConflict` correctly increment counters and observe histograms.
+3. **Unit tests** for `categorizeError`: Verify error categorization for all Kubernetes error types.
+4. **Integration test**: Deploy Grove with metrics enabled, create a PodCliqueSet, and verify metrics are exposed at the `/metrics` endpoint with correct label values.
+5. **E2E test**: Deploy at scale (multiple PodCliqueSets with many replicas), scrape metrics, and verify sub-operation and conflict metrics are populated.
+
+### Graduation Criteria
+
+**Alpha (this proposal):**
+- All three controllers wrapped with `ObservedReconciler`
+- Sub-operation timing at major step boundaries
+- Conflict tracking on status update/patch calls
+- Documentation and example PromQL queries
+- Unit tests for all new code
+
+**Beta (future):**
+- Grafana dashboard JSON included in the chart
+- ServiceMonitor template in Helm chart
+- Additional controller-specific business metrics based on alpha data analysis
+
+**GA (future):**
+- Metrics stable for 2+ releases
+- Community feedback incorporated
+- Alert rule examples based on production usage patterns
+
+## Implementation History
+
+- 2026-03-11: Initial GREP draft created
+
+## Alternatives
+
+### Alt 1: Structured Logging Only
+
+**Pros:** No code changes to metrics infrastructure; flexible querying.
+
+**Cons:** Cannot create real-time dashboards or alerts; higher storage cost; slower to query than Prometheus; no time-series aggregation.
+
+**Rejected because:** Prometheus metrics are the established Kubernetes ecosystem standard. Log analysis is complementary but not a substitute for time-series monitoring.
+
+### Alt 2: OpenTelemetry Tracing
+
+**Pros:** Rich per-request trace context with spans; distributed tracing across operator → API server.
+
+**Cons:** Requires additional infrastructure (Jaeger/Tempo); higher per-request overhead; not yet standard in controller-runtime; overkill for aggregate monitoring.
+
+**Rejected because:** Tracing is valuable for deep-dive debugging but requires significant infrastructure investment. Prometheus metrics provide the aggregate view needed for dashboards and alerts with minimal overhead. Tracing can be added later.
+
+### Alt 3: Custom client.Client Wrapper
+
+**Pros:** Automatically instruments all API calls without per-controller changes.
+
+**Cons:** Loses controller context (which controller triggered the call); complex to implement (must handle all client.Client methods); client-go already provides `rest_client_*` metrics.
+
+**Rejected because:** The `MetricsContext` approach provides controller attribution while being simpler. Combined with existing client-go metrics, this is sufficient.
+
+## Appendix
+
+### Appendix A: Cross-Controller Conflict Storm Analysis
+
+When Grove is used by an upstream operator (e.g., NVIDIA Dynamo), the following contention pattern occurs during large-scale deployments:
+
+**Object ownership:**
+```
+Upstream Operator (e.g., Dynamo DGD Controller)
+  creates → PodCliqueSet (PCS)
+  scales  → PodClique (PC) / PodCliqueScalingGroup (PCSG) via Scale subresource
+  reads   → PC/PCSG status for readiness checks
+
+Grove Operator
+  PCS Controller → creates PC/PCSG, updates PCS status
+  PC Controller  → creates Pods, updates PC status (replicas, readyReplicas)
+  PCSG Controller → manages PC replicas, updates PCSG status
+```
+
+**Contention mechanism:**
+
+1. Upstream operator scales PodClique via Scale subresource (Get scale → Update scale).
+2. Between the Get and Update, Grove's PC controller updates PC status (e.g., readyReplicas changes as a Pod becomes Ready).
+3. The upstream operator's Scale Update receives 409 Conflict (resourceVersion mismatch).
+4. Similarly, Grove's PCS `reconcileStatus` calls `r.client.Status().Update(ctx, pcs)`. If the upstream operator concurrently modifies PCS (e.g., spec update via SyncResource), Grove's status update can also conflict.
+
+**Why Grove needs these metrics:**
+
+Without metrics on the Grove side, we can only see the upstream operator's view of the conflict. The `grove_operator_status_update_conflict_total` metric provides the other half: how often Grove's own status updates are failing due to concurrent external writes. Combined with the upstream operator's metrics, this gives a complete picture of the contention and guides architectural decisions (e.g., switching from `Status().Update()` to `Status().Patch()` with optimistic merge, or using Server-Side Apply).
+
+**Future work enabled by these metrics:**
+
+1. **Status Patch optimization** — If `status_update_conflict_total` is high for PCS, consider switching PCS `reconcileStatus` from `Status().Update()` to field-level `Status().Patch()` to reduce conflict surface.
+2. **Rate limiter tuning** — Use `reconcile_inflight` and `workqueue_depth` data to tune `MaxConcurrentReconciles` per controller.
+3. **Watch predicate optimization** — Use sub-operation latency data to determine if watch predicates should be tightened to reduce unnecessary reconcile triggers.
+4. **Upstream coordination** — Share conflict data with upstream operator teams to jointly optimize the interaction pattern.
+
+### Appendix B: Terminology
+
+| Term | Definition |
+|------|------------|
+| **PCS** | PodCliqueSet — top-level Grove CRD representing a set of PodCliques |
+| **PC / PCLQ** | PodClique — Grove CRD representing a group of co-scheduled Pods |
+| **PCSG** | PodCliqueScalingGroup — Grove CRD for managing multiple PodClique replicas |
+| **Conflict storm** | A pattern where concurrent writes to the same Kubernetes object produce cascading 409 Conflict errors |
+| **Optimistic concurrency** | Kubernetes mechanism where every object has a `resourceVersion`; an Update must match the current version or receive 409 Conflict |
+| **Sub-operation** | A discrete step within a reconciliation loop (e.g., syncResources, reconcileStatus) |
+| **Watch amplification** | The effect of Watch predicates triggering many reconciliations from frequent status changes |
+
+> NOTE: This GREP template has been inspired by [KEP Template](https://github.com/kubernetes/enhancements/blob/f90055d254c356b2c038a1bdf4610bf4acd8d7be/keps/NNNN-kep-template/README.md).

--- a/docs/proposals/498-controller-reconcile-metrics/README.md
+++ b/docs/proposals/498-controller-reconcile-metrics/README.md
@@ -14,15 +14,12 @@
     - [Story 3: Distinguishing Transient vs Persistent Errors](#story-3-distinguishing-transient-vs-persistent-errors)
   - [Limitations/Risks &amp; Mitigations](#limitationsrisks--mitigations)
 - [Design Details](#design-details)
-  - [Metric Definitions](#metric-definitions)
-    - [Sub-Operation Timing](#sub-operation-timing)
-    - [Conflict Tracking](#conflict-tracking)
-    - [Error Categorization](#error-categorization)
-  - [MetricsContext Implementation](#metricscontext-implementation)
-  - [Usage in Controllers](#usage-in-controllers)
-  - [Conflict and Error Tracking](#conflict-and-error-tracking)
+  - [Metric Surface](#metric-surface)
+    - [<code>grove_operator_status_update_conflict_total</code>](#grove_operator_status_update_conflict_total)
+    - [<code>grove_operator_reconcile_errors_total</code>](#grove_operator_reconcile_errors_total)
+  - [Cardinality Bound](#cardinality-bound)
+  - [Recording Verbs (Contract Only)](#recording-verbs-contract-only)
   - [Built-in controller-runtime Metrics Reference](#built-in-controller-runtime-metrics-reference)
-  - [File Changes Summary](#file-changes-summary)
   - [Example PromQL Queries](#example-promql-queries)
   - [Monitoring](#monitoring)
   - [Dependencies](#dependencies)
@@ -33,6 +30,9 @@
   - [Alt 1: Structured Logging Only](#alt-1-structured-logging-only)
   - [Alt 2: OpenTelemetry Tracing](#alt-2-opentelemetry-tracing)
   - [Alt 3: ObservedReconciler Wrapper for All Metrics](#alt-3-observedreconciler-wrapper-for-all-metrics)
+- [Future Work](#future-work)
+  - [Per-Reconcile Sub-Operation Visibility via Tracing](#per-reconcile-sub-operation-visibility-via-tracing)
+  - [Target-Kind Breakdown on <code>reconcile_errors_total</code>](#target-kind-breakdown-on-reconcile_errors_total)
 - [Appendix](#appendix)
   - [Appendix A: Cross-Controller Conflict Storm Analysis](#appendix-a-cross-controller-conflict-storm-analysis)
   - [Appendix B: Terminology](#appendix-b-terminology)
@@ -40,367 +40,164 @@
 
 ## Summary
 
-The Grove operator currently has **no custom Prometheus metrics**. While controller-runtime already provides built-in reconcile-level metrics (`controller_runtime_reconcile_total`, `controller_runtime_reconcile_time_seconds`, `controller_runtime_active_workers`) and workqueue metrics (`workqueue_depth`, `workqueue_queue_duration_seconds`, etc.), these only cover the overall reconcile outcome and duration. They provide no visibility into **which sub-operation within a reconcile is slow**, **how often 409 Conflicts occur on specific resource types**, or **what categories of errors are causing failures**.
+The Grove operator currently has **no custom Prometheus metrics**. While controller-runtime already provides built-in reconcile-level metrics (`controller_runtime_reconcile_total`, `controller_runtime_reconcile_time_seconds`, `controller_runtime_active_workers`) and workqueue metrics (`workqueue_depth`, `workqueue_queue_duration_seconds`, etc.), these only cover the overall reconcile outcome and duration. They provide no visibility into **how often 409 Conflicts occur on specific resource types**, or **what categories of errors are causing failures**.
 
-This proposal adds three focused custom metrics to all Grove controllers (PodCliqueSet, PodClique, PodCliqueScalingGroup) that complement the existing built-in metrics, filling the observability gaps that cannot be addressed by controller-runtime alone.
+This proposal adds two focused custom metrics to all Grove controllers (PodCliqueSet, PodClique, PodCliqueScalingGroup) that complement the existing built-in metrics, filling aggregate, fleet-level observability gaps that cannot be addressed by controller-runtime alone.
+
+Per-request, sub-operation visibility ("which step inside *this* reconcile is slow?") is a distributed-tracing concern and is explicitly out of scope for this proposal; see [Alternatives](#alt-2-opentelemetry-tracing) and [Future Work](#per-reconcile-sub-operation-visibility-via-tracing).
 
 ## Motivation
 
 During large-scale inference graph deployments using Grove (via NVIDIA Dynamo), we observed significant reconciliation performance degradation. Deploying an inference graph with 5 services × 10 replicas produces 50+ PodClique Pods, each transitioning through multiple states (Pending → Running → Ready). This generates a high rate of status changes that cascade through the Grove controller hierarchy (PodClique → PodCliqueScalingGroup → PodCliqueSet).
 
-The built-in controller-runtime metrics tell us **that** reconciliation is slow or erroring, but not **why**:
+The built-in controller-runtime metrics tell us **that** reconciliation is slow or erroring, but not in sufficient detail to answer the following aggregate, fleet-level questions:
 
-1. **No sub-operation visibility** — Each reconcile performs multiple steps (ensureFinalizer, processRollingUpdate, syncResources, updateObservedGeneration, reconcileStatus). The built-in `controller_runtime_reconcile_time_seconds` only captures the total duration. We cannot determine which step is the bottleneck.
+1. **No conflict attribution** — Status updates via `r.client.Status().Update()` and `r.client.Status().Patch()` can fail with 409 Conflict when an external controller (e.g., Dynamo's DGD controller) concurrently modifies the same PodClique/PodCliqueSet objects. The built-in `controller_runtime_reconcile_total{result="error"}` counts all errors equally — we cannot see the conflict rate or which resource type is affected.
 
-2. **No conflict attribution** — Status updates via `r.client.Status().Update()` and `r.client.Status().Patch()` can fail with 409 Conflict when an external controller (e.g., Dynamo's DGD controller) concurrently modifies the same PodClique/PodCliqueSet objects. The built-in `controller_runtime_reconcile_total{result="error"}` counts all errors equally — we cannot see the conflict rate or which resource type is affected.
+2. **No error categorization** — Errors are returned with rich type information (`k8serrors.IsConflict`, `IsNotFound`, `IsAlreadyExists`, `IsTimeout`, etc.), but the built-in metrics collapse all errors into a single `result="error"` label. We cannot distinguish transient errors (conflict, timeout) from persistent errors (forbidden, invalid) at the fleet level.
 
-3. **No error categorization** — The built-in metrics only distinguish `success`, `error`, `requeue`, and `requeue_after`. We cannot distinguish a transient 409 Conflict (likely to self-resolve on retry) from a persistent validation error or a timeout, making it impossible to prioritize debugging effort.
+Additionally, sub-operation timing within a single reconcile (i.e., "which step of *this* reconcile is slow?") is a **per-request** question best served by distributed tracing, not by aggregate histograms with function-name labels. This proposal deliberately scopes itself to the aggregate, fleet-level questions where Prometheus metrics are the right tool, and tracks sub-operation visibility as future work under tracing (see [Future Work](#per-reconcile-sub-operation-visibility-via-tracing)).
 
 ### Goals
 
-* Add three custom Prometheus metrics to fill gaps not covered by controller-runtime built-in metrics
-* Track sub-operation timing within each reconcile loop to identify internal bottlenecks
-* Track 409 Conflict errors with target-resource-kind attribution to diagnose cross-controller contention
-* Track error categorization by Kubernetes error type for targeted debugging
-* Document the full set of available metrics (built-in + custom) for Grove operators
-* Design the framework as extensible — controller-specific business metrics can be added incrementally
+* Add a custom metric to track 409 Conflict errors by target resource kind, complementing built-in error counters that do not distinguish conflict attribution.
+* Add a custom metric to categorize reconciliation errors by Kubernetes error type, enabling triage of transient vs persistent failures at the fleet level.
+* Document how Grove's built-in controller-runtime metrics answer standard reconciliation questions, so custom metrics remain scoped to what's genuinely missing.
+* Stay within the aggregate, fleet-level scope that Prometheus metrics are designed for; defer per-request sub-operation visibility to distributed tracing.
 
 ### Non-Goals
 
-* This proposal does NOT duplicate any controller-runtime built-in metrics
-* This proposal does NOT add metrics to the Grove scheduler component (only the operator)
-* This proposal does NOT change reconciliation logic; it is purely additive instrumentation
-* This proposal does NOT define alert thresholds or SLOs (those are deployment-specific)
-* This proposal does NOT add metrics to upstream consumers of Grove (e.g., Dynamo Operator)
-* Architectural mitigations for the conflict storm (e.g., watch predicate throttling, SSA adoption) require separate proposals informed by data this proposal provides
+* This proposal does NOT duplicate built-in controller-runtime metrics (`controller_runtime_reconcile_time_seconds`, `controller_runtime_reconcile_total`, `controller_runtime_active_workers`). These are already exposed by the metrics endpoint and should be used as-is for reconcile-level observability.
+* This proposal does NOT add metrics to Grove's scheduler backends (these are external components Grove supports, not part of Grove itself); it covers only the Grove operator controllers.
+* This proposal does NOT add per-request, sub-operation timing via Prometheus metrics. That question belongs to tracing and is tracked as Future Work.
+* This proposal does NOT modify the Grove CRD API, reconciliation behavior, or any user-facing functionality beyond the `/metrics` endpoint.
+* This proposal does NOT specify alerting rules or dashboard JSON (these are consumer concerns, not operator-side concerns).
 
 ## Proposal
 
 ### Overview
 
-Introduce a lightweight `MetricsContext` mechanism that controllers use to record sub-operation timings, conflict events, and error classifications. The context is injected at the reconcile entry point and propagated via Go's `context.Context`.
+Introduce two custom Prometheus metrics exposed by all three Grove controllers (PodCliqueSet, PodClique, PodCliqueScalingGroup). Both are **aggregate, fleet-level** signals that complement the built-in controller-runtime metrics without duplicating them.
 
-New package: `operator/internal/controller/metrics/` containing:
-
-1. **`metrics.go`** — Three custom Prometheus metric definitions and `InitMetrics()` registration.
-2. **`metrics_context.go`** — `MetricsContext` struct, context helpers, `RecordSubOperation`, `RecordConflict`, and `RecordError`.
-
-No `ObservedReconciler` wrapper is needed — controller-runtime already handles reconcile-level metrics. The `MetricsContext` is created at the beginning of each controller's `Reconcile()` method and used throughout the reconcile flow.
+How controllers record these metrics (recording helpers, context propagation, registration) is an implementation detail of the follow-up PR. This proposal describes only the **metric surface** — names, labels, semantics — and the rationale for each.
 
 ### Relationship to Built-in Metrics
 
-The following metrics are already provided by controller-runtime and should NOT be duplicated:
+controller-runtime automatically registers a rich set of metrics via `sigs.k8s.io/controller-runtime/pkg/metrics`. The following table maps common reconciliation questions to the metric that answers them:
 
-| Built-in Metric | What It Provides |
-|----------------|-----------------|
-| `controller_runtime_reconcile_time_seconds` | Total reconcile duration per controller (histogram) |
-| `controller_runtime_reconcile_total` | Reconcile count by result: success, error, requeue, requeue_after |
-| `controller_runtime_active_workers` | In-flight reconciliation count per controller |
-| `controller_runtime_max_concurrent_reconciles` | Configured MaxConcurrentReconciles per controller |
-| `workqueue_depth` | Current work queue depth per controller |
-| `workqueue_adds_total` | Total items added to work queue |
-| `workqueue_queue_duration_seconds` | Time items wait in queue before processing |
-| `workqueue_work_duration_seconds` | Time spent processing items |
-| `workqueue_retries_total` | Total retries |
-| `rest_client_requests_total` | API requests by verb and status code |
-| `rest_client_request_duration_seconds` | API request latency by verb and URL |
-
-This proposal adds **only** what the built-in metrics cannot provide.
+| Question | Metric | Source |
+|----------|--------|--------|
+| How long does reconciliation take? | `controller_runtime_reconcile_time_seconds` (Histogram) | built-in |
+| How many reconciles have occurred? | `controller_runtime_reconcile_total` (Counter, labeled by `result`) | built-in |
+| How many reconciles are in flight? | `controller_runtime_active_workers` (Gauge) | built-in |
+| How deep is the work queue? | `workqueue_depth` (Gauge) | built-in |
+| How long do items wait in queue? | `workqueue_queue_duration_seconds` (Histogram) | built-in |
+| How long before a retry? | `workqueue_unfinished_work_seconds` (Gauge) | built-in |
+| API client performance? | `rest_client_request_duration_seconds` (Histogram) | built-in |
+| **Which resource type is the 409 contention hotspot?** | `grove_operator_status_update_conflict_total` | **new (this proposal)** |
+| **What fraction of errors are transient vs persistent?** | `grove_operator_reconcile_errors_total` | **new (this proposal)** |
 
 ### User Stories
 
 #### Story 1: Diagnosing Slow Deployment at Scale
 
-As a platform operator deploying large inference graphs via Grove, I see from `controller_runtime_reconcile_time_seconds` that PodClique reconciliations are taking 5+ seconds. I need to see **which sub-operation** is slow (is it `sync_pods`, `reconcile_status`, or `process_rolling_update`?) so that I can file a targeted bug report or tune the system.
+**As** a Grove operator
+**When** a user reports that deploying a large inference graph (50+ PodCliques) takes significantly longer than expected
+**I want** to query built-in metrics (`controller_runtime_reconcile_time_seconds`, `workqueue_depth`, `workqueue_queue_duration_seconds`) to see whether the bottleneck is reconcile duration, queue backlog, or queue-wait latency
+**So that** I can determine whether to tune `MaxConcurrentReconciles`, optimize the reconcile path, or investigate upstream load.
+
+For drilling into *which step of a single reconcile* is slow, tracing (not this proposal) is the right tool.
 
 #### Story 2: Identifying Cross-Controller Resource Contention
 
-As a developer integrating Grove with an upstream operator (e.g., Dynamo), I see from `controller_runtime_reconcile_total{result="error"}` that errors are increasing. I need to know **how many are 409 Conflicts** and **which resource type** (PodClique vs PodCliqueSet) is the contention hotspot, so that I can determine the right mitigation strategy.
+**As** a Grove developer
+**When** investigating status update failures during high-load deployments
+**I want** to see which Grove resource types (`PodCliqueSet` vs `PodClique` vs `PodCliqueScalingGroup`) are most affected by 409 Conflicts
+**So that** I can prioritize architectural changes (e.g., migrating to `Status().Patch()` or Server-Side Apply) for the highest-contention resources.
+
+This is an aggregate, fleet-level question: "across all instances and all time, which resource type sees the most contention?" It is exactly what Prometheus metrics do well.
 
 #### Story 3: Distinguishing Transient vs Persistent Errors
 
-As a cluster administrator, I see reconcile errors but cannot tell if they are transient conflicts (self-resolving on retry) or persistent validation errors (requiring manual intervention). I need error categorization by Kubernetes error type.
+**As** an SRE operating Grove in production
+**When** the `controller_runtime_reconcile_total{result="error"}` rate is elevated
+**I want** to see the breakdown by error type (conflict, timeout, not_found, invalid, etc.)
+**So that** I can distinguish transient issues (retries will succeed) from persistent issues (require intervention) without reading logs.
 
 ### Limitations/Risks & Mitigations
 
-| Risk | Mitigation |
-|------|------------|
-| Label cardinality from `operation` × histogram buckets | `operation` values are bounded and explicitly defined per controller (~6 per controller). Without `namespace` label, estimated total new time series: ~500-1,000, very low. |
-| Performance overhead of metric recording | All metric operations (Inc, Observe) are O(1) atomic operations. Overhead is < 1μs per call. The `MetricsContext` nil-check pattern ensures zero overhead when not injected. |
+1. **Risk:** High-cardinality labels can cause Prometheus memory pressure.
+   **Mitigation:** All labels in this proposal have bounded, small cardinalities (controller name: 3 values; target_kind: 3 values; error_type: 8 values from `k8serrors.Is*` predicates). Total new time-series count is bounded (see [Cardinality Bound](#cardinality-bound)).
+
+2. **Risk:** Metric naming collision with upstream or sibling operators.
+   **Mitigation:** All custom metrics use the `grove_operator_` namespace prefix, following Prometheus naming conventions and matching Grove's existing label (`app.kubernetes.io/name=grove-operator`).
+
+3. **Risk:** Overlap with controller-runtime built-ins.
+   **Mitigation:** This proposal explicitly avoids duplicating `controller_runtime_reconcile_*` and `workqueue_*` metrics. The [Relationship to Built-in Metrics](#relationship-to-built-in-metrics) table defines the boundary.
+
+4. **Risk:** Coupling metric labels to internal code structure.
+   **Mitigation:** No label value in this proposal references a Go function name, file path, or package. All labels are domain-level identifiers that survive refactors (`target_kind` = Kubernetes Kind; `error_type` = semantic class from `k8serrors.Is*`).
 
 ## Design Details
 
-### Metric Definitions
+### Metric Surface
 
-All custom metrics use the `grove_operator` namespace prefix and are registered with the controller-runtime metrics registry via `InitMetrics()`.
+Two custom metrics are exposed. Both use the `grove_operator` namespace prefix and are registered against `ctrlmetrics.Registry` so they appear at the same `/metrics` endpoint as the built-in controller-runtime metrics.
 
-#### Sub-Operation Timing
+#### `grove_operator_status_update_conflict_total`
 
-| Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
-| `grove_operator_reconcile_sub_operation_duration_seconds` | Histogram | `controller`, `operation` | Duration of individual sub-operations within a reconcile loop |
+- **Type:** Counter
+- **Labels:** `controller`, `target_kind`
+- **Description:** Count of 409 Conflict errors returned by `Status().Update()` or `Status().Patch()` calls, attributed to the target resource kind.
+- **`controller` values:** `podcliqueset-controller`, `podclique-controller`, `podcliquescalinggroup-controller`
+- **`target_kind` values:** `PodCliqueSet`, `PodClique`, `PodCliqueScalingGroup`
+- **Question answered:** "Which resource type is the cross-controller contention hotspot?"
+- **Why built-in metrics cannot answer this:** `controller_runtime_reconcile_total{result="error"}` aggregates all errors at the reconcile level; it does not identify the target resource of the failing Status Update/Patch, nor does it distinguish conflicts from other error kinds.
 
-**`operation` label values per controller:**
+#### `grove_operator_reconcile_errors_total`
 
-| Controller | Operations |
-|------------|------------|
-| PodCliqueSet | `ensure_finalizer`, `process_generation_hash`, `sync_resources`, `update_observed_generation`, `reconcile_status` |
-| PodClique | `ensure_finalizer`, `process_rolling_update`, `sync_pods`, `update_observed_generation`, `reconcile_status` |
-| PodCliqueScalingGroup | `ensure_finalizer`, `process_rolling_update`, `sync_resources`, `update_observed_generation`, `reconcile_status` |
+- **Type:** Counter
+- **Labels:** `controller`, `error_type`
+- **Description:** Reconciliation errors categorized by well-known Kubernetes error classes.
+- **`controller` values:** same as above.
+- **`error_type` values:** one of `not_found`, `conflict`, `already_exists`, `timeout`, `forbidden`, `invalid`, `rate_limited`, `internal` (mapped 1:1 from `k8serrors.IsNotFound`, `IsConflict`, `IsAlreadyExists`, `IsTimeout`, `IsForbidden`, `IsInvalid`, `IsTooManyRequests`, default).
+- **Question answered:** "What fraction of errors are transient (conflict, timeout, rate_limited) vs persistent (invalid, forbidden)?"
+- **Why built-in metrics cannot answer this:** `controller_runtime_reconcile_total{result="error"}` provides no error classification.
 
-#### Conflict Tracking
+### Cardinality Bound
 
-| Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
-| `grove_operator_status_update_conflict_total` | Counter | `controller`, `target_kind` | Count of 409 Conflict errors on Status Update/Patch operations, attributed to the target resource kind |
+With three controllers, eight error types, and three target kinds, the total new time-series count is bounded by:
 
-**`target_kind` values:** `PodCliqueSet`, `PodClique`, `PodCliqueScalingGroup`
+- `status_update_conflict_total`: 3 controllers × 3 target kinds = **9 series**
+- `reconcile_errors_total`: 3 controllers × 8 error types = **24 series**
 
-This metric answers "which resource type is the contention hotspot?" — a question the built-in `controller_runtime_reconcile_total{result="error"}` cannot answer because it only counts errors at the reconcile level without identifying the target resource.
+**Total: ≤ 33 new series.** No high-cardinality labels are introduced (no namespace, no resource name, no function name, no pod UID). The bound is static and refactor-insensitive.
 
-#### Error Categorization
+### Recording Verbs (Contract Only)
 
-| Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
-| `grove_operator_reconcile_errors_total` | Counter | `controller`, `error_type` | Reconciliation errors categorized by Kubernetes error type |
+Recording is intended to be synchronous, O(1), and side-effect-free on the reconciler's control flow:
 
-**`error_type` values:** `not_found`, `conflict`, `already_exists`, `timeout`, `forbidden`, `invalid`, `rate_limited`, `internal`
+- `status_update_conflict_total` is incremented in the error path of `Status().Update()` / `Status().Patch()` immediately after a 409 is detected (via `k8serrors.IsConflict`). The increment does not alter the returned error.
+- `reconcile_errors_total` is incremented in the reconcile-loop error path, after the error is classified by the `k8serrors.Is*` predicates. A single error increments exactly one series.
 
-This metric answers "what kinds of errors are occurring?" — the built-in metrics only tell you `result="error"` without further classification.
-
-### MetricsContext Implementation
-
-```go
-package metrics
-
-import (
-    "context"
-    "time"
-
-    "github.com/prometheus/client_golang/prometheus"
-    k8serrors "k8s.io/apimachinery/pkg/api/errors"
-    ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
-)
-
-const metricsNamespace = "grove_operator"
-
-var (
-    reconcileSubOpDuration = prometheus.NewHistogramVec(
-        prometheus.HistogramOpts{
-            Namespace: metricsNamespace,
-            Name:      "reconcile_sub_operation_duration_seconds",
-            Help:      "Duration of individual sub-operations within a reconcile loop",
-            Buckets:   []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
-        },
-        []string{"controller", "operation"},
-    )
-
-    statusUpdateConflictTotal = prometheus.NewCounterVec(
-        prometheus.CounterOpts{
-            Namespace: metricsNamespace,
-            Name:      "status_update_conflict_total",
-            Help:      "Total 409 Conflict errors on Status Update/Patch, by target resource kind",
-        },
-        []string{"controller", "target_kind"},
-    )
-
-    reconcileErrorsTotal = prometheus.NewCounterVec(
-        prometheus.CounterOpts{
-            Namespace: metricsNamespace,
-            Name:      "reconcile_errors_total",
-            Help:      "Reconciliation errors categorized by Kubernetes error type",
-        },
-        []string{"controller", "error_type"},
-    )
-)
-
-func InitMetrics() {
-    ctrlmetrics.Registry.MustRegister(
-        reconcileSubOpDuration,
-        statusUpdateConflictTotal,
-        reconcileErrorsTotal,
-    )
-}
-```
-
-```go
-package metrics
-
-import (
-    "context"
-    "time"
-
-    k8serrors "k8s.io/apimachinery/pkg/api/errors"
-)
-
-type contextKey struct{}
-
-type MetricsContext struct {
-    controllerName string
-}
-
-func NewMetricsContext(controllerName string) *MetricsContext {
-    return &MetricsContext{controllerName: controllerName}
-}
-
-func WithMetricsContext(ctx context.Context, mc *MetricsContext) context.Context {
-    return context.WithValue(ctx, contextKey{}, mc)
-}
-
-func MetricsContextFromContext(ctx context.Context) *MetricsContext {
-    mc, _ := ctx.Value(contextKey{}).(*MetricsContext)
-    return mc
-}
-
-func (mc *MetricsContext) RecordSubOperation(operation string, start time.Time) {
-    if mc == nil {
-        return
-    }
-    reconcileSubOpDuration.WithLabelValues(
-        mc.controllerName, operation,
-    ).Observe(time.Since(start).Seconds())
-}
-
-func (mc *MetricsContext) RecordConflict(targetKind string) {
-    if mc == nil {
-        return
-    }
-    statusUpdateConflictTotal.WithLabelValues(
-        mc.controllerName, targetKind,
-    ).Inc()
-}
-
-func (mc *MetricsContext) RecordError(err error) {
-    if mc == nil || err == nil {
-        return
-    }
-    reconcileErrorsTotal.WithLabelValues(
-        mc.controllerName, CategorizeError(err),
-    ).Inc()
-}
-
-func CategorizeError(err error) string {
-    switch {
-    case k8serrors.IsNotFound(err):
-        return "not_found"
-    case k8serrors.IsConflict(err):
-        return "conflict"
-    case k8serrors.IsAlreadyExists(err):
-        return "already_exists"
-    case k8serrors.IsTimeout(err), k8serrors.IsServerTimeout(err):
-        return "timeout"
-    case k8serrors.IsForbidden(err):
-        return "forbidden"
-    case k8serrors.IsInvalid(err):
-        return "invalid"
-    case k8serrors.IsTooManyRequests(err):
-        return "rate_limited"
-    default:
-        return "internal"
-    }
-}
-```
-
-### Usage in Controllers
-
-No `ObservedReconciler` wrapper is needed. Controllers create a `MetricsContext` at the beginning of their `Reconcile()` method:
-
-```go
-func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-    logger := ctrllogger.FromContext(ctx).WithName(controllerName)
-
-    mc := metrics.NewMetricsContext(controllerName)
-    ctx = metrics.WithMetricsContext(ctx, mc)
-
-    // ... existing reconcile logic unchanged ...
-}
-```
-
-Sub-operations are timed at step boundaries in `reconcileSpec` and `reconcileStatus`:
-
-```go
-func (r *Reconciler) reconcileSpec(ctx context.Context, logger logr.Logger, pclq *grovecorev1alpha1.PodClique) ctrlcommon.ReconcileStepResult {
-    mc := metrics.MetricsContextFromContext(ctx)
-
-    start := time.Now()
-    if stepResult := r.ensureFinalizer(ctx, logger, pclq); ctrlcommon.ShortCircuitReconcileFlow(stepResult) {
-        return r.recordIncompleteReconcile(ctx, logger, pclq, &stepResult)
-    }
-    mc.RecordSubOperation("ensure_finalizer", start)
-
-    start = time.Now()
-    if stepResult := r.processRollingUpdate(ctx, logger, pclq); ctrlcommon.ShortCircuitReconcileFlow(stepResult) {
-        return r.recordIncompleteReconcile(ctx, logger, pclq, &stepResult)
-    }
-    mc.RecordSubOperation("process_rolling_update", start)
-
-    start = time.Now()
-    if stepResult := r.syncPCLQResources(ctx, logger, pclq); ctrlcommon.ShortCircuitReconcileFlow(stepResult) {
-        return r.recordIncompleteReconcile(ctx, logger, pclq, &stepResult)
-    }
-    mc.RecordSubOperation("sync_pods", start)
-
-    start = time.Now()
-    if stepResult := r.updateObservedGeneration(ctx, logger, pclq); ctrlcommon.ShortCircuitReconcileFlow(stepResult) {
-        return r.recordIncompleteReconcile(ctx, logger, pclq, &stepResult)
-    }
-    mc.RecordSubOperation("update_observed_generation", start)
-
-    return ctrlcommon.ContinueReconcile()
-}
-```
-
-### Conflict and Error Tracking
-
-Conflicts and errors are recorded at the call sites where `Status().Update()` or `Status().Patch()` may fail:
-
-```go
-func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pcs *grovecorev1alpha1.PodCliqueSet) ctrlcommon.ReconcileStepResult {
-    mc := metrics.MetricsContextFromContext(ctx)
-
-    // ... existing logic to mutate pcs.Status ...
-
-    if err = r.client.Status().Update(ctx, pcs); err != nil {
-        if k8serrors.IsConflict(err) {
-            mc.RecordConflict("PodCliqueSet")
-        }
-        mc.RecordError(err)
-        return ctrlcommon.ReconcileWithErrors("failed to update PodCliqueSet status", err)
-    }
-    return ctrlcommon.ContinueReconcile()
-}
-```
+Exact helper types, function signatures, registration code, and call sites are defined in the implementation PR and are not part of the contract reviewed here.
 
 ### Built-in controller-runtime Metrics Reference
 
-The following metrics are already available and should be used for reconcile-level monitoring. They require no code changes:
+For convenience of reviewers and future readers, the built-in metrics that Grove already exposes (automatically, via the controller-runtime dependency) are summarized below. This proposal adds to this surface; it does not modify or replace any of the below.
 
-| Metric | What It Tells You |
-|--------|------------------|
-| `controller_runtime_reconcile_time_seconds{controller="..."}` | How long reconciliations take (P50/P95/P99) |
-| `controller_runtime_reconcile_total{controller="...",result="..."}` | Reconcile count by outcome (success/error/requeue) |
-| `controller_runtime_active_workers{controller="..."}` | Current in-flight reconcile count |
-| `controller_runtime_max_concurrent_reconciles{controller="..."}` | Configured concurrency limit |
-| `workqueue_depth{name="..."}` | Work queue backlog |
-| `workqueue_queue_duration_seconds{name="..."}` | How long items wait in queue |
-| `workqueue_retries_total{name="..."}` | Retry count |
-
-### File Changes Summary
-
-| File | Change |
-|------|--------|
-| `internal/controller/metrics/metrics.go` | **New**: 3 metric definitions + `InitMetrics()` |
-| `internal/controller/metrics/metrics_context.go` | **New**: `MetricsContext` with `RecordSubOperation`, `RecordConflict`, `RecordError` |
-| `internal/controller/manager.go` | Add `metrics.InitMetrics()` call |
-| `internal/controller/podcliqueset/reconciler.go` | Create and inject `MetricsContext` |
-| `internal/controller/podcliqueset/reconcilespec.go` | Add `mc.RecordSubOperation()` at step boundaries |
-| `internal/controller/podcliqueset/reconcilestatus.go` | Add `mc.RecordSubOperation()`, `mc.RecordConflict()`, `mc.RecordError()` |
-| `internal/controller/podclique/reconciler.go` | Create and inject `MetricsContext` |
-| `internal/controller/podclique/reconcilespec.go` | Add `mc.RecordSubOperation()` at step boundaries |
-| `internal/controller/podclique/reconcilestatus.go` | Add `mc.RecordSubOperation()`, `mc.RecordConflict()`, `mc.RecordError()` |
-| `internal/controller/podcliquescalinggroup/reconciler.go` | Create and inject `MetricsContext` |
-| `internal/controller/podcliquescalinggroup/reconcilespec.go` | Add `mc.RecordSubOperation()` at step boundaries |
-| `internal/controller/podcliquescalinggroup/reconcilestatus.go` | Add `mc.RecordSubOperation()`, `mc.RecordConflict()`, `mc.RecordError()` |
+| Metric | Type | Labels | What it answers |
+|--------|------|--------|-----------------|
+| `controller_runtime_reconcile_time_seconds` | Histogram | `controller` | Reconcile duration distribution |
+| `controller_runtime_reconcile_total` | Counter | `controller`, `result` | Reconcile count by outcome (success/error/requeue) |
+| `controller_runtime_active_workers` | Gauge | `controller` | In-flight reconciles |
+| `controller_runtime_max_concurrent_reconciles` | Gauge | `controller` | Configured concurrency limit |
+| `workqueue_adds_total` | Counter | `name` | Total items added to queue |
+| `workqueue_depth` | Gauge | `name` | Current queue depth |
+| `workqueue_queue_duration_seconds` | Histogram | `name` | Queue wait time |
+| `workqueue_retries_total` | Counter | `name` | Retry count |
+| `rest_client_request_duration_seconds` | Histogram | `verb`, `host`, `code` | API client request latency |
+| `rest_client_requests_total` | Counter | `verb`, `host`, `code` | API client request count |
 
 ### Example PromQL Queries
 
@@ -425,94 +222,77 @@ controller_runtime_active_workers / controller_runtime_max_concurrent_reconciles
 # Work queue depth per controller
 workqueue_depth{name=~"podcliqueset-controller|podclique-controller|podcliquescalinggroup-controller"}
 
-# Work queue wait time P99
-histogram_quantile(0.99,
-  sum by (name, le) (
-    rate(workqueue_queue_duration_seconds_bucket[5m])
-  )
-)
-
 # ===== New Custom Metrics (added by this proposal) =====
-
-# Sub-operation P95 latency for PodClique — where is time spent?
-histogram_quantile(0.95,
-  sum by (operation, le) (
-    rate(grove_operator_reconcile_sub_operation_duration_seconds_bucket{
-      controller="podclique-controller"
-    }[5m])
-  )
-)
 
 # 409 Conflict rate — which resource is the contention hotspot?
 sum by (controller, target_kind) (
   rate(grove_operator_status_update_conflict_total[5m])
 )
 
-# Error breakdown by type — transient conflicts vs persistent errors
+# Error breakdown by type — transient vs persistent
 sum by (controller, error_type) (
   rate(grove_operator_reconcile_errors_total[5m])
 )
 
-# Conflict-to-total-error ratio — what fraction of errors are conflicts?
+# Fraction of errors that are conflicts
 sum(rate(grove_operator_reconcile_errors_total{error_type="conflict"}[5m]))
 /
-sum(rate(controller_runtime_reconcile_total{result="error"}[5m]))
+sum(rate(grove_operator_reconcile_errors_total[5m]))
 ```
 
 ### Monitoring
 
 The custom metrics introduced by this proposal, combined with the built-in controller-runtime metrics, provide:
 
-1. **Sub-Operation Bottleneck Identification**: Per-step latency breakdown to pinpoint slow operations (e.g., `sync_pods` vs `reconcile_status`).
-2. **Conflict Detection and Attribution**: 409 Conflict rate by target resource kind, identifying cross-controller contention hotspots.
-3. **Error Triage**: Errors categorized by Kubernetes error type, distinguishing transient conflicts from persistent failures.
+1. **Conflict Detection and Attribution:** 409 Conflict rate by target resource kind, identifying cross-controller contention hotspots.
+2. **Error Triage:** Errors categorized by Kubernetes error type, distinguishing transient issues from persistent failures.
 
 The built-in metrics already provide reconciliation health (duration, throughput, success rate), capacity saturation (active workers, queue depth), and API client performance.
 
 Recommended alert examples (not enforced by this proposal):
-- `grove_operator_status_update_conflict_total` rate > 1/s → cross-controller contention
+- `grove_operator_status_update_conflict_total` rate > 1/s per `(controller, target_kind)` → cross-controller contention
 - `grove_operator_reconcile_errors_total{error_type="timeout"}` rate > 0.1/s → API server pressure
 - `workqueue_depth{name="podclique-controller"}` > 50 for 5m → PodClique controller falling behind
 
 ### Dependencies
 
-- `github.com/prometheus/client_golang` — already an indirect dependency via controller-runtime
-- `sigs.k8s.io/controller-runtime/pkg/metrics` — already used for the metrics server endpoint
+- `github.com/prometheus/client_golang` — already an indirect dependency via controller-runtime.
+- `sigs.k8s.io/controller-runtime/pkg/metrics` — already used for the metrics server endpoint.
 
 No new external dependencies are introduced.
 
 ### Test Plan
 
-1. **Unit tests** for `MetricsContext`: Verify `RecordSubOperation`, `RecordConflict`, and `RecordError` correctly observe histograms and increment counters.
-2. **Unit tests** for `CategorizeError`: Verify error categorization for all Kubernetes error types.
-3. **Integration test**: Deploy Grove, create a PodCliqueSet, and verify custom metrics are exposed at the `/metrics` endpoint alongside the existing built-in metrics.
-4. **E2E test**: Deploy at scale (multiple PodCliqueSets with many replicas), scrape metrics, and verify sub-operation and conflict metrics are populated.
+1. **Unit tests (implementation PR):** Error-type classification covers all targeted `k8serrors.Is*` predicates. Conflict-path recording is triggered iff a 409 Conflict is observed on a Status Update/Patch call.
+2. **Integration test:** With a Grove operator running against a real API server, verify both custom metrics appear at `/metrics` alongside the existing built-in metrics, with the expected label sets and only bounded cardinality.
+3. **E2E test:** A concurrent-write workload (Grove reconciler + a synthetic upstream writer modifying the same resources) produces a non-zero `grove_operator_status_update_conflict_total` counter for the contended resource kind.
+4. **Coexistence check:** Verify these metrics do not duplicate or interfere with the scale-test milestone instrumentation in `operator/e2e/measurement/`. The new metrics expose aggregate per-controller signals via the `/metrics` endpoint; the measurement package continues to own scale-test milestone logging. Different pipelines, no expected interference.
 
 ### Graduation Criteria
 
 **Alpha (this proposal):**
-- Three custom metrics registered and recorded in all three controllers
-- Sub-operation timing at major step boundaries
-- Conflict tracking on status update/patch calls
-- Error categorization on reconcile errors
-- Documentation covering both built-in and custom metrics
-- Unit tests for all new code
+- Two custom metrics registered and recorded in all three controllers.
+- Conflict tracking on Status Update/Patch calls.
+- Error categorization on reconcile-loop errors.
+- Documentation covering both built-in and custom metrics.
+- Unit and integration tests for the metric surface.
 
 **Beta (future):**
-- Grafana dashboard JSON included in the chart (combining built-in and custom metrics)
-- ServiceMonitor template in Helm chart
-- Additional controller-specific metrics based on alpha data analysis
+- Grafana dashboard JSON included in the chart (combining built-in and custom metrics).
+- ServiceMonitor template in Helm chart.
+- Additional controller-specific metrics based on alpha data analysis.
 
 **GA (future):**
-- Metrics stable for 2+ releases
-- Community feedback incorporated
-- Alert rule examples based on production usage patterns
+- Metrics stable for 2+ releases.
+- Community feedback incorporated.
+- Alert rule examples based on production usage patterns.
 
 ## Implementation History
 
-- 2026-03-11: Initial GREP draft created
-- 2026-03-24: PR #499 opened
-- 2026-03-30: Updated based on review feedback — removed 4 duplicate metrics, removed namespace label, refocused on 3 genuinely new metrics
+- 2026-03-11: Initial GREP draft created.
+- 2026-03-24: PR #499 opened.
+- 2026-03-30: Updated based on review feedback — removed 4 duplicate metrics, removed namespace label, refocused on 3 genuinely new metrics.
+- 2026-05-09: Revised per review — scoped to aggregate, fleet-level metrics only (dropped sub-operation histogram in favor of future tracing work); removed embedded Go source per design-doc-scope feedback; fixed scheduler-backend terminology; PC → PCLQ across the document.
 
 ## Alternatives
 
@@ -522,23 +302,39 @@ No new external dependencies are introduced.
 
 **Cons:** Cannot create real-time dashboards or alerts; higher storage cost; slower to query than Prometheus; no time-series aggregation.
 
-**Rejected because:** Prometheus metrics are the established Kubernetes ecosystem standard. Log analysis is complementary but not a substitute for time-series monitoring.
+**Rejected because:** Prometheus metrics are the established Kubernetes ecosystem standard for aggregate, fleet-level observability. Log analysis is complementary but not a substitute for time-series monitoring.
 
 ### Alt 2: OpenTelemetry Tracing
 
-**Pros:** Rich per-request trace context with spans; distributed tracing across operator → API server.
+**Pros:** Rich per-request trace context with spans; distributed tracing across operator → API server; the natural tool for "which step inside *this* reconcile is slow?"
 
-**Cons:** Requires additional infrastructure (Jaeger/Tempo); higher per-request overhead; not yet standard in controller-runtime; overkill for aggregate monitoring.
+**Cons:** Requires additional infrastructure (collector + backend such as Jaeger or Tempo); larger adoption effort than adding two metrics; tracing is not yet standard in controller-runtime.
 
-**Rejected because:** Tracing is valuable for deep-dive debugging but requires significant infrastructure investment. Prometheus metrics provide the aggregate view needed for dashboards and alerts with minimal overhead. Tracing can be added later.
+**Scoped out (not rejected):** Tracing is the correct tool for per-request, sub-operation visibility. An aggregate histogram labeled by function name (e.g., `ensure_finalizer`, `sync_pods`) cannot answer a per-request question and risks breaking silently on refactor.
+
+**This proposal deliberately scopes itself to aggregate, fleet-level signals.** Per-request sub-operation visibility via OpenTelemetry is complementary and is tracked as [Future Work](#per-reconcile-sub-operation-visibility-via-tracing). It is not in competition with this proposal.
 
 ### Alt 3: ObservedReconciler Wrapper for All Metrics
 
-**Pros:** Single wrapper provides all metrics automatically without per-controller changes.
+**Pros:** A single wrapper could provide reconcile-level metrics automatically without per-controller changes.
 
-**Cons:** Duplicates controller-runtime built-in metrics (`controller_runtime_reconcile_time_seconds`, `controller_runtime_reconcile_total`, `controller_runtime_active_workers`). Creates confusion with two sources of truth for the same data.
+**Cons:** Duplicates controller-runtime built-ins (`controller_runtime_reconcile_time_seconds`, `controller_runtime_reconcile_total`, `controller_runtime_active_workers`). Creates two sources of truth for the same data.
 
-**Rejected because:** controller-runtime already provides reconcile-level metrics. Wrapping the reconciler would duplicate these. The `MetricsContext` approach focuses on what's genuinely missing (sub-operation timing, conflict attribution, error categorization) without duplication.
+**Rejected because:** controller-runtime already provides reconcile-level metrics. Wrapping the reconciler would duplicate them. This proposal focuses on what's genuinely missing at the fleet level (conflict attribution, error categorization) without duplication.
+
+## Future Work
+
+### Per-Reconcile Sub-Operation Visibility via Tracing
+
+The question "which step inside *this* reconcile is slow?" is a per-request, single-trace question. It belongs to distributed tracing, not Prometheus metrics.
+
+A follow-up GREP will propose adding OpenTelemetry span instrumentation to Grove controllers so that operators can inspect the span tree of an individual reconcile, with stable span names that do not break on internal refactors.
+
+This proposal deliberately does not fill that gap with a sub-operation histogram labeled by function name, because such labels couple the metric surface to internal code structure.
+
+### Target-Kind Breakdown on `reconcile_errors_total`
+
+If `grove_operator_status_update_conflict_total` does not fully capture contention patterns in production, a `target_kind` label can be added to `reconcile_errors_total` in a follow-up. Deferred until alpha-stage data is available.
 
 ## Appendix
 
@@ -547,34 +343,25 @@ No new external dependencies are introduced.
 When Grove is used by an upstream operator (e.g., NVIDIA Dynamo), the following contention pattern occurs during large-scale deployments:
 
 **Object ownership:**
-```
-Upstream Operator (e.g., Dynamo DGD Controller)
-  creates → PodCliqueSet (PCS)
-  scales  → PodClique (PC) / PodCliqueScalingGroup (PCSG) via Scale subresource
-  reads   → PC/PCSG status for readiness checks
-
-Grove Operator
-  PCS Controller → creates PC/PCSG, updates PCS status
-  PC Controller  → creates Pods, updates PC status (replicas, readyReplicas)
-  PCSG Controller → manages PC replicas, updates PCSG status
-```
+- **Upstream Operator (e.g., Dynamo DGD Controller)** creates PodCliqueSet (PCS); scales PodClique (PCLQ) / PodCliqueScalingGroup (PCSG) via the Scale subresource; reads PCLQ/PCSG status for readiness checks.
+- **Grove Operator** — PCS Controller creates PCLQ/PCSG and updates PCS status; PCLQ Controller creates Pods and updates PCLQ status (replicas, readyReplicas); PCSG Controller manages PCLQ replicas and updates PCSG status.
 
 **Contention mechanism:**
 
 1. Upstream operator scales PodClique via Scale subresource (Get scale → Update scale).
-2. Between the Get and Update, Grove's PC controller updates PC status (e.g., readyReplicas changes as a Pod becomes Ready).
+2. Between the Get and Update, Grove's PCLQ controller updates PCLQ status (e.g., readyReplicas changes as a Pod becomes Ready).
 3. The upstream operator's Scale Update receives 409 Conflict (resourceVersion mismatch).
 4. Similarly, Grove's PCS `reconcileStatus` calls `r.client.Status().Update(ctx, pcs)`. If the upstream operator concurrently modifies PCS, Grove's status update can also conflict.
 
 **Why Grove needs these metrics:**
 
-Without metrics on the Grove side, we can only see the upstream operator's view of the conflict. The `grove_operator_status_update_conflict_total` metric provides the other half: how often Grove's own status updates fail due to concurrent external writes. Combined with the upstream operator's metrics, this gives a complete picture of the contention and guides architectural decisions (e.g., switching from `Status().Update()` to field-level `Status().Patch()`, or using Server-Side Apply).
+Without fleet-level metrics on the Grove side, we can only see the upstream operator's view of the conflict. The `grove_operator_status_update_conflict_total` metric provides the other half: how often Grove's own status updates fail due to concurrent external writes, and on which resource kind. Combined with the upstream operator's metrics, this gives a complete picture of the contention and guides architectural decisions (e.g., switching from `Status().Update()` to field-level `Status().Patch()`, or adopting Server-Side Apply).
 
 **Future work enabled by these metrics:**
 
-1. **Status Patch optimization** — If `status_update_conflict_total` is high for PCS, consider switching `reconcileStatus` from `Status().Update()` to field-level `Status().Patch()` to reduce conflict surface.
+1. **Status Patch optimization** — If `status_update_conflict_total` is high for PCS, consider switching `reconcileStatus` from `Status().Update()` to field-level `Status().Patch()` to reduce the conflict surface.
 2. **Rate limiter tuning** — Use built-in `controller_runtime_active_workers` and `workqueue_depth` data to tune `MaxConcurrentReconciles` per controller.
-3. **Watch predicate optimization** — Use sub-operation latency data to determine if watch predicates should be tightened to reduce unnecessary reconcile triggers.
+3. **Watch predicate optimization** — Sub-operation latency data (from tracing, in Future Work) can guide whether watch predicates should be tightened to reduce unnecessary reconcile triggers.
 4. **Upstream coordination** — Share conflict data with upstream operator teams to jointly optimize the interaction pattern.
 
 ### Appendix B: Terminology
@@ -582,10 +369,9 @@ Without metrics on the Grove side, we can only see the upstream operator's view 
 | Term | Definition |
 |------|------------|
 | **PCS** | PodCliqueSet — top-level Grove CRD representing a set of PodCliques |
-| **PC / PCLQ** | PodClique — Grove CRD representing a group of co-scheduled Pods |
+| **PCLQ** | PodClique — Grove CRD representing a group of co-scheduled Pods |
 | **PCSG** | PodCliqueScalingGroup — Grove CRD for managing multiple PodClique replicas |
 | **Conflict storm** | A pattern where concurrent writes to the same Kubernetes object produce cascading 409 Conflict errors |
 | **Optimistic concurrency** | Kubernetes mechanism where every object has a `resourceVersion`; an Update must match the current version or receive 409 Conflict |
-| **Sub-operation** | A discrete step within a reconciliation loop (e.g., syncResources, reconcileStatus) |
 
 > NOTE: This GREP template has been inspired by [KEP Template](https://github.com/kubernetes/enhancements/blob/f90055d254c356b2c038a1bdf4610bf4acd8d7be/keps/NNNN-kep-template/README.md).

--- a/docs/proposals/498-controller-reconcile-metrics/README.md
+++ b/docs/proposals/498-controller-reconcile-metrics/README.md
@@ -5,13 +5,12 @@
 - [Motivation](#motivation)
   - [Goals](#goals)
   - [Non-Goals](#non-goals)
+  - [Existing Signals and Gaps](#existing-signals-and-gaps)
 - [Proposal](#proposal)
   - [Overview](#overview)
-  - [Relationship to Built-in Metrics](#relationship-to-built-in-metrics)
   - [User Stories](#user-stories)
-    - [Story 1: Diagnosing Slow Deployment at Scale](#story-1-diagnosing-slow-deployment-at-scale)
-    - [Story 2: Identifying Cross-Controller Resource Contention](#story-2-identifying-cross-controller-resource-contention)
-    - [Story 3: Distinguishing Transient vs Persistent Errors](#story-3-distinguishing-transient-vs-persistent-errors)
+    - [Story 1: Identifying the Cross-Controller Contention Hotspot](#story-1-identifying-the-cross-controller-contention-hotspot)
+    - [Story 2: Triaging Errors as Self-Healing vs Operator-Action-Required](#story-2-triaging-errors-as-self-healing-vs-operator-action-required)
   - [Limitations/Risks &amp; Mitigations](#limitationsrisks--mitigations)
 - [Design Details](#design-details)
   - [Metric Surface](#metric-surface)
@@ -19,6 +18,7 @@
     - [<code>grove_operator_reconcile_errors_total</code>](#grove_operator_reconcile_errors_total)
   - [Cardinality Bound](#cardinality-bound)
   - [Recording Verbs (Contract Only)](#recording-verbs-contract-only)
+  - [Relationship to Built-in Metrics](#relationship-to-built-in-metrics)
   - [Built-in controller-runtime Metrics Reference](#built-in-controller-runtime-metrics-reference)
   - [Example PromQL Queries](#example-promql-queries)
   - [Monitoring](#monitoring)
@@ -44,8 +44,6 @@ The Grove operator currently has **no custom Prometheus metrics**. While control
 
 This proposal adds two focused custom metrics to all Grove controllers (PodCliqueSet, PodClique, PodCliqueScalingGroup) that complement the existing built-in metrics, filling aggregate, fleet-level observability gaps that cannot be addressed by controller-runtime alone.
 
-Per-request, sub-operation visibility ("which step inside *this* reconcile is slow?") is a distributed-tracing concern and is explicitly out of scope for this proposal; see [Alternatives](#alt-2-opentelemetry-tracing) and [Future Work](#per-reconcile-sub-operation-visibility-via-tracing).
-
 ## Motivation
 
 During large-scale inference graph deployments using Grove (via NVIDIA Dynamo), we observed significant reconciliation performance degradation. Deploying an inference graph with 5 services × 10 replicas produces 50+ PodClique Pods, each transitioning through multiple states (Pending → Running → Ready). This generates a high rate of status changes that cascade through the Grove controller hierarchy (PodClique → PodCliqueScalingGroup → PodCliqueSet).
@@ -56,73 +54,67 @@ The built-in controller-runtime metrics tell us **that** reconciliation is slow 
 
 2. **No error categorization** — Errors are returned with rich type information (`k8serrors.IsConflict`, `IsNotFound`, `IsAlreadyExists`, `IsTimeout`, etc.), but the built-in metrics collapse all errors into a single `result="error"` label. We cannot distinguish transient errors (conflict, timeout) from persistent errors (forbidden, invalid) at the fleet level.
 
-Additionally, sub-operation timing within a single reconcile (i.e., "which step of *this* reconcile is slow?") is a **per-request** question best served by distributed tracing, not by aggregate histograms with function-name labels. This proposal deliberately scopes itself to the aggregate, fleet-level questions where Prometheus metrics are the right tool, and tracks sub-operation visibility as future work under tracing (see [Future Work](#per-reconcile-sub-operation-visibility-via-tracing)).
-
 ### Goals
 
-* Add a custom metric to track 409 Conflict errors by target resource kind, complementing built-in error counters that do not distinguish conflict attribution.
-* Add a custom metric to categorize reconciliation errors by Kubernetes error type, enabling triage of transient vs persistent failures at the fleet level.
-* Document how Grove's built-in controller-runtime metrics answer standard reconciliation questions, so custom metrics remain scoped to what's genuinely missing.
-* Stay within the aggregate, fleet-level scope that Prometheus metrics are designed for; defer per-request sub-operation visibility to distributed tracing.
+* Attribute Status Update 409 Conflicts by Grove controller and target resource kind.
+* Categorize reconciliation errors by Kubernetes API error class (`k8serrors.Is*` predicates).
+* Keep the metric surface bounded (≤ 33 series), aggregate-only, and free of high-cardinality labels.
 
 ### Non-Goals
 
-* This proposal does NOT duplicate built-in controller-runtime metrics (`controller_runtime_reconcile_time_seconds`, `controller_runtime_reconcile_total`, `controller_runtime_active_workers`). These are already exposed by the metrics endpoint and should be used as-is for reconcile-level observability.
-* This proposal does NOT add metrics to Grove's scheduler backends (these are external components Grove supports, not part of Grove itself); it covers only the Grove operator controllers.
-* This proposal does NOT add per-request, sub-operation timing via Prometheus metrics. That question belongs to tracing and is tracked as Future Work.
-* This proposal does NOT modify the Grove CRD API, reconciliation behavior, or any user-facing functionality beyond the `/metrics` endpoint.
-* This proposal does NOT specify alerting rules or dashboard JSON (these are consumer concerns, not operator-side concerns).
+* This proposal does not duplicate built-in controller-runtime metrics (`controller_runtime_reconcile_*`, `workqueue_*`, `rest_client_*`). These are already exposed by the metrics endpoint and should be used as-is for reconcile-level observability (see [Existing Signals and Gaps](#existing-signals-and-gaps)).
+* This proposal does not add per-request, sub-operation visibility. That question belongs to distributed tracing and is tracked in [Future Work](#per-reconcile-sub-operation-visibility-via-tracing).
+* This proposal does not introduce high-cardinality labels (no namespace, no resource name, no function name, no pod UID). Such labels would couple the metric surface to internal code structure and break silently on refactor.
+* This proposal does not add metrics to Grove's scheduler backends (these are external components Grove supports, not part of the Grove operator itself); it covers only the Grove operator controllers.
+* This proposal does not modify the Grove CRD API, reconciliation behavior, or any user-facing functionality beyond the `/metrics` endpoint.
+* This proposal does not specify alerting rules or dashboard JSON (these are consumer concerns, not operator-side concerns).
+
+### Existing Signals and Gaps
+
+Grove's controller-runtime base already covers a large portion of standard observability. This proposal does not duplicate any of it. The remaining gaps below are what motivate the two new metrics.
+
+| Question | Today | Gap |
+|----------|-------|-----|
+| Reconcile latency / queue backlog / active workers (capacity-shaped) | `controller_runtime_reconcile_time_seconds`, `workqueue_depth`, `controller_runtime_active_workers` | None — covered by built-ins. |
+| Total API 409 traffic | `rest_client_requests_total{code="409"}` | The `url` label is the request path, not the Kubernetes Kind being mutated. The metric **cannot attribute** a conflict to a specific Grove controller, nor to the status update target kind. 409s on `Pods` issued by upstream operators are indistinguishable from 409s on `PodCliqueSet` issued by Grove. |
+| Error class breakdown (transient vs persistent) | `controller_runtime_reconcile_total{result="error"}` | All errors are collapsed into a single `error` label; conflict / timeout / rate-limited cannot be distinguished from invalid / forbidden. |
+
+The full list of relevant built-in metrics is reproduced in [Built-in controller-runtime Metrics Reference](#built-in-controller-runtime-metrics-reference) for convenience.
 
 ## Proposal
 
 ### Overview
 
-Introduce two custom Prometheus metrics exposed by all three Grove controllers (PodCliqueSet, PodClique, PodCliqueScalingGroup). Both are **aggregate, fleet-level** signals that complement the built-in controller-runtime metrics without duplicating them.
+Introduce two custom Prometheus metrics exposed by all three Grove controllers (PodCliqueSet, PodClique, PodCliqueScalingGroup):
 
-How controllers record these metrics (recording helpers, context propagation, registration) is an implementation detail of the follow-up PR. This proposal describes only the **metric surface** — names, labels, semantics — and the rationale for each.
+| Metric | Labels | Purpose |
+|--------|--------|---------|
+| `grove_operator_status_update_conflict_total` | `controller`, `target_kind` | Attribute 409 conflicts to the contended resource type |
+| `grove_operator_reconcile_errors_total` | `controller`, `error_type` | Categorize errors by Kubernetes API error class |
 
-### Relationship to Built-in Metrics
-
-controller-runtime automatically registers a rich set of metrics via `sigs.k8s.io/controller-runtime/pkg/metrics`. The following table maps common reconciliation questions to the metric that answers them:
-
-| Question | Metric | Source |
-|----------|--------|--------|
-| How long does reconciliation take? | `controller_runtime_reconcile_time_seconds` (Histogram) | built-in |
-| How many reconciles have occurred? | `controller_runtime_reconcile_total` (Counter, labeled by `result`) | built-in |
-| How many reconciles are in flight? | `controller_runtime_active_workers` (Gauge) | built-in |
-| How deep is the work queue? | `workqueue_depth` (Gauge) | built-in |
-| How long do items wait in queue? | `workqueue_queue_duration_seconds` (Histogram) | built-in |
-| How long before a retry? | `workqueue_unfinished_work_seconds` (Gauge) | built-in |
-| API client performance? | `rest_client_request_duration_seconds` (Histogram) | built-in |
-| **Which resource type is the 409 contention hotspot?** | `grove_operator_status_update_conflict_total` | **new (this proposal)** |
-| **What fraction of errors are transient vs persistent?** | `grove_operator_reconcile_errors_total` | **new (this proposal)** |
+Both are aggregate, fleet-level signals that complement the built-in controller-runtime metrics. Cardinality bound, semantics, and recording verbs are covered in [Design Details](#design-details).
 
 ### User Stories
 
-#### Story 1: Diagnosing Slow Deployment at Scale
+#### Story 1: Identifying the Cross-Controller Contention Hotspot
 
-**As** a Grove operator
-**When** a user reports that deploying a large inference graph (50+ PodCliques) takes significantly longer than expected
-**I want** to query built-in metrics (`controller_runtime_reconcile_time_seconds`, `workqueue_depth`, `workqueue_queue_duration_seconds`) to see whether the bottleneck is reconcile duration, queue backlog, or queue-wait latency
-**So that** I can determine whether to tune `MaxConcurrentReconciles`, optimize the reconcile path, or investigate upstream load.
+**Persona:** Grove operator on call.
 
-For drilling into *which step of a single reconcile* is slow, tracing (not this proposal) is the right tool.
+**Scenario:** During a large inference graph rollout (50+ PodCliques), Pod scheduling latency spikes. I suspect status-write contention between Grove controllers and an upstream operator (e.g., NVIDIA Dynamo's DGD controller managing the same PodClique objects), but I have no way to confirm which Grove resource type is the hotspot.
 
-#### Story 2: Identifying Cross-Controller Resource Contention
+**Today's pain:** I have to grep controller logs across all three Grove controllers for "Conflict", manually correlate them by timestamp, and reason about which Grove resource type is most affected. This does not scale, cannot be alerted on, and produces no historical record I can plot or compare across releases.
 
-**As** a Grove developer
-**When** investigating status update failures during high-load deployments
-**I want** to see which Grove resource types (`PodCliqueSet` vs `PodClique` vs `PodCliqueScalingGroup`) are most affected by 409 Conflicts
-**So that** I can prioritize architectural changes (e.g., migrating to `Status().Patch()` or Server-Side Apply) for the highest-contention resources.
+**What I'm missing:** a fleet-level signal that lets me, in a single Grafana panel, see something like "PodCliqueSet conflicts spiked 10× in the last 5 minutes" without leaving the metrics surface, and that I can wire into alerts when contention crosses a threshold.
 
-This is an aggregate, fleet-level question: "across all instances and all time, which resource type sees the most contention?" It is exactly what Prometheus metrics do well.
+#### Story 2: Triaging Errors as Self-Healing vs Operator-Action-Required
 
-#### Story 3: Distinguishing Transient vs Persistent Errors
+**Persona:** SRE operating Grove in production.
 
-**As** an SRE operating Grove in production
-**When** the `controller_runtime_reconcile_total{result="error"}` rate is elevated
-**I want** to see the breakdown by error type (conflict, timeout, not_found, invalid, etc.)
-**So that** I can distinguish transient issues (retries will succeed) from persistent issues (require intervention) without reading logs.
+**Scenario:** The reconcile error rate alert fires at 03:00. I need to decide in under a minute whether to wake an operator now, or let the system self-heal and triage in the morning.
+
+**Today's pain:** the error counter is a single flat number. The only way to determine if errors are transient (will retry successfully) or persistent (need human intervention) is to read controller logs and the API server audit log. This makes the on-call experience poor and prevents differentiated alert policies (page on persistent errors, warn on transient).
+
+**What I'm missing:** an automatable error classification I can use to build alert rules that page only on persistent errors and treat transient errors as warnings.
 
 ### Limitations/Risks & Mitigations
 
@@ -181,6 +173,22 @@ Recording is intended to be synchronous, O(1), and side-effect-free on the recon
 - `reconcile_errors_total` is incremented in the reconcile-loop error path, after the error is classified by the `k8serrors.Is*` predicates. A single error increments exactly one series.
 
 Exact helper types, function signatures, registration code, and call sites are defined in the implementation PR and are not part of the contract reviewed here.
+
+### Relationship to Built-in Metrics
+
+controller-runtime automatically registers a rich set of metrics via `sigs.k8s.io/controller-runtime/pkg/metrics`. The two custom metrics in this proposal sit alongside those built-ins; they do not replace them. The following table maps common reconciliation questions to the metric that answers them.
+
+| Question | Metric | Source |
+|----------|--------|--------|
+| How long does reconciliation take? | `controller_runtime_reconcile_time_seconds` (Histogram) | built-in |
+| How many reconciles have occurred? | `controller_runtime_reconcile_total` (Counter, labeled by `result`) | built-in |
+| How many reconciles are in flight? | `controller_runtime_active_workers` (Gauge) | built-in |
+| How deep is the work queue? | `workqueue_depth` (Gauge) | built-in |
+| How long do items wait in queue? | `workqueue_queue_duration_seconds` (Histogram) | built-in |
+| How long before a retry? | `workqueue_unfinished_work_seconds` (Gauge) | built-in |
+| API client performance? | `rest_client_request_duration_seconds` (Histogram) | built-in |
+| Which resource type is the 409 contention hotspot? | `grove_operator_status_update_conflict_total` | **new (this proposal)** |
+| What fraction of errors are transient vs persistent? | `grove_operator_reconcile_errors_total` | **new (this proposal)** |
 
 ### Built-in controller-runtime Metrics Reference
 
@@ -293,6 +301,7 @@ No new external dependencies are introduced.
 - 2026-03-24: PR #499 opened.
 - 2026-03-30: Updated based on review feedback — removed 4 duplicate metrics, removed namespace label, refocused on 3 genuinely new metrics.
 - 2026-05-09: Revised per review — scoped to aggregate, fleet-level metrics only (dropped sub-operation histogram in favor of future tracing work); removed embedded Go source per design-doc-scope feedback; fixed scheduler-backend terminology; PC → PCLQ across the document.
+- 2026-05-26: Restructured per second review round — Goals rewritten as positive acceptance criteria; Overview opens with a 2-row metric table; built-in coverage split between an *Existing Signals and Gaps* table in Motivation and the full reference table in Design Details; User Stories trimmed to 2 and reframed around missing user capability; "diagnosing slow deployment" relocated from a user story to the gap table; capitalized `NOT` → `not`.
 
 ## Alternatives
 


### PR DESCRIPTION
## Summary

Add Prometheus metrics to all three Grove controllers (PodCliqueSet, PodClique, PodCliqueScalingGroup).

Grove currently has **zero custom Prometheus metrics**. This GREP proposes a metrics framework providing:
- Reconcile duration, count, error rate, and in-flight tracking via `ObservedReconciler` wrapper
- Sub-operation timing within each reconcile loop via `MetricsContext`
- 409 Conflict tracking with target-resource attribution for cross-controller contention diagnosis

**Tracking issue:** Fixes #498

## Motivation

During large-scale inference graph deployments (e.g., via NVIDIA Dynamo), reconciliation performance degrades significantly due to high event rates and cross-controller resource contention on PCS/PC objects. Without metrics, diagnosing these issues requires ad-hoc log analysis.

## Key Design Decisions

- **ObservedReconciler wrapper**: Generic wrapper for all 3 controllers, minimal code change
- **MetricsContext via context.Context**: Nil-safe, zero overhead when not present, no interface changes
- **Conflict tracking**: `grove_operator_status_update_conflict_total` with `target_kind` label for precise contention attribution
- **No new dependencies**: Uses existing prometheus/client_golang via controller-runtime
- **No logic changes**: Purely additive instrumentation

## Test Plan

- Unit tests for ObservedReconciler, MetricsContext, and error categorization
- Integration test verifying metrics at /metrics endpoint
- E2E test at scale verifying sub-operation and conflict metrics