### PR TITLE
implement KAI-Scheduler backend

### DIFF
--- a/docs/proposals/525-KAI-Scheduler-Backend/README.md
+++ b/docs/proposals/525-KAI-Scheduler-Backend/README.md
@@ -1,0 +1,244 @@
+# GREP-525: KAI Scheduler Backend for Scheduler Backend Framework
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+    - [Story 1: Platform Operator Enables KAI Backend](#story-1-platform-operator-enables-kai-backend)
+    - [Story 2: Workload Owner Uses KAI Scheduler](#story-2-workload-owner-uses-kai-scheduler)
+  - [Limitations/Risks &amp; Mitigations](#limitationsrisks--mitigations)
+    - [Risk: Duplicate Ownership During Migration](#risk-duplicate-ownership-during-migration)
+- [Design Details](#design-details)
+  - [Architecture Overview](#architecture-overview)
+  - [Backend Lifecycle Contract](#backend-lifecycle-contract)
+  - [Precondition: KAI Backend Enabled](#precondition-kai-backend-enabled)
+  - [KAI Backend Responsibilities](#kai-backend-responsibilities)
+  - [PodGang to PodGroup Mapping](#podgang-to-podgroup-mapping)
+  - [Pod Preparation](#pod-preparation)
+  - [PodGroup Update Semantics](#podgroup-update-semantics)
+  - [Reconciliation Flow](#reconciliation-flow)
+  - [API and Registration Requirements](#api-and-registration-requirements)
+  - [RBAC Matrix](#rbac-matrix)
+  - [Test Plan](#test-plan)
+    - [Unit Tests](#unit-tests)
+    - [E2E Tests](#e2e-tests)
+  - [Graduation Criteria](#graduation-criteria)
+    - [Alpha](#alpha)
+    - [Beta](#beta)
+    - [GA](#ga)
+- [Appendix](#appendix)
+<!-- /toc -->
+
+## Summary
+
+This proposal adds a dedicated KAI scheduler backend to Grove's Scheduler Backend Framework so Grove can natively create, update, and delete KAI PodGroup resources for Grove PodGang workloads. This proposal is intentionally limited to PodGroup creation and management; it does not include topology-aware scheduling support or KAI Topology synchronization from Grove ClusterTopology. The change improves maintainability, clarifies ownership boundaries, and enables predictable KAI-specific lifecycle handling for PodGang workloads by relying on KAI-Scheduler's externally-created PodGroup support.
+
+## Motivation
+
+GREP-375 introduced a generic Scheduler Backend Framework, but the KAI integration still needs a concrete backend implementation pattern and operational contract for production use. Without this backend, KAI support depends on legacy behavior that can cause ambiguous ownership of PodGroup resources and complicate migration as Grove evolves.
+
+### Goals
+
+- Define the KAI backend behavior under the Scheduler Backend Framework lifecycle.
+- Define `PreparePod` behavior so Pods are scheduled by KAI consistently with Grove's scheduling gate flow and opt out of KAI podgrouper reconciliation when Grove owns the PodGroup.
+- Specify PodGang to KAI PodGroup translation and reconciliation responsibilities.
+- Define deletion-time cleanup behavior for KAI-owned scheduling resources.
+- Document the dependency on KAI-Scheduler support for externally-created PodGroups and podgrouper skip behavior.
+- Clarify required RBAC, scheme registration, and dependency/version expectations for KAI resources.
+- Establish test expectations for pod preparation, PodGroup sync, and delete paths.
+
+### Non-Goals
+
+- Redesigning the Scheduler Backend Framework introduced by GREP-375.
+- Introducing new user-facing scheduling APIs in PodCliqueSet or PodGang for this phase.
+- Covering support for all third-party schedulers; this proposal only scopes KAI backend behavior.
+- Defining advanced KAI-only scheduling semantics beyond existing PodGang intent.
+- Replacing or deprecating non-KAI backends.
+- Defining how scheduler backends are enabled, selected, or resolved from operator configuration and workload templates. This proposal assumes the `kai-scheduler` backend is already enabled by the Scheduler Backend Framework.
+- Requiring PodGang status-only updates to trigger backend reconciliation. The current backend controller reacts to create, delete, and generation-changing updates.
+- Creating, updating, or deleting KAI Topology resources from Grove `ClusterTopology`.
+- Defining topology-aware scheduling behavior for KAI. That functionality is out of scope for this proposal and should be covered separately.
+
+## Proposal
+
+Grove will ship a built-in `kai-scheduler` backend that implements the Scheduler Backend Framework lifecycle hooks needed to manage KAI PodGroups. The backend is responsible for converting Grove PodGang intent to KAI PodGroup resources, preparing Pods to use KAI, participating in admission validation, and keeping KAI PodGroups in sync with Grove lifecycle events.
+
+This proposal only covers KAI PodGroup creation and management. It does not propose any KAI Topology creation/update flow, does not add startup-time topology synchronization, and does not define topology-aware scheduling behavior.
+
+At a high level, the proposal introduces:
+
+1. **KAI backend ownership model**: Grove backend controller is the single owner of KAI PodGroup reconciliation for PodGang resources that select `kai-scheduler`.
+2. **Deterministic lifecycle behavior**: backend initialization happens during operator startup, `PreparePod` sets the scheduler name and podgrouper skip annotation during Pod construction, `SyncPodGang` handles create/update reconciliation, and `OnPodGangDelete` handles cleanup.
+3. **External PodGroup support dependency**: This backend relies on KAI-Scheduler support for externally-created PodGroups, including `kai.scheduler/skip-podgrouper`, so KAI does not recreate or overwrite Grove-owned PodGroups.
+4. **Operator readiness requirements**: KAI PodGroup API types are registered in Grove scheme and RBAC allows backend operations on KAI PodGroups.
+5. **Update safety**: Grove preserves fields that KAI runtime components own so backend reconciliation does not erase scheduler decisions or mutable runtime state.
+
+### User Stories
+
+#### Story 1: Platform Operator Enables KAI Backend
+
+As a platform operator, I want Grove to manage KAI scheduling resources through its backend framework so that KAI integration follows a consistent operator lifecycle and is easier to operate and troubleshoot.
+
+#### Story 2: Workload Owner Uses KAI Scheduler
+
+As a workload owner, I want my PodGang workloads targeting KAI to automatically produce and maintain the required KAI PodGroup resources so that gang scheduling intent is enforced without manual intervention.
+
+### Limitations/Risks & Mitigations
+
+#### Risk: Duplicate Ownership During Migration
+
+If KAI-Scheduler does not support externally-created PodGroups, KAI podgrouper behavior may compete with Grove-owned PodGroup reconciliation.
+
+**Mitigation**:
+
+- Require a KAI-Scheduler version that includes external PodGroup support from [kai-scheduler/KAI-Scheduler PR #1552](https://github.com/kai-scheduler/KAI-Scheduler/pull/1552).
+- Use `PreparePod()` to add KAI-Scheduler's `kai.scheduler/skip-podgrouper` annotation when it is missing, so KAI podgrouper skips Pods that are intentionally backed by externally-created PodGroups.
+- Keep ownership boundaries documented and validated in tests.
+
+## Design Details
+
+### Architecture Overview
+
+The KAI backend extends GREP-375 by implementing KAI-specific translations and lifecycle handling while preserving framework-level control flow.
+
+```mermaid
+flowchart TD
+    E[PodCliqueSet admission] --> F[Resolve backend and validate scheduler selection]
+    G[PodCliqueSet controller] --> H[Create PodGang with scheduler label]
+    I[PodClique controller] --> J[PreparePod sets schedulerName and skip-podgrouper annotation]
+    H --> K[PodGang backend controller]
+    K --> L[KAI Backend SyncPodGang]
+    L --> M[Create or update KAI PodGroup]
+    K --> O[OnPodGangDelete]
+    O --> P[Delete KAI PodGroup]
+```
+
+### Backend Lifecycle Contract
+
+The backend must cover the PodGroup-related backend surface from GREP-375:
+
+| Lifecycle surface | Trigger | KAI backend responsibility |
+| --- | --- | --- |
+| Backend initialization | Operator startup after manager creation | Construct and initialize the `kai-scheduler` backend profile. |
+| Admission validation | PodCliqueSet create/update webhook | Validate scheduler selection and run KAI-specific validation when defined. |
+| Pod preparation | PodClique controller builds a Pod | Set Pod `schedulerName` to `kai-scheduler` and ensure `kai.scheduler/skip-podgrouper` is present. |
+| PodGang sync | PodGang create or generation-changing update | Reconcile the Grove-owned KAI PodGroup. |
+| PodGang deletion | PodGang delete event | Delete associated KAI PodGroup, ignoring not-found errors. |
+
+### Precondition: KAI Backend Enabled
+
+This proposal assumes the Scheduler Backend Framework has already enabled and initialized the `kai-scheduler` backend. The mechanics of enabling scheduler profiles, default scheduler selection, and validation of scheduler names are defined by GREP-375 and are not redefined here.
+
+Under that assumption, this proposal only relies on the resolved backend identity:
+
+- Pods prepared by this backend are scheduled with `schedulerName: kai-scheduler`.
+- PodGang resources routed to this backend are reconciled into KAI PodGroups.
+
+### KAI Backend Responsibilities
+
+- Resolve only workloads assigned to `kai-scheduler`.
+- Participate in PodCliqueSet validation through the framework hook.
+- Prepare Pods by setting `schedulerName` to `kai-scheduler`.
+- Ensure prepared Pods have `kai.scheduler/skip-podgrouper` annotation so KAI podgrouper does not create or overwrite PodGroups that Grove owns.
+- Translate PodGang group semantics to KAI PodGroup semantics.
+- Reconcile KAI PodGroup state on PodGang create and update.
+- Handle KAI resource cleanup on PodGang delete.
+- Rely on KAI-Scheduler external PodGroup support so KAI podgrouper does not take ownership of Grove-managed PodGroups.
+
+### PodGang to PodGroup Mapping
+
+The KAI backend translates a Grove PodGang to a KAI PodGroup with the following ownership and mapping rules:
+
+| Grove source | KAI PodGroup target |
+| --- | --- |
+| PodGang name and namespace | PodGroup name and namespace |
+| PodGang labels and annotations | PodGroup labels and annotations, preserving existing target-only keys |
+| Sum of PodGang pod group minimum replicas | PodGroup `minMember` |
+| PodGang priority class | PodGroup priority class |
+| Queue label or annotation | PodGroup queue on initial creation |
+| PodGang pod groups | Leaf KAI subgroups with min member and optional parent |
+| PodGang owner reference | PodGroup controller owner reference |
+
+This mapping focuses on PodGroup ownership and gang membership. KAI Topology resources and topology-aware scheduling semantics are outside the scope of this proposal.
+
+### Pod Preparation
+
+When the KAI backend prepares a Pod, it must:
+
+- Set `pod.spec.schedulerName` to `kai-scheduler`.
+- Ensure `pod.metadata.annotations["kai.scheduler/skip-podgrouper"]` is present when missing.
+- Preserve any existing user or controller annotations on the Pod.
+
+The skip-podgrouper annotation is required because the KAI PodGroup is created externally by Grove. Without it, KAI podgrouper may still try to infer or reconcile PodGroup membership for the same Pod, competing with the Grove-owned PodGroup.
+
+### PodGroup Update Semantics
+
+After creation, some PodGroup fields are owned or mutated by KAI runtime components. The KAI backend must not blindly overwrite them on every Grove reconciliation. Existing runtime-managed values are inherited before comparison and update. This includes:
+
+- Scheduler backoff state.
+- Mark-unschedulable state.
+- Existing queue value.
+- Runtime-assigned KAI queue and node-pool labels.
+
+For source-owned labels and annotations, Grove ensures values from the desired PodGang are present on the PodGroup while preserving unrelated existing keys.
+
+### Reconciliation Flow
+
+1. Backend controller receives PodGang event and resolves `kai-scheduler` backend.
+2. KAI backend computes desired PodGroup representation from PodGang state.
+3. Backend creates the KAI PodGroup if none exists.
+4. Backend inherits KAI runtime-managed fields from the existing PodGroup before comparing desired and actual state.
+5. Backend updates only when source-owned fields or desired scheduling intent changed.
+6. On PodGang deletion, backend removes the associated KAI PodGroup and ignores not-found errors.
+
+The backend controller only handles PodGang create, delete, and generation-changing update events. Status-only transitions, such as the PodGang `Initialized` condition, do not trigger backend reconciliation. The KAI backend design must therefore rely on spec and metadata changes for PodGroup reconciliation.
+
+### API and Registration Requirements
+
+- Grove runtime scheme includes KAI PodGroup API types for backend client operations.
+- Operator RBAC grants read/write/delete access for KAI PodGroup resources.
+- KAI-Scheduler version includes externally-created PodGroup support from [kai-scheduler/KAI-Scheduler PR #1552](https://github.com/kai-scheduler/KAI-Scheduler/pull/1552).
+- Backend initialization should validate required API availability before normal reconciliation where practical.
+- KAI dependency imports should consistently use the same module path and version across backend code, scheme registration, unit tests, and e2e helpers.
+
+### RBAC Matrix
+
+| API group | Resource | Scope | Required verbs | Purpose |
+| --- | --- | --- | --- | --- |
+| `scheduling.run.ai` | `podgroups` | Namespaced | create, get, list, watch, patch, update, delete | PodGang to KAI PodGroup reconciliation and cleanup. |
+
+### Test Plan
+
+#### Unit Tests
+
+- Validate `PreparePod` sets Pod `schedulerName` to `kai-scheduler` and adds `kai.scheduler/skip-podgrouper` when missing without dropping existing annotations.
+- Validate `SyncPodGang` creates and updates KAI PodGroup state, including required field mapping and runtime-managed field preservation.
+- Validate `OnPodGangDelete` removes the associated KAI PodGroup and ignores already-deleted resources.
+
+#### E2E Tests
+
+- Deploy a minimal PodCliqueSet that uses `schedulerName: kai-scheduler` through the existing e2e `PrepareTest` and `DeployAndVerifyWorkload` flow. Verify the created Pods use `kai-scheduler`, include `kai.scheduler/skip-podgrouper`, the backend creates a KAI PodGroup for the Grove PodGang, and the PodGroup contains the expected basic fields such as owner reference, `minMember`, queue, and subgroups.
+- Delete the same PodCliqueSet with the existing workload deletion helper and verify the KAI PodGroup for that workload is removed. This covers the `OnPodGangDelete` path without adding topology-specific e2e coverage.
+
+### Graduation Criteria
+
+#### Alpha
+
+- KAI backend is implemented behind framework lifecycle hooks.
+- Unit tests cover pod preparation, PodGroup translation, sync, and delete behavior.
+
+#### Beta
+
+- E2E coverage validates KAI backend behavior in realistic cluster environments.
+
+#### GA
+
+- KAI backend is stable across multiple releases with no unresolved critical issues.
+
+## Appendix
+
+- Scheduler Backend Framework baseline: GREP-375.
+- KAI scheduler dependency context: [kai-scheduler/KAI-Scheduler PR #1552](https://github.com/kai-scheduler/KAI-Scheduler/pull/1552), which adds support for externally-created PodGroups and allows Grove to own PodGroup creation through this backend.

--- a/docs/proposals/525-KAI-Scheduler-Backend/README.md
+++ b/docs/proposals/525-KAI-Scheduler-Backend/README.md
@@ -34,7 +34,7 @@
 
 ## Summary
 
-This proposal adds a dedicated KAI scheduler backend to Grove's Scheduler Backend Framework so Grove can natively create, update, and delete KAI PodGroup resources for Grove PodGang workloads. This proposal is intentionally limited to PodGroup creation and management; it does not include topology-aware scheduling support or KAI Topology synchronization from Grove ClusterTopology. The change improves maintainability, clarifies ownership boundaries, and enables predictable KAI-specific lifecycle handling for PodGang workloads by relying on KAI-Scheduler's externally-created PodGroup support.
+This proposal adds a dedicated KAI scheduler backend to Grove's Scheduler Backend Framework so Grove can natively create, update, and delete KAI PodGroup resources for Grove PodGang workloads. This proposal is intentionally limited to PodGroup creation and management; it does not add new topology-aware scheduling support and does not change existing KAI Topology synchronization behavior from Grove ClusterTopology. The change improves maintainability, clarifies ownership boundaries, and enables predictable KAI-specific lifecycle handling for PodGang workloads by relying on KAI-Scheduler's externally-created PodGroup support.
 
 ## Motivation
 
@@ -59,7 +59,7 @@ GREP-375 introduced a generic Scheduler Backend Framework, but the KAI integrati
 - Replacing or deprecating non-KAI backends.
 - Defining how scheduler backends are enabled, selected, or resolved from operator configuration and workload templates. This proposal assumes the `kai-scheduler` backend is already enabled by the Scheduler Backend Framework.
 - Requiring PodGang status-only updates to trigger backend reconciliation. The current backend controller reacts to create, delete, and generation-changing updates.
-- Creating, updating, or deleting KAI Topology resources from Grove `ClusterTopology`.
+- Extending or refactoring existing KAI Topology resource management from Grove `ClusterTopology`/`ClusterTopologyBinding`.
 - Defining topology-aware scheduling behavior for KAI. That functionality is out of scope for this proposal and should be covered separately.
 
 ## Proposal
@@ -202,7 +202,7 @@ The backend controller only handles PodGang create, delete, and generation-chang
 - Operator RBAC grants read/write/delete access for KAI PodGroup resources.
 - KAI-Scheduler version includes externally-created PodGroup support from [kai-scheduler/KAI-Scheduler PR #1552](https://github.com/kai-scheduler/KAI-Scheduler/pull/1552).
 - Backend initialization should validate required API availability before normal reconciliation where practical.
-- KAI dependency imports should consistently use the same module path and version across backend code, scheme registration, unit tests, and e2e helpers.
+- KAI dependency imports should consistently use the same module path and version across backend code, scheme registration, unit tests, and e2e helpers (canonical module path: `github.com/kai-scheduler/KAI-scheduler`).
 
 ### RBAC Matrix
 

--- a/operator/charts/templates/clusterrole.yaml
+++ b/operator/charts/templates/clusterrole.yaml
@@ -142,6 +142,18 @@ rules:
   - patch
   - update
   - delete
+- apiGroups:
+  - scheduling.run.ai
+  resources:
+  - podgroups
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - patch
+  - update
+  - delete
 {{- if .Values.config.network.autoMNNVLEnabled }}
 # MNNVL (Multi-Node NVLink) support requires permissions for ComputeDomain and ResourceClaimTemplate resources.
 # Note: Kubernetes allows RBAC rules for resources that don't exist yet. If the ComputeDomain CRD is not installed,

--- a/operator/charts/templates/clusterrole.yaml
+++ b/operator/charts/templates/clusterrole.yaml
@@ -143,16 +143,12 @@ rules:
   - patch
   - update
   - delete
+
 # DRA (Dynamic Resource Allocation) integration for resource sharing
 - apiGroups:
   - resource.k8s.io
   resources:
   - resourceclaims
-  verbs:
-  - create
-  - get
-  - list
-  - watch
   - delete
   - deletecollection
   - patch
@@ -162,9 +158,26 @@ rules:
   resources:
   - resourceclaimtemplates
   verbs:
+  - create
   - get
   - list
   - watch
+  - get
+  - list
+  - watch
+# KAI Scheduler integration for resource sharing
+- apiGroups:
+  - scheduling.run.ai
+  resources:
+  - podgroups
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - patch
+  - update
+  - delete
 {{- if .Values.config.network.autoMNNVLEnabled }}
 # MNNVL (Multi-Node NVLink) support requires permissions for ComputeDomain and ResourceClaimTemplate resources.
 # Note: Kubernetes allows RBAC rules for resources that don't exist yet. If the ComputeDomain CRD is not installed,

--- a/operator/internal/client/scheme.go
+++ b/operator/internal/client/scheme.go
@@ -21,6 +21,7 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 
 	kaitopologyv1alpha1 "github.com/NVIDIA/KAI-scheduler/pkg/apis/kai/v1alpha1"
+	kaischedulingv2alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	schedv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,6 +38,7 @@ func init() {
 		grovecorev1alpha1.AddToScheme,
 		schedv1alpha1.AddToScheme,
 		kaitopologyv1alpha1.AddToScheme,
+		kaischedulingv2alpha2.AddToScheme,
 		k8sscheme.AddToScheme,
 	)
 	utilruntime.Must(metav1.AddMetaToScheme(Scheme))

--- a/operator/internal/client/scheme.go
+++ b/operator/internal/client/scheme.go
@@ -22,6 +22,7 @@ import (
 
 	schedv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	kaitopologyv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
+	kaischedulingv2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -37,6 +38,7 @@ func init() {
 		grovecorev1alpha1.AddToScheme,
 		schedv1alpha1.AddToScheme,
 		kaitopologyv1alpha1.AddToScheme,
+		kaischedulingv2alpha2.AddToScheme,
 		k8sscheme.AddToScheme,
 	)
 	utilruntime.Must(metav1.AddMetaToScheme(Scheme))

--- a/operator/internal/scheduler/kai/backend.go
+++ b/operator/internal/scheduler/kai/backend.go
@@ -18,20 +18,27 @@ package kai
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 
+	apicommonconstants "github.com/ai-dynamo/grove/operator/api/common/constants"
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/ai-dynamo/grove/operator/internal/scheduler"
 
+	kaischedulingv2alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // schedulerBackend implements the scheduler Backend interface (Backend in scheduler package) for KAI scheduler.
-// TODO: Converts PodGang → PodGroup
 type schedulerBackend struct {
 	client        client.Client
 	scheme        *runtime.Scheme
@@ -41,6 +48,13 @@ type schedulerBackend struct {
 }
 
 var _ scheduler.Backend = (*schedulerBackend)(nil)
+
+const (
+	labelKeyQueueName        = "kai.scheduler/queue"
+	labelKeyNodePoolName     = "kai.scheduler/node-pool"
+	annotationKeyIgnoreGrove = "grove.io/ignore"
+	annotationValIgnoreGrove = "true"
+)
 
 // New creates a new KAI backend instance. profile is the scheduler profile for kai-scheduler;
 // schedulerBackend uses profile.Name and may unmarshal profile.Config for kai-specific options.
@@ -65,13 +79,47 @@ func (b *schedulerBackend) Init() error {
 }
 
 // SyncPodGang converts PodGang to KAI PodGroup and synchronizes it
-func (b *schedulerBackend) SyncPodGang(_ context.Context, _ *groveschedulerv1alpha1.PodGang) error {
-	return nil
+func (b *schedulerBackend) SyncPodGang(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) error {
+	if podGang == nil {
+		return fmt.Errorf("podGang is nil")
+	}
+	if err := b.ensurePodGangIgnoredByGrovePlugin(ctx, podGang); err != nil {
+		return err
+	}
+
+	newPodGroup, err := b.buildPodGroupForPodGang(podGang)
+	if err != nil {
+		return err
+	}
+
+	oldPodGroup := &kaischedulingv2alpha2.PodGroup{}
+	key := client.ObjectKeyFromObject(newPodGroup)
+	if err = b.client.Get(ctx, key, oldPodGroup); err != nil {
+		if apierrors.IsNotFound(err) {
+			return b.client.Create(ctx, newPodGroup)
+		}
+		return err
+	}
+
+	newPodGroup = b.inheritRuntimeManagedFields(oldPodGroup, newPodGroup)
+	if podGroupsEqual(oldPodGroup, newPodGroup) {
+		return nil
+	}
+	updatePodGroup(oldPodGroup, newPodGroup)
+	return b.client.Update(ctx, oldPodGroup)
 }
 
 // OnPodGangDelete removes the PodGroup owned by this PodGang
-func (b *schedulerBackend) OnPodGangDelete(_ context.Context, _ *groveschedulerv1alpha1.PodGang) error {
-	return nil
+func (b *schedulerBackend) OnPodGangDelete(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) error {
+	if podGang == nil {
+		return nil
+	}
+	return client.IgnoreNotFound(b.client.Delete(ctx, &kaischedulingv2alpha2.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podGang.Name,
+			Namespace: podGang.Namespace,
+		},
+	}))
 }
 
 // PreparePod adds KAI scheduler-specific configuration to the Pod.
@@ -83,4 +131,199 @@ func (b *schedulerBackend) PreparePod(pod *corev1.Pod) {
 // ValidatePodCliqueSet runs KAI-specific validations on the PodCliqueSet.
 func (b *schedulerBackend) ValidatePodCliqueSet(_ context.Context, _ *grovecorev1alpha1.PodCliqueSet) error {
 	return nil
+}
+
+// ensurePodGangIgnoredByGrovePlugin marks PodGang so legacy Grove podgrouper ignores it.
+func (b *schedulerBackend) ensurePodGangIgnoredByGrovePlugin(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) error {
+	if podGang.Annotations != nil && podGang.Annotations[annotationKeyIgnoreGrove] == annotationValIgnoreGrove {
+		return nil
+	}
+	patchBase := podGang.DeepCopy()
+	if podGang.Annotations == nil {
+		podGang.Annotations = map[string]string{}
+	}
+	podGang.Annotations[annotationKeyIgnoreGrove] = annotationValIgnoreGrove
+	return b.client.Patch(ctx, podGang, client.MergeFrom(patchBase))
+}
+
+// buildPodGroupForPodGang translates a Grove PodGang into a KAI PodGroup object.
+func (b *schedulerBackend) buildPodGroupForPodGang(podGang *groveschedulerv1alpha1.PodGang) (*kaischedulingv2alpha2.PodGroup, error) {
+	topologyName := getTopologyName(podGang)
+	topologyConstraint, err := toKAITopologyConstraint(podGang.Spec.TopologyConstraint, topologyName)
+	if err != nil {
+		return nil, err
+	}
+
+	parentBySubGroupName := map[string]string{}
+	subGroups := make([]kaischedulingv2alpha2.SubGroup, 0, len(podGang.Spec.TopologyConstraintGroupConfigs)+len(podGang.Spec.PodGroups))
+
+	for _, groupConfig := range podGang.Spec.TopologyConstraintGroupConfigs {
+		groupTopologyConstraint, groupErr := toKAITopologyConstraint(groupConfig.TopologyConstraint, topologyName)
+		if groupErr != nil {
+			return nil, groupErr
+		}
+		subGroups = append(subGroups, kaischedulingv2alpha2.SubGroup{
+			Name:               groupConfig.Name,
+			MinMember:          0,
+			TopologyConstraint: groupTopologyConstraint,
+		})
+		for _, podGroupName := range groupConfig.PodGroupNames {
+			parentBySubGroupName[podGroupName] = groupConfig.Name
+		}
+	}
+
+	var minMember int32
+	for _, podGroup := range podGang.Spec.PodGroups {
+		subGroupTopologyConstraint, groupErr := toKAITopologyConstraint(podGroup.TopologyConstraint, topologyName)
+		if groupErr != nil {
+			return nil, groupErr
+		}
+		subGroup := kaischedulingv2alpha2.SubGroup{
+			Name:               podGroup.Name,
+			MinMember:          podGroup.MinReplicas,
+			TopologyConstraint: subGroupTopologyConstraint,
+		}
+		if parentName, found := parentBySubGroupName[podGroup.Name]; found {
+			subGroup.Parent = ptr.To(parentName)
+		}
+		subGroups = append(subGroups, subGroup)
+		minMember += podGroup.MinReplicas
+	}
+
+	result := &kaischedulingv2alpha2.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        podGang.Name,
+			Namespace:   podGang.Namespace,
+			Labels:      cloneStringMap(podGang.Labels),
+			Annotations: cloneStringMap(podGang.Annotations),
+		},
+		Spec: kaischedulingv2alpha2.PodGroupSpec{
+			MinMember:         minMember,
+			Queue:             resolveQueueName(podGang),
+			PriorityClassName: podGang.Spec.PriorityClassName,
+			SubGroups:         subGroups,
+		},
+	}
+	if topologyConstraint != nil {
+		result.Spec.TopologyConstraint = *topologyConstraint
+	}
+	if err := controllerutil.SetControllerReference(podGang, result, b.scheme); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// getTopologyName resolves topology name from PodGang annotations with fallback keys.
+func getTopologyName(podGang *groveschedulerv1alpha1.PodGang) string {
+	if podGang.Annotations == nil {
+		return ""
+	}
+	if topologyName := podGang.Annotations[apicommonconstants.AnnotationTopologyName]; topologyName != "" {
+		return topologyName
+	}
+	// Backward compatibility with KAI annotation key.
+	return podGang.Annotations["kai.scheduler/topology"]
+}
+
+// toKAITopologyConstraint converts Grove topology constraint to KAI topology constraint.
+func toKAITopologyConstraint(topologyConstraint *groveschedulerv1alpha1.TopologyConstraint, topologyName string) (*kaischedulingv2alpha2.TopologyConstraint, error) {
+	if topologyConstraint == nil || topologyConstraint.PackConstraint == nil {
+		return nil, nil
+	}
+	if topologyName == "" {
+		return nil, fmt.Errorf("topology name cannot be empty when topology constraints are defined")
+	}
+	result := &kaischedulingv2alpha2.TopologyConstraint{
+		Topology: topologyName,
+	}
+	if topologyConstraint.PackConstraint.Preferred != nil {
+		result.PreferredTopologyLevel = *topologyConstraint.PackConstraint.Preferred
+	}
+	if topologyConstraint.PackConstraint.Required != nil {
+		result.RequiredTopologyLevel = *topologyConstraint.PackConstraint.Required
+	}
+	return result, nil
+}
+
+// resolveQueueName returns queue from labels first, then falls back to annotations.
+func resolveQueueName(podGang *groveschedulerv1alpha1.PodGang) string {
+	if podGang.Labels != nil && podGang.Labels[labelKeyQueueName] != "" {
+		return podGang.Labels[labelKeyQueueName]
+	}
+	if podGang.Annotations != nil {
+		return podGang.Annotations[labelKeyQueueName]
+	}
+	return ""
+}
+
+// inheritRuntimeManagedFields preserves fields that are managed by KAI runtime components.
+func (b *schedulerBackend) inheritRuntimeManagedFields(oldPodGroup, newPodGroup *kaischedulingv2alpha2.PodGroup) *kaischedulingv2alpha2.PodGroup {
+	newPodGroupCopy := newPodGroup.DeepCopy()
+	// These fields are managed by KAI components after initial creation.
+	newPodGroupCopy.Spec.MarkUnschedulable = oldPodGroup.Spec.MarkUnschedulable
+	newPodGroupCopy.Spec.SchedulingBackoff = oldPodGroup.Spec.SchedulingBackoff
+	newPodGroupCopy.Spec.Queue = oldPodGroup.Spec.Queue
+
+	if newPodGroupCopy.Labels == nil {
+		newPodGroupCopy.Labels = map[string]string{}
+	}
+	if nodePoolName := oldPodGroup.Labels[labelKeyNodePoolName]; nodePoolName != "" {
+		newPodGroupCopy.Labels[labelKeyNodePoolName] = nodePoolName
+	}
+	if queueName := oldPodGroup.Labels[labelKeyQueueName]; queueName != "" {
+		newPodGroupCopy.Labels[labelKeyQueueName] = queueName
+	}
+	return newPodGroupCopy
+}
+
+// podGroupsEqual compares spec plus source-owned metadata fields for update decisions.
+func podGroupsEqual(oldPodGroup, newPodGroup *kaischedulingv2alpha2.PodGroup) bool {
+	return reflect.DeepEqual(oldPodGroup.Spec, newPodGroup.Spec) &&
+		reflect.DeepEqual(oldPodGroup.OwnerReferences, newPodGroup.OwnerReferences) &&
+		mapsEqualBySourceKeys(newPodGroup.Labels, oldPodGroup.Labels) &&
+		mapsEqualBySourceKeys(newPodGroup.Annotations, oldPodGroup.Annotations)
+}
+
+// mapsEqualBySourceKeys checks whether target contains all key-values from source.
+func mapsEqualBySourceKeys(source, target map[string]string) bool {
+	if source != nil && target == nil {
+		return false
+	}
+	for key, sourceValue := range source {
+		if targetValue, exists := target[key]; !exists || targetValue != sourceValue {
+			return false
+		}
+	}
+	return true
+}
+
+// updatePodGroup copies desired fields from newPodGroup into existing object.
+func updatePodGroup(oldPodGroup, newPodGroup *kaischedulingv2alpha2.PodGroup) {
+	oldPodGroup.Annotations = copyStringMap(newPodGroup.Annotations, oldPodGroup.Annotations)
+	oldPodGroup.Labels = copyStringMap(newPodGroup.Labels, oldPodGroup.Labels)
+	oldPodGroup.Spec = newPodGroup.Spec
+	oldPodGroup.OwnerReferences = newPodGroup.OwnerReferences
+}
+
+// copyStringMap copies all key-values from source into target map.
+func copyStringMap(source, target map[string]string) map[string]string {
+	if source != nil && target == nil {
+		target = map[string]string{}
+	}
+	for k, v := range source {
+		target[k] = v
+	}
+	return target
+}
+
+// cloneStringMap returns a shallow copy of the input string map.
+func cloneStringMap(input map[string]string) map[string]string {
+	if input == nil {
+		return nil
+	}
+	cloned := make(map[string]string, len(input))
+	for k, v := range input {
+		cloned[k] = v
+	}
+	return cloned
 }

--- a/operator/internal/scheduler/kai/backend.go
+++ b/operator/internal/scheduler/kai/backend.go
@@ -26,7 +26,7 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/ai-dynamo/grove/operator/internal/scheduler"
 
-	kaischedulingv2alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+	kaischedulingv2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -52,8 +52,8 @@ var _ scheduler.Backend = (*schedulerBackend)(nil)
 const (
 	labelKeyQueueName        = "kai.scheduler/queue"
 	labelKeyNodePoolName     = "kai.scheduler/node-pool"
-	annotationKeyIgnoreGrove = "grove.io/ignore"
-	annotationValIgnoreGrove = "true"
+	annotationKeySkipPGR     = "kai.scheduler/skip-podgrouper"
+	annotationValSkipPGR     = "true"
 )
 
 // New creates a new KAI backend instance. profile is the scheduler profile for kai-scheduler;
@@ -82,9 +82,6 @@ func (b *schedulerBackend) Init() error {
 func (b *schedulerBackend) SyncPodGang(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) error {
 	if podGang == nil {
 		return fmt.Errorf("podGang is nil")
-	}
-	if err := b.ensurePodGangIgnoredByGrovePlugin(ctx, podGang); err != nil {
-		return err
 	}
 
 	newPodGroup, err := b.buildPodGroupForPodGang(podGang)
@@ -126,24 +123,17 @@ func (b *schedulerBackend) OnPodGangDelete(ctx context.Context, podGang *grovesc
 // Sets Pod.Spec.SchedulerName so the pod is scheduled by KAI.
 func (b *schedulerBackend) PreparePod(pod *corev1.Pod) {
 	pod.Spec.SchedulerName = b.Name()
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+	if _, exists := pod.Annotations[annotationKeySkipPGR]; !exists {
+		pod.Annotations[annotationKeySkipPGR] = annotationValSkipPGR
+	}
 }
 
 // ValidatePodCliqueSet runs KAI-specific validations on the PodCliqueSet.
 func (b *schedulerBackend) ValidatePodCliqueSet(_ context.Context, _ *grovecorev1alpha1.PodCliqueSet) error {
 	return nil
-}
-
-// ensurePodGangIgnoredByGrovePlugin marks PodGang so legacy Grove podgrouper ignores it.
-func (b *schedulerBackend) ensurePodGangIgnoredByGrovePlugin(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) error {
-	if podGang.Annotations != nil && podGang.Annotations[annotationKeyIgnoreGrove] == annotationValIgnoreGrove {
-		return nil
-	}
-	patchBase := podGang.DeepCopy()
-	if podGang.Annotations == nil {
-		podGang.Annotations = map[string]string{}
-	}
-	podGang.Annotations[annotationKeyIgnoreGrove] = annotationValIgnoreGrove
-	return b.client.Patch(ctx, podGang, client.MergeFrom(patchBase))
 }
 
 // buildPodGroupForPodGang translates a Grove PodGang into a KAI PodGroup object.

--- a/operator/internal/scheduler/kai/backend_test.go
+++ b/operator/internal/scheduler/kai/backend_test.go
@@ -17,13 +17,20 @@
 package kai
 
 import (
+	"context"
 	"testing"
 
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
+	kaischedulingv2alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestBackend_PreparePod(t *testing.T) {
@@ -39,4 +46,118 @@ func TestBackend_PreparePod(t *testing.T) {
 	b.PreparePod(pod)
 
 	assert.Equal(t, "kai-scheduler", pod.Spec.SchedulerName)
+}
+
+func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
+	podGang := testutils.NewPodGangBuilder("test-podgang", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		Build()
+	podGang.Labels["kai.scheduler/queue"] = "team-a"
+	podGang.Annotations = map[string]string{"grove.io/topology-name": "cluster-topology"}
+	podGang.Spec.PriorityClassName = "high-priority"
+	podGang.Spec.TopologyConstraint = &groveschedulerv1alpha1.TopologyConstraint{
+		PackConstraint: &groveschedulerv1alpha1.TopologyPackConstraint{
+			Required: ptr.To("zone"),
+		},
+	}
+	podGang.Spec.TopologyConstraintGroupConfigs = []groveschedulerv1alpha1.TopologyConstraintGroupConfig{
+		{
+			Name:          "decoder-group",
+			PodGroupNames: []string{"decoder"},
+			TopologyConstraint: &groveschedulerv1alpha1.TopologyConstraint{
+				PackConstraint: &groveschedulerv1alpha1.TopologyPackConstraint{
+					Preferred: ptr.To("rack"),
+				},
+			},
+		},
+	}
+	podGang.Spec.PodGroups = []groveschedulerv1alpha1.PodGroup{
+		{
+			Name:        "encoder",
+			MinReplicas: 2,
+			TopologyConstraint: &groveschedulerv1alpha1.TopologyConstraint{
+				PackConstraint: &groveschedulerv1alpha1.TopologyPackConstraint{
+					Required: ptr.To("host"),
+				},
+			},
+		},
+		{
+			Name:        "decoder",
+			MinReplicas: 3,
+		},
+	}
+
+	cl := testutils.NewTestClientBuilder().
+		WithObjects(podGang).
+		Build()
+	recorder := record.NewFakeRecorder(10)
+	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}
+	b := New(cl, cl.Scheme(), recorder, profile)
+
+	ctx := context.Background()
+	require.NoError(t, b.SyncPodGang(ctx, podGang))
+
+	syncedPodGang := &groveschedulerv1alpha1.PodGang{}
+	require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(podGang), syncedPodGang))
+	assert.Equal(t, "true", syncedPodGang.Annotations["grove.io/ignore"])
+
+	gotPodGroup := &kaischedulingv2alpha2.PodGroup{}
+	require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: podGang.Name, Namespace: podGang.Namespace}, gotPodGroup))
+
+	assert.Equal(t, int32(5), gotPodGroup.Spec.MinMember)
+	assert.Equal(t, "team-a", gotPodGroup.Spec.Queue)
+	assert.Equal(t, "high-priority", gotPodGroup.Spec.PriorityClassName)
+	assert.Equal(t, "zone", gotPodGroup.Spec.TopologyConstraint.RequiredTopologyLevel)
+
+	require.Len(t, gotPodGroup.Spec.SubGroups, 3)
+	assert.Equal(t, "decoder-group", gotPodGroup.Spec.SubGroups[0].Name)
+	assert.Equal(t, int32(0), gotPodGroup.Spec.SubGroups[0].MinMember)
+
+	assert.Equal(t, "encoder", gotPodGroup.Spec.SubGroups[1].Name)
+	assert.Equal(t, int32(2), gotPodGroup.Spec.SubGroups[1].MinMember)
+	assert.Nil(t, gotPodGroup.Spec.SubGroups[1].Parent)
+	assert.Equal(t, "host", gotPodGroup.Spec.SubGroups[1].TopologyConstraint.RequiredTopologyLevel)
+
+	assert.Equal(t, "decoder", gotPodGroup.Spec.SubGroups[2].Name)
+	require.NotNil(t, gotPodGroup.Spec.SubGroups[2].Parent)
+	assert.Equal(t, "decoder-group", *gotPodGroup.Spec.SubGroups[2].Parent)
+	assert.Equal(t, int32(3), gotPodGroup.Spec.SubGroups[2].MinMember)
+
+	// Update PodGang: remove queue label and change min replicas.
+	updatedPodGang := syncedPodGang.DeepCopy()
+	delete(updatedPodGang.Labels, "kai.scheduler/queue")
+	updatedPodGang.Spec.PodGroups[0].MinReplicas = 4
+	require.NoError(t, cl.Update(ctx, updatedPodGang))
+
+	require.NoError(t, b.SyncPodGang(ctx, updatedPodGang))
+	gotAfterUpdate := &kaischedulingv2alpha2.PodGroup{}
+	require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: podGang.Name, Namespace: podGang.Namespace}, gotAfterUpdate))
+
+	// Existing queue should be preserved even when source label is removed.
+	assert.Equal(t, "team-a", gotAfterUpdate.Spec.Queue)
+	assert.Equal(t, int32(7), gotAfterUpdate.Spec.MinMember)
+	assert.Equal(t, int32(4), gotAfterUpdate.Spec.SubGroups[1].MinMember)
+}
+
+func TestBackend_OnPodGangDelete(t *testing.T) {
+	podGang := testutils.NewPodGangBuilder("to-delete", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		Build()
+	podGroup := &kaischedulingv2alpha2.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-delete",
+			Namespace: "default",
+		},
+	}
+
+	cl := testutils.NewTestClientBuilder().WithObjects(podGang, podGroup).Build()
+	recorder := record.NewFakeRecorder(10)
+	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}
+	b := New(cl, cl.Scheme(), recorder, profile)
+
+	ctx := context.Background()
+	require.NoError(t, b.OnPodGangDelete(ctx, podGang))
+
+	err := cl.Get(ctx, client.ObjectKey{Name: podGroup.Name, Namespace: podGroup.Namespace}, &kaischedulingv2alpha2.PodGroup{})
+	assert.Error(t, err)
 }

--- a/operator/internal/scheduler/kai/backend_test.go
+++ b/operator/internal/scheduler/kai/backend_test.go
@@ -23,7 +23,7 @@ import (
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
-	kaischedulingv2alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+	kaischedulingv2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,10 +42,28 @@ func TestBackend_PreparePod(t *testing.T) {
 	pod := testutils.NewPodBuilder("test-pod", "default").
 		WithSchedulerName("default-scheduler").
 		Build()
+	pod.Annotations = map[string]string{"keep": "me"}
 
 	b.PreparePod(pod)
 
 	assert.Equal(t, "kai-scheduler", pod.Spec.SchedulerName)
+	assert.Equal(t, "me", pod.Annotations["keep"])
+	assert.Equal(t, "true", pod.Annotations["kai.scheduler/skip-podgrouper"])
+}
+
+func TestBackend_PreparePod_PreservesExistingSkipAnnotation(t *testing.T) {
+	cl := testutils.CreateDefaultFakeClient(nil)
+	recorder := record.NewFakeRecorder(10)
+	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}
+	b := New(cl, cl.Scheme(), recorder, profile)
+
+	pod := testutils.NewPodBuilder("test-pod", "default").
+		Build()
+	pod.Annotations = map[string]string{"kai.scheduler/skip-podgrouper": "custom"}
+
+	b.PreparePod(pod)
+
+	assert.Equal(t, "custom", pod.Annotations["kai.scheduler/skip-podgrouper"])
 }
 
 func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
@@ -97,10 +115,6 @@ func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, b.SyncPodGang(ctx, podGang))
 
-	syncedPodGang := &groveschedulerv1alpha1.PodGang{}
-	require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(podGang), syncedPodGang))
-	assert.Equal(t, "true", syncedPodGang.Annotations["grove.io/ignore"])
-
 	gotPodGroup := &kaischedulingv2alpha2.PodGroup{}
 	require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: podGang.Name, Namespace: podGang.Namespace}, gotPodGroup))
 
@@ -124,7 +138,7 @@ func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
 	assert.Equal(t, int32(3), gotPodGroup.Spec.SubGroups[2].MinMember)
 
 	// Update PodGang: remove queue label and change min replicas.
-	updatedPodGang := syncedPodGang.DeepCopy()
+	updatedPodGang := podGang.DeepCopy()
 	delete(updatedPodGang.Labels, "kai.scheduler/queue")
 	updatedPodGang.Spec.PodGroups[0].MinReplicas = 4
 	require.NoError(t, cl.Update(ctx, updatedPodGang))


### PR DESCRIPTION
#### What type of PR is this?

This PR implements the KAI scheduler backend `SyncPodGang()` flow in Grove’s scheduler backend framework.
Specifically, it:
- Adds PodGang -> KAI PodGroup translation and reconciliation (create/update) in `operator/internal/scheduler/kai/backend.go`
- Adds PodGroup cleanup on PodGang deletion via `OnPodGangDelete()`
- Adds migration-safe behavior by annotating PodGang with `grove.io/ignore: "true"` so legacy KAI Grove podgrouper can ignore these PodGangs
- Registers KAI PodGroup API types in Grove scheme (`scheduling.run.ai/v2alpha2`)
- Adds RBAC permissions for `scheduling.run.ai/podgroups` in the Helm ClusterRole
- Adds/extends unit tests for KAI backend sync and delete paths

#### What this PR does / why we need it:

- Grove now owns backend-specific scheduling resources directly for KAI.
- Without this, KAI backend remains incomplete and relies on legacy plugin behavior.
- The ignore annotation prevents duplicate/competing PodGroup management during migration.

#### Which issue(s) this PR fixes:
Fixes #525

#### Special notes for your reviewer:

- This change is designed to work with KAI-Scheduler support for ignoring PodGangs annotated with `grove.io/ignore`:
  - https://github.com/kai-scheduler/KAI-Scheduler/pull/1001
- The new KAI backend path reuses the same topology/subgroup semantics used by the legacy Grove plugin mapping, but moves ownership into Grove operator backend reconciliation.

#### Does this PR introduce a API change?
NONE

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:
NONE