### PR TITLE
fix: propagate PodCliqueSet annotations to PodGang 

### DIFF
--- a/operator/internal/controller/podcliqueset/components/podgang/podgang.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/podgang.go
@@ -128,12 +128,13 @@ func (r _resource) Delete(ctx context.Context, logger logr.Logger, pcsObjectMeta
 // buildResource configures a PodGang with pod groups and priority.
 func (r _resource) buildResource(pcs *grovecorev1alpha1.PodCliqueSet, pgi *podGangInfo, pg *groveschedulerv1alpha1.PodGang) error {
 	pg.Labels = getLabels(pcs.Name)
+	// Merge PCS annotations with computed annotations (topology annotation takes precedence)
+	toplologyAnnotations := make(map[string]string)
 	if r.tasConfig.Enabled {
-		if pg.Annotations == nil {
-			pg.Annotations = make(map[string]string)
-		}
-		pg.Annotations[apicommonconstants.AnnotationTopologyName] = grovecorev1alpha1.DefaultClusterTopologyName
+		toplologyAnnotations[apicommonconstants.AnnotationTopologyName] = grovecorev1alpha1.DefaultClusterTopologyName
 	}
+	pg.Annotations = lo.Assign(pcs.Annotations, toplologyAnnotations)
+
 	if err := controllerutil.SetControllerReference(pcs, pg, r.scheme); err != nil {
 		return groveerr.WrapError(
 			err,

--- a/operator/internal/controller/podcliqueset/components/podgang/podgang.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/podgang.go
@@ -127,13 +127,13 @@ func (r _resource) Delete(ctx context.Context, logger logr.Logger, pcsObjectMeta
 
 // buildResource configures a PodGang with pod groups and priority.
 func (r _resource) buildResource(pcs *grovecorev1alpha1.PodCliqueSet, pgi *podGangInfo, pg *groveschedulerv1alpha1.PodGang) error {
-	pg.Labels = getLabels(pcs.Name)
+	pg.Labels = lo.Assign(pg.Labels, getLabels(pcs.Name))
 	// Merge PCS annotations with computed annotations (topology annotation takes precedence)
-	toplologyAnnotations := make(map[string]string)
+	topologyAnnotations := make(map[string]string)
 	if r.tasConfig.Enabled {
-		toplologyAnnotations[apicommonconstants.AnnotationTopologyName] = grovecorev1alpha1.DefaultClusterTopologyName
+		topologyAnnotations[apicommonconstants.AnnotationTopologyName] = grovecorev1alpha1.DefaultClusterTopologyName
 	}
-	pg.Annotations = lo.Assign(pcs.Annotations, toplologyAnnotations)
+	pg.Annotations = lo.Assign(pg.Annotations,pcs.Annotations, topologyAnnotations)
 
 	if err := controllerutil.SetControllerReference(pcs, pg, r.scheme); err != nil {
 		return groveerr.WrapError(

--- a/operator/internal/controller/podcliqueset/components/podgang/podgang_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/podgang_test.go
@@ -1,0 +1,162 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package podgang
+
+import (
+	"testing"
+
+	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+
+	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestPodGangAnnotationsFromPodCliqueSet verifies that scheduler queue annotations
+// from PodCliqueSet are propagated to PodGang resources.
+// This test reproduces the bug where kai-scheduler-queue annotation is lost when
+// creating instances via dynamo.
+func TestPodGangAnnotationsFromPodCliqueSet(t *testing.T) {
+	tests := []struct {
+		name                    string
+		pcsAnnotations          map[string]string
+		expectedPodGangContains map[string]string
+		description             string
+	}{
+		{
+			name: "PCS with kai-scheduler-queue annotation",
+			pcsAnnotations: map[string]string{
+				"nvidia.com/kai-scheduler-queue": "worker-queue",
+			},
+			expectedPodGangContains: map[string]string{
+				"nvidia.com/kai-scheduler-queue": "worker-queue",
+			},
+			description: "Queue annotation from PCS should be present in PodGang",
+		},
+		{
+			name: "PCS with multiple scheduler annotations",
+			pcsAnnotations: map[string]string{
+				"nvidia.com/kai-scheduler-queue":      "worker-queue",
+				"nvidia.com/dynamo-discovery-backend": "kubernetes",
+			},
+			expectedPodGangContains: map[string]string{
+				"nvidia.com/kai-scheduler-queue":      "worker-queue",
+				"nvidia.com/dynamo-discovery-backend": "kubernetes",
+			},
+			description: "Multiple scheduler annotations should be propagated to PodGang",
+		},
+		{
+			name: "PCS with queue annotation and other annotations",
+			pcsAnnotations: map[string]string{
+				"nvidia.com/kai-scheduler-queue": "special-queue",
+				"custom.annotation/key":          "value",
+			},
+			expectedPodGangContains: map[string]string{
+				"nvidia.com/kai-scheduler-queue": "special-queue",
+				"custom.annotation/key":          "value",
+			},
+			description: "All PCS annotations including queue should be in PodGang",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create PodCliqueSet with scheduler queue annotation
+			pcs := &grovecorev1alpha1.PodCliqueSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-pcs",
+					Namespace:   "default",
+					UID:         "test-uid-123",
+					Annotations: test.pcsAnnotations,
+				},
+				Spec: grovecorev1alpha1.PodCliqueSetSpec{
+					Replicas: 1,
+					Template: grovecorev1alpha1.PodCliqueSetTemplateSpec{
+						PriorityClassName: "default-priority",
+						Cliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
+							{
+								Name: "test-clique",
+								Spec: grovecorev1alpha1.PodCliqueSpec{
+									Replicas: 2,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			// Create a fake client and scheme
+			scheme := runtime.NewScheme()
+			require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
+			require.NoError(t, groveschedulerv1alpha1.AddToScheme(scheme))
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(pcs).
+				Build()
+
+			// Create the podgang resource operator
+			eventRecorder := record.NewFakeRecorder(10)
+			tasConfig := configv1alpha1.TopologyAwareSchedulingConfiguration{
+				Enabled: false,
+			}
+
+			r := &_resource{
+				client:        fakeClient,
+				scheme:        scheme,
+				eventRecorder: eventRecorder,
+				tasConfig:     tasConfig,
+			}
+
+			// Create a PodGang object to be populated
+			pg := &groveschedulerv1alpha1.PodGang{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-pcs-0",
+				},
+			}
+
+			// Create podGangInfo with mock data
+			pgi := &podGangInfo{
+				fqn: "test-pcs-0",
+				pclqs: []pclqInfo{
+					{
+						fqn:      "test-clique-0",
+						replicas: 2,
+					},
+				},
+			}
+
+			// Call buildResource which should populate annotations
+			err := r.buildResource(pcs, pgi, pg)
+			require.NoError(t, err, "buildResource should not error")
+
+			// Verify that all expected annotations are present in PodGang
+			for expectedKey, expectedValue := range test.expectedPodGangContains {
+				actualValue, exists := pg.Annotations[expectedKey]
+				assert.True(t, exists, "PodGang should have annotation %s", expectedKey)
+				assert.Equal(t, expectedValue, actualValue,
+					"PodGang annotation %s should match PCS annotation", expectedKey)
+			}
+		})
+	}
+}

--- a/operator/internal/controller/podcliqueset/components/podgang/podgang_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/podgang_test.go
@@ -19,6 +19,8 @@ package podgang
 import (
 	"testing"
 
+	apicommon "github.com/ai-dynamo/grove/operator/api/common"
+	apicommonconstants "github.com/ai-dynamo/grove/operator/api/common/constants"
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 
@@ -31,56 +33,96 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-// TestPodGangAnnotationsFromPodCliqueSet verifies that scheduler queue annotations
-// from PodCliqueSet are propagated to PodGang resources.
-// This test reproduces the bug where kai-scheduler-queue annotation is lost when
-// creating instances via dynamo.
-func TestPodGangAnnotationsFromPodCliqueSet(t *testing.T) {
+func TestBuildResource(t *testing.T) {
 	tests := []struct {
-		name                    string
-		pcsAnnotations          map[string]string
-		expectedPodGangContains map[string]string
-		description             string
+		name                      string
+		tasEnabled                bool
+		pcsAnnotations            map[string]string
+		initialPodGangLabels      map[string]string
+		initialPodGangAnnotations map[string]string
+		expectedLabels            map[string]string
+		expectedAnnotations       map[string]string
 	}{
 		{
-			name: "PCS with kai-scheduler-queue annotation",
+			name: "copies PCS annotations onto empty podgang",
 			pcsAnnotations: map[string]string{
 				"nvidia.com/kai-scheduler-queue": "worker-queue",
 			},
-			expectedPodGangContains: map[string]string{
+			expectedLabels: map[string]string{
+				apicommon.LabelComponentKey: apicommon.LabelComponentNamePodGang,
+			},
+			expectedAnnotations: map[string]string{
 				"nvidia.com/kai-scheduler-queue": "worker-queue",
 			},
-			description: "Queue annotation from PCS should be present in PodGang",
 		},
 		{
-			name: "PCS with multiple scheduler annotations",
+			name: "copies multiple PCS annotations onto empty podgang",
 			pcsAnnotations: map[string]string{
 				"nvidia.com/kai-scheduler-queue":      "worker-queue",
 				"nvidia.com/dynamo-discovery-backend": "kubernetes",
 			},
-			expectedPodGangContains: map[string]string{
+			expectedLabels: map[string]string{
+				apicommon.LabelComponentKey: apicommon.LabelComponentNamePodGang,
+			},
+			expectedAnnotations: map[string]string{
 				"nvidia.com/kai-scheduler-queue":      "worker-queue",
 				"nvidia.com/dynamo-discovery-backend": "kubernetes",
 			},
-			description: "Multiple scheduler annotations should be propagated to PodGang",
 		},
 		{
-			name: "PCS with queue annotation and other annotations",
+			name:       "preserves existing annotations on update path when tas is disabled",
+			tasEnabled: false,
 			pcsAnnotations: map[string]string{
-				"nvidia.com/kai-scheduler-queue": "special-queue",
-				"custom.annotation/key":          "value",
+				"nvidia.com/kai-scheduler-queue": "worker-queue",
+				"custom.annotation/from-pcs":     "pcs-value",
 			},
-			expectedPodGangContains: map[string]string{
-				"nvidia.com/kai-scheduler-queue": "special-queue",
-				"custom.annotation/key":          "value",
+			initialPodGangLabels: map[string]string{
+				"external.label/keep": "true",
 			},
-			description: "All PCS annotations including queue should be in PodGang",
+			initialPodGangAnnotations: map[string]string{
+				"external.annotation/keep":                "true",
+				apicommonconstants.AnnotationTopologyName: "existing-topology",
+			},
+			expectedLabels: map[string]string{
+				"external.label/keep":       "true",
+				apicommon.LabelComponentKey: apicommon.LabelComponentNamePodGang,
+			},
+			expectedAnnotations: map[string]string{
+				"nvidia.com/kai-scheduler-queue":          "worker-queue",
+				"custom.annotation/from-pcs":              "pcs-value",
+				"external.annotation/keep":                "true",
+				apicommonconstants.AnnotationTopologyName: "existing-topology",
+			},
+		},
+		{
+			name:       "preserves existing metadata and overrides topology annotation when tas is enabled",
+			tasEnabled: true,
+			pcsAnnotations: map[string]string{
+				"nvidia.com/kai-scheduler-queue": "worker-queue",
+				"custom.annotation/from-pcs":     "pcs-value",
+			},
+			initialPodGangLabels: map[string]string{
+				"external.label/keep": "true",
+			},
+			initialPodGangAnnotations: map[string]string{
+				"external.annotation/keep":                "true",
+				apicommonconstants.AnnotationTopologyName: "old-topology",
+			},
+			expectedLabels: map[string]string{
+				"external.label/keep":       "true",
+				apicommon.LabelComponentKey: apicommon.LabelComponentNamePodGang,
+			},
+			expectedAnnotations: map[string]string{
+				"nvidia.com/kai-scheduler-queue":          "worker-queue",
+				"custom.annotation/from-pcs":              "pcs-value",
+				"external.annotation/keep":                "true",
+				apicommonconstants.AnnotationTopologyName: grovecorev1alpha1.DefaultClusterTopologyName,
+			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			// Create PodCliqueSet with scheduler queue annotation
 			pcs := &grovecorev1alpha1.PodCliqueSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "test-pcs",
@@ -104,7 +146,6 @@ func TestPodGangAnnotationsFromPodCliqueSet(t *testing.T) {
 				},
 			}
 
-			// Create a fake client and scheme
 			scheme := runtime.NewScheme()
 			require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
 			require.NoError(t, groveschedulerv1alpha1.AddToScheme(scheme))
@@ -114,28 +155,24 @@ func TestPodGangAnnotationsFromPodCliqueSet(t *testing.T) {
 				WithObjects(pcs).
 				Build()
 
-			// Create the podgang resource operator
-			eventRecorder := record.NewFakeRecorder(10)
-			tasConfig := configv1alpha1.TopologyAwareSchedulingConfiguration{
-				Enabled: false,
-			}
-
 			r := &_resource{
 				client:        fakeClient,
 				scheme:        scheme,
-				eventRecorder: eventRecorder,
-				tasConfig:     tasConfig,
-			}
-
-			// Create a PodGang object to be populated
-			pg := &groveschedulerv1alpha1.PodGang{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "test-pcs-0",
+				eventRecorder: record.NewFakeRecorder(10),
+				tasConfig: configv1alpha1.TopologyAwareSchedulingConfiguration{
+					Enabled: test.tasEnabled,
 				},
 			}
 
-			// Create podGangInfo with mock data
+			pg := &groveschedulerv1alpha1.PodGang{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "default",
+					Name:        "test-pcs-0",
+					Labels:      test.initialPodGangLabels,
+					Annotations: test.initialPodGangAnnotations,
+				},
+			}
+
 			pgi := &podGangInfo{
 				fqn: "test-pcs-0",
 				pclqs: []pclqInfo{
@@ -146,16 +183,21 @@ func TestPodGangAnnotationsFromPodCliqueSet(t *testing.T) {
 				},
 			}
 
-			// Call buildResource which should populate annotations
 			err := r.buildResource(pcs, pgi, pg)
-			require.NoError(t, err, "buildResource should not error")
+			require.NoError(t, err)
 
-			// Verify that all expected annotations are present in PodGang
-			for expectedKey, expectedValue := range test.expectedPodGangContains {
+			for expectedKey, expectedValue := range test.expectedLabels {
+				actualValue, exists := pg.Labels[expectedKey]
+				assert.True(t, exists, "PodGang should have label %s", expectedKey)
+				assert.Equal(t, expectedValue, actualValue,
+					"PodGang label %s should match expected value", expectedKey)
+			}
+
+			for expectedKey, expectedValue := range test.expectedAnnotations {
 				actualValue, exists := pg.Annotations[expectedKey]
 				assert.True(t, exists, "PodGang should have annotation %s", expectedKey)
 				assert.Equal(t, expectedValue, actualValue,
-					"PodGang annotation %s should match PCS annotation", expectedKey)
+					"PodGang annotation %s should match expected value", expectedKey)
 			}
 		})
 	}


### PR DESCRIPTION
 #### What type of PR is this?

  /kind bug

  #### What this PR does / why we need it:

  #### Problem

  When creating a disaggregated instance via Dynamo with a custom
  `nvidia.com/kai-scheduler-queue` annotation, the resulting `PodGang`
  is created without that annotation.

  The kai-scheduler reads queue assignment from the `PodGang`, so it
  raises `QueueDoesNotExist` even though the queue exists and was
  validated successfully by the Dynamo operator.

  #### Root cause

  `buildResource` in `podgang.go` constructs `PodGang` metadata but does
  not copy `pcs.Annotations` into `pg.Annotations`.

  This differs from the existing behavior in `pod.go`, where annotations
  from the parent resource are propagated to each `Pod`.

  #### Fix

  Merge `pcs.Annotations` into `pg.Annotations` using `lo.Assign`, with
  computed annotations taking precedence over user-provided values when
  the same key is present.

  ```
  topologyAnnotations := map[string]string{}
  if r.tasConfig.Enabled {
      topologyAnnotations[apicommonconstants.AnnotationTopologyName] =
          grovecorev1alpha1.DefaultClusterTopologyName
  }
  pg.Annotations = lo.Assign(pcs.Annotations, topologyAnnotations)
```
  #### Test

  Added TestPodGangAnnotationsFromPodCliqueSet in podgang_test.go.

  The test calls buildResource with a PodCliqueSet carrying scheduler
  annotations and asserts that the resulting PodGang contains the same
  annotations. Covers three cases:

  - single annotation (nvidia.com/kai-scheduler-queue)
  - multiple scheduler annotations
  - mixed custom and scheduler annotations

    #### Which issue(s) this PR fixes:

  Fixes #490

  #### Special notes for your reviewer:

  The merge order in lo.Assign(pcs.Annotations, topologyAnnotations)
  is intentional — topology annotations derived during reconciliation
  overwrite any user-provided annotation with the same key.

  ####  Does this PR introduce an API change?

  NONE