### PR TITLE
feat: GREP-0368 Preferred Topology Constraint API

### DIFF
--- a/docs/proposals/0368-preferred-topology-constraint/README.md
+++ b/docs/proposals/0368-preferred-topology-constraint/README.md
@@ -60,7 +60,6 @@ As a **Run:ai platform operator** deploying Dynamo workloads over Grove, I want 
 ### Limitations/Risks & Mitigations
 
 - **Scheduler performance:** `packDomainPreferred` triggers a scheduling algorithm that might be compute-intensive. Misuse (e.g. setting it on all workloads at scale) could degrade scheduler performance. *Mitigation: it's an explicit opt-in, never a default.*
-- **Interaction with `packDomain`:** The semantics when both fields are set need to be well-defined.
 
 ## Design Details
 

--- a/docs/proposals/0368-preferred-topology-constraint/README.md
+++ b/docs/proposals/0368-preferred-topology-constraint/README.md
@@ -34,7 +34,7 @@ Grove topology-aware scheduling currently supports required packing through `pac
 
 ## Motivation
 
-Grove is increasingly used as an orchestration layer by higher-level tools (e.g. Dynamo on Run:ai) that submit workloads on behalf of users. These tools often want topology-aware placement to improve workload performance, but the existing workload-facing constraint, `packDomain`, is required: if the requested domain cannot fit the workload, scheduling may remain blocked.
+Grove is increasingly used as an orchestration layer by higher-level tools that submit workloads on behalf of users. These tools often want topology-aware placement to improve workload performance, but the existing workload-facing constraint, `packDomain`, is required: if the requested domain cannot fit the workload, scheduling may remain blocked.
 
 Preferred topology placement addresses this gap by letting the scheduler try for a more optimized placement while still allowing the workload to run when the preference cannot be satisfied. This is useful for platforms that want to apply topology-aware optimization transparently, and for workloads that benefit from locality but should not fail or remain pending solely because the most optimized placement is unavailable.
 
@@ -135,7 +135,7 @@ As a cluster administrator, I want to configure the preferred packing domain on 
 
 #### Story 4: External orchestration platform
 
-As an orchestration platform, such as Dynamo on Run:ai, I want to set `topologyName` when submitting Grove workloads so that topology-aware placement is attempted transparently for users while preserving scheduling fallback behavior.
+As an orchestration platform, I want to set `topologyName` when submitting Grove workloads so that topology-aware placement is attempted transparently for users while preserving scheduling fallback behavior.
 
 ### Limitations/Risks & Mitigations
 
@@ -233,7 +233,7 @@ Existing topology health signals remain relevant:
 - Unit and e2e tests pass
 
 #### Beta
-- Validated in at least one production workload or platform integration, such as Dynamo on Run:ai
+- Validated in at least one production workload or platform integration
 - No breaking API changes since alpha
 - No significant scheduler performance regressions observed from opted-in workloads
 

--- a/docs/proposals/0368-preferred-topology-constraint/README.md
+++ b/docs/proposals/0368-preferred-topology-constraint/README.md
@@ -1,0 +1,156 @@
+# GREP-0368: Preferred Topology Constraint API
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+    - [Story 1: Automated preferred topology in Dynamo on Run:ai](#story-1-automated-preferred-topology-in-dynamo-on-runai)
+  - [Limitations/Risks &amp; Mitigations](#limitationsrisks--mitigations)
+- [Design Details](#design-details)
+  - [API Change](#api-change)
+  - [PodGang Propagation](#podgang-propagation)
+  - [Webhook Validation](#webhook-validation)
+  - [Monitoring](#monitoring)
+  - [Test Plan](#test-plan)
+  - [Graduation Criteria](#graduation-criteria)
+    - [Alpha](#alpha)
+    - [Beta](#beta)
+    - [GA](#ga)
+- [Alternatives](#alternatives)
+  - [Always-on preferred topology at the lowest level](#always-on-preferred-topology-at-the-lowest-level)
+  - [Boolean opt-in on <code>PodCliqueSet</code>](#boolean-opt-in-on-podcliqueset)
+<!-- /toc -->
+
+## Summary
+
+Grove currently supports topology-aware scheduling through a required constraint (`packDomain`), which fails the workload entirely if the requested topology cannot be satisfied. This GREP introduces a **preferred** topology constraint — a best-effort mode that requests topology-aware placement without making it a hard requirement. If the constraint cannot be met, the workload is still scheduled rather than failing, making topology optimization accessible in scenarios where strict placement is undesirable or incompatible with the scheduler.
+
+## Motivation
+
+Grove is increasingly used as an orchestration layer by higher-level tools (e.g. Dynamo on Run:ai) that manage workload submission on behalf of users. These tools often want to apply topology preferences automatically — without exposing scheduling decisions to end users — but cannot do so today because the only available topology constraint is required (`packDomain`), which risks failing workloads when the topology cannot be satisfied.
+
+Additionally, preferred topology scheduling is a compute-intensive operation for the scheduler. It therefore cannot be enabled by default for all workloads — it must be an explicit opt-in. Exposing a preferred constraint API gives tools and users a way to request best-effort topology placement, decoupled from the all-or-nothing semantics of the current required constraint.
+
+### Goals
+
+- Introduce a preferred (best-effort) topology constraint API on `PodClique`, `PodGangScalingGroup`, and `PodCliqueSet`
+- Ensure workloads with a preferred constraint are never blocked — if topology cannot be satisfied, scheduling proceeds without it
+
+### Non-Goals
+
+- Automatically applying preferred topology to all workloads (it remains an explicit opt-in)
+- Changing the semantics of the existing required constraint (`packDomain`)
+- Guaranteeing topology-optimal placement — preferred is best-effort only
+
+## Proposal
+
+This GREP proposes adding a `packDomainPreferred` field alongside the existing `packDomain` field on `PodClique`, `PodGangScalingGroup`, and `PodCliqueSet`. When set, it signals to the scheduler that topology-aware placement is desired at the specified domain level on a best-effort basis — the workload is never failed if the constraint cannot be satisfied.
+
+`packDomainPreferred` and `packDomain` can coexist on the same resource. For example, a user may set `packDomainPreferred=host` and `packDomain=rack` to express that host-level packing is desired but not required, while rack-level packing is mandatory. When both are set, the scheduler attempts preferred placement first and falls back toward the required level if the preferred constraint cannot be satisfied. It is recommended (but not enforced) that `packDomainPreferred` be stricter than or equal to `packDomain` — setting a coarser preferred level than the required one is semantically redundant.
+
+### User Stories
+
+#### Story 1: Automated preferred topology in Dynamo on Run:ai
+
+As a **Run:ai platform operator** deploying Dynamo workloads over Grove, I want to automatically apply a preferred topology constraint to all submitted workloads — without requiring end users to configure scheduling parameters — so that topology-aware placement is attempted as a best-effort optimization while ensuring no workload is ever blocked due to an unsatisfiable constraint.
+
+### Limitations/Risks & Mitigations
+
+- **Scheduler performance:** `packDomainPreferred` triggers a scheduling algorithm that might be compute-intensive. Misuse (e.g. setting it on all workloads at scale) could degrade scheduler performance. *Mitigation: it's an explicit opt-in, never a default.*
+- **Interaction with `packDomain`:** The semantics when both fields are set need to be well-defined.
+
+## Design Details
+
+### API Change
+
+A single field is added to the existing `TopologyConstraint` struct in the operator API (`operator/api/core/v1alpha1/podcliqueset.go`), which is already shared across `PodCliqueSet`, `PodCliqueTemplateSpec`, and `PodCliqueScalingGroupConfig`:
+
+```go
+// TopologyConstraint defines topology placement requirements.
+type TopologyConstraint struct {
+    // PackDomain specifies the required topology domain for grouping replicas.
+    // The workload will not be scheduled if this constraint cannot be satisfied.
+    // +kubebuilder:validation:Enum=region;zone;datacenter;block;rack;host;numa
+    // +optional
+    PackDomain *TopologyDomain `json:"packDomain,omitempty"`
+
+    // PackDomainPreferred specifies a preferred (best-effort) topology domain.
+    // If the constraint cannot be satisfied, the workload is scheduled anyway.
+    // When set alongside PackDomain, it is recommended that PackDomainPreferred
+    // be stricter than or equal to PackDomain.
+    // +kubebuilder:validation:Enum=region;zone;datacenter;block;rack;host;numa
+    // +optional
+    PackDomainPreferred *TopologyDomain `json:"packDomainPreferred,omitempty"`
+}
+```
+
+Note: `PackDomain` changes from a value type to a pointer (`*TopologyDomain`) to allow a `TopologyConstraint` with only `PackDomainPreferred` set. This is not a breaking API change — existing resources with `packDomain` set continue to work. Controller code accessing `PackDomain` will need nil checks.
+
+### PodGang Propagation
+
+The scheduler API (`scheduler/api/core/v1alpha1/podgang.go`) already supports both constraints via `TopologyPackConstraint.Required` and `TopologyPackConstraint.Preferred`. No changes are needed on the scheduler side.
+
+The only required implementation change is in `createTopologyPackConstraint` (`operator/internal/controller/podcliqueset/components/podgang/syncflow.go`), which translates Grove's `TopologyConstraint` into the scheduler's `TopologyPackConstraint`. It currently only populates `Required`. It must be extended to also resolve `PackDomainPreferred` to its topology key and populate `Preferred`.
+
+The domain-to-key translation follows the same existing path: looking up the domain name in the `ClusterTopology` levels to obtain the corresponding node label key. If the preferred domain is not found in the current `ClusterTopology`, it is silently skipped (same behavior as the existing required constraint).
+
+### Webhook Validation
+
+The admission webhook (`operator/internal/webhook/admission/pcs/validation/topologyconstraints.go`) validates that child constraints are stricter than or equal to parent constraints. This validation must be extended to cover `PackDomainPreferred` with the same hierarchy rules.
+
+### Monitoring
+
+There is no scheduler-side feedback on whether preferred placement was achieved. This is consistent with the existing behavior for `packDomain`, which also has no placement-outcome indicator.
+
+The existing `TopologyLevelUnavailable` status condition on `PodCliqueSet`, which checks whether referenced topology domains exist in the `ClusterTopology` CR, will be extended to also cover `packDomainPreferred` domains.
+
+### Test Plan
+
+**Unit — webhook validation:**
+- `packDomainPreferred` domain not present in `ClusterTopology` is rejected
+- `packDomainPreferred` stricter than parent is accepted; coarser passes without enforcement
+- `packDomainPreferred` can be set without `packDomain`, and vice versa
+
+**Unit — syncflow (`TestComputeExpectedPodGangsWithTopologyConstraints`):**
+- `packDomainPreferred` alone → `TopologyPackConstraint.Preferred` set, `Required` nil
+- Both fields set → both `Preferred` and `Required` populated correctly
+- `packDomainPreferred` domain missing from `ClusterTopology` → `Preferred` silently skipped, workload still created
+
+**E2E:**
+- Preferred constraint that can be satisfied → workload schedules successfully and scheduler receives the preferred constraint (validates the full propagation path including the scheduler)
+- Preferred constraint that cannot be satisfied → workload schedules successfully (key behavioral difference from required)
+
+### Graduation Criteria
+
+#### Alpha
+- `packDomainPreferred` field available on all three resources (`PodCliqueSet`, `PodCliqueScalingGroupConfig`, `PodCliqueTemplateSpec`)
+- Unit and e2e tests passing
+
+#### Beta
+- Validated in at least one production workload (e.g. Dynamo on Run:ai)
+- No breaking API changes since alpha
+
+#### GA
+- Stable API
+- No open issues related to the feature
+
+## Alternatives
+
+Two coarser-grained alternatives were considered and ruled out. Grove, as a generic infrastructure layer, should remain neutral — exposing fine-grained, explicit controls and leaving opinionated defaults to higher-level tools.
+
+### Always-on preferred topology at the lowest level
+
+The scheduler could automatically apply a preferred constraint at the finest available topology level for every workload, with no user opt-in.
+
+- **Pro:** Zero configuration required.
+- **Con:** Preferred topology scheduling is compute-intensive and unsuitable as a blanket default. Removes user control entirely, and is incompatible with workloads that have no topology preference.
+
+### Boolean opt-in on `PodCliqueSet`
+
+A single boolean field on `PodCliqueSet` (e.g. `preferredTopologyEnabled`) would enable preferred placement at the lowest topology level for all cliques, without allowing per-resource or per-level control.
+
+- **Pro:** Simpler API surface.
+- **Con:** Provides no control over which topology level is preferred, and cannot express different preferences across `PodCliqueSet`, `PodCliqueScalingGroup`, and `PodClique`. Higher-level tools can trivially implement this coarser interface on top of `packDomainPreferred`, but the reverse is not true.

--- a/docs/proposals/0368-preferred-topology-constraint/README.md
+++ b/docs/proposals/0368-preferred-topology-constraint/README.md
@@ -7,7 +7,10 @@
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
   - [User Stories](#user-stories)
-    - [Story 1: Automated preferred topology in Dynamo on Run:ai](#story-1-automated-preferred-topology-in-dynamo-on-runai)
+    - [Story 1: Topology-aware placement with graceful fallback](#story-1-topology-aware-placement-with-graceful-fallback)
+    - [Story 2: Mixed required and preferred constraints for disaggregated inference](#story-2-mixed-required-and-preferred-constraints-for-disaggregated-inference)
+    - [Story 3: Admin-controlled preferred topology](#story-3-admin-controlled-preferred-topology)
+    - [Story 4: External orchestration platform](#story-4-external-orchestration-platform)
   - [Limitations/Risks &amp; Mitigations](#limitationsrisks--mitigations)
 - [Design Details](#design-details)
   - [API Change](#api-change)
@@ -21,138 +24,245 @@
     - [GA](#ga)
 - [Alternatives](#alternatives)
   - [Always-on preferred topology at the lowest level](#always-on-preferred-topology-at-the-lowest-level)
+  - [Workload-level preferred domain](#workload-level-preferred-domain)
   - [Boolean opt-in on <code>PodCliqueSet</code>](#boolean-opt-in-on-podcliqueset)
 <!-- /toc -->
 
 ## Summary
 
-Grove currently supports topology-aware scheduling through a required constraint (`packDomain`), which blocks the workload pending resources if the requested topology cannot be satisfied. This GREP introduces a **preferred** topology constraint — a best-effort mode that requests topology-aware placement without making it a hard requirement. If the constraint cannot be met, the workload is still scheduled rather than remaining blocked, making topology optimization accessible in scenarios where strict placement is undesirable or incompatible with the scheduler.
+Grove topology-aware scheduling currently supports required packing through `packDomain`, which can leave workloads pending when the requested topology domain cannot fit them. This GREP introduces `ClusterTopology.spec.preferredPackDomain`, an administrator-controlled preferred packing domain that Grove applies as a best-effort scheduler preference to workloads that reference that `ClusterTopology`. Workloads can opt into topology-aware placement by setting `topologyName` with or without a required `packDomain`; when the referenced topology defines `preferredPackDomain`, Grove propagates it to the scheduler as a preferred constraint so placement can be optimized without blocking scheduling if the preference cannot be satisfied.
 
 ## Motivation
 
-Grove is increasingly used as an orchestration layer by higher-level tools (e.g. Dynamo on Run:ai) that manage workload submission on behalf of users. These tools often want to apply topology preferences automatically — without exposing scheduling decisions to end users — but cannot do so today because the only available topology constraint is required (`packDomain`), which risks blocking workloads indefinitely when the topology cannot be satisfied.
+Grove is increasingly used as an orchestration layer by higher-level tools (e.g. Dynamo on Run:ai) that submit workloads on behalf of users. These tools often want topology-aware placement to improve workload performance, but the existing workload-facing constraint, `packDomain`, is required: if the requested domain cannot fit the workload, scheduling may remain blocked.
 
-Additionally, preferred topology scheduling is a compute-intensive operation for the scheduler. It therefore cannot be enabled by default for all workloads — it must be an explicit opt-in. Exposing a preferred constraint API gives tools and users a way to request best-effort topology placement, decoupled from the all-or-nothing semantics of the current required constraint.
+Preferred topology placement addresses this gap by letting the scheduler try for a more optimized placement while still allowing the workload to run when the preference cannot be satisfied. This is useful for platforms that want to apply topology-aware optimization transparently, and for workloads that benefit from locality but should not fail or remain pending solely because the most optimized placement is unavailable.
+
+At the same time, preferred topology scheduling is a compute-intensive scheduler operation. Grove should not simply enable preferred placement by default at the lowest topology level for every workload, because doing so could impose scheduler cost on workloads that did not opt into topology-aware scheduling. Instead, this GREP makes preferred placement an explicit topology policy: administrators configure the preferred domain on `ClusterTopology`, and workloads opt into that topology by setting `topologyName`.
 
 ### Goals
 
-- Introduce a preferred (best-effort) topology constraint API on `PodClique`, `PodGangScalingGroup`, and `PodCliqueSet`
-- Ensure workloads with a preferred constraint are never blocked — if topology cannot be satisfied, scheduling proceeds without it
+- Add `preferredPackDomain` to `ClusterTopology.spec` as the administrator-configured best-effort topology packing domain.
+- Validate that `preferredPackDomain`, when set, refers to a domain defined in the same `ClusterTopology.spec.levels` list.
+- Allow workloads to set `topologyName` without `packDomain`, enabling preferred-only topology-aware scheduling when the referenced `ClusterTopology` defines `preferredPackDomain`.
+- Propagate the resolved preferred topology key to the scheduler API through `TopologyPackConstraint.Preferred`.
+- Preserve the existing required `packDomain` behavior and allow required and preferred constraints to be used together.
 
 ### Non-Goals
 
-- Automatically applying preferred topology to all workloads (it remains an explicit opt-in)
-- Changing the semantics of the existing required constraint (`packDomain`)
-- Guaranteeing topology-optimal placement — preferred is best-effort only
+- Automatically applying preferred topology to workloads that do not reference a `ClusterTopology`.
+- Selecting the preferred topology domain independently on each workload resource.
+- Changing the hard scheduling semantics of `packDomain`.
+- Guaranteeing topology-optimal placement. Preferred topology placement is best-effort only.
+- Changing the scheduler API. The scheduler already exposes `TopologyPackConstraint.Preferred`.
 
 ## Proposal
 
-This GREP proposes adding a `packDomainPreferred` field alongside the existing `packDomain` field on `PodClique`, `PodGangScalingGroup`, and `PodCliqueSet`. When set, it signals to the scheduler that topology-aware placement is desired at the specified domain level on a best-effort basis — the workload is never blocked if the constraint cannot be satisfied.
+This GREP proposes adding `preferredPackDomain` to `ClusterTopology.spec`. The field identifies the topology domain that Grove should use as the scheduler's preferred packing domain for workloads that opt into that topology.
 
-`packDomainPreferred` and `packDomain` can coexist on the same resource. For example, a user may set `packDomainPreferred=host` and `packDomain=rack` to express that host-level packing is desired but not required, while rack-level packing is mandatory. When both are set, the scheduler attempts preferred placement first and falls back toward the required level if the preferred constraint cannot be satisfied. It is recommended (but not enforced) that `packDomainPreferred` be stricter than or equal to `packDomain` — setting a coarser preferred level than the required one is semantically redundant.
+A workload opts into topology-aware scheduling by setting `topologyName` in its `TopologyConstraint`. The workload may also set `packDomain` when it needs a hard placement requirement. If `packDomain` is omitted, Grove may still emit a preferred scheduler constraint if the referenced `ClusterTopology` defines `preferredPackDomain`.
+
+The resulting behavior is:
+
+- Workload has no `topologyName`: Grove emits no topology constraint for that workload.
+- Workload has `topologyName`, and the referenced `ClusterTopology` has no `preferredPackDomain`: existing required `packDomain` behavior is preserved.
+- Workload has `topologyName`, and the referenced `ClusterTopology` defines `preferredPackDomain`: Grove resolves that domain to its topology key and emits it as `TopologyPackConstraint.Preferred`.
+- Workload has both `topologyName` and `packDomain`: Grove emits `packDomain` as `TopologyPackConstraint.Required` and, if configured on the topology, emits `preferredPackDomain` as `TopologyPackConstraint.Preferred`.
+
+For example, an administrator can configure host-level preferred packing for a topology:
+
+```yaml
+apiVersion: grove.io/v1alpha1
+kind: ClusterTopology
+metadata:
+  name: h100-topology
+spec:
+  preferredPackDomain: host
+  levels:
+    - domain: zone
+      key: topology.kubernetes.io/zone
+    - domain: rack
+      key: topology.kubernetes.io/rack
+    - domain: host
+      key: kubernetes.io/hostname
+```
+
+A workload can then opt into preferred-only topology-aware placement:
+
+```yaml
+apiVersion: grove.io/v1alpha1
+kind: PodCliqueSet
+metadata:
+  name: prefill
+spec:
+  template:
+    topologyConstraint:
+      topologyName: h100-topology
+    cliques:
+      - name: worker
+        spec:
+          replicas: 8
+          template:
+            spec:
+              containers:
+                - name: worker
+                  image: example.com/worker:latest
+```
+
+The same workload can add a required rack-level constraint while retaining the topology's host-level preferred constraint:
+
+```yaml
+spec:
+  template:
+    topologyConstraint:
+      topologyName: h100-topology
+      packDomain: rack
+```
 
 ### User Stories
 
-#### Story 1: Automated preferred topology in Dynamo on Run:ai
+#### Story 1: Topology-aware placement with graceful fallback
 
-As a **Run:ai platform operator** deploying Dynamo workloads over Grove, I want to automatically apply a preferred topology constraint to all submitted workloads — without requiring end users to configure scheduling parameters — so that topology-aware placement is attempted as a best-effort optimization while ensuring no workload is ever blocked due to an unsatisfiable constraint.
+As an ML engineer, I want to request topology-aware placement for my workload so that Grove attempts optimized placement without failing the job if the preferred topology domain cannot fit it.
+
+#### Story 2: Mixed required and preferred constraints for disaggregated inference
+
+As an ML engineer running disaggregated inference, I want to require that each PodCliqueScalingGroup is packed within a rack while preferring that scheduling uses a narrower topology domain when possible, so that critical locality is guaranteed while additional optimization remains best-effort.
+
+#### Story 3: Admin-controlled preferred topology
+
+As a cluster administrator, I want to configure the preferred packing domain on each `ClusterTopology` so that workloads using that topology receive consistent best-effort placement behavior without each workload choosing infrastructure-specific policy.
+
+#### Story 4: External orchestration platform
+
+As an orchestration platform, such as Dynamo on Run:ai, I want to set `topologyName` when submitting Grove workloads so that topology-aware placement is attempted transparently for users while preserving scheduling fallback behavior.
 
 ### Limitations/Risks & Mitigations
 
-- **Scheduler performance:** `packDomainPreferred` triggers a scheduling algorithm that might be compute-intensive. Misuse (e.g. setting it on all workloads at scale) could degrade scheduler performance. *Mitigation: it's an explicit opt-in, never a default.*
+- **Scheduler performance:** Preferred topology placement can trigger compute-intensive scheduler work. *Mitigation: preferred placement is only emitted for workloads that set `topologyName` and reference a `ClusterTopology` that defines `preferredPackDomain`; it is not a blanket default for all workloads.*
+- **Cluster-wide policy for a topology:** A `preferredPackDomain` applies to all workloads that reference the `ClusterTopology`, which may be too broad for clusters with different workload classes. *Mitigation: administrators can define separate `ClusterTopology` resources with different preferred packing policies and direct workloads to the appropriate topology via `topologyName`.*
+- **Misconfigured preferred domain:** If `preferredPackDomain` does not match a configured topology level, Grove cannot resolve it to a scheduler topology key. *Mitigation: admission validation rejects `ClusterTopology` resources where `preferredPackDomain` is not present in `spec.levels[*].domain`.*
+- **Preference is not a guarantee:** A workload may still run outside the preferred domain if the scheduler cannot satisfy the preferred placement. *Mitigation: users must continue to use `packDomain` for hard placement requirements.*
 
 ## Design Details
 
 ### API Change
 
-A single field is added to the existing `TopologyConstraint` struct in the operator API (`operator/api/core/v1alpha1/podcliqueset.go`), which is already shared across `PodCliqueSet`, `PodCliqueTemplateSpec`, and `PodCliqueScalingGroupConfig`:
+This GREP builds on the `ClusterTopology` and `PodCliqueSet` topology APIs where workload `TopologyConstraint` selects a topology with `topologyName` and may specify a required domain with `packDomain`. A single field is added to `ClusterTopologySpec` in `operator/api/core/v1alpha1/clustertopology.go`:
 
 ```go
