### PR TITLE
feat: Expose pod index as a label to allow user-defined env vars to reference it via Downward API

### DIFF
--- a/operator/api/common/labels.go
+++ b/operator/api/common/labels.go
@@ -41,6 +41,8 @@ const (
 	LabelPodCliqueScalingGroup = "grove.io/podcliquescalinggroup"
 	// LabelPodCliqueScalingGroupReplicaIndex is a key for a label that sets the replica index of a PodCliqueScalingGroup within PodCliqueSet.
 	LabelPodCliqueScalingGroupReplicaIndex = "grove.io/podcliquescalinggroup-replica-index"
+	// LabelPodCliquePodIndex is a key for a label that sets the index of a pod within its PodClique.
+	LabelPodCliquePodIndex = "grove.io/podclique-pod-index"
 	// LabelPodTemplateHash is a key for a label that sets the hash of the PodSpec. This label will be set on a PodClique and will be shared by all pods in the PodClique.
 	LabelPodTemplateHash = "grove.io/pod-template-hash"
 )

--- a/operator/internal/controller/podclique/components/pod/pod.go
+++ b/operator/internal/controller/podclique/components/pod/pod.go
@@ -144,7 +144,7 @@ func (r _resource) buildResource(pcs *grovecorev1alpha1.PodCliqueSet, pclq *grov
 		)
 	}
 
-	labels := getLabels(pclq.ObjectMeta, pcsName, podGangName, pcsReplicaIndex)
+	labels := getLabels(pclq.ObjectMeta, pcsName, podGangName, pcsReplicaIndex, podIndex)
 	pod.ObjectMeta = metav1.ObjectMeta{
 		GenerateName: fmt.Sprintf("%s-", pclq.Name),
 		Namespace:    pclq.Namespace,
@@ -161,7 +161,7 @@ func (r _resource) buildResource(pcs *grovecorev1alpha1.PodCliqueSet, pclq *grov
 	pod.Spec = *pclq.Spec.PodSpec.DeepCopy()
 	pod.Spec.SchedulingGates = []corev1.PodSchedulingGate{{Name: podGangSchedulingGate}}
 	// Add GROVE specific Pod environment variables
-	addEnvironmentVariables(pod, pclq, pcsName, pcsReplicaIndex, podIndex)
+	addEnvironmentVariables(pod, pclq, pcsName, pcsReplicaIndex)
 	// Configure hostname and subdomain for service discovery
 	configurePodHostname(pcsName, pcsReplicaIndex, pclq.Name, pod, podIndex)
 	// If there is a need to enforce a Startup-Order then configure the init container and add it to the Pod Spec.
@@ -215,11 +215,12 @@ func getSelectorLabelsForPods(pclqObjectMeta metav1.ObjectMeta) map[string]strin
 }
 
 // getLabels constructs the complete set of labels for a pod including Grove-specific and template labels
-func getLabels(pclqObjectMeta metav1.ObjectMeta, pcsName, podGangName string, pcsReplicaIndex int) map[string]string {
+func getLabels(pclqObjectMeta metav1.ObjectMeta, pcsName, podGangName string, pcsReplicaIndex, podIndex int) map[string]string {
 	labels := map[string]string{
 		apicommon.LabelPodClique:                pclqObjectMeta.Name,
 		apicommon.LabelPodCliqueSetReplicaIndex: strconv.Itoa(pcsReplicaIndex),
 		apicommon.LabelPodGang:                  podGangName,
+		apicommon.LabelPodCliquePodIndex:        strconv.Itoa(podIndex),
 	}
 	return lo.Assign(
 		apicommon.GetDefaultLabelsForPodCliqueSetManagedResources(pcsName),
@@ -229,7 +230,7 @@ func getLabels(pclqObjectMeta metav1.ObjectMeta, pcsName, podGangName string, pc
 }
 
 // addEnvironmentVariables adds Grove-specific environment variables to all containers and init-containers.
-func addEnvironmentVariables(pod *corev1.Pod, pclq *grovecorev1alpha1.PodClique, pcsName string, pcsReplicaIndex, podIndex int) {
+func addEnvironmentVariables(pod *corev1.Pod, pclq *grovecorev1alpha1.PodClique, pcsName string, pcsReplicaIndex int) {
 	groveEnvVars := []corev1.EnvVar{
 		{
 			Name:  constants.EnvVarPodCliqueSetName,
@@ -250,8 +251,12 @@ func addEnvironmentVariables(pod *corev1.Pod, pclq *grovecorev1alpha1.PodClique,
 				pod.Namespace),
 		},
 		{
-			Name:  constants.EnvVarPodIndex,
-			Value: strconv.Itoa(podIndex),
+			Name: constants.EnvVarPodIndex,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: fmt.Sprintf("metadata.labels['%s']", apicommon.LabelPodCliquePodIndex),
+				},
+			},
 		},
 	}
 	componentutils.AddEnvVarsToContainers(pod.Spec.Containers, groveEnvVars)

--- a/operator/internal/controller/podclique/components/pod/pod_test.go
+++ b/operator/internal/controller/podclique/components/pod/pod_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pod
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/ai-dynamo/grove/operator/api/common"
@@ -193,7 +194,7 @@ func TestAddEnvironmentVariables(t *testing.T) {
 				Spec: tt.pclq.Spec.PodSpec,
 			}
 
-			addEnvironmentVariables(pod, tt.pclq, "test-pcs", 0, 0)
+			addEnvironmentVariables(pod, tt.pclq, "test-pcs", 0)
 
 			// Check that all containers have the expected environment variables
 			for _, container := range pod.Spec.Containers {
@@ -210,8 +211,10 @@ func TestAddEnvironmentVariables(t *testing.T) {
 					}
 				}
 
-				// Verify Grove environment variables use direct values
-				assertGroveEnvVarsDirectValues(t, container, tt.expectedEnvVars)
+				// Verify Grove environment variables use direct values (except pod index which uses fieldRef)
+				directValueEnvVars := filterOutEnvVar(tt.expectedEnvVars, constants.EnvVarPodIndex)
+				assertGroveEnvVarsDirectValues(t, container, directValueEnvVars)
+				assertEnvVarUsesFieldRef(t, container, constants.EnvVarPodIndex, fmt.Sprintf("metadata.labels['%s']", common.LabelPodCliquePodIndex))
 			}
 		})
 	}