-// TopologyConstraint defines topology placement requirements.
-type TopologyConstraint struct {
-    // PackDomain specifies the required topology domain for grouping replicas.
-    // The workload will not be scheduled if this constraint cannot be satisfied.
-    // +kubebuilder:validation:Enum=region;zone;datacenter;block;rack;host;numa
-    // +optional
-    PackDomain *TopologyDomain `json:"packDomain,omitempty"`
+// ClusterTopologySpec defines the topology hierarchy specification.
+type ClusterTopologySpec struct {
+    // Levels is an ordered list of topology levels from broadest to narrowest scope.
+    // The order in this list defines the hierarchy (index 0 = broadest level).
+    // +kubebuilder:validation:MinItems=1
+    Levels []TopologyLevel `json:"levels"`
 
-    // PackDomainPreferred specifies a preferred (best-effort) topology domain.
-    // If the constraint cannot be satisfied, the workload is scheduled anyway.
-    // When set alongside PackDomain, it is recommended that PackDomainPreferred
-    // be stricter than or equal to PackDomain.
-    // +kubebuilder:validation:Enum=region;zone;datacenter;block;rack;host;numa
+    // PreferredPackDomain specifies the topology domain Grove should propagate
+    // to the scheduler as a best-effort preferred packing constraint for workloads
+    // that reference this ClusterTopology.
+    // Must match one of the domains in Levels.
     // +optional
-    PackDomainPreferred *TopologyDomain `json:"packDomainPreferred,omitempty"`
+    PreferredPackDomain *TopologyDomain `json:"preferredPackDomain,omitempty"`
+
+    // SchedulerReferences controls per-backend topology resource management.
+    // +optional
+    SchedulerReferences []SchedulerReference `json:"schedulerReferences,omitempty"`
 }
 ```
 
-Note: `PackDomain` changes from a value type to a pointer (`*TopologyDomain`) to allow a `TopologyConstraint` with only `PackDomainPreferred` set. This is not a breaking API change — existing resources with `packDomain` set continue to work. Controller code accessing `PackDomain` will need nil checks.
+The workload-facing `TopologyConstraint` continues to use `topologyName` to select the `ClusterTopology` and `packDomain` to express a hard packing requirement. `packDomain` remains optional, so a workload can set `topologyName` without requiring a hard packing domain.
 
 ### PodGang Propagation
 
-The scheduler API (`scheduler/api/core/v1alpha1/podgang.go`) already supports both constraints via `TopologyPackConstraint.Required` and `TopologyPackConstraint.Preferred`. No changes are needed on the scheduler side.
+The scheduler API (`scheduler/api/core/v1alpha1/podgang.go`) already supports both constraints via `TopologyPackConstraint.Required` and `TopologyPackConstraint.Preferred`. No scheduler API change is needed.
 
-The only required implementation change is in `createTopologyPackConstraint` (`operator/internal/controller/podcliqueset/components/podgang/syncflow.go`), which translates Grove's `TopologyConstraint` into the scheduler's `TopologyPackConstraint`. It currently only populates `Required`. It must be extended to also resolve `PackDomainPreferred` to its topology key and populate `Preferred`.
+The PodCliqueSet PodGang sync flow will load the referenced `ClusterTopology` for the workload's `topologyName`. In addition to the topology levels, the sync context will retain the resolved topology key for `ClusterTopology.spec.preferredPackDomain` when it is configured.
 
-The domain-to-key translation follows the same existing path: looking up the domain name in the `ClusterTopology` levels to obtain the corresponding node label key. If the preferred domain is not found in the current `ClusterTopology`, it is silently skipped (same behavior as the existing required constraint).
+`createTopologyPackConstraint` (`operator/internal/controller/podcliqueset/components/podgang/syncflow.go`) will populate scheduler constraints as follows:
+
+- If the workload `TopologyConstraint.packDomain` is non-empty, resolve it through `ClusterTopology.spec.levels` and set `TopologyPackConstraint.Required`.
+- If the selected `ClusterTopology.spec.preferredPackDomain` is set, resolve it through `ClusterTopology.spec.levels` and set `TopologyPackConstraint.Preferred`.
+- If neither required nor preferred can be resolved, omit the scheduler topology constraint.
+
+This logic applies wherever Grove emits scheduler topology constraints: the PodGang-level constraint, PodCliqueScalingGroup `TopologyConstraintGroupConfig` constraints, and PodGroup constraints for PodClique-level topology constraints.
 
 ### Webhook Validation
 
-The admission webhook (`operator/internal/webhook/admission/pcs/validation/topologyconstraints.go`) must be extended to cover `PackDomainPreferred` with the same rules that apply to `PackDomain`:
+ClusterTopology admission validation must reject resources where `preferredPackDomain` is set but does not match any `domain` in `spec.levels`.
 
-- **Domain existence:** A `packDomainPreferred` value that does not exist in the `ClusterTopology` CR is rejected at admission time, same as `packDomain`.
-- **Hierarchy:** `packDomainPreferred` on a child resource must be stricter than or equal to the parent's `packDomainPreferred`.
+PodCliqueSet admission validation must continue to validate workload `packDomain` values against the referenced `ClusterTopology` and enforce the existing hierarchy rules across PodCliqueSet, PodCliqueScalingGroup, and PodClique constraints. Empty `packDomain` is valid when `topologyName` is set. When topology-aware scheduling is disabled, topology constraints remain disallowed, including constraints that only set `topologyName`.
 
 ### Monitoring
 
-There is no scheduler-side feedback on whether preferred placement was achieved. This is consistent with the existing behavior for `packDomain`, which also has no placement-outcome indicator.
+There is no dedicated status condition that reports whether preferred placement was achieved. Operators can verify propagation by inspecting the generated `PodGang` resources and checking `spec.topologyConstraint.packConstraint.preferred`, group config constraints, or PodGroup constraints as appropriate.
 
-The existing `TopologyLevelUnavailable` status condition on `PodCliqueSet`, which checks whether referenced topology domains exist in the `ClusterTopology` CR, will be extended to also cover `packDomainPreferred` domains.
+Existing topology health signals remain relevant:
+
+- `ClusterTopology.status.schedulerTopologyStatuses` and the `SchedulerTopologyDrift` condition report whether scheduler backend topology resources are in sync with Grove topology definitions.
+- `PodCliqueSet` topology availability conditions continue to report unavailable required topology levels for workload constraints.
+- Scheduler-specific placement quality signals, such as `PodGang.status.placementScore` when populated by the scheduler, can help diagnose placement quality, but they are not a hard success/failure signal for preferred placement.
 
 ### Test Plan
 
-**Unit — webhook validation:**
-- `packDomainPreferred` domain not present in `ClusterTopology` is rejected
-- `packDomainPreferred` stricter than parent is accepted; coarser passes without enforcement
-- `packDomainPreferred` can be set without `packDomain`, and vice versa
+**Unit - webhook validation:**
+- `ClusterTopology.spec.preferredPackDomain` is accepted when it matches a domain in `spec.levels`
+- `ClusterTopology.spec.preferredPackDomain` is rejected when it does not match a domain in `spec.levels`
+- `PodCliqueSet` with `topologyName` and no `packDomain` is accepted when topology-aware scheduling is enabled
+- `PodCliqueSet` with `topologyName` and no `packDomain` is rejected when topology-aware scheduling is disabled
+- Existing `packDomain` domain-existence and hierarchy validation continues to pass and fail as expected
 
-**Unit — syncflow (`TestComputeExpectedPodGangsWithTopologyConstraints`):**
-- `packDomainPreferred` alone → `TopologyPackConstraint.Preferred` set, `Required` nil
-- Both fields set → both `Preferred` and `Required` populated correctly
-- `packDomainPreferred` domain missing from `ClusterTopology` → `Preferred` silently skipped, workload still created
+**Unit - syncflow (`TestComputeExpectedPodGangsWithTopologyConstraints`):**
+- `topologyName` with `ClusterTopology.spec.preferredPackDomain` and no `packDomain` creates a preferred-only scheduler constraint
+- `topologyName` with both `ClusterTopology.spec.preferredPackDomain` and workload `packDomain` creates both `Preferred` and `Required`
+- `topologyName` with no `ClusterTopology.spec.preferredPackDomain` preserves required-only behavior
+- `ClusterTopology.spec.preferredPackDomain` is propagated to PodGang-level, PodCliqueScalingGroup group, and PodClique PodGroup constraints where Grove emits scheduler topology constraints
+- Missing or unresolved preferred domain at reconciliation time is skipped without blocking workload creation
 
 **E2E:**
-- Preferred constraint that can be satisfied → workload schedules successfully and scheduler receives the preferred constraint (validates the full propagation path including the scheduler)
-- Preferred constraint that cannot be satisfied → workload schedules successfully (key behavioral difference from required)
+- Preferred-only workload schedules successfully and the scheduler receives the preferred constraint
+- Workload with both required and preferred constraints schedules successfully when the required constraint is satisfiable
+- Workload remains schedulable when the preferred domain cannot be satisfied, demonstrating the best-effort behavior
+- Required `packDomain` behavior remains unchanged: unsatisfiable required constraints can still keep the workload pending
 
 ### Graduation Criteria
 
 #### Alpha
-- `packDomainPreferred` field available on all three resources (`PodCliqueSet`, `PodCliqueScalingGroupConfig`, `PodCliqueTemplateSpec`)
-- Unit and e2e tests passing
+- `ClusterTopology.spec.preferredPackDomain` is available in the v1alpha1 API
+- Admission validation and PodGang propagation are implemented
+- Unit and e2e tests pass
 
 #### Beta
-- Validated in at least one production workload (e.g. Dynamo on Run:ai)
+- Validated in at least one production workload or platform integration, such as Dynamo on Run:ai
 - No breaking API changes since alpha
+- No significant scheduler performance regressions observed from opted-in workloads
 
 #### GA
 - Stable API
-- No open issues related to the feature
+- Documentation covers admin configuration and workload opt-in behavior
+- No open issues related to preferred topology propagation or validation for at least two releases after beta
 
 ## Alternatives
 
-Two coarser-grained alternatives were considered and ruled out. Grove, as a generic infrastructure layer, should remain neutral — exposing fine-grained, explicit controls and leaving opinionated defaults to higher-level tools.
+The following alternatives were considered and ruled out.
 
 ### Always-on preferred topology at the lowest level
 
 The scheduler could automatically apply a preferred constraint at the finest available topology level for every workload, with no user opt-in.
 
 - **Pro:** Zero configuration required.
-- **Con:** Preferred topology scheduling is compute-intensive and unsuitable as a blanket default. Removes user control entirely, and is incompatible with workloads that have no topology preference.
+- **Con:** Preferred topology scheduling is compute-intensive and unsuitable as a blanket default. It would impose scheduling cost on workloads that did not request topology-aware placement.
+
+### Workload-level preferred domain
+
+A workload-facing field could let users select the preferred domain directly for each PodCliqueSet, PodCliqueScalingGroup, or PodClique.
+
+- **Pro:** Gives workload authors fine-grained control.
+- **Con:** Pushes infrastructure policy into workload manifests and makes it harder for administrators to tune preferred topology behavior consistently across a cluster.
 
 ### Boolean opt-in on `PodCliqueSet`
 
-A single boolean field on `PodCliqueSet` (e.g. `preferredTopologyEnabled`) would enable preferred placement at the lowest topology level for all cliques, without allowing per-resource or per-level control.
+A boolean field on `PodCliqueSet` could enable preferred placement without requiring the workload to choose a domain.
 
-- **Pro:** Simpler API surface.
-- **Con:** Provides no control over which topology level is preferred, and cannot express different preferences across `PodCliqueSet`, `PodCliqueScalingGroup`, and `PodClique`. Higher-level tools can trivially implement this coarser interface on top of `packDomainPreferred`, but the reverse is not true.
+- **Pro:** Simple workload-facing API.
+- **Con:** Still requires another source of truth for the preferred domain and provides less reuse than attaching that policy to the referenced `ClusterTopology`.

--- a/docs/proposals/0368-preferred-topology-constraint/README.md
+++ b/docs/proposals/0368-preferred-topology-constraint/README.md
@@ -26,11 +26,11 @@
 
 ## Summary
 
-Grove currently supports topology-aware scheduling through a required constraint (`packDomain`), which fails the workload entirely if the requested topology cannot be satisfied. This GREP introduces a **preferred** topology constraint — a best-effort mode that requests topology-aware placement without making it a hard requirement. If the constraint cannot be met, the workload is still scheduled rather than failing, making topology optimization accessible in scenarios where strict placement is undesirable or incompatible with the scheduler.
+Grove currently supports topology-aware scheduling through a required constraint (`packDomain`), which blocks the workload pending resources if the requested topology cannot be satisfied. This GREP introduces a **preferred** topology constraint — a best-effort mode that requests topology-aware placement without making it a hard requirement. If the constraint cannot be met, the workload is still scheduled rather than remaining blocked, making topology optimization accessible in scenarios where strict placement is undesirable or incompatible with the scheduler.
 
 ## Motivation
 
-Grove is increasingly used as an orchestration layer by higher-level tools (e.g. Dynamo on Run:ai) that manage workload submission on behalf of users. These tools often want to apply topology preferences automatically — without exposing scheduling decisions to end users — but cannot do so today because the only available topology constraint is required (`packDomain`), which risks failing workloads when the topology cannot be satisfied.
+Grove is increasingly used as an orchestration layer by higher-level tools (e.g. Dynamo on Run:ai) that manage workload submission on behalf of users. These tools often want to apply topology preferences automatically — without exposing scheduling decisions to end users — but cannot do so today because the only available topology constraint is required (`packDomain`), which risks blocking workloads indefinitely when the topology cannot be satisfied.
 
 Additionally, preferred topology scheduling is a compute-intensive operation for the scheduler. It therefore cannot be enabled by default for all workloads — it must be an explicit opt-in. Exposing a preferred constraint API gives tools and users a way to request best-effort topology placement, decoupled from the all-or-nothing semantics of the current required constraint.
 
@@ -47,7 +47,7 @@ Additionally, preferred topology scheduling is a compute-intensive operation for
 
 ## Proposal
 
-This GREP proposes adding a `packDomainPreferred` field alongside the existing `packDomain` field on `PodClique`, `PodGangScalingGroup`, and `PodCliqueSet`. When set, it signals to the scheduler that topology-aware placement is desired at the specified domain level on a best-effort basis — the workload is never failed if the constraint cannot be satisfied.
+This GREP proposes adding a `packDomainPreferred` field alongside the existing `packDomain` field on `PodClique`, `PodGangScalingGroup`, and `PodCliqueSet`. When set, it signals to the scheduler that topology-aware placement is desired at the specified domain level on a best-effort basis — the workload is never blocked if the constraint cannot be satisfied.
 
 `packDomainPreferred` and `packDomain` can coexist on the same resource. For example, a user may set `packDomainPreferred=host` and `packDomain=rack` to express that host-level packing is desired but not required, while rack-level packing is mandatory. When both are set, the scheduler attempts preferred placement first and falls back toward the required level if the preferred constraint cannot be satisfied. It is recommended (but not enforced) that `packDomainPreferred` be stricter than or equal to `packDomain` — setting a coarser preferred level than the required one is semantically redundant.
 
@@ -99,7 +99,10 @@ The domain-to-key translation follows the same existing path: looking up the dom
 
 ### Webhook Validation
 
-The admission webhook (`operator/internal/webhook/admission/pcs/validation/topologyconstraints.go`) validates that child constraints are stricter than or equal to parent constraints. This validation must be extended to cover `PackDomainPreferred` with the same hierarchy rules.
+The admission webhook (`operator/internal/webhook/admission/pcs/validation/topologyconstraints.go`) must be extended to cover `PackDomainPreferred` with the same rules that apply to `PackDomain`:
+
+- **Domain existence:** A `packDomainPreferred` value that does not exist in the `ClusterTopology` CR is rejected at admission time, same as `packDomain`.
+- **Hierarchy:** `packDomainPreferred` on a child resource must be stricter than or equal to the parent's `packDomainPreferred`.
 
 ### Monitoring
 

--- a/docs/proposals/0368-preferred-topology-constraint/README.md
+++ b/docs/proposals/0368-preferred-topology-constraint/README.md
@@ -191,6 +191,7 @@ The existing `TopologyLevelUnavailable` status condition on `PodCliqueSet`, whic
 #### Beta
 - Validated in at least one production workload
 - No breaking API changes since alpha
+- Deprecated `packDomain` API field removed after existing workload migration has been validated
 
 #### GA
 - Stable API

--- a/docs/proposals/0368-preferred-topology-constraint/README.md
+++ b/docs/proposals/0368-preferred-topology-constraint/README.md
@@ -8,6 +8,7 @@
 - [Proposal](#proposal)
   - [User Stories](#user-stories)
     - [Story 1: Automated preferred topology for externally managed workloads](#story-1-automated-preferred-topology-for-externally-managed-workloads)
+  - [Limitations/Risks &amp; Mitigations](#limitationsrisks--mitigations)
 - [Design Details](#design-details)
   - [API Change](#api-change)
   - [PodGang Propagation](#podgang-propagation)
@@ -25,30 +26,33 @@
 
 ## Summary
 
-Grove currently supports topology-aware scheduling through a required constraint (`packDomain`), which blocks the workload pending resources if the requested topology cannot be satisfied. This GREP introduces a **preferred** topology constraint — a best-effort mode that requests topology-aware placement without making it a hard requirement. If the constraint cannot be met, the workload is still scheduled rather than remaining blocked, making topology optimization accessible in scenarios where strict placement is undesirable or incompatible with the scheduler.
+Grove currently supports topology-aware scheduling through `packDomain`, a required constraint that leaves workloads pending if the requested topology cannot be satisfied. This GREP makes the API more explicit by renaming that field to `requiredPackDomain` and adding `preferredPackDomain`, a best-effort constraint that requests topology-aware placement without making it a hard requirement. If the preferred constraint cannot be met, the workload still schedules.
 
 ## Motivation
 
-Grove is increasingly used as an orchestration layer by higher-level tools that manage workload submission on behalf of users. These tools often want to apply topology preferences automatically — without exposing scheduling decisions to end users — but cannot do so today because the only available topology constraint is required (`packDomain`), which risks blocking workloads indefinitely when the topology cannot be satisfied.
+Grove is increasingly used as an orchestration layer by higher-level tools that manage workload submission on behalf of users. These tools often want to apply topology preferences automatically, without exposing scheduling decisions to end users, but cannot do so today because the only available topology constraint is required (`packDomain`).
 
-Additionally, preferred topology scheduling is a compute-intensive operation for the scheduler. It therefore cannot be enabled by default for all workloads — it must be an explicit opt-in. Exposing a preferred constraint API gives tools and users a way to request best-effort topology placement, decoupled from the all-or-nothing semantics of the current required constraint.
+Additionally, preferred topology scheduling is a compute-intensive operation for the scheduler. It therefore cannot be enabled by default for all workloads — it must be an explicit opt-in. Exposing a preferred constraint API gives tools and users a way to request best-effort topology placement, decoupled from the all-or-nothing semantics of the current required constraint. Renaming the required field from `packDomain` to `requiredPackDomain` makes the API clearer when required and preferred packing can be specified side by side.
 
 ### Goals
 
 - Introduce a preferred (best-effort) topology constraint API on `PodClique`, `PodCliqueScalingGroup`, and `PodCliqueSet`
+- Rename the required topology constraint field from `packDomain` to `requiredPackDomain` while preserving existing workloads that already use `packDomain`
 - Ensure workloads with a preferred constraint are never blocked — if topology cannot be satisfied, scheduling proceeds without it
 
 ### Non-Goals
 
 - Automatically applying preferred topology to all workloads (it remains an explicit opt-in)
-- Changing the semantics of the existing required constraint (`packDomain`)
+- Changing the semantics of the existing required constraint, which remains a hard scheduling requirement under the new `requiredPackDomain` name
 - Guaranteeing topology-optimal placement — preferred is best-effort only
 
 ## Proposal
 
-This GREP proposes adding a `packDomainPreferred` field alongside the existing `packDomain` field on `PodClique`, `PodCliqueScalingGroup`, and `PodCliqueSet`. When set, it signals to the scheduler that topology-aware placement is desired at the specified domain level on a best-effort basis — the workload is never blocked if the constraint cannot be satisfied.
+This GREP proposes adding `requiredPackDomain` and `preferredPackDomain` fields to `TopologyConstraint`, which is used by `PodClique`, `PodCliqueScalingGroup`, and `PodCliqueSet`. `requiredPackDomain` is the explicit replacement for the existing `packDomain` field and keeps the same hard scheduling semantics. `preferredPackDomain` signals to the scheduler that topology-aware placement is desired at the specified domain level on a best-effort basis — the workload is never blocked if the preferred constraint cannot be satisfied.
 
-`packDomainPreferred` and `packDomain` can coexist on the same resource. For example, a user may set `packDomainPreferred=host` and `packDomain=rack` to express that host-level packing is desired but not required, while rack-level packing is mandatory. When both are set, the scheduler attempts preferred placement first and falls back toward the required level if the preferred constraint cannot be satisfied. It is recommended that `packDomainPreferred` be stricter than or equal to `packDomain`. Setting a coarser preferred level than the required one is semantically redundant, so admission allows it but returns a warning to give users feedback without blocking the workload.
+`preferredPackDomain` and `requiredPackDomain` can coexist on the same resource. For example, a user may set `preferredPackDomain=host` and `requiredPackDomain=rack` to express that host-level packing is desired but not required, while rack-level packing is mandatory. When both are set, the scheduler attempts preferred placement first and falls back toward the required level if the preferred constraint cannot be satisfied. It is recommended that `preferredPackDomain` be stricter than or equal to `requiredPackDomain`. Setting a coarser preferred level than the required one is semantically redundant, so admission allows it but returns a warning to give users feedback without blocking the workload.
+
+The existing `packDomain` field is deprecated. It remains in the API only for compatibility with existing workloads that were created before this GREP is implemented. The operator continues to honor `packDomain` for those workloads as the required packing domain. New workload creation that uses `packDomain` is rejected; new workloads must use `requiredPackDomain`. Updates to existing workloads that still use `packDomain` are allowed when they do not otherwise violate immutability rules, but admission returns a warning directing users to `requiredPackDomain` for future workloads.
 
 ### User Stories
 
@@ -56,79 +60,101 @@ This GREP proposes adding a `packDomainPreferred` field alongside the existing `
 
 As a platform operator managing workloads over Grove, I want to automatically apply a preferred topology constraint to submitted workloads — without requiring end users to configure scheduling parameters — so that topology-aware placement is attempted as a best-effort optimization while ensuring no workload is ever blocked due to an unsatisfiable constraint.
 
+### Limitations/Risks & Mitigations
+
+- **Scheduler cost:** Preferred topology placement can be compute-intensive for scheduler backends. *Mitigation: preferred placement is explicit opt-in through `preferredPackDomain`; Grove does not apply it by default.*
+- **API transition complexity:** Keeping deprecated `packDomain` for existing workloads while rejecting it for new workloads adds validation and controller complexity. *Mitigation: controller code resolves one effective required domain, and admission tests cover create, update, warning, and ambiguity cases.*
+- **Admission warnings may be missed:** Some clients may not surface warnings for deprecated `packDomain` or redundant preferred domains. *Mitigation: warnings are advisory only; invalid or ambiguous configurations are still rejected.*
+
 ## Design Details
 
 ### API Change
 
-A single field is added to the existing `TopologyConstraint` struct in the operator API (`operator/api/core/v1alpha1/podcliqueset.go`), which is already shared across `PodCliqueSet`, `PodCliqueTemplateSpec`, and `PodCliqueScalingGroupConfig`:
+The existing `TopologyConstraint` struct in the operator API (`operator/api/core/v1alpha1/podcliqueset.go`) is updated. The struct is already shared across `PodCliqueSet`, `PodCliqueTemplateSpec`, and `PodCliqueScalingGroupConfig`:
 
 ```go
 // TopologyConstraint defines topology placement requirements.
 type TopologyConstraint struct {
-    // PackDomain specifies the required topology domain for grouping replicas.
+    // RequiredPackDomain specifies the required topology domain for grouping replicas.
     // The workload will not be scheduled if this constraint cannot be satisfied.
     // +kubebuilder:validation:Enum=region;zone;datacenter;block;rack;host;numa
     // +optional
-    PackDomain *TopologyDomain `json:"packDomain,omitempty"`
+    RequiredPackDomain *TopologyDomain `json:"requiredPackDomain,omitempty"`
 
-    // PackDomainPreferred specifies a preferred (best-effort) topology domain.
+    // PreferredPackDomain specifies a preferred (best-effort) topology domain.
     // If the constraint cannot be satisfied, the workload is scheduled anyway.
-    // When set alongside PackDomain, it is recommended that PackDomainPreferred
-    // be stricter than or equal to PackDomain.
+    // When set alongside RequiredPackDomain, it is recommended that
+    // PreferredPackDomain be stricter than or equal to RequiredPackDomain.
     // +kubebuilder:validation:Enum=region;zone;datacenter;block;rack;host;numa
     // +optional
-    PackDomainPreferred *TopologyDomain `json:"packDomainPreferred,omitempty"`
+    PreferredPackDomain *TopologyDomain `json:"preferredPackDomain,omitempty"`
+
+    // PackDomain specifies the required topology domain using the legacy field name.
+    // Deprecated: use RequiredPackDomain. This field is honored for existing
+    // workloads, rejected on new workload creation, and warned on update when still in use.
+    // +kubebuilder:validation:Enum=region;zone;datacenter;block;rack;host;numa
+    // +optional
+    PackDomain *TopologyDomain `json:"packDomain,omitempty"`
 }
 ```
 
-Note: `PackDomain` changes from a value type to a pointer (`*TopologyDomain`) to allow a `TopologyConstraint` with only `PackDomainPreferred` set. This is not a breaking API change — existing resources with `packDomain` set continue to work. Controller code accessing `PackDomain` will need nil checks.
+`RequiredPackDomain` preserves the required placement behavior of the legacy `PackDomain` field. `PreferredPackDomain` is optional and can be used alone for preferred-only topology placement. The legacy `PackDomain` field changes from a value type to an optional pointer so new workloads can omit it while existing workloads that already use it remain readable. Controller code must resolve the effective required domain from `RequiredPackDomain` first, then fall back to deprecated `PackDomain` for existing workloads.
 
 ### PodGang Propagation
 
 The scheduler API (`scheduler/api/core/v1alpha1/podgang.go`) already supports both constraints via `TopologyPackConstraint.Required` and `TopologyPackConstraint.Preferred`. No changes are needed on the scheduler side.
 
-The only required implementation change is in `createTopologyPackConstraint` (`operator/internal/controller/podcliqueset/components/podgang/syncflow.go`), which translates Grove's `TopologyConstraint` into the scheduler's `TopologyPackConstraint`. It currently only populates `Required`. It must be extended to also resolve `PackDomainPreferred` to its topology key and populate `Preferred`.
+The required implementation change is in `createTopologyPackConstraint` (`operator/internal/controller/podcliqueset/components/podgang/syncflow.go`), which translates Grove's `TopologyConstraint` into the scheduler's `TopologyPackConstraint`. It currently populates `Required` from `packDomain`. It must instead resolve the effective required domain from `requiredPackDomain`, falling back to deprecated `packDomain` for existing workloads, and populate `Required` with the resolved topology key. It must also resolve `preferredPackDomain` to its topology key and populate `Preferred`.
 
-The domain-to-key translation follows the same existing path: looking up the domain name in the `ClusterTopology` levels to obtain the corresponding node label key. Admission validation rejects invalid domains on create and update. If a previously valid preferred domain is no longer found during reconciliation because the referenced `ClusterTopology` changed after admission, it is silently skipped without blocking workload creation (same behavior as the existing required constraint).
+The domain-to-key translation follows the same existing path: looking up the domain name in the `ClusterTopology` levels to obtain the corresponding node label key. Admission validation rejects invalid domains on create and update. If a previously valid required or preferred domain is no longer found during reconciliation because the referenced `ClusterTopology` changed after admission, the missing scheduler constraint is silently skipped without blocking workload creation (same behavior as the existing required constraint).
 
 ### Webhook Validation
 
-The admission webhook (`operator/internal/webhook/admission/pcs/validation/topologyconstraints.go`) must be extended to cover `PackDomainPreferred` with the same rules that apply to `PackDomain`:
+The admission webhook (`operator/internal/webhook/admission/pcs/validation/topologyconstraints.go`) must be extended to validate the new field names and the deprecated `packDomain` compatibility path:
 
-- **Domain existence:** Creation or update with a `packDomainPreferred` value that does not exist in the referenced `ClusterTopology` CR is rejected at admission time, same as `packDomain`.
-- **Hierarchy:** `packDomainPreferred` on a child resource must be stricter than or equal to the parent's `packDomainPreferred`.
-- **Same-resource preferred vs. required domain:** When `packDomainPreferred` is coarser than `packDomain` on the same resource, the request is allowed but admission returns a warning because the preferred domain is semantically redundant.
-- **Update immutability:** `packDomainPreferred` cannot be changed on update, matching the existing immutability behavior for `packDomain`.
+- **Domain existence:** Creation or update with a `requiredPackDomain` or `preferredPackDomain` value that does not exist in the referenced `ClusterTopology` CR is rejected at admission time, same as `packDomain` is today. Accepted legacy `packDomain` values on existing workloads continue to be validated against the same domain list on update.
+- **Deprecated field on create:** New workload creation that sets `packDomain` is rejected. New workloads must use `requiredPackDomain`.
+- **Deprecated field on update:** Existing workloads that already use `packDomain` remain valid and continue to use it as the required packing domain, but admission returns a warning on update while the deprecated field remains in use.
+- **Required domain ambiguity:** A single `TopologyConstraint` must not set both `requiredPackDomain` and deprecated `packDomain`.
+- **Hierarchy:** `requiredPackDomain` follows the same hierarchy rules as the existing required `packDomain`. `preferredPackDomain` on a child resource must be stricter than or equal to the parent's `preferredPackDomain`.
+- **Same-resource preferred vs. required domain:** When `preferredPackDomain` is coarser than the effective required domain on the same resource, the request is allowed but admission returns a warning because the preferred domain is semantically redundant.
+- **Update immutability:** `requiredPackDomain`, `preferredPackDomain`, and deprecated `packDomain` cannot be changed on update, matching the existing immutability behavior for `packDomain`.
 
 ### Monitoring
 
-There is no scheduler-side feedback on whether preferred placement was achieved. This is consistent with the existing behavior for `packDomain`, which also has no placement-outcome indicator.
+There is no scheduler-side feedback on whether preferred placement was achieved. This is consistent with the existing behavior for required topology placement, which also has no placement-outcome indicator.
 
-The existing `TopologyLevelUnavailable` status condition on `PodCliqueSet`, which checks whether referenced topology domains exist in the `ClusterTopology` CR, will be extended to also cover `packDomainPreferred` domains.
+The existing `TopologyLevelUnavailable` status condition on `PodCliqueSet`, which checks whether referenced topology domains exist in the `ClusterTopology` CR, will be extended to cover `requiredPackDomain` and `preferredPackDomain` domains. For existing workloads that still use deprecated `packDomain`, the condition continues to treat `packDomain` as the effective required domain.
 
 ### Test Plan
 
 **Unit — webhook validation:**
-- `packDomainPreferred` domain not present in `ClusterTopology` is rejected
-- Creation with an invalid `packDomainPreferred` domain level name is rejected, same as `packDomain`
-- Updates that change `packDomainPreferred` are rejected, same as `packDomain`
-- `packDomainPreferred` stricter than parent is accepted; coarser than the parent's `packDomainPreferred` is rejected
-- `packDomainPreferred` coarser than `packDomain` on the same resource is allowed with an admission warning
-- `packDomainPreferred` can be set without `packDomain`, and vice versa
+- `requiredPackDomain` and `preferredPackDomain` domain names not present in `ClusterTopology` are rejected
+- Creation with deprecated `packDomain` is rejected
+- Updates to existing workloads that still use deprecated `packDomain` are allowed with an admission warning
+- Updates that change `requiredPackDomain`, `preferredPackDomain`, or deprecated `packDomain` are rejected
+- A single `TopologyConstraint` that sets both `requiredPackDomain` and deprecated `packDomain` is rejected
+- `preferredPackDomain` stricter than parent is accepted; coarser than the parent's `preferredPackDomain` is rejected
+- `preferredPackDomain` coarser than the effective required domain on the same resource is allowed with an admission warning
+- `preferredPackDomain` can be set without `requiredPackDomain`, and vice versa
 
 **Unit — syncflow (`TestComputeExpectedPodGangsWithTopologyConstraints`):**
-- `packDomainPreferred` alone → `TopologyPackConstraint.Preferred` set, `Required` nil
-- Both fields set → both `Preferred` and `Required` populated correctly
-- Previously valid `packDomainPreferred` domain missing from `ClusterTopology` during reconciliation after a topology change → `Preferred` silently skipped, workload still created
+- `preferredPackDomain` alone → `TopologyPackConstraint.Preferred` set, `Required` nil
+- `requiredPackDomain` alone → `TopologyPackConstraint.Required` set, `Preferred` nil
+- Deprecated `packDomain` on an existing workload → `TopologyPackConstraint.Required` set from `packDomain`
+- `requiredPackDomain` and `preferredPackDomain` set together → both `Required` and `Preferred` populated correctly
+- Previously valid `requiredPackDomain` or `preferredPackDomain` domain missing from `ClusterTopology` during reconciliation after a topology change → the missing scheduler constraint is silently skipped, workload still created
 
 **E2E:**
 - Preferred constraint that can be satisfied → workload schedules successfully and scheduler receives the preferred constraint (validates the full propagation path including the scheduler)
 - Preferred constraint that cannot be satisfied → workload schedules successfully (key behavioral difference from required)
+- Existing workload created with deprecated `packDomain` before upgrade continues to reconcile and propagate the required scheduler constraint after upgrade
 
 ### Graduation Criteria
 
 #### Alpha
-- `packDomainPreferred` field available on all three resources (`PodCliqueSet`, `PodCliqueScalingGroupConfig`, `PodCliqueTemplateSpec`)
+- `requiredPackDomain` and `preferredPackDomain` fields available on all three resources (`PodCliqueSet`, `PodCliqueScalingGroupConfig`, `PodCliqueTemplateSpec`)
+- Deprecated `packDomain` remains honored for existing workloads and rejected for new workloads
 - Unit and e2e tests passing
 
 #### Beta
@@ -155,4 +181,4 @@ The scheduler could automatically apply a preferred constraint at the finest ava
 A single boolean field on `PodCliqueSet` (e.g. `preferredTopologyEnabled`) would enable preferred placement at the lowest topology level for all cliques, without allowing per-resource or per-level control.
 
 - **Pro:** Simpler API surface.
-- **Con:** Provides no control over which topology level is preferred, and cannot express different preferences across `PodCliqueSet`, `PodCliqueScalingGroup`, and `PodClique`. Higher-level tools can trivially implement this coarser interface on top of `packDomainPreferred`, but the reverse is not true.
+- **Con:** Provides no control over which topology level is preferred, and cannot express different preferences across `PodCliqueSet`, `PodCliqueScalingGroup`, and `PodClique`. Higher-level tools can trivially implement this coarser interface on top of `preferredPackDomain`, but the reverse is not true.

--- a/docs/proposals/0368-preferred-topology-constraint/README.md
+++ b/docs/proposals/0368-preferred-topology-constraint/README.md
@@ -31,7 +31,7 @@ Grove currently supports topology-aware scheduling through `packDomain`, a requi
 
 ## Motivation
 
-Grove is increasingly used as an orchestration layer by higher-level tools that manage workload submission on behalf of users. These tools often want to apply topology preferences automatically, without exposing scheduling decisions to end users, but cannot do so today because the only available topology constraint is required (`packDomain`).
+Grove is increasingly used as an orchestration layer by higher-level tools that manage workload submission on behalf of users. These tools often want to apply topology preferences as soft hints, without exposing scheduling decisions to end users, but cannot do so today because the only available topology constraint is required (`packDomain`).
 
 Additionally, preferred topology scheduling is a compute-intensive operation for the scheduler. It therefore cannot be enabled by default for all workloads — it must be an explicit opt-in. Exposing a preferred constraint API gives tools and users a way to request best-effort topology placement, decoupled from the all-or-nothing semantics of the current required constraint. Grouping required and preferred packing under `pack` makes the API clearer when both modes are specified side by side.
 
@@ -94,37 +94,37 @@ type TopologyConstraint struct {
     Pack *TopologyPackConstraint `json:"pack,omitempty"`
 
     // PackDomain specifies the required topology domain using the legacy field name.
-    // Deprecated: use Pack.Required.
+    // Deprecated: use Pack.RequiredDomain.
     // This field is honored for existing workloads, rejected on new workload
     // creation, and warned on update when still in use. Existing workloads may
-    // migrate from PackDomain to Pack.Required if the domain value is unchanged.
+    // migrate from PackDomain to Pack.RequiredDomain if the domain value is unchanged.
     // +optional
     PackDomain *TopologyDomain `json:"packDomain,omitempty"`
 }
 
 // TopologyPackConstraint defines topology pack placement requirements.
 type TopologyPackConstraint struct {
-    // Required specifies the required topology packing constraint of each replica of the resource.
+    // RequiredDomain specifies the required topology packing constraint of each replica of the resource.
     // The workload will not be scheduled if this constraint cannot be satisfied.
     // Must reference a domain in the topology levels defined in the selected ClusterTopology.
     // Example: "rack" means each replica is independently placed within one rack.
     // Note: Does NOT constrain all replicas to the same rack together.
     // Different replicas can be in different topology domains.
     // +optional
-    Required *TopologyDomain `json:"required,omitempty"`
+    RequiredDomain  *TopologyDomain `json:"required,omitempty"`
 
-    // Preferred specifies a preferred (best-effort) topology domain.
+    // PreferredDomain specifies a preferred (best-effort) topology domain.
     // If the constraint cannot be satisfied, the workload is scheduled anyway.
-    // When set alongside Required, it is recommended that Preferred be stricter
-    // than or equal to Required.
+    // When set alongside RequiredDomain, it is recommended that PreferredDomain be stricter
+    // than or equal to RequiredDomain.
     // +optional
-    Preferred *TopologyDomain `json:"preferred,omitempty"`
+    PreferredDomain *TopologyDomain `json:"preferred,omitempty"`
 }
 ```
 
-`TopologyName` remains part of `TopologyConstraint` and continues to select the `ClusterTopology` used for domain-to-key resolution, following the existing topology-name inheritance behavior. `Pack.Required` preserves the required placement behavior of the legacy `PackDomain` field, but is optional so a workload can use `Pack.Preferred` without a hard topology requirement. `Pack.Preferred` is optional and can be used alone for preferred-only topology placement.
+`TopologyName` remains part of `TopologyConstraint` and continues to select the `ClusterTopology` used for domain-to-key resolution, following the existing topology-name inheritance behavior. `Pack.RequiredDomain` preserves the required placement behavior of the legacy `PackDomain` field, but is optional so a workload can use `Pack.PreferredDomain` without a hard topology requirement. `Pack.PreferredDomain` is optional and can be used alone for preferred-only topology placement.
 
-The legacy `PackDomain` field changes from a required value to an optional pointer and remains in the API only for compatibility with existing workloads. New workloads must use `Pack.Required` for hard placement requirements; preferred-only workloads can set only `Pack.Preferred`. `PackDomain` is honored for existing workloads, rejected on new workload creation, and warned on update when still in use. Existing workloads may move from `PackDomain` to `Pack.Required` in an update if the domain value is identical; this migration is a field-name repair, not a semantic change. Controller code must resolve the effective required domain from `Pack.Required` first, then fall back to deprecated `PackDomain` for existing workloads.
+The legacy `PackDomain` field changes from a required value to an optional pointer and remains in the API only for compatibility with existing workloads. New workloads must use `Pack.RequiredDomain` for hard placement requirements; preferred-only workloads can set only `Pack.PreferredDomain`. `PackDomain` is honored for existing workloads, rejected on new workload creation, and warned on update when still in use. Existing workloads may move from `PackDomain` to `Pack.RequiredDomain` in an update if the domain value is identical; this migration is a field-name repair, not a semantic change. Controller code must resolve the effective required domain from `Pack.RequiredDomain` first, then fall back to deprecated `PackDomain` for existing workloads.
 
 ### PodGang Propagation
 

--- a/docs/proposals/0368-preferred-topology-constraint/README.md
+++ b/docs/proposals/0368-preferred-topology-constraint/README.md
@@ -27,39 +27,39 @@
 
 ## Summary
 
-Grove currently supports topology-aware scheduling through `packDomain`, a required constraint that leaves workloads pending if the requested topology cannot be satisfied. This GREP makes the API more explicit by renaming that field to `requiredPackDomain` and adding `preferredPackDomain`, a best-effort constraint that requests topology-aware placement without making it a hard requirement. If the preferred constraint cannot be met, the workload still schedules.
+Grove currently supports topology-aware scheduling through `packDomain`, a required constraint that leaves workloads pending if the requested topology cannot be satisfied. This GREP makes the API more explicit by deprecating `packDomain` in favor of `pack.required`, and by adding `pack.preferred`, a best-effort constraint that requests topology-aware placement without making it a hard requirement. If the preferred constraint cannot be met, the workload still schedules.
 
 ## Motivation
 
 Grove is increasingly used as an orchestration layer by higher-level tools that manage workload submission on behalf of users. These tools often want to apply topology preferences automatically, without exposing scheduling decisions to end users, but cannot do so today because the only available topology constraint is required (`packDomain`).
 
-Additionally, preferred topology scheduling is a compute-intensive operation for the scheduler. It therefore cannot be enabled by default for all workloads — it must be an explicit opt-in. Exposing a preferred constraint API gives tools and users a way to request best-effort topology placement, decoupled from the all-or-nothing semantics of the current required constraint. Renaming the required field from `packDomain` to `requiredPackDomain` makes the API clearer when required and preferred packing can be specified side by side.
+Additionally, preferred topology scheduling is a compute-intensive operation for the scheduler. It therefore cannot be enabled by default for all workloads — it must be an explicit opt-in. Exposing a preferred constraint API gives tools and users a way to request best-effort topology placement, decoupled from the all-or-nothing semantics of the current required constraint. Grouping required and preferred packing under `pack` makes the API clearer when both modes are specified side by side.
 
 ### Goals
 
 - Introduce a preferred (best-effort) topology constraint API on `PodClique`, `PodCliqueScalingGroup`, and `PodCliqueSet`
-- Rename the required topology constraint field from `packDomain` to `requiredPackDomain` while preserving existing workloads that already use `packDomain`
+- Replace the required topology constraint field `packDomain` with `pack.required` while preserving existing workloads that already use `packDomain`
 - Ensure workloads with a preferred constraint are never blocked — if topology cannot be satisfied, scheduling proceeds without it
 
 ### Non-Goals
 
 - Automatically applying preferred topology to all workloads (it remains an explicit opt-in)
-- Changing the semantics of the existing required constraint, which remains a hard scheduling requirement under the new `requiredPackDomain` name
+- Changing the semantics of the existing required constraint, which remains a hard scheduling requirement under `pack.required`
 - Guaranteeing topology-optimal placement — preferred is best-effort only
 
 ## Proposal
 
-This GREP proposes adding `requiredPackDomain` and `preferredPackDomain` fields to `TopologyConstraint`, which is used by `PodClique`, `PodCliqueScalingGroup`, and `PodCliqueSet`. `requiredPackDomain` is the explicit replacement for the existing `packDomain` field and keeps the same hard scheduling semantics. `preferredPackDomain` signals to the scheduler that topology-aware placement is desired at the specified domain level on a best-effort basis — the workload is never blocked if the preferred constraint cannot be satisfied.
+This GREP proposes adding a nested `pack` field to `TopologyConstraint`, which is used by `PodClique`, `PodCliqueScalingGroup`, and `PodCliqueSet`. `pack.required` is the explicit replacement for the existing `packDomain` field and keeps the same hard scheduling semantics. `pack.preferred` signals to the scheduler that topology-aware placement is desired at the specified domain level on a best-effort basis — the workload is never blocked if the preferred constraint cannot be satisfied.
 
-`preferredPackDomain` and `requiredPackDomain` can coexist on the same resource. For example, a user may set `preferredPackDomain=host` and `requiredPackDomain=rack` to express that host-level packing is desired but not required, while rack-level packing is mandatory. When both are set, the scheduler attempts preferred placement first and falls back toward the required level if the preferred constraint cannot be satisfied. It is recommended that `preferredPackDomain` be stricter than or equal to `requiredPackDomain`. Setting a coarser preferred level than the required one is semantically redundant, so admission allows it but returns a warning to give users feedback without blocking the workload.
+`pack.preferred` and `pack.required` can coexist on the same resource. For example, a user may set `pack.preferred=host` and `pack.required=rack` to express that host-level packing is desired but not required, while rack-level packing is mandatory. When both are set, the scheduler attempts preferred placement first and falls back toward the required level if the preferred constraint cannot be satisfied. It is recommended that `pack.preferred` be stricter than or equal to `pack.required`. Setting a coarser preferred level than the required one is semantically redundant, so admission allows it but returns a warning to give users feedback without blocking the workload.
 
-The existing `packDomain` field is deprecated. It remains in the API only for compatibility with existing workloads that were created before this GREP is implemented. The operator continues to honor `packDomain` for those workloads as the required packing domain. New workload creation that uses `packDomain` is rejected; new workloads must use `requiredPackDomain`. Updates to existing workloads that still use `packDomain` are allowed when they do not otherwise violate immutability rules, but admission returns a warning directing users to `requiredPackDomain` for future workloads.
+The existing `packDomain` field is deprecated. It remains in the API only for compatibility with existing workloads that were created before this GREP is implemented. The operator continues to honor `packDomain` for those workloads as the required packing domain. New workload creation that uses `packDomain` is rejected; new workloads must use `pack.required` for hard placement requirements. Updates to existing workloads that still use `packDomain` are allowed when they do not otherwise violate immutability rules, but admission returns a warning directing users to `pack.required`. Users can suppress the warning by migrating from `packDomain` to `pack.required` in an update, but only when the topology domain value is unchanged.
 
 ### User Stories
 
 #### Story 1: Preferred host-level locality for a workload
 
-As an ML engineer submitting a workload with Grove, I want to set `preferredPackDomain: host` to signal that my pods benefit from being placed close together, so that Grove and the scheduler attempt host-level locality without blocking the workload when that placement is unavailable.
+As an ML engineer submitting a workload with Grove, I want to set `pack.preferred: host` to signal that my pods benefit from being placed close together, so that Grove and the scheduler attempt host-level locality without blocking the workload when that placement is unavailable.
 
 #### Story 2: Automated preferred topology for externally managed workloads
 
@@ -67,8 +67,8 @@ As a platform operator managing workloads over Grove, I want to automatically ap
 
 ### Limitations/Risks & Mitigations
 
-- **Scheduler cost:** Preferred topology placement can be compute-intensive for scheduler backends. *Mitigation: preferred placement is explicit opt-in through `preferredPackDomain`; Grove does not apply it by default.*
-- **API transition complexity:** Keeping deprecated `packDomain` for existing workloads while rejecting it for new workloads adds validation and controller complexity. *Mitigation: controller code resolves one effective required domain, and admission tests cover create, update, warning, and ambiguity cases.*
+- **Scheduler cost:** Preferred topology placement can be compute-intensive for scheduler backends. *Mitigation: preferred placement is explicit opt-in through `pack.preferred`; Grove does not apply it by default.*
+- **API transition complexity:** Keeping deprecated `packDomain` for existing workloads while rejecting it for new workloads adds validation and controller complexity. *Mitigation: controller code resolves one effective required domain, and admission tests cover create, update, warning, same-value migration, and ambiguity cases.*
 - **Admission warnings may be missed:** Some clients may not surface warnings for deprecated `packDomain` or redundant preferred domains. *Mitigation: warnings are advisory only; invalid or ambiguous configurations are still rejected.*
 
 ## Design Details
@@ -81,86 +81,100 @@ The existing `TopologyConstraint` struct in the operator API (`operator/api/core
 // TopologyConstraint defines topology placement requirements.
 type TopologyConstraint struct {
     // TopologyName is the name of the ClusterTopology resource to use for topology-aware scheduling.
-    // If topologyConstraint is set, topologyName must be specified.
+    // Setting TopologyName is optional when the name can be inherited from a parent scope.
+    // When TopologyName is specified at the PodCliqueSet or PodCliqueScalingGroup level,
+    // it is inherited as the default ClusterTopology name by child constraints unless
+    // the child specifies another TopologyName.
     // Immutable after creation.
-    // +required
-    TopologyName string `json:"topologyName"`
+    // +optional
+    TopologyName string `json:"topologyName,omitempty"`
 
-    // RequiredPackDomain specifies the required topology domain for grouping replicas.
-    // Controls placement constraint for EACH individual replica instance.
+    // Pack specifies the topology packing constraints of each replica of the resource.
+    // +optional
+    Pack *TopologyPackConstraint `json:"pack,omitempty"`
+
+    // PackDomain specifies the required topology domain using the legacy field name.
+    // Deprecated: use Pack.Required.
+    // This field is honored for existing workloads, rejected on new workload
+    // creation, and warned on update when still in use. Existing workloads may
+    // migrate from PackDomain to Pack.Required if the domain value is unchanged.
+    // +optional
+    PackDomain *TopologyDomain `json:"packDomain,omitempty"`
+}
+
+// TopologyPackConstraint defines topology pack placement requirements.
+type TopologyPackConstraint struct {
+    // Required specifies the required topology packing constraint of each replica of the resource.
     // The workload will not be scheduled if this constraint cannot be satisfied.
-    // Must reference a domain in the topology levels defined in the ClusterTopology
-    // CR named by TopologyName.
+    // Must reference a domain in the topology levels defined in the selected ClusterTopology.
     // Example: "rack" means each replica is independently placed within one rack.
     // Note: Does NOT constrain all replicas to the same rack together.
     // Different replicas can be in different topology domains.
     // +optional
-    RequiredPackDomain *TopologyDomain `json:"requiredPackDomain,omitempty"`
+    Required *TopologyDomain `json:"required,omitempty"`
 
-    // PreferredPackDomain specifies a preferred (best-effort) topology domain.
+    // Preferred specifies a preferred (best-effort) topology domain.
     // If the constraint cannot be satisfied, the workload is scheduled anyway.
-    // When set alongside RequiredPackDomain, it is recommended that
-    // PreferredPackDomain be stricter than or equal to RequiredPackDomain.
+    // When set alongside Required, it is recommended that Preferred be stricter
+    // than or equal to Required.
     // +optional
-    PreferredPackDomain *TopologyDomain `json:"preferredPackDomain,omitempty"`
-
-    // PackDomain specifies the required topology domain using the legacy field name.
-    // Deprecated: use RequiredPackDomain.
-    // This field is honored for existing workloads, rejected on new workload
-    // creation, and warned on update when still in use.
-    // +optional
-    PackDomain *TopologyDomain `json:"packDomain,omitempty"`
+    Preferred *TopologyDomain `json:"preferred,omitempty"`
 }
 ```
 
-`TopologyName` remains part of `TopologyConstraint` and continues to select the `ClusterTopology` used for domain-to-key resolution. `RequiredPackDomain` preserves the required placement behavior of the legacy `PackDomain` field, but is optional so a workload can use `PreferredPackDomain` without a hard topology requirement. `PreferredPackDomain` is optional and can be used alone for preferred-only topology placement. Admission requires a `TopologyConstraint` to include `topologyName` and at least one packing domain field.
+`TopologyName` remains part of `TopologyConstraint` and continues to select the `ClusterTopology` used for domain-to-key resolution, following the existing topology-name inheritance behavior. `Pack.Required` preserves the required placement behavior of the legacy `PackDomain` field, but is optional so a workload can use `Pack.Preferred` without a hard topology requirement. `Pack.Preferred` is optional and can be used alone for preferred-only topology placement.
 
-The legacy `PackDomain` field changes from a required value to an optional pointer and remains in the API only for compatibility with existing workloads. New workloads must use `RequiredPackDomain` for hard placement requirements; `PackDomain` is honored for existing workloads, rejected on new workload creation, and warned on update when still in use. Controller code must resolve the effective required domain from `RequiredPackDomain` first, then fall back to deprecated `PackDomain` for existing workloads.
+The legacy `PackDomain` field changes from a required value to an optional pointer and remains in the API only for compatibility with existing workloads. New workloads must use `Pack.Required` for hard placement requirements; preferred-only workloads can set only `Pack.Preferred`. `PackDomain` is honored for existing workloads, rejected on new workload creation, and warned on update when still in use. Existing workloads may move from `PackDomain` to `Pack.Required` in an update if the domain value is identical; this migration is a field-name repair, not a semantic change. Controller code must resolve the effective required domain from `Pack.Required` first, then fall back to deprecated `PackDomain` for existing workloads.
 
 ### PodGang Propagation
 
 The scheduler API (`scheduler/api/core/v1alpha1/podgang.go`) already supports both constraints via `TopologyPackConstraint.Required` and `TopologyPackConstraint.Preferred`. No changes are needed on the scheduler side.
 
-The required implementation change is in `createTopologyPackConstraint` (`operator/internal/controller/podcliqueset/components/podgang/syncflow.go`), which translates Grove's `TopologyConstraint` into the scheduler's `TopologyPackConstraint`. It currently populates `Required` from `packDomain`. It must instead resolve the effective required domain from `requiredPackDomain`, falling back to deprecated `packDomain` for existing workloads, and populate `Required` with the resolved topology key. It must also resolve `preferredPackDomain` to its topology key and populate `Preferred`.
+The required implementation change is in `createTopologyPackConstraint` (`operator/internal/controller/podcliqueset/components/podgang/syncflow.go`), which translates Grove's `TopologyConstraint` into the scheduler's `TopologyPackConstraint`. It currently populates `Required` from `packDomain`. It must instead resolve the effective required domain from `pack.required`, falling back to deprecated `packDomain` for existing workloads, and populate `Required` with the resolved topology key. It must also resolve `pack.preferred` to its topology key and populate `Preferred`.
 
 The domain-to-key translation follows the same existing path: looking up the domain name in the `ClusterTopology` levels to obtain the corresponding node label key. Admission validation rejects invalid domains on create and update. If a previously valid required or preferred domain is no longer found during reconciliation because the referenced `ClusterTopology` changed after admission, the missing scheduler constraint is silently skipped without blocking workload creation (same behavior as the existing required constraint).
 
 ### Webhook Validation
 
-The admission webhook (`operator/internal/webhook/admission/pcs/validation/topologyconstraints.go`) must be extended to validate the new field names and the deprecated `packDomain` compatibility path:
+The admission webhook (`operator/internal/webhook/admission/pcs/validation/topologyconstraints.go`) must be extended to validate the nested `pack` field and the deprecated `packDomain` compatibility path:
 
-- **Domain existence:** Creation or update with a `requiredPackDomain` or `preferredPackDomain` value that does not exist in the referenced `ClusterTopology` CR is rejected at admission time, same as `packDomain` is today. Accepted legacy `packDomain` values on existing workloads continue to be validated against the same domain list on update.
-- **Deprecated field on create:** New workload creation that sets `packDomain` is rejected. New workloads must use `requiredPackDomain`.
-- **Deprecated field on update:** Existing workloads that already use `packDomain` remain valid and continue to use it as the required packing domain, but admission returns a warning on update while the deprecated field remains in use.
-- **Required domain ambiguity:** A single `TopologyConstraint` must not set both `requiredPackDomain` and deprecated `packDomain`.
-- **Hierarchy:** `requiredPackDomain` follows the same hierarchy rules as the existing required `packDomain`. `preferredPackDomain` on a child resource must be stricter than or equal to the parent's `preferredPackDomain`.
-- **Same-resource preferred vs. required domain:** When `preferredPackDomain` is coarser than the effective required domain on the same resource, the request is allowed but admission returns a warning because the preferred domain is semantically redundant.
-- **Update immutability:** `requiredPackDomain`, `preferredPackDomain`, and deprecated `packDomain` cannot be changed on update, matching the existing immutability behavior for `packDomain`.
+- **Pack completeness:** New topology constraints must set `pack` with at least one of `required` or `preferred`. An empty `pack` is rejected.
+- **Domain existence:** Creation or update with a `pack.required` or `pack.preferred` value that does not exist in the resolved `ClusterTopology` CR is rejected at admission time, same as `packDomain` is today. Accepted legacy `packDomain` values on existing workloads continue to be validated against the same domain list on update.
+- **Deprecated field on create:** New workload creation that sets `packDomain` is rejected. New workloads must use `pack.required` for hard placement requirements.
+- **Deprecated field on update:** Existing workloads that already use `packDomain` remain valid and continue to use it as the required packing domain, but admission returns a warning on update while the deprecated field remains in use. The warning can be suppressed by removing `packDomain` and setting `pack.required` to the same domain value in the update.
+- **Required domain migration:** Updating an existing workload from deprecated `packDomain` to `pack.required` is allowed only when the topology domain value is unchanged. Changing the required topology domain during this migration is rejected.
+- **Required domain ambiguity:** A resulting `TopologyConstraint` must not set both `pack.required` and deprecated `packDomain`.
+- **Hierarchy:** `pack.required` follows the same hierarchy rules as the existing required `packDomain`. `pack.preferred` on a child resource must be stricter than or equal to the parent's `pack.preferred`.
+- **Same-resource preferred vs. required domain:** When `pack.preferred` is coarser than the effective required domain on the same resource, the request is allowed but admission returns a warning because the preferred domain is semantically redundant.
+- **Update immutability:** `pack.required`, `pack.preferred`, and deprecated `packDomain` cannot be changed on update, matching the existing immutability behavior for `packDomain`, except for the same-value migration from deprecated `packDomain` to `pack.required`.
 
 ### Monitoring
 
 There is no scheduler-side feedback on whether preferred placement was achieved. This is consistent with the existing behavior for required topology placement, which also has no placement-outcome indicator.
 
-The existing `TopologyLevelUnavailable` status condition on `PodCliqueSet`, which checks whether referenced topology domains exist in the `ClusterTopology` CR, will be extended to cover `requiredPackDomain` and `preferredPackDomain` domains. For existing workloads that still use deprecated `packDomain`, the condition continues to treat `packDomain` as the effective required domain.
+The existing `TopologyLevelUnavailable` status condition on `PodCliqueSet`, which checks whether referenced topology domains exist in the `ClusterTopology` CR, will be extended to cover `pack.required` and `pack.preferred` domains. For existing workloads that still use deprecated `packDomain`, the condition continues to treat `packDomain` as the effective required domain.
 
 ### Test Plan
 
 **Unit — webhook validation:**
-- `requiredPackDomain` and `preferredPackDomain` domain names not present in `ClusterTopology` are rejected
+- `pack.required` and `pack.preferred` domain names not present in `ClusterTopology` are rejected
+- New topology constraints with empty `pack` are rejected
 - Creation with deprecated `packDomain` is rejected
 - Updates to existing workloads that still use deprecated `packDomain` are allowed with an admission warning
-- Updates that change `requiredPackDomain`, `preferredPackDomain`, or deprecated `packDomain` are rejected
-- A single `TopologyConstraint` that sets both `requiredPackDomain` and deprecated `packDomain` is rejected
-- `preferredPackDomain` stricter than parent is accepted; coarser than the parent's `preferredPackDomain` is rejected
-- `preferredPackDomain` coarser than the effective required domain on the same resource is allowed with an admission warning
-- `preferredPackDomain` can be set without `requiredPackDomain`, and vice versa
+- Updates that migrate from deprecated `packDomain` to `pack.required` with the same domain value are allowed without the deprecated-field warning
+- Updates that migrate from deprecated `packDomain` to `pack.required` with a different domain value are rejected
+- Updates that otherwise change `pack.required`, `pack.preferred`, or deprecated `packDomain` are rejected
+- A resulting `TopologyConstraint` that sets both `pack.required` and deprecated `packDomain` is rejected
+- `pack.preferred` stricter than parent is accepted; coarser than the parent's `pack.preferred` is rejected
+- `pack.preferred` coarser than the effective required domain on the same resource is allowed with an admission warning
+- `pack.preferred` can be set without `pack.required`, and vice versa
 
 **Unit — syncflow (`TestComputeExpectedPodGangsWithTopologyConstraints`):**
-- `preferredPackDomain` alone → `TopologyPackConstraint.Preferred` set, `Required` nil
-- `requiredPackDomain` alone → `TopologyPackConstraint.Required` set, `Preferred` nil
+- `pack.preferred` alone → `TopologyPackConstraint.Preferred` set, `Required` nil
+- `pack.required` alone → `TopologyPackConstraint.Required` set, `Preferred` nil
 - Deprecated `packDomain` on an existing workload → `TopologyPackConstraint.Required` set from `packDomain`
-- `requiredPackDomain` and `preferredPackDomain` set together → both `Required` and `Preferred` populated correctly
-- Previously valid `requiredPackDomain` or `preferredPackDomain` domain missing from `ClusterTopology` during reconciliation after a topology change → the missing scheduler constraint is silently skipped, workload still created
+- `pack.required` and `pack.preferred` set together → both `Required` and `Preferred` populated correctly
+- Previously valid `pack.required` or `pack.preferred` domain missing from `ClusterTopology` during reconciliation after a topology change → the missing scheduler constraint is silently skipped, workload still created
 
 **E2E:**
 - Preferred constraint that can be satisfied → workload schedules successfully and scheduler receives the preferred constraint (validates the full propagation path including the scheduler)
@@ -170,7 +184,7 @@ The existing `TopologyLevelUnavailable` status condition on `PodCliqueSet`, whic
 ### Graduation Criteria
 
 #### Alpha
-- `requiredPackDomain` and `preferredPackDomain` fields available on all three resources (`PodCliqueSet`, `PodCliqueScalingGroupConfig`, `PodCliqueTemplateSpec`)
+- `pack.required` and `pack.preferred` fields available on all three resources (`PodCliqueSet`, `PodCliqueScalingGroupConfig`, `PodCliqueTemplateSpec`)
 - Deprecated `packDomain` remains honored for existing workloads and rejected for new workloads
 - Unit and e2e tests passing
 
@@ -198,4 +212,4 @@ The scheduler could automatically apply a preferred constraint at the finest ava
 A single boolean field on `PodCliqueSet` (e.g. `preferredTopologyEnabled`) would enable preferred placement at the lowest topology level for all cliques, without allowing per-resource or per-level control.
 
 - **Pro:** Simpler API surface.
-- **Con:** Provides no control over which topology level is preferred, and cannot express different preferences across `PodCliqueSet`, `PodCliqueScalingGroup`, and `PodClique`. A literal boolean is also technically insufficient because the workload must still select a `ClusterTopology` through `topologyName`; this alternative would need a topology reference plus the boolean opt-in. Higher-level tools can trivially implement this coarser interface on top of `preferredPackDomain`, but the reverse is not true.
+- **Con:** Provides no control over which topology level is preferred, and cannot express different preferences across `PodCliqueSet`, `PodCliqueScalingGroup`, and `PodClique`. A literal boolean is also technically insufficient because the workload must still select a `ClusterTopology` through `topologyName`; this alternative would need a topology reference plus the boolean opt-in. Higher-level tools can trivially implement this coarser interface on top of `pack.preferred`, but the reverse is not true.

--- a/docs/proposals/0368-preferred-topology-constraint/README.md
+++ b/docs/proposals/0368-preferred-topology-constraint/README.md
@@ -7,10 +7,7 @@
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
   - [User Stories](#user-stories)
-    - [Story 1: Topology-aware placement with graceful fallback](#story-1-topology-aware-placement-with-graceful-fallback)
-    - [Story 2: Mixed required and preferred constraints for disaggregated inference](#story-2-mixed-required-and-preferred-constraints-for-disaggregated-inference)
-    - [Story 3: Admin-controlled preferred topology](#story-3-admin-controlled-preferred-topology)
-    - [Story 4: External orchestration platform](#story-4-external-orchestration-platform)
+    - [Story 1: Automated preferred topology in Dynamo on Run:ai](#story-1-automated-preferred-topology-in-dynamo-on-runai)
   - [Limitations/Risks &amp; Mitigations](#limitationsrisks--mitigations)
 - [Design Details](#design-details)
   - [API Change](#api-change)
@@ -24,245 +21,138 @@
     - [GA](#ga)
 - [Alternatives](#alternatives)
   - [Always-on preferred topology at the lowest level](#always-on-preferred-topology-at-the-lowest-level)
-  - [Workload-level preferred domain](#workload-level-preferred-domain)
   - [Boolean opt-in on <code>PodCliqueSet</code>](#boolean-opt-in-on-podcliqueset)
 <!-- /toc -->
 
 ## Summary
 
-Grove topology-aware scheduling currently supports required packing through `packDomain`, which can leave workloads pending when the requested topology domain cannot fit them. This GREP introduces `ClusterTopology.spec.preferredPackDomain`, an administrator-controlled preferred packing domain that Grove applies as a best-effort scheduler preference to workloads that reference that `ClusterTopology`. Workloads can opt into topology-aware placement by setting `topologyName` with or without a required `packDomain`; when the referenced topology defines `preferredPackDomain`, Grove propagates it to the scheduler as a preferred constraint so placement can be optimized without blocking scheduling if the preference cannot be satisfied.
+Grove currently supports topology-aware scheduling through a required constraint (`packDomain`), which blocks the workload pending resources if the requested topology cannot be satisfied. This GREP introduces a **preferred** topology constraint — a best-effort mode that requests topology-aware placement without making it a hard requirement. If the constraint cannot be met, the workload is still scheduled rather than remaining blocked, making topology optimization accessible in scenarios where strict placement is undesirable or incompatible with the scheduler.
 
 ## Motivation
 
-Grove is increasingly used as an orchestration layer by higher-level tools that submit workloads on behalf of users. These tools often want topology-aware placement to improve workload performance, but the existing workload-facing constraint, `packDomain`, is required: if the requested domain cannot fit the workload, scheduling may remain blocked.
+Grove is increasingly used as an orchestration layer by higher-level tools (e.g. Dynamo on Run:ai) that manage workload submission on behalf of users. These tools often want to apply topology preferences automatically — without exposing scheduling decisions to end users — but cannot do so today because the only available topology constraint is required (`packDomain`), which risks blocking workloads indefinitely when the topology cannot be satisfied.
 
-Preferred topology placement addresses this gap by letting the scheduler try for a more optimized placement while still allowing the workload to run when the preference cannot be satisfied. This is useful for platforms that want to apply topology-aware optimization transparently, and for workloads that benefit from locality but should not fail or remain pending solely because the most optimized placement is unavailable.
-
-At the same time, preferred topology scheduling is a compute-intensive scheduler operation. Grove should not simply enable preferred placement by default at the lowest topology level for every workload, because doing so could impose scheduler cost on workloads that did not opt into topology-aware scheduling. Instead, this GREP makes preferred placement an explicit topology policy: administrators configure the preferred domain on `ClusterTopology`, and workloads opt into that topology by setting `topologyName`.
+Additionally, preferred topology scheduling is a compute-intensive operation for the scheduler. It therefore cannot be enabled by default for all workloads — it must be an explicit opt-in. Exposing a preferred constraint API gives tools and users a way to request best-effort topology placement, decoupled from the all-or-nothing semantics of the current required constraint.
 
 ### Goals
 
-- Add `preferredPackDomain` to `ClusterTopology.spec` as the administrator-configured best-effort topology packing domain.
-- Validate that `preferredPackDomain`, when set, refers to a domain defined in the same `ClusterTopology.spec.levels` list.
-- Allow workloads to set `topologyName` without `packDomain`, enabling preferred-only topology-aware scheduling when the referenced `ClusterTopology` defines `preferredPackDomain`.
-- Propagate the resolved preferred topology key to the scheduler API through `TopologyPackConstraint.Preferred`.
-- Preserve the existing required `packDomain` behavior and allow required and preferred constraints to be used together.
+- Introduce a preferred (best-effort) topology constraint API on `PodClique`, `PodGangScalingGroup`, and `PodCliqueSet`
+- Ensure workloads with a preferred constraint are never blocked — if topology cannot be satisfied, scheduling proceeds without it
 
 ### Non-Goals
 
-- Automatically applying preferred topology to workloads that do not reference a `ClusterTopology`.
-- Selecting the preferred topology domain independently on each workload resource.
-- Changing the hard scheduling semantics of `packDomain`.
-- Guaranteeing topology-optimal placement. Preferred topology placement is best-effort only.
-- Changing the scheduler API. The scheduler already exposes `TopologyPackConstraint.Preferred`.
+- Automatically applying preferred topology to all workloads (it remains an explicit opt-in)
+- Changing the semantics of the existing required constraint (`packDomain`)
+- Guaranteeing topology-optimal placement — preferred is best-effort only
 
 ## Proposal
 
-This GREP proposes adding `preferredPackDomain` to `ClusterTopology.spec`. The field identifies the topology domain that Grove should use as the scheduler's preferred packing domain for workloads that opt into that topology.
+This GREP proposes adding a `packDomainPreferred` field alongside the existing `packDomain` field on `PodClique`, `PodGangScalingGroup`, and `PodCliqueSet`. When set, it signals to the scheduler that topology-aware placement is desired at the specified domain level on a best-effort basis — the workload is never blocked if the constraint cannot be satisfied.
 
-A workload opts into topology-aware scheduling by setting `topologyName` in its `TopologyConstraint`. The workload may also set `packDomain` when it needs a hard placement requirement. If `packDomain` is omitted, Grove may still emit a preferred scheduler constraint if the referenced `ClusterTopology` defines `preferredPackDomain`.
-
-The resulting behavior is:
-
-- Workload has no `topologyName`: Grove emits no topology constraint for that workload.
-- Workload has `topologyName`, and the referenced `ClusterTopology` has no `preferredPackDomain`: existing required `packDomain` behavior is preserved.
-- Workload has `topologyName`, and the referenced `ClusterTopology` defines `preferredPackDomain`: Grove resolves that domain to its topology key and emits it as `TopologyPackConstraint.Preferred`.
-- Workload has both `topologyName` and `packDomain`: Grove emits `packDomain` as `TopologyPackConstraint.Required` and, if configured on the topology, emits `preferredPackDomain` as `TopologyPackConstraint.Preferred`.
-
-For example, an administrator can configure host-level preferred packing for a topology:
-
-```yaml
-apiVersion: grove.io/v1alpha1
-kind: ClusterTopology
-metadata:
-  name: h100-topology
-spec:
-  preferredPackDomain: host
-  levels:
-    - domain: zone
-      key: topology.kubernetes.io/zone
-    - domain: rack
-      key: topology.kubernetes.io/rack
-    - domain: host
-      key: kubernetes.io/hostname
-```
-
-A workload can then opt into preferred-only topology-aware placement:
-
-```yaml
-apiVersion: grove.io/v1alpha1
-kind: PodCliqueSet
-metadata:
-  name: prefill
-spec:
-  template:
-    topologyConstraint:
-      topologyName: h100-topology
-    cliques:
-      - name: worker
-        spec:
-          replicas: 8
-          template:
-            spec:
-              containers:
-                - name: worker
-                  image: example.com/worker:latest
-```
-
-The same workload can add a required rack-level constraint while retaining the topology's host-level preferred constraint:
-
-```yaml
-spec:
-  template:
-    topologyConstraint:
-      topologyName: h100-topology
-      packDomain: rack
-```
+`packDomainPreferred` and `packDomain` can coexist on the same resource. For example, a user may set `packDomainPreferred=host` and `packDomain=rack` to express that host-level packing is desired but not required, while rack-level packing is mandatory. When both are set, the scheduler attempts preferred placement first and falls back toward the required level if the preferred constraint cannot be satisfied. It is recommended (but not enforced) that `packDomainPreferred` be stricter than or equal to `packDomain` — setting a coarser preferred level than the required one is semantically redundant.
 
 ### User Stories
 
-#### Story 1: Topology-aware placement with graceful fallback
+#### Story 1: Automated preferred topology in Dynamo on Run:ai
 
-As an ML engineer, I want to request topology-aware placement for my workload so that Grove attempts optimized placement without failing the job if the preferred topology domain cannot fit it.
-
-#### Story 2: Mixed required and preferred constraints for disaggregated inference
-
-As an ML engineer running disaggregated inference, I want to require that each PodCliqueScalingGroup is packed within a rack while preferring that scheduling uses a narrower topology domain when possible, so that critical locality is guaranteed while additional optimization remains best-effort.
-
-#### Story 3: Admin-controlled preferred topology
-
-As a cluster administrator, I want to configure the preferred packing domain on each `ClusterTopology` so that workloads using that topology receive consistent best-effort placement behavior without each workload choosing infrastructure-specific policy.
-
-#### Story 4: External orchestration platform
-
-As an orchestration platform, I want to set `topologyName` when submitting Grove workloads so that topology-aware placement is attempted transparently for users while preserving scheduling fallback behavior.
+As a **Run:ai platform operator** deploying Dynamo workloads over Grove, I want to automatically apply a preferred topology constraint to all submitted workloads — without requiring end users to configure scheduling parameters — so that topology-aware placement is attempted as a best-effort optimization while ensuring no workload is ever blocked due to an unsatisfiable constraint.
 
 ### Limitations/Risks & Mitigations
 
-- **Scheduler performance:** Preferred topology placement can trigger compute-intensive scheduler work. *Mitigation: preferred placement is only emitted for workloads that set `topologyName` and reference a `ClusterTopology` that defines `preferredPackDomain`; it is not a blanket default for all workloads.*
-- **Cluster-wide policy for a topology:** A `preferredPackDomain` applies to all workloads that reference the `ClusterTopology`, which may be too broad for clusters with different workload classes. *Mitigation: administrators can define separate `ClusterTopology` resources with different preferred packing policies and direct workloads to the appropriate topology via `topologyName`.*
-- **Misconfigured preferred domain:** If `preferredPackDomain` does not match a configured topology level, Grove cannot resolve it to a scheduler topology key. *Mitigation: admission validation rejects `ClusterTopology` resources where `preferredPackDomain` is not present in `spec.levels[*].domain`.*
-- **Preference is not a guarantee:** A workload may still run outside the preferred domain if the scheduler cannot satisfy the preferred placement. *Mitigation: users must continue to use `packDomain` for hard placement requirements.*
+- **Scheduler performance:** `packDomainPreferred` triggers a scheduling algorithm that might be compute-intensive. Misuse (e.g. setting it on all workloads at scale) could degrade scheduler performance. *Mitigation: it's an explicit opt-in, never a default.*
 
 ## Design Details
 
 ### API Change
 
-This GREP builds on the `ClusterTopology` and `PodCliqueSet` topology APIs where workload `TopologyConstraint` selects a topology with `topologyName` and may specify a required domain with `packDomain`. A single field is added to `ClusterTopologySpec` in `operator/api/core/v1alpha1/clustertopology.go`:
+A single field is added to the existing `TopologyConstraint` struct in the operator API (`operator/api/core/v1alpha1/podcliqueset.go`), which is already shared across `PodCliqueSet`, `PodCliqueTemplateSpec`, and `PodCliqueScalingGroupConfig`:
 
 ```go
-// ClusterTopologySpec defines the topology hierarchy specification.
-type ClusterTopologySpec struct {
-    // Levels is an ordered list of topology levels from broadest to narrowest scope.
-    // The order in this list defines the hierarchy (index 0 = broadest level).
-    // +kubebuilder:validation:MinItems=1
-    Levels []TopologyLevel `json:"levels"`
-
-    // PreferredPackDomain specifies the topology domain Grove should propagate
-    // to the scheduler as a best-effort preferred packing constraint for workloads
-    // that reference this ClusterTopology.
-    // Must match one of the domains in Levels.
+// TopologyConstraint defines topology placement requirements.
+type TopologyConstraint struct {
+    // PackDomain specifies the required topology domain for grouping replicas.
+    // The workload will not be scheduled if this constraint cannot be satisfied.
+    // +kubebuilder:validation:Enum=region;zone;datacenter;block;rack;host;numa
     // +optional
-    PreferredPackDomain *TopologyDomain `json:"preferredPackDomain,omitempty"`
+    PackDomain *TopologyDomain `json:"packDomain,omitempty"`
 
-    // SchedulerReferences controls per-backend topology resource management.
+    // PackDomainPreferred specifies a preferred (best-effort) topology domain.
+    // If the constraint cannot be satisfied, the workload is scheduled anyway.
+    // When set alongside PackDomain, it is recommended that PackDomainPreferred
+    // be stricter than or equal to PackDomain.
+    // +kubebuilder:validation:Enum=region;zone;datacenter;block;rack;host;numa
     // +optional
-    SchedulerReferences []SchedulerReference `json:"schedulerReferences,omitempty"`
+    PackDomainPreferred *TopologyDomain `json:"packDomainPreferred,omitempty"`
 }
 ```
 
-The workload-facing `TopologyConstraint` continues to use `topologyName` to select the `ClusterTopology` and `packDomain` to express a hard packing requirement. `packDomain` remains optional, so a workload can set `topologyName` without requiring a hard packing domain.
+Note: `PackDomain` changes from a value type to a pointer (`*TopologyDomain`) to allow a `TopologyConstraint` with only `PackDomainPreferred` set. This is not a breaking API change — existing resources with `packDomain` set continue to work. Controller code accessing `PackDomain` will need nil checks.
 
 ### PodGang Propagation
 
-The scheduler API (`scheduler/api/core/v1alpha1/podgang.go`) already supports both constraints via `TopologyPackConstraint.Required` and `TopologyPackConstraint.Preferred`. No scheduler API change is needed.
+The scheduler API (`scheduler/api/core/v1alpha1/podgang.go`) already supports both constraints via `TopologyPackConstraint.Required` and `TopologyPackConstraint.Preferred`. No changes are needed on the scheduler side.
 
-The PodCliqueSet PodGang sync flow will load the referenced `ClusterTopology` for the workload's `topologyName`. In addition to the topology levels, the sync context will retain the resolved topology key for `ClusterTopology.spec.preferredPackDomain` when it is configured.
+The only required implementation change is in `createTopologyPackConstraint` (`operator/internal/controller/podcliqueset/components/podgang/syncflow.go`), which translates Grove's `TopologyConstraint` into the scheduler's `TopologyPackConstraint`. It currently only populates `Required`. It must be extended to also resolve `PackDomainPreferred` to its topology key and populate `Preferred`.
 
-`createTopologyPackConstraint` (`operator/internal/controller/podcliqueset/components/podgang/syncflow.go`) will populate scheduler constraints as follows:
-
-- If the workload `TopologyConstraint.packDomain` is non-empty, resolve it through `ClusterTopology.spec.levels` and set `TopologyPackConstraint.Required`.
-- If the selected `ClusterTopology.spec.preferredPackDomain` is set, resolve it through `ClusterTopology.spec.levels` and set `TopologyPackConstraint.Preferred`.
-- If neither required nor preferred can be resolved, omit the scheduler topology constraint.
-
-This logic applies wherever Grove emits scheduler topology constraints: the PodGang-level constraint, PodCliqueScalingGroup `TopologyConstraintGroupConfig` constraints, and PodGroup constraints for PodClique-level topology constraints.
+The domain-to-key translation follows the same existing path: looking up the domain name in the `ClusterTopology` levels to obtain the corresponding node label key. If the preferred domain is not found in the current `ClusterTopology`, it is silently skipped (same behavior as the existing required constraint).
 
 ### Webhook Validation
 
-ClusterTopology admission validation must reject resources where `preferredPackDomain` is set but does not match any `domain` in `spec.levels`.
+The admission webhook (`operator/internal/webhook/admission/pcs/validation/topologyconstraints.go`) must be extended to cover `PackDomainPreferred` with the same rules that apply to `PackDomain`:
 
-PodCliqueSet admission validation must continue to validate workload `packDomain` values against the referenced `ClusterTopology` and enforce the existing hierarchy rules across PodCliqueSet, PodCliqueScalingGroup, and PodClique constraints. Empty `packDomain` is valid when `topologyName` is set. When topology-aware scheduling is disabled, topology constraints remain disallowed, including constraints that only set `topologyName`.
+- **Domain existence:** A `packDomainPreferred` value that does not exist in the `ClusterTopology` CR is rejected at admission time, same as `packDomain`.
+- **Hierarchy:** `packDomainPreferred` on a child resource must be stricter than or equal to the parent's `packDomainPreferred`.
 
 ### Monitoring
 
-There is no dedicated status condition that reports whether preferred placement was achieved. Operators can verify propagation by inspecting the generated `PodGang` resources and checking `spec.topologyConstraint.packConstraint.preferred`, group config constraints, or PodGroup constraints as appropriate.
+There is no scheduler-side feedback on whether preferred placement was achieved. This is consistent with the existing behavior for `packDomain`, which also has no placement-outcome indicator.
 
-Existing topology health signals remain relevant:
-
-- `ClusterTopology.status.schedulerTopologyStatuses` and the `SchedulerTopologyDrift` condition report whether scheduler backend topology resources are in sync with Grove topology definitions.
-- `PodCliqueSet` topology availability conditions continue to report unavailable required topology levels for workload constraints.
-- Scheduler-specific placement quality signals, such as `PodGang.status.placementScore` when populated by the scheduler, can help diagnose placement quality, but they are not a hard success/failure signal for preferred placement.
+The existing `TopologyLevelUnavailable` status condition on `PodCliqueSet`, which checks whether referenced topology domains exist in the `ClusterTopology` CR, will be extended to also cover `packDomainPreferred` domains.
 
 ### Test Plan
 
-**Unit - webhook validation:**
-- `ClusterTopology.spec.preferredPackDomain` is accepted when it matches a domain in `spec.levels`
-- `ClusterTopology.spec.preferredPackDomain` is rejected when it does not match a domain in `spec.levels`
-- `PodCliqueSet` with `topologyName` and no `packDomain` is accepted when topology-aware scheduling is enabled
-- `PodCliqueSet` with `topologyName` and no `packDomain` is rejected when topology-aware scheduling is disabled
-- Existing `packDomain` domain-existence and hierarchy validation continues to pass and fail as expected
+**Unit — webhook validation:**
+- `packDomainPreferred` domain not present in `ClusterTopology` is rejected
+- `packDomainPreferred` stricter than parent is accepted; coarser passes without enforcement
+- `packDomainPreferred` can be set without `packDomain`, and vice versa
 
-**Unit - syncflow (`TestComputeExpectedPodGangsWithTopologyConstraints`):**
-- `topologyName` with `ClusterTopology.spec.preferredPackDomain` and no `packDomain` creates a preferred-only scheduler constraint
-- `topologyName` with both `ClusterTopology.spec.preferredPackDomain` and workload `packDomain` creates both `Preferred` and `Required`
-- `topologyName` with no `ClusterTopology.spec.preferredPackDomain` preserves required-only behavior
-- `ClusterTopology.spec.preferredPackDomain` is propagated to PodGang-level, PodCliqueScalingGroup group, and PodClique PodGroup constraints where Grove emits scheduler topology constraints
-- Missing or unresolved preferred domain at reconciliation time is skipped without blocking workload creation
+**Unit — syncflow (`TestComputeExpectedPodGangsWithTopologyConstraints`):**
+- `packDomainPreferred` alone → `TopologyPackConstraint.Preferred` set, `Required` nil
+- Both fields set → both `Preferred` and `Required` populated correctly
+- `packDomainPreferred` domain missing from `ClusterTopology` → `Preferred` silently skipped, workload still created
 
 **E2E:**
-- Preferred-only workload schedules successfully and the scheduler receives the preferred constraint
-- Workload with both required and preferred constraints schedules successfully when the required constraint is satisfiable
-- Workload remains schedulable when the preferred domain cannot be satisfied, demonstrating the best-effort behavior
-- Required `packDomain` behavior remains unchanged: unsatisfiable required constraints can still keep the workload pending
+- Preferred constraint that can be satisfied → workload schedules successfully and scheduler receives the preferred constraint (validates the full propagation path including the scheduler)
+- Preferred constraint that cannot be satisfied → workload schedules successfully (key behavioral difference from required)
 
 ### Graduation Criteria
 
 #### Alpha
-- `ClusterTopology.spec.preferredPackDomain` is available in the v1alpha1 API
-- Admission validation and PodGang propagation are implemented
-- Unit and e2e tests pass
+- `packDomainPreferred` field available on all three resources (`PodCliqueSet`, `PodCliqueScalingGroupConfig`, `PodCliqueTemplateSpec`)
+- Unit and e2e tests passing
 
 #### Beta
-- Validated in at least one production workload or platform integration
+- Validated in at least one production workload (e.g. Dynamo on Run:ai)
 - No breaking API changes since alpha
-- No significant scheduler performance regressions observed from opted-in workloads
 
 #### GA
 - Stable API
-- Documentation covers admin configuration and workload opt-in behavior
-- No open issues related to preferred topology propagation or validation for at least two releases after beta
+- No open issues related to the feature
 
 ## Alternatives
 
-The following alternatives were considered and ruled out.
+Two coarser-grained alternatives were considered and ruled out. Grove, as a generic infrastructure layer, should remain neutral — exposing fine-grained, explicit controls and leaving opinionated defaults to higher-level tools.
 
 ### Always-on preferred topology at the lowest level
 
 The scheduler could automatically apply a preferred constraint at the finest available topology level for every workload, with no user opt-in.
 
 - **Pro:** Zero configuration required.
-- **Con:** Preferred topology scheduling is compute-intensive and unsuitable as a blanket default. It would impose scheduling cost on workloads that did not request topology-aware placement.
-
-### Workload-level preferred domain
-
-A workload-facing field could let users select the preferred domain directly for each PodCliqueSet, PodCliqueScalingGroup, or PodClique.
-
-- **Pro:** Gives workload authors fine-grained control.
-- **Con:** Pushes infrastructure policy into workload manifests and makes it harder for administrators to tune preferred topology behavior consistently across a cluster.
+- **Con:** Preferred topology scheduling is compute-intensive and unsuitable as a blanket default. Removes user control entirely, and is incompatible with workloads that have no topology preference.
 
 ### Boolean opt-in on `PodCliqueSet`
 
-A boolean field on `PodCliqueSet` could enable preferred placement without requiring the workload to choose a domain.
+A single boolean field on `PodCliqueSet` (e.g. `preferredTopologyEnabled`) would enable preferred placement at the lowest topology level for all cliques, without allowing per-resource or per-level control.
 
-- **Pro:** Simple workload-facing API.
-- **Con:** Still requires another source of truth for the preferred domain and provides less reuse than attaching that policy to the referenced `ClusterTopology`.
+- **Pro:** Simpler API surface.
+- **Con:** Provides no control over which topology level is preferred, and cannot express different preferences across `PodCliqueSet`, `PodCliqueScalingGroup`, and `PodClique`. Higher-level tools can trivially implement this coarser interface on top of `packDomainPreferred`, but the reverse is not true.

--- a/docs/proposals/0368-preferred-topology-constraint/README.md
+++ b/docs/proposals/0368-preferred-topology-constraint/README.md
@@ -7,8 +7,7 @@
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
   - [User Stories](#user-stories)
-    - [Story 1: Automated preferred topology in Dynamo on Run:ai](#story-1-automated-preferred-topology-in-dynamo-on-runai)
-  - [Limitations/Risks &amp; Mitigations](#limitationsrisks--mitigations)
+    - [Story 1: Automated preferred topology for externally managed workloads](#story-1-automated-preferred-topology-for-externally-managed-workloads)
 - [Design Details](#design-details)
   - [API Change](#api-change)
   - [PodGang Propagation](#podgang-propagation)
@@ -30,13 +29,13 @@ Grove currently supports topology-aware scheduling through a required constraint
 
 ## Motivation
 
-Grove is increasingly used as an orchestration layer by higher-level tools (e.g. Dynamo on Run:ai) that manage workload submission on behalf of users. These tools often want to apply topology preferences automatically — without exposing scheduling decisions to end users — but cannot do so today because the only available topology constraint is required (`packDomain`), which risks blocking workloads indefinitely when the topology cannot be satisfied.
+Grove is increasingly used as an orchestration layer by higher-level tools that manage workload submission on behalf of users. These tools often want to apply topology preferences automatically — without exposing scheduling decisions to end users — but cannot do so today because the only available topology constraint is required (`packDomain`), which risks blocking workloads indefinitely when the topology cannot be satisfied.
 
 Additionally, preferred topology scheduling is a compute-intensive operation for the scheduler. It therefore cannot be enabled by default for all workloads — it must be an explicit opt-in. Exposing a preferred constraint API gives tools and users a way to request best-effort topology placement, decoupled from the all-or-nothing semantics of the current required constraint.
 
 ### Goals
 
-- Introduce a preferred (best-effort) topology constraint API on `PodClique`, `PodGangScalingGroup`, and `PodCliqueSet`
+- Introduce a preferred (best-effort) topology constraint API on `PodClique`, `PodCliqueScalingGroup`, and `PodCliqueSet`
 - Ensure workloads with a preferred constraint are never blocked — if topology cannot be satisfied, scheduling proceeds without it
 
 ### Non-Goals
@@ -47,19 +46,15 @@ Additionally, preferred topology scheduling is a compute-intensive operation for
 
 ## Proposal
 
-This GREP proposes adding a `packDomainPreferred` field alongside the existing `packDomain` field on `PodClique`, `PodGangScalingGroup`, and `PodCliqueSet`. When set, it signals to the scheduler that topology-aware placement is desired at the specified domain level on a best-effort basis — the workload is never blocked if the constraint cannot be satisfied.
+This GREP proposes adding a `packDomainPreferred` field alongside the existing `packDomain` field on `PodClique`, `PodCliqueScalingGroup`, and `PodCliqueSet`. When set, it signals to the scheduler that topology-aware placement is desired at the specified domain level on a best-effort basis — the workload is never blocked if the constraint cannot be satisfied.
 
-`packDomainPreferred` and `packDomain` can coexist on the same resource. For example, a user may set `packDomainPreferred=host` and `packDomain=rack` to express that host-level packing is desired but not required, while rack-level packing is mandatory. When both are set, the scheduler attempts preferred placement first and falls back toward the required level if the preferred constraint cannot be satisfied. It is recommended (but not enforced) that `packDomainPreferred` be stricter than or equal to `packDomain` — setting a coarser preferred level than the required one is semantically redundant.
+`packDomainPreferred` and `packDomain` can coexist on the same resource. For example, a user may set `packDomainPreferred=host` and `packDomain=rack` to express that host-level packing is desired but not required, while rack-level packing is mandatory. When both are set, the scheduler attempts preferred placement first and falls back toward the required level if the preferred constraint cannot be satisfied. It is recommended that `packDomainPreferred` be stricter than or equal to `packDomain`. Setting a coarser preferred level than the required one is semantically redundant, so admission allows it but returns a warning to give users feedback without blocking the workload.
 
 ### User Stories
 
-#### Story 1: Automated preferred topology in Dynamo on Run:ai
+#### Story 1: Automated preferred topology for externally managed workloads
 
-As a **Run:ai platform operator** deploying Dynamo workloads over Grove, I want to automatically apply a preferred topology constraint to all submitted workloads — without requiring end users to configure scheduling parameters — so that topology-aware placement is attempted as a best-effort optimization while ensuring no workload is ever blocked due to an unsatisfiable constraint.
-
-### Limitations/Risks & Mitigations
-
-- **Scheduler performance:** `packDomainPreferred` triggers a scheduling algorithm that might be compute-intensive. Misuse (e.g. setting it on all workloads at scale) could degrade scheduler performance. *Mitigation: it's an explicit opt-in, never a default.*
+As a platform operator managing workloads over Grove, I want to automatically apply a preferred topology constraint to submitted workloads — without requiring end users to configure scheduling parameters — so that topology-aware placement is attempted as a best-effort optimization while ensuring no workload is ever blocked due to an unsatisfiable constraint.
 
 ## Design Details
 
@@ -94,14 +89,16 @@ The scheduler API (`scheduler/api/core/v1alpha1/podgang.go`) already supports bo
 
 The only required implementation change is in `createTopologyPackConstraint` (`operator/internal/controller/podcliqueset/components/podgang/syncflow.go`), which translates Grove's `TopologyConstraint` into the scheduler's `TopologyPackConstraint`. It currently only populates `Required`. It must be extended to also resolve `PackDomainPreferred` to its topology key and populate `Preferred`.
 
-The domain-to-key translation follows the same existing path: looking up the domain name in the `ClusterTopology` levels to obtain the corresponding node label key. If the preferred domain is not found in the current `ClusterTopology`, it is silently skipped (same behavior as the existing required constraint).
+The domain-to-key translation follows the same existing path: looking up the domain name in the `ClusterTopology` levels to obtain the corresponding node label key. Admission validation rejects invalid domains on create and update. If a previously valid preferred domain is no longer found during reconciliation because the referenced `ClusterTopology` changed after admission, it is silently skipped without blocking workload creation (same behavior as the existing required constraint).
 
 ### Webhook Validation
 
 The admission webhook (`operator/internal/webhook/admission/pcs/validation/topologyconstraints.go`) must be extended to cover `PackDomainPreferred` with the same rules that apply to `PackDomain`:
 
-- **Domain existence:** A `packDomainPreferred` value that does not exist in the `ClusterTopology` CR is rejected at admission time, same as `packDomain`.
+- **Domain existence:** Creation or update with a `packDomainPreferred` value that does not exist in the referenced `ClusterTopology` CR is rejected at admission time, same as `packDomain`.
 - **Hierarchy:** `packDomainPreferred` on a child resource must be stricter than or equal to the parent's `packDomainPreferred`.
+- **Same-resource preferred vs. required domain:** When `packDomainPreferred` is coarser than `packDomain` on the same resource, the request is allowed but admission returns a warning because the preferred domain is semantically redundant.
+- **Update immutability:** `packDomainPreferred` cannot be changed on update, matching the existing immutability behavior for `packDomain`.
 
 ### Monitoring
 
@@ -113,13 +110,16 @@ The existing `TopologyLevelUnavailable` status condition on `PodCliqueSet`, whic
 
 **Unit — webhook validation:**
 - `packDomainPreferred` domain not present in `ClusterTopology` is rejected
-- `packDomainPreferred` stricter than parent is accepted; coarser passes without enforcement
+- Creation with an invalid `packDomainPreferred` domain level name is rejected, same as `packDomain`
+- Updates that change `packDomainPreferred` are rejected, same as `packDomain`
+- `packDomainPreferred` stricter than parent is accepted; coarser than the parent's `packDomainPreferred` is rejected
+- `packDomainPreferred` coarser than `packDomain` on the same resource is allowed with an admission warning
 - `packDomainPreferred` can be set without `packDomain`, and vice versa
 
 **Unit — syncflow (`TestComputeExpectedPodGangsWithTopologyConstraints`):**
 - `packDomainPreferred` alone → `TopologyPackConstraint.Preferred` set, `Required` nil
 - Both fields set → both `Preferred` and `Required` populated correctly
-- `packDomainPreferred` domain missing from `ClusterTopology` → `Preferred` silently skipped, workload still created
+- Previously valid `packDomainPreferred` domain missing from `ClusterTopology` during reconciliation after a topology change → `Preferred` silently skipped, workload still created
 
 **E2E:**
 - Preferred constraint that can be satisfied → workload schedules successfully and scheduler receives the preferred constraint (validates the full propagation path including the scheduler)
@@ -132,7 +132,7 @@ The existing `TopologyLevelUnavailable` status condition on `PodCliqueSet`, whic
 - Unit and e2e tests passing
 
 #### Beta
-- Validated in at least one production workload (e.g. Dynamo on Run:ai)
+- Validated in at least one production workload
 - No breaking API changes since alpha
 
 #### GA

--- a/docs/proposals/0368-preferred-topology-constraint/README.md
+++ b/docs/proposals/0368-preferred-topology-constraint/README.md
@@ -7,7 +7,8 @@
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
   - [User Stories](#user-stories)
-    - [Story 1: Automated preferred topology for externally managed workloads](#story-1-automated-preferred-topology-for-externally-managed-workloads)
+    - [Story 1: Preferred host-level locality for a workload](#story-1-preferred-host-level-locality-for-a-workload)
+    - [Story 2: Automated preferred topology for externally managed workloads](#story-2-automated-preferred-topology-for-externally-managed-workloads)
   - [Limitations/Risks &amp; Mitigations](#limitationsrisks--mitigations)
 - [Design Details](#design-details)
   - [API Change](#api-change)
@@ -56,7 +57,11 @@ The existing `packDomain` field is deprecated. It remains in the API only for co
 
 ### User Stories
 
-#### Story 1: Automated preferred topology for externally managed workloads
+#### Story 1: Preferred host-level locality for a workload
+
+As an ML engineer submitting a workload with Grove, I want to set `preferredPackDomain: host` to signal that my pods benefit from being placed close together, so that Grove and the scheduler attempt host-level locality without blocking the workload when that placement is unavailable.
+
+#### Story 2: Automated preferred topology for externally managed workloads
 
 As a platform operator managing workloads over Grove, I want to automatically apply a preferred topology constraint to submitted workloads — without requiring end users to configure scheduling parameters — so that topology-aware placement is attempted as a best-effort optimization while ensuring no workload is ever blocked due to an unsatisfiable constraint.
 
@@ -75,9 +80,20 @@ The existing `TopologyConstraint` struct in the operator API (`operator/api/core
 ```go
 // TopologyConstraint defines topology placement requirements.
 type TopologyConstraint struct {
+    // TopologyName is the name of the ClusterTopology resource to use for topology-aware scheduling.
+    // If topologyConstraint is set, topologyName must be specified.
+    // Immutable after creation.
+    // +required
+    TopologyName string `json:"topologyName"`
+
     // RequiredPackDomain specifies the required topology domain for grouping replicas.
+    // Controls placement constraint for EACH individual replica instance.
     // The workload will not be scheduled if this constraint cannot be satisfied.
-    // +kubebuilder:validation:Enum=region;zone;datacenter;block;rack;host;numa
+    // Must reference a domain in the topology levels defined in the ClusterTopology
+    // CR named by TopologyName.
+    // Example: "rack" means each replica is independently placed within one rack.
+    // Note: Does NOT constrain all replicas to the same rack together.
+    // Different replicas can be in different topology domains.
     // +optional
     RequiredPackDomain *TopologyDomain `json:"requiredPackDomain,omitempty"`
 
@@ -85,20 +101,21 @@ type TopologyConstraint struct {
     // If the constraint cannot be satisfied, the workload is scheduled anyway.
     // When set alongside RequiredPackDomain, it is recommended that
     // PreferredPackDomain be stricter than or equal to RequiredPackDomain.
-    // +kubebuilder:validation:Enum=region;zone;datacenter;block;rack;host;numa
     // +optional
     PreferredPackDomain *TopologyDomain `json:"preferredPackDomain,omitempty"`
 
     // PackDomain specifies the required topology domain using the legacy field name.
-    // Deprecated: use RequiredPackDomain. This field is honored for existing
-    // workloads, rejected on new workload creation, and warned on update when still in use.
-    // +kubebuilder:validation:Enum=region;zone;datacenter;block;rack;host;numa
+    // Deprecated: use RequiredPackDomain.
+    // This field is honored for existing workloads, rejected on new workload
+    // creation, and warned on update when still in use.
     // +optional
     PackDomain *TopologyDomain `json:"packDomain,omitempty"`
 }
 ```
 
-`RequiredPackDomain` preserves the required placement behavior of the legacy `PackDomain` field. `PreferredPackDomain` is optional and can be used alone for preferred-only topology placement. The legacy `PackDomain` field changes from a value type to an optional pointer so new workloads can omit it while existing workloads that already use it remain readable. Controller code must resolve the effective required domain from `RequiredPackDomain` first, then fall back to deprecated `PackDomain` for existing workloads.
+`TopologyName` remains part of `TopologyConstraint` and continues to select the `ClusterTopology` used for domain-to-key resolution. `RequiredPackDomain` preserves the required placement behavior of the legacy `PackDomain` field, but is optional so a workload can use `PreferredPackDomain` without a hard topology requirement. `PreferredPackDomain` is optional and can be used alone for preferred-only topology placement. Admission requires a `TopologyConstraint` to include `topologyName` and at least one packing domain field.
+
+The legacy `PackDomain` field changes from a required value to an optional pointer and remains in the API only for compatibility with existing workloads. New workloads must use `RequiredPackDomain` for hard placement requirements; `PackDomain` is honored for existing workloads, rejected on new workload creation, and warned on update when still in use. Controller code must resolve the effective required domain from `RequiredPackDomain` first, then fall back to deprecated `PackDomain` for existing workloads.
 
 ### PodGang Propagation
 
@@ -181,4 +198,4 @@ The scheduler could automatically apply a preferred constraint at the finest ava
 A single boolean field on `PodCliqueSet` (e.g. `preferredTopologyEnabled`) would enable preferred placement at the lowest topology level for all cliques, without allowing per-resource or per-level control.
 
 - **Pro:** Simpler API surface.
-- **Con:** Provides no control over which topology level is preferred, and cannot express different preferences across `PodCliqueSet`, `PodCliqueScalingGroup`, and `PodClique`. Higher-level tools can trivially implement this coarser interface on top of `preferredPackDomain`, but the reverse is not true.
+- **Con:** Provides no control over which topology level is preferred, and cannot express different preferences across `PodCliqueSet`, `PodCliqueScalingGroup`, and `PodClique`. A literal boolean is also technically insufficient because the workload must still select a `ClusterTopology` through `topologyName`; this alternative would need a topology reference plus the boolean opt-in. Higher-level tools can trivially implement this coarser interface on top of `preferredPackDomain`, but the reverse is not true.


### PR DESCRIPTION
## Summary

- Proposes adding a nested `topologyConstraint.pack` API for topology packing constraints
- Adds `topologyConstraint.pack.preferred` as a best-effort topology packing domain
- Replaces the required packing field `topologyConstraint.packDomain` with `topologyConstraint.pack.required`
- Keeps `topologyConstraint.packDomain` as a deprecated compatibility field for existing workloads

## Key design decisions

- Preferred placement is workload opt-in through `topologyConstraint.pack.preferred`; Grove does not apply it by default
- `topologyConstraint.pack.required` preserves the existing hard scheduling semantics of `packDomain`
- Existing workloads that already use `packDomain` continue to be honored
- New workloads using `packDomain` are rejected and should use `pack.required`
- Existing workloads may migrate from `packDomain` to `pack.required` on update when the topology domain value is unchanged
- `topologyName` is assumed to follow the inherited topology-name behavior from the preceding topology API changes

References #368