@@ -365,7 +368,7 @@ func TestAddGroveEnvironmentVariables_NoDuplicates(t *testing.T) {
 				Spec: tt.pclq.Spec.PodSpec,
 			}
 
-			addEnvironmentVariables(pod, tt.pclq, "test-pcs", 0, 0)
+			addEnvironmentVariables(pod, tt.pclq, "test-pcs", 0)
 
 			// Check that all containers have the expected environment variables
 			for _, container := range pod.Spec.Containers {
@@ -391,7 +394,7 @@ func TestAddGroveEnvironmentVariables_EmptyContainers(t *testing.T) {
 	}
 
 	// Should not panic with empty containers
-	addEnvironmentVariables(pod, pclq, "test-pcs", 0, 0)
+	addEnvironmentVariables(pod, pclq, "test-pcs", 0)
 	assert.Empty(t, pod.Spec.Containers)
 }
 
@@ -420,7 +423,7 @@ func TestAddGroveEnvironmentVariables_MultipleContainers(t *testing.T) {
 		},
 	}
 
-	addEnvironmentVariables(pod, pclq, "test-pcs", 0, 0)
+	addEnvironmentVariables(pod, pclq, "test-pcs", 0)
 
 	// Both containers should have Grove environment variables
 	expectedEnvVars := []string{
@@ -524,4 +527,30 @@ func assertNoDuplicateEnvVars(t *testing.T, container corev1.Container) {
 	for envName, count := range envVarCounts {
 		assert.Equal(t, 1, count, "environment variable %s appears %d times (should be 1)", envName, count)
 	}
+}
+
+func assertEnvVarUsesFieldRef(t *testing.T, container corev1.Container, envVarName, expectedFieldPath string) {
+	for _, env := range container.Env {
+		if env.Name == envVarName {
+			assert.Empty(t, env.Value, "environment variable %s should not have a direct value", envVarName)
+			if assert.NotNil(t, env.ValueFrom, "environment variable %s should use ValueFrom", envVarName) {
+				if assert.NotNil(t, env.ValueFrom.FieldRef, "environment variable %s should use FieldRef", envVarName) {
+					assert.Equal(t, expectedFieldPath, env.ValueFrom.FieldRef.FieldPath,
+						"environment variable %s has wrong FieldPath", envVarName)
+				}
+			}
+			return
+		}
+	}
+	t.Errorf("environment variable %s not found in container %s", envVarName, container.Name)
+}
+
+func filterOutEnvVar(envVars []string, exclude string) []string {
+	var result []string
+	for _, v := range envVars {
+		if v != exclude {
+			result = append(result, v)
+		}
+	}
+	return result
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

As a PCS user, I want to define custom environment variables (e.g. `ENGINE_ID` for Dynamo) that are derived from `GROVE_PCLQ_POD_INDEX`. This is not possible today because the operator injects `GROVE_PCLQ_POD_INDEX` as a direct value at pod creation time -- there is no label or field users can reference via the Kubernetes Downward API in their own env var definitions.

This PR:
- Adds a new pod label `grove.io/podclique-pod-index` carrying the pod's index within its PodClique.
- Changes `GROVE_PCLQ_POD_INDEX` from a direct-value env var to one sourced via `fieldRef` from that label.

This follows the same pattern already used for `GROVE_PCSG_INDEX` / `GROVE_PCSG_NAME`.

Users can now define their own env vars referencing the pod index:

```yaml
env:
  - name: ENGINE_ID
    valueFrom:
      fieldRef:
        fieldPath: metadata.labels['grove.io/podclique-pod-index']
```

#### Which issue(s) this PR fixes:

Fixes [#506](https://github.com/ai-dynamo/grove/issues/506)

#### Special notes for your reviewer:

This is a backward-compatible change. `GROVE_PCLQ_POD_INDEX` still resolves to the same value at runtime -- the only difference is that it is now sourced from a pod label via `fieldRef` instead of being set as a direct value.

#### Does this PR introduce a API change?

```release-note
Add `grove.io/podclique-pod-index` label to pods, allowing users to reference the pod index via the Kubernetes Downward API in custom environment variables. `GROVE_PCLQ_POD_INDEX` is now sourced from this label via fieldRef.
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
