### PR TITLE
Add mnnvl-group annotation validation and extend webhook to PodClique…

### DIFF
--- a/operator/internal/mnnvl/constants.go
+++ b/operator/internal/mnnvl/constants.go
@@ -56,6 +56,14 @@ const (
 	// automatic MNNVL support should be disabled.
 	AnnotationAutoMNNVLDisabled = "disabled"
 
+	// AnnotationMNNVLGroup is the annotation key used to assign a PodClique to a named
+	// MNNVL group. PodCliques with the same group name share a ComputeDomain per replica.
+	// The presence of this annotation implicitly enables MNNVL — auto-mnnvl: enabled is
+	// not required when mnnvl-group is set.
+	// The value must be a valid Kubernetes name component (lowercase alphanumeric or dashes,
+	// starting and ending with alphanumeric, max 63 characters).
+	AnnotationMNNVLGroup = "grove.io/mnnvl-group"
+
 	// FinalizerComputeDomain is the finalizer added to ComputeDomains to prevent accidental
 	// deletion while workloads are using them. This finalizer is removed by the PCS controller
 	// during scale-in or PCS deletion.

--- a/operator/internal/mnnvl/helpers.go
+++ b/operator/internal/mnnvl/helpers.go
@@ -18,12 +18,14 @@ package mnnvl
 
 import (
 	"fmt"
+	"strings"
 
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/ai-dynamo/grove/operator/internal/constants"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 // IsAutoMNNVLEnabled checks if MNNVL is enabled via the grove.io/auto-mnnvl annotation.
@@ -32,6 +34,36 @@ func IsAutoMNNVLEnabled(annotations map[string]string) bool {
 		return false
 	}
 	return annotations[AnnotationAutoMNNVL] == AnnotationAutoMNNVLEnabled
+}
+
+// ValidateMNNVLGroupName validates that the given string is a valid DNS-1123
+// label, suitable for use as an mnnvl-group annotation value. The group name
+// becomes part of the ComputeDomain resource name, so it must conform to
+// Kubernetes naming rules.
+func ValidateMNNVLGroupName(name string) error {
+	if name == "" {
+		return fmt.Errorf("mnnvl-group value must not be empty")
+	}
+	if errs := validation.IsDNS1123Label(name); len(errs) > 0 {
+		return fmt.Errorf("mnnvl-group value %q is not a valid DNS-1123 label: %s", name, strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// DetectMNNVLConflict returns an error if the annotations contain contradictory
+// MNNVL settings: auto-mnnvl: disabled combined with a mnnvl-group value.
+func DetectMNNVLConflict(annotations map[string]string) error {
+	if annotations == nil {
+		return nil
+	}
+	autoVal, hasAuto := annotations[AnnotationAutoMNNVL]
+	_, hasGroup := annotations[AnnotationMNNVLGroup]
+	if hasAuto && strings.EqualFold(autoVal, AnnotationAutoMNNVLDisabled) && hasGroup {
+		return fmt.Errorf("contradictory MNNVL annotations: %s is %q but %s is also set; "+
+			"cannot disable MNNVL and assign a group simultaneously",
+			AnnotationAutoMNNVL, autoVal, AnnotationMNNVLGroup)
+	}
+	return nil
 }
 
 // GenerateRCTName creates the ResourceClaimTemplate name for a PCS replica.
@@ -92,13 +124,4 @@ func containerHasGPU(container *corev1.Container) bool {
 		}
 	}
 	return false
-}
-
-// getAnnotationValue safely retrieves an annotation value from a PCS.
-func getAnnotationValue(pcs *grovecorev1alpha1.PodCliqueSet, key string) (string, bool) {
-	if pcs.Annotations == nil {
-		return "", false
-	}
-	value, exists := pcs.Annotations[key]
-	return value, exists
 }

--- a/operator/internal/mnnvl/helpers_test.go
+++ b/operator/internal/mnnvl/helpers_test.go
@@ -114,6 +114,171 @@ func TestGenerateRCTName(t *testing.T) {
 	}
 }
 
+func TestValidateMNNVLGroupName(t *testing.T) {
+	tests := []struct {
+		description string
+		name        string
+		expectErr   bool
+	}{
+		{
+			description: "simple lowercase name",
+			name:        "training",
+			expectErr:   false,
+		},
+		{
+			description: "name with dashes",
+			name:        "my-workers",
+			expectErr:   false,
+		},
+		{
+			description: "single character",
+			name:        "a",
+			expectErr:   false,
+		},
+		{
+			description: "alphanumeric with numbers",
+			name:        "group1",
+			expectErr:   false,
+		},
+		{
+			description: "starts with number",
+			name:        "1group",
+			expectErr:   false,
+		},
+		{
+			description: "max length (63 chars)",
+			name:        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			expectErr:   false,
+		},
+		{
+			description: "empty string",
+			name:        "",
+			expectErr:   true,
+		},
+		{
+			description: "exceeds 63 chars",
+			name:        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			expectErr:   true,
+		},
+		{
+			description: "uppercase letters",
+			name:        "Training",
+			expectErr:   true,
+		},
+		{
+			description: "contains underscore",
+			name:        "my_group",
+			expectErr:   true,
+		},
+		{
+			description: "contains dot",
+			name:        "my.group",
+			expectErr:   true,
+		},
+		{
+			description: "contains space",
+			name:        "my group",
+			expectErr:   true,
+		},
+		{
+			description: "starts with dash",
+			name:        "-workers",
+			expectErr:   true,
+		},
+		{
+			description: "ends with dash",
+			name:        "workers-",
+			expectErr:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			err := ValidateMNNVLGroupName(tc.name)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestDetectMNNVLConflict(t *testing.T) {
+	tests := []struct {
+		description string
+		annotations map[string]string
+		expectErr   bool
+	}{
+		{
+			description: "nil annotations — no conflict",
+			annotations: nil,
+			expectErr:   false,
+		},
+		{
+			description: "empty annotations — no conflict",
+			annotations: map[string]string{},
+			expectErr:   false,
+		},
+		{
+			description: "auto-mnnvl enabled only — no conflict",
+			annotations: map[string]string{
+				AnnotationAutoMNNVL: AnnotationAutoMNNVLEnabled,
+			},
+			expectErr: false,
+		},
+		{
+			description: "auto-mnnvl disabled only — no conflict",
+			annotations: map[string]string{
+				AnnotationAutoMNNVL: AnnotationAutoMNNVLDisabled,
+			},
+			expectErr: false,
+		},
+		{
+			description: "mnnvl-group only — no conflict",
+			annotations: map[string]string{
+				AnnotationMNNVLGroup: "workers",
+			},
+			expectErr: false,
+		},
+		{
+			description: "enabled + group — no conflict",
+			annotations: map[string]string{
+				AnnotationAutoMNNVL:  AnnotationAutoMNNVLEnabled,
+				AnnotationMNNVLGroup: "workers",
+			},
+			expectErr: false,
+		},
+		{
+			description: "disabled + group — conflict",
+			annotations: map[string]string{
+				AnnotationAutoMNNVL:  AnnotationAutoMNNVLDisabled,
+				AnnotationMNNVLGroup: "workers",
+			},
+			expectErr: true,
+		},
+		{
+			description: "disabled (uppercase) + group — conflict (case-insensitive)",
+			annotations: map[string]string{
+				AnnotationAutoMNNVL:  "Disabled",
+				AnnotationMNNVLGroup: "training",
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			err := DetectMNNVLConflict(tc.annotations)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func Test_hasGPURequirement(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -225,6 +390,26 @@ func createPCSWithGPU(annotations map[string]string) *grovecorev1alpha1.PodCliqu
 				Build(),
 		).
 		Build()
+}
+
+type cliqueAnnotation struct {
+	name        string
+	annotations map[string]string
+}
+
+// createPCSWithCliques creates a PCS with PCS-level annotations and per-clique annotations.
+func createPCSWithCliques(pcsAnnotations map[string]string, cliques []cliqueAnnotation) *grovecorev1alpha1.PodCliqueSet {
+	builder := testutils.NewPodCliqueSetBuilder("test-pcs", "default", "").
+		WithAnnotations(pcsAnnotations)
+	for _, c := range cliques {
+		builder.WithPodCliqueTemplateSpec(
+			testutils.NewPodCliqueTemplateSpecBuilder(c.name).
+				WithAnnotations(c.annotations).
+				WithContainer(testutils.NewGPUContainer("train", "nvidia/cuda:latest", 8)).
+				Build(),
+		)
+	}
+	return builder.Build()
 }
 
 // createPCSWithoutGPU creates a PCS without GPU using the builder for tests in this package.

--- a/operator/internal/mnnvl/helpers_test.go
+++ b/operator/internal/mnnvl/helpers_test.go
@@ -397,10 +397,9 @@ type cliqueAnnotation struct {
 	annotations map[string]string
 }
 
-// createPCSWithCliques creates a PCS with PCS-level annotations and per-clique annotations.
-func createPCSWithCliques(pcsAnnotations map[string]string, cliques []cliqueAnnotation) *grovecorev1alpha1.PodCliqueSet {
-	builder := testutils.NewPodCliqueSetBuilder("test-pcs", "default", "").
-		WithAnnotations(pcsAnnotations)
+// createPCSWithCliques creates a PCS with per-clique annotations.
+func createPCSWithCliques(cliques []cliqueAnnotation) *grovecorev1alpha1.PodCliqueSet {
+	builder := testutils.NewPodCliqueSetBuilder("test-pcs", "default", "")
 	for _, c := range cliques {
 		builder.WithPodCliqueTemplateSpec(
 			testutils.NewPodCliqueTemplateSpecBuilder(c.name).

--- a/operator/internal/mnnvl/webhook.go
+++ b/operator/internal/mnnvl/webhook.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
+const mnnvlNotEnabledMsgFormat = "MNNVL is not enabled in the operator configuration. Either enable MNNVL globally or remove the %s annotation"
+
 // MutateAutoMNNVL adds the grove.io/auto-mnnvl annotation to a PodCliqueSet
 // if all conditions are met:
 // 1. Annotation does not already exist
@@ -111,8 +113,7 @@ func validateMNNVLAnnotationsOnCreate(annotations map[string]string, autoMNNVLEn
 		}
 		if value == AnnotationAutoMNNVLEnabled && !autoMNNVLEnabled {
 			allErrs = append(allErrs, field.Invalid(path, value,
-				fmt.Sprintf("MNNVL is not enabled in the operator configuration. "+
-					"Either enable MNNVL globally or remove the %s annotation", AnnotationAutoMNNVL)))
+				fmt.Sprintf(mnnvlNotEnabledMsgFormat, AnnotationAutoMNNVL)))
 		}
 	}
 
@@ -123,8 +124,7 @@ func validateMNNVLAnnotationsOnCreate(annotations map[string]string, autoMNNVLEn
 		}
 		if !autoMNNVLEnabled {
 			allErrs = append(allErrs, field.Invalid(path, value,
-				fmt.Sprintf("MNNVL is not enabled in the operator configuration. "+
-					"Either enable MNNVL globally or remove the %s annotation", AnnotationMNNVLGroup)))
+				fmt.Sprintf(mnnvlNotEnabledMsgFormat, AnnotationMNNVLGroup)))
 		}
 	}
 
@@ -150,13 +150,32 @@ func validatePodCliqueTemplateSpecOnCreate(clique *grovecorev1alpha1.PodCliqueTe
 	return validateMNNVLAnnotationsOnCreate(clique.Annotations, autoMNNVLEnabled, fldPath.Child("annotations"))
 }
 
+// validatePodCliqueSetTemplateSpecOnUpdate checks MNNVL annotation immutability for each clique
+// template. Old and new specs are matched by clique name, not slice index: the default
+// CliqueStartupTypeAnyOrder allows reordering cliques, and PCS validation already pairs by name.
+// Adding, removing, or renaming cliques is not allowed on update; that is enforced by the
+// PodCliqueSet validating admission path (validatePodCliqueUpdate), which runs after this
+// package’s ValidatePCSOnUpdate. A new clique name with no counterpart in oldTemplate is
+// therefore skipped here. Field paths use the index in newTemplate so errors point at the
+// object being admitted.
 func validatePodCliqueSetTemplateSpecOnUpdate(oldTemplate, newTemplate *grovecorev1alpha1.PodCliqueSetTemplateSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	for i := 0; i < len(oldTemplate.Cliques) && i < len(newTemplate.Cliques); i++ {
-		if oldTemplate.Cliques[i] == nil || newTemplate.Cliques[i] == nil {
+	oldByName := make(map[string]*grovecorev1alpha1.PodCliqueTemplateSpec, len(oldTemplate.Cliques))
+	for _, clique := range oldTemplate.Cliques {
+		if clique == nil {
 			continue
 		}
-		allErrs = append(allErrs, validatePodCliqueTemplateSpecOnUpdate(oldTemplate.Cliques[i], newTemplate.Cliques[i], fldPath.Child("cliques").Index(i))...)
+		oldByName[clique.Name] = clique
+	}
+	for i, newClique := range newTemplate.Cliques {
+		if newClique == nil {
+			continue
+		}
+		oldClique, ok := oldByName[newClique.Name]
+		if !ok {
+			continue
+		}
+		allErrs = append(allErrs, validatePodCliqueTemplateSpecOnUpdate(oldClique, newClique, fldPath.Child("cliques").Index(i))...)
 	}
 	return allErrs
 }

--- a/operator/internal/mnnvl/webhook.go
+++ b/operator/internal/mnnvl/webhook.go
@@ -64,117 +64,145 @@ func MutateAutoMNNVL(logger logr.Logger, pcs *grovecorev1alpha1.PodCliqueSet, au
 		"value", AnnotationAutoMNNVLEnabled)
 }
 
-// ValidateMetadataOnCreate validates metadata-level concerns on PCS creation.
-// This is the entry point for metadata validation during create operations.
-func ValidateMetadataOnCreate(pcs *grovecorev1alpha1.PodCliqueSet, autoMNNVLEnabled bool) field.ErrorList {
-	return validateAutoMNNVLAnnotationOnCreate(pcs, autoMNNVLEnabled)
-}
-
-// validateAutoMNNVLAnnotationOnCreate validates the grove.io/auto-mnnvl annotation on creation.
-// Returns field errors if the annotation value is invalid or if MNNVL is requested but not enabled.
-func validateAutoMNNVLAnnotationOnCreate(pcs *grovecorev1alpha1.PodCliqueSet, autoMNNVLEnabled bool) field.ErrorList {
-	value, exists := pcs.Annotations[AnnotationAutoMNNVL]
-	if !exists {
-		return nil
-	}
-
-	annotationPath := field.NewPath("metadata", "annotations", AnnotationAutoMNNVL)
-
+// ValidatePCSOnCreate validates all MNNVL annotations on a PodCliqueSet during creation:
+// PCS-level metadata and each PodCliqueTemplateSpec in the spec.
+func ValidatePCSOnCreate(pcs *grovecorev1alpha1.PodCliqueSet, autoMNNVLEnabled bool) field.ErrorList {
 	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, validateAutoMNNVLAnnotationValue(value, annotationPath)...)
-	allErrs = append(allErrs, validateMNNVLFeatureEnabled(value, autoMNNVLEnabled, annotationPath)...)
-
+	allErrs = append(allErrs, validateMetadataOnCreate(pcs, autoMNNVLEnabled)...)
+	allErrs = append(allErrs, validateSpecOnCreate(pcs, autoMNNVLEnabled)...)
 	return allErrs
 }
 
-// validateAutoMNNVLAnnotationValue validates the annotation has an allowed value.
-func validateAutoMNNVLAnnotationValue(value string, path *field.Path) field.ErrorList {
-	if value != AnnotationAutoMNNVLEnabled && value != AnnotationAutoMNNVLDisabled {
-		return field.ErrorList{
-			field.Invalid(
-				path,
-				value,
-				fmt.Sprintf("must be %q or %q", AnnotationAutoMNNVLEnabled, AnnotationAutoMNNVLDisabled),
-			),
-		}
-	}
-	return nil
+// ValidatePCSOnUpdate validates MNNVL annotation immutability on a PodCliqueSet during update:
+// PCS-level metadata and each PodCliqueTemplateSpec in the spec.
+func ValidatePCSOnUpdate(oldPCS, newPCS *grovecorev1alpha1.PodCliqueSet) field.ErrorList {
+	allErrs := field.ErrorList{}
+	allErrs = append(allErrs, validateMetadataOnUpdate(oldPCS, newPCS)...)
+	allErrs = append(allErrs, validateSpecOnUpdate(oldPCS, newPCS)...)
+	return allErrs
 }
 
-// validateMNNVLFeatureEnabled validates MNNVL is enabled when annotation requests it.
-// This prevents users from explicitly requesting MNNVL when the cluster doesn't support it.
-func validateMNNVLFeatureEnabled(value string, autoMNNVLEnabled bool, path *field.Path) field.ErrorList {
-	if value == AnnotationAutoMNNVLEnabled && !autoMNNVLEnabled {
-		return field.ErrorList{
-			field.Invalid(
-				path,
-				value,
+func validateMetadataOnCreate(pcs *grovecorev1alpha1.PodCliqueSet, autoMNNVLEnabled bool) field.ErrorList {
+	return validateMNNVLAnnotationsOnCreate(pcs.Annotations, autoMNNVLEnabled, field.NewPath("metadata", "annotations"))
+}
+
+func validateSpecOnCreate(pcs *grovecorev1alpha1.PodCliqueSet, autoMNNVLEnabled bool) field.ErrorList {
+	return validatePodCliqueSetTemplateSpecOnCreate(&pcs.Spec.Template, autoMNNVLEnabled, field.NewPath("spec", "template"))
+}
+
+func validateMetadataOnUpdate(oldPCS, newPCS *grovecorev1alpha1.PodCliqueSet) field.ErrorList {
+	return validateMNNVLAnnotationsImmutability(oldPCS.Annotations, newPCS.Annotations, field.NewPath("metadata", "annotations"))
+}
+
+func validateSpecOnUpdate(oldPCS, newPCS *grovecorev1alpha1.PodCliqueSet) field.ErrorList {
+	return validatePodCliqueSetTemplateSpecOnUpdate(&oldPCS.Spec.Template, &newPCS.Spec.Template, field.NewPath("spec", "template"))
+}
+
+// validateMNNVLAnnotationsOnCreate validates both MNNVL annotations on a single
+// annotation map: value correctness, feature enablement, and conflict detection.
+func validateMNNVLAnnotationsOnCreate(annotations map[string]string, autoMNNVLEnabled bool, basePath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if value, exists := annotations[AnnotationAutoMNNVL]; exists {
+		path := basePath.Child(AnnotationAutoMNNVL)
+		if value != AnnotationAutoMNNVLEnabled && value != AnnotationAutoMNNVLDisabled {
+			allErrs = append(allErrs, field.Invalid(path, value,
+				fmt.Sprintf("must be %q or %q", AnnotationAutoMNNVLEnabled, AnnotationAutoMNNVLDisabled)))
+		}
+		if value == AnnotationAutoMNNVLEnabled && !autoMNNVLEnabled {
+			allErrs = append(allErrs, field.Invalid(path, value,
 				fmt.Sprintf("MNNVL is not enabled in the operator configuration. "+
-					"Either enable MNNVL globally or remove the %s annotation", AnnotationAutoMNNVL),
-			),
+					"Either enable MNNVL globally or remove the %s annotation", AnnotationAutoMNNVL)))
 		}
 	}
-	return nil
-}
 
-// ValidateMetadataOnUpdate validates metadata-level concerns on PCS update.
-// This is the entry point for metadata validation during update operations.
-func ValidateMetadataOnUpdate(oldPCS, newPCS *grovecorev1alpha1.PodCliqueSet) field.ErrorList {
-	return validateAutoMNNVLAnnotationOnUpdate(oldPCS, newPCS)
-}
+	if value, exists := annotations[AnnotationMNNVLGroup]; exists {
+		path := basePath.Child(AnnotationMNNVLGroup)
+		if err := ValidateMNNVLGroupName(value); err != nil {
+			allErrs = append(allErrs, field.Invalid(path, value, err.Error()))
+		}
+		if !autoMNNVLEnabled {
+			allErrs = append(allErrs, field.Invalid(path, value,
+				fmt.Sprintf("MNNVL is not enabled in the operator configuration. "+
+					"Either enable MNNVL globally or remove the %s annotation", AnnotationMNNVLGroup)))
+		}
+	}
 
-// validateAutoMNNVLAnnotationOnUpdate ensures the grove.io/auto-mnnvl annotation is immutable.
-// Returns field errors if the annotation was added, removed, or its value was changed.
-func validateAutoMNNVLAnnotationOnUpdate(oldPCS, newPCS *grovecorev1alpha1.PodCliqueSet) field.ErrorList {
-	oldValue, oldExists := getAnnotationValue(oldPCS, AnnotationAutoMNNVL)
-	newValue, newExists := getAnnotationValue(newPCS, AnnotationAutoMNNVL)
-
-	annotationPath := field.NewPath("metadata", "annotations", AnnotationAutoMNNVL)
-
-	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, validateAnnotationNotAdded(oldExists, newExists, annotationPath)...)
-	allErrs = append(allErrs, validateAnnotationNotRemoved(oldExists, newExists, annotationPath)...)
-	allErrs = append(allErrs, validateAnnotationNotChanged(oldValue, newValue, oldExists, newExists, annotationPath)...)
+	if err := DetectMNNVLConflict(annotations); err != nil {
+		allErrs = append(allErrs, field.Forbidden(basePath, err.Error()))
+	}
 
 	return allErrs
 }
 
-// validateAnnotationNotAdded validates that the annotation was not added after creation.
-func validateAnnotationNotAdded(oldExists, newExists bool, path *field.Path) field.ErrorList {
+func validatePodCliqueSetTemplateSpecOnCreate(templateSpec *grovecorev1alpha1.PodCliqueSetTemplateSpec, autoMNNVLEnabled bool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for i, clique := range templateSpec.Cliques {
+		if clique == nil {
+			continue
+		}
+		allErrs = append(allErrs, validatePodCliqueTemplateSpecOnCreate(clique, autoMNNVLEnabled, fldPath.Child("cliques").Index(i))...)
+	}
+	return allErrs
+}
+
+func validatePodCliqueTemplateSpecOnCreate(clique *grovecorev1alpha1.PodCliqueTemplateSpec, autoMNNVLEnabled bool, fldPath *field.Path) field.ErrorList {
+	return validateMNNVLAnnotationsOnCreate(clique.Annotations, autoMNNVLEnabled, fldPath.Child("annotations"))
+}
+
+func validatePodCliqueSetTemplateSpecOnUpdate(oldTemplate, newTemplate *grovecorev1alpha1.PodCliqueSetTemplateSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for i := 0; i < len(oldTemplate.Cliques) && i < len(newTemplate.Cliques); i++ {
+		if oldTemplate.Cliques[i] == nil || newTemplate.Cliques[i] == nil {
+			continue
+		}
+		allErrs = append(allErrs, validatePodCliqueTemplateSpecOnUpdate(oldTemplate.Cliques[i], newTemplate.Cliques[i], fldPath.Child("cliques").Index(i))...)
+	}
+	return allErrs
+}
+func validatePodCliqueTemplateSpecOnUpdate(oldClique, newClique *grovecorev1alpha1.PodCliqueTemplateSpec, fldPath *field.Path) field.ErrorList {
+	return validateMNNVLAnnotationsImmutability(oldClique.Annotations, newClique.Annotations, fldPath.Child("annotations"))
+}
+
+// validateMNNVLAnnotationsImmutability checks both MNNVL annotations are
+// unchanged between old and new annotation maps.
+func validateMNNVLAnnotationsImmutability(oldAnnotations, newAnnotations map[string]string, basePath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for _, key := range []string{AnnotationAutoMNNVL, AnnotationMNNVLGroup} {
+		path := basePath.Child(key)
+		oldValue, oldExists := oldAnnotations[key]
+		newValue, newExists := newAnnotations[key]
+		allErrs = append(allErrs, validateAnnotationNotAdded(oldExists, newExists, key, path)...)
+		allErrs = append(allErrs, validateAnnotationNotRemoved(oldExists, newExists, key, path)...)
+		allErrs = append(allErrs, validateAnnotationNotChanged(oldValue, newValue, oldExists, newExists, key, path)...)
+	}
+	return allErrs
+}
+
+
+func validateAnnotationNotAdded(oldExists, newExists bool, annotationKey string, path *field.Path) field.ErrorList {
 	if !oldExists && newExists {
 		return field.ErrorList{
-			field.Forbidden(
-				path,
-				fmt.Sprintf("annotation %s cannot be added after PodCliqueSet creation", AnnotationAutoMNNVL),
-			),
+			field.Forbidden(path, fmt.Sprintf("annotation %s cannot be added after PodCliqueSet creation", annotationKey)),
 		}
 	}
 	return nil
 }
 
-// validateAnnotationNotRemoved validates that the annotation was not removed after creation.
-func validateAnnotationNotRemoved(oldExists, newExists bool, path *field.Path) field.ErrorList {
+func validateAnnotationNotRemoved(oldExists, newExists bool, annotationKey string, path *field.Path) field.ErrorList {
 	if oldExists && !newExists {
 		return field.ErrorList{
-			field.Forbidden(
-				path,
-				fmt.Sprintf("annotation %s cannot be removed after PodCliqueSet creation", AnnotationAutoMNNVL),
-			),
+			field.Forbidden(path, fmt.Sprintf("annotation %s cannot be removed after PodCliqueSet creation", annotationKey)),
 		}
 	}
 	return nil
 }
 
-// validateAnnotationNotChanged validates that the annotation value was not changed.
-func validateAnnotationNotChanged(oldValue, newValue string, oldExists, newExists bool, path *field.Path) field.ErrorList {
+func validateAnnotationNotChanged(oldValue, newValue string, oldExists, newExists bool, annotationKey string, path *field.Path) field.ErrorList {
 	if newExists && oldExists && oldValue != newValue {
 		return field.ErrorList{
-			field.Invalid(
-				path,
-				newValue,
-				fmt.Sprintf("annotation %s is immutable and cannot be changed from %q to %q",
-					AnnotationAutoMNNVL, oldValue, newValue),
-			),
+			field.Invalid(path, newValue, fmt.Sprintf("annotation %s is immutable and cannot be changed from %q to %q",
+				annotationKey, oldValue, newValue)),
 		}
 	}
 	return nil

--- a/operator/internal/mnnvl/webhook.go
+++ b/operator/internal/mnnvl/webhook.go
@@ -160,6 +160,7 @@ func validatePodCliqueSetTemplateSpecOnUpdate(oldTemplate, newTemplate *grovecor
 	}
 	return allErrs
 }
+
 func validatePodCliqueTemplateSpecOnUpdate(oldClique, newClique *grovecorev1alpha1.PodCliqueTemplateSpec, fldPath *field.Path) field.ErrorList {
 	return validateMNNVLAnnotationsImmutability(oldClique.Annotations, newClique.Annotations, fldPath.Child("annotations"))
 }
@@ -178,7 +179,6 @@ func validateMNNVLAnnotationsImmutability(oldAnnotations, newAnnotations map[str
 	}
 	return allErrs
 }
-
 
 func validateAnnotationNotAdded(oldExists, newExists bool, annotationKey string, path *field.Path) field.ErrorList {
 	if !oldExists && newExists {

--- a/operator/internal/mnnvl/webhook_test.go
+++ b/operator/internal/mnnvl/webhook_test.go
@@ -349,7 +349,7 @@ func TestValidatePCSOnCreate_Spec(t *testing.T) {
 	}{
 		{
 			description: "valid mnnvl-group on clique template + feature enabled -> no error",
-			pcs: createPCSWithCliques(nil, []cliqueAnnotation{
+			pcs: createPCSWithCliques([]cliqueAnnotation{
 				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "workers"}},
 			}),
 			autoMNNVLEnabled: true,
@@ -357,7 +357,7 @@ func TestValidatePCSOnCreate_Spec(t *testing.T) {
 		},
 		{
 			description: "invalid mnnvl-group on clique template -> error",
-			pcs: createPCSWithCliques(nil, []cliqueAnnotation{
+			pcs: createPCSWithCliques([]cliqueAnnotation{
 				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "INVALID"}},
 			}),
 			autoMNNVLEnabled: true,
@@ -366,7 +366,7 @@ func TestValidatePCSOnCreate_Spec(t *testing.T) {
 		},
 		{
 			description: "conflict on clique template (disabled + group) -> error",
-			pcs: createPCSWithCliques(nil, []cliqueAnnotation{
+			pcs: createPCSWithCliques([]cliqueAnnotation{
 				{name: "workers", annotations: map[string]string{AnnotationAutoMNNVL: AnnotationAutoMNNVLDisabled, AnnotationMNNVLGroup: "training"}},
 			}),
 			autoMNNVLEnabled: true,
@@ -375,7 +375,7 @@ func TestValidatePCSOnCreate_Spec(t *testing.T) {
 		},
 		{
 			description: "mnnvl-group on clique template + feature disabled -> error",
-			pcs: createPCSWithCliques(nil, []cliqueAnnotation{
+			pcs: createPCSWithCliques([]cliqueAnnotation{
 				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "workers"}},
 			}),
 			autoMNNVLEnabled: false,
@@ -384,7 +384,7 @@ func TestValidatePCSOnCreate_Spec(t *testing.T) {
 		},
 		{
 			description: "clique with empty mnnvl-group -> error",
-			pcs: createPCSWithCliques(nil, []cliqueAnnotation{
+			pcs: createPCSWithCliques([]cliqueAnnotation{
 				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: ""}},
 			}),
 			autoMNNVLEnabled: true,
@@ -393,7 +393,7 @@ func TestValidatePCSOnCreate_Spec(t *testing.T) {
 		},
 		{
 			description: "multiple cliques, one valid one invalid -> error",
-			pcs: createPCSWithCliques(nil, []cliqueAnnotation{
+			pcs: createPCSWithCliques([]cliqueAnnotation{
 				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "workers"}},
 				{name: "encoders", annotations: map[string]string{AnnotationMNNVLGroup: "-bad"}},
 			}),
@@ -403,7 +403,7 @@ func TestValidatePCSOnCreate_Spec(t *testing.T) {
 		},
 		{
 			description: "multiple cliques all valid -> no error",
-			pcs: createPCSWithCliques(nil, []cliqueAnnotation{
+			pcs: createPCSWithCliques([]cliqueAnnotation{
 				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "training"}},
 				{name: "encoders", annotations: map[string]string{AnnotationMNNVLGroup: "encoding"}},
 			}),
@@ -412,7 +412,7 @@ func TestValidatePCSOnCreate_Spec(t *testing.T) {
 		},
 		{
 			description: "clique without annotations -> no error",
-			pcs: createPCSWithCliques(nil, []cliqueAnnotation{
+			pcs: createPCSWithCliques([]cliqueAnnotation{
 				{name: "workers", annotations: nil},
 			}),
 			autoMNNVLEnabled: true,
@@ -444,20 +444,20 @@ func TestValidatePCSOnUpdate_Spec(t *testing.T) {
 	}{
 		{
 			description: "clique-level mnnvl-group unchanged -> no error",
-			oldPCS: createPCSWithCliques(nil, []cliqueAnnotation{
+			oldPCS: createPCSWithCliques([]cliqueAnnotation{
 				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "training"}},
 			}),
-			newPCS: createPCSWithCliques(nil, []cliqueAnnotation{
+			newPCS: createPCSWithCliques([]cliqueAnnotation{
 				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "training"}},
 			}),
 			expectError: false,
 		},
 		{
 			description: "clique-level mnnvl-group added -> error",
-			oldPCS: createPCSWithCliques(nil, []cliqueAnnotation{
+			oldPCS: createPCSWithCliques([]cliqueAnnotation{
 				{name: "workers", annotations: nil},
 			}),
-			newPCS: createPCSWithCliques(nil, []cliqueAnnotation{
+			newPCS: createPCSWithCliques([]cliqueAnnotation{
 				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "training"}},
 			}),
 			expectError: true,
@@ -465,10 +465,10 @@ func TestValidatePCSOnUpdate_Spec(t *testing.T) {
 		},
 		{
 			description: "clique-level mnnvl-group removed -> error",
-			oldPCS: createPCSWithCliques(nil, []cliqueAnnotation{
+			oldPCS: createPCSWithCliques([]cliqueAnnotation{
 				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "training"}},
 			}),
-			newPCS: createPCSWithCliques(nil, []cliqueAnnotation{
+			newPCS: createPCSWithCliques([]cliqueAnnotation{
 				{name: "workers", annotations: nil},
 			}),
 			expectError: true,
@@ -476,10 +476,10 @@ func TestValidatePCSOnUpdate_Spec(t *testing.T) {
 		},
 		{
 			description: "clique-level mnnvl-group changed -> error",
-			oldPCS: createPCSWithCliques(nil, []cliqueAnnotation{
+			oldPCS: createPCSWithCliques([]cliqueAnnotation{
 				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "training"}},
 			}),
-			newPCS: createPCSWithCliques(nil, []cliqueAnnotation{
+			newPCS: createPCSWithCliques([]cliqueAnnotation{
 				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "inference"}},
 			}),
 			expectError: true,
@@ -487,10 +487,10 @@ func TestValidatePCSOnUpdate_Spec(t *testing.T) {
 		},
 		{
 			description: "clique without annotations on both -> no error",
-			oldPCS: createPCSWithCliques(nil, []cliqueAnnotation{
+			oldPCS: createPCSWithCliques([]cliqueAnnotation{
 				{name: "workers", annotations: nil},
 			}),
-			newPCS: createPCSWithCliques(nil, []cliqueAnnotation{
+			newPCS: createPCSWithCliques([]cliqueAnnotation{
 				{name: "workers", annotations: nil},
 			}),
 			expectError: false,

--- a/operator/internal/mnnvl/webhook_test.go
+++ b/operator/internal/mnnvl/webhook_test.go
@@ -495,6 +495,31 @@ func TestValidatePCSOnUpdate_Spec(t *testing.T) {
 			}),
 			expectError: false,
 		},
+		{
+			description: "two cliques reordered (AnyOrder): MNNVL annotations unchanged per clique name -> no error",
+			oldPCS: createPCSWithCliques([]cliqueAnnotation{
+				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "training"}},
+				{name: "encoders", annotations: map[string]string{AnnotationMNNVLGroup: "encoding"}},
+			}),
+			newPCS: createPCSWithCliques([]cliqueAnnotation{
+				{name: "encoders", annotations: map[string]string{AnnotationMNNVLGroup: "encoding"}},
+				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "training"}},
+			}),
+			expectError: false,
+		},
+		{
+			description: "two cliques reordered and mnnvl-group changed on one clique (by name) -> error",
+			oldPCS: createPCSWithCliques([]cliqueAnnotation{
+				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "training"}},
+				{name: "encoders", annotations: map[string]string{AnnotationMNNVLGroup: "encoding"}},
+			}),
+			newPCS: createPCSWithCliques([]cliqueAnnotation{
+				{name: "encoders", annotations: map[string]string{AnnotationMNNVLGroup: "encoding"}},
+				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "inference"}},
+			}),
+			expectError: true,
+			errorMsg:    "immutable",
+		},
 	}
 
 	for _, test := range tests {

--- a/operator/internal/mnnvl/webhook_test.go
+++ b/operator/internal/mnnvl/webhook_test.go
@@ -86,7 +86,7 @@ func TestMutateAutoMNNVL(t *testing.T) {
 	}
 }
 
-func TestValidateMetadataOnCreate(t *testing.T) {
+func TestValidatePCSOnCreate_Metadata(t *testing.T) {
 	tests := []struct {
 		description      string
 		pcs              *grovecorev1alpha1.PodCliqueSet
@@ -180,11 +180,51 @@ func TestValidateMetadataOnCreate(t *testing.T) {
 			expectError:      true,
 			errorContains:    "must be",
 		},
+		{
+			description:      "valid mnnvl-group + feature enabled -> no error",
+			pcs:              createPCSWithGPU(map[string]string{AnnotationMNNVLGroup: "workers"}),
+			autoMNNVLEnabled: true,
+			expectError:      false,
+		},
+		{
+			description:      "valid mnnvl-group + feature disabled -> error",
+			pcs:              createPCSWithGPU(map[string]string{AnnotationMNNVLGroup: "workers"}),
+			autoMNNVLEnabled: false,
+			expectError:      true,
+			errorContains:    "MNNVL is not enabled",
+		},
+		{
+			description:      "invalid mnnvl-group value (uppercase) -> error",
+			pcs:              createPCSWithGPU(map[string]string{AnnotationMNNVLGroup: "Workers"}),
+			autoMNNVLEnabled: true,
+			expectError:      true,
+			errorContains:    "not a valid DNS-1123 label",
+		},
+		{
+			description:      "invalid mnnvl-group value (empty) -> error",
+			pcs:              createPCSWithGPU(map[string]string{AnnotationMNNVLGroup: ""}),
+			autoMNNVLEnabled: true,
+			expectError:      true,
+			errorContains:    "must not be empty",
+		},
+		{
+			description:      "enabled + mnnvl-group -> no error (compatible)",
+			pcs:              createPCSWithGPU(map[string]string{AnnotationAutoMNNVL: AnnotationAutoMNNVLEnabled, AnnotationMNNVLGroup: "training"}),
+			autoMNNVLEnabled: true,
+			expectError:      false,
+		},
+		{
+			description:      "disabled + mnnvl-group -> error (conflict)",
+			pcs:              createPCSWithGPU(map[string]string{AnnotationAutoMNNVL: AnnotationAutoMNNVLDisabled, AnnotationMNNVLGroup: "training"}),
+			autoMNNVLEnabled: true,
+			expectError:      true,
+			errorContains:    "contradictory",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			errs := ValidateMetadataOnCreate(test.pcs, test.autoMNNVLEnabled)
+			errs := ValidatePCSOnCreate(test.pcs, test.autoMNNVLEnabled)
 
 			if test.expectError {
 				assert.NotEmpty(t, errs, "expected validation errors")
@@ -196,7 +236,7 @@ func TestValidateMetadataOnCreate(t *testing.T) {
 	}
 }
 
-func TestValidateMetadataOnUpdate(t *testing.T) {
+func TestValidatePCSOnUpdate_Metadata(t *testing.T) {
 	tests := []struct {
 		description string
 		oldPCS      *grovecorev1alpha1.PodCliqueSet
@@ -256,11 +296,210 @@ func TestValidateMetadataOnUpdate(t *testing.T) {
 			newPCS:      createPCSWithGPU(map[string]string{AnnotationAutoMNNVL: AnnotationAutoMNNVLEnabled, "other": "new"}),
 			expectError: false,
 		},
+		{
+			description: "mnnvl-group unchanged -> no error",
+			oldPCS:      createPCSWithGPU(map[string]string{AnnotationMNNVLGroup: "workers"}),
+			newPCS:      createPCSWithGPU(map[string]string{AnnotationMNNVLGroup: "workers"}),
+			expectError: false,
+		},
+		{
+			description: "mnnvl-group added -> error",
+			oldPCS:      createPCSWithGPU(nil),
+			newPCS:      createPCSWithGPU(map[string]string{AnnotationMNNVLGroup: "workers"}),
+			expectError: true,
+			errorMsg:    "cannot be added",
+		},
+		{
+			description: "mnnvl-group removed -> error",
+			oldPCS:      createPCSWithGPU(map[string]string{AnnotationMNNVLGroup: "workers"}),
+			newPCS:      createPCSWithGPU(nil),
+			expectError: true,
+			errorMsg:    "cannot be removed",
+		},
+		{
+			description: "mnnvl-group changed -> error",
+			oldPCS:      createPCSWithGPU(map[string]string{AnnotationMNNVLGroup: "workers"}),
+			newPCS:      createPCSWithGPU(map[string]string{AnnotationMNNVLGroup: "training"}),
+			expectError: true,
+			errorMsg:    "immutable",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			errs := ValidateMetadataOnUpdate(test.oldPCS, test.newPCS)
+			errs := ValidatePCSOnUpdate(test.oldPCS, test.newPCS)
+
+			if test.expectError {
+				assert.NotEmpty(t, errs, "expected validation errors")
+				assert.Contains(t, errs.ToAggregate().Error(), test.errorMsg)
+			} else {
+				assert.Empty(t, errs, "expected no validation errors")
+			}
+		})
+	}
+}
+
+func TestValidatePCSOnCreate_Spec(t *testing.T) {
+	tests := []struct {
+		description      string
+		pcs              *grovecorev1alpha1.PodCliqueSet
+		autoMNNVLEnabled bool
+		expectError      bool
+		errorContains    string
+	}{
+		{
+			description: "valid mnnvl-group on clique template + feature enabled -> no error",
+			pcs: createPCSWithCliques(nil, []cliqueAnnotation{
+				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "workers"}},
+			}),
+			autoMNNVLEnabled: true,
+			expectError:      false,
+		},
+		{
+			description: "invalid mnnvl-group on clique template -> error",
+			pcs: createPCSWithCliques(nil, []cliqueAnnotation{
+				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "INVALID"}},
+			}),
+			autoMNNVLEnabled: true,
+			expectError:      true,
+			errorContains:    "not a valid DNS-1123 label",
+		},
+		{
+			description: "conflict on clique template (disabled + group) -> error",
+			pcs: createPCSWithCliques(nil, []cliqueAnnotation{
+				{name: "workers", annotations: map[string]string{AnnotationAutoMNNVL: AnnotationAutoMNNVLDisabled, AnnotationMNNVLGroup: "training"}},
+			}),
+			autoMNNVLEnabled: true,
+			expectError:      true,
+			errorContains:    "contradictory",
+		},
+		{
+			description: "mnnvl-group on clique template + feature disabled -> error",
+			pcs: createPCSWithCliques(nil, []cliqueAnnotation{
+				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "workers"}},
+			}),
+			autoMNNVLEnabled: false,
+			expectError:      true,
+			errorContains:    "MNNVL is not enabled",
+		},
+		{
+			description: "clique with empty mnnvl-group -> error",
+			pcs: createPCSWithCliques(nil, []cliqueAnnotation{
+				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: ""}},
+			}),
+			autoMNNVLEnabled: true,
+			expectError:      true,
+			errorContains:    "must not be empty",
+		},
+		{
+			description: "multiple cliques, one valid one invalid -> error",
+			pcs: createPCSWithCliques(nil, []cliqueAnnotation{
+				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "workers"}},
+				{name: "encoders", annotations: map[string]string{AnnotationMNNVLGroup: "-bad"}},
+			}),
+			autoMNNVLEnabled: true,
+			expectError:      true,
+			errorContains:    "not a valid DNS-1123 label",
+		},
+		{
+			description: "multiple cliques all valid -> no error",
+			pcs: createPCSWithCliques(nil, []cliqueAnnotation{
+				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "training"}},
+				{name: "encoders", annotations: map[string]string{AnnotationMNNVLGroup: "encoding"}},
+			}),
+			autoMNNVLEnabled: true,
+			expectError:      false,
+		},
+		{
+			description: "clique without annotations -> no error",
+			pcs: createPCSWithCliques(nil, []cliqueAnnotation{
+				{name: "workers", annotations: nil},
+			}),
+			autoMNNVLEnabled: true,
+			expectError:      false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			errs := ValidatePCSOnCreate(test.pcs, test.autoMNNVLEnabled)
+
+			if test.expectError {
+				assert.NotEmpty(t, errs, "expected validation errors")
+				assert.Contains(t, errs.ToAggregate().Error(), test.errorContains)
+			} else {
+				assert.Empty(t, errs, "expected no validation errors")
+			}
+		})
+	}
+}
+
+func TestValidatePCSOnUpdate_Spec(t *testing.T) {
+	tests := []struct {
+		description string
+		oldPCS      *grovecorev1alpha1.PodCliqueSet
+		newPCS      *grovecorev1alpha1.PodCliqueSet
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			description: "clique-level mnnvl-group unchanged -> no error",
+			oldPCS: createPCSWithCliques(nil, []cliqueAnnotation{
+				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "training"}},
+			}),
+			newPCS: createPCSWithCliques(nil, []cliqueAnnotation{
+				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "training"}},
+			}),
+			expectError: false,
+		},
+		{
+			description: "clique-level mnnvl-group added -> error",
+			oldPCS: createPCSWithCliques(nil, []cliqueAnnotation{
+				{name: "workers", annotations: nil},
+			}),
+			newPCS: createPCSWithCliques(nil, []cliqueAnnotation{
+				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "training"}},
+			}),
+			expectError: true,
+			errorMsg:    "cannot be added",
+		},
+		{
+			description: "clique-level mnnvl-group removed -> error",
+			oldPCS: createPCSWithCliques(nil, []cliqueAnnotation{
+				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "training"}},
+			}),
+			newPCS: createPCSWithCliques(nil, []cliqueAnnotation{
+				{name: "workers", annotations: nil},
+			}),
+			expectError: true,
+			errorMsg:    "cannot be removed",
+		},
+		{
+			description: "clique-level mnnvl-group changed -> error",
+			oldPCS: createPCSWithCliques(nil, []cliqueAnnotation{
+				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "training"}},
+			}),
+			newPCS: createPCSWithCliques(nil, []cliqueAnnotation{
+				{name: "workers", annotations: map[string]string{AnnotationMNNVLGroup: "inference"}},
+			}),
+			expectError: true,
+			errorMsg:    "immutable",
+		},
+		{
+			description: "clique without annotations on both -> no error",
+			oldPCS: createPCSWithCliques(nil, []cliqueAnnotation{
+				{name: "workers", annotations: nil},
+			}),
+			newPCS: createPCSWithCliques(nil, []cliqueAnnotation{
+				{name: "workers", annotations: nil},
+			}),
+			expectError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			errs := ValidatePCSOnUpdate(test.oldPCS, test.newPCS)
 
 			if test.expectError {
 				assert.NotEmpty(t, errs, "expected validation errors")

--- a/operator/internal/webhook/admission/pcs/validation/handler.go
+++ b/operator/internal/webhook/admission/pcs/validation/handler.go
@@ -75,8 +75,8 @@ func (h *Handler) ValidateCreate(ctx context.Context, obj runtime.Object) (admis
 	warnings, errs := v.validate()
 	allErrs = append(allErrs, errs...)
 
-	// Validate MNNVL annotation: reject if annotation="true" but feature is disabled
-	allErrs = append(allErrs, mnnvl.ValidateMetadataOnCreate(pcs, h.networkConfig.AutoMNNVLEnabled)...)
+	// Validate MNNVL annotations on PCS metadata and spec (clique templates)
+	allErrs = append(allErrs, mnnvl.ValidatePCSOnCreate(pcs, h.networkConfig.AutoMNNVLEnabled)...)
 
 	// Scheduler-backend-specific validation
 	if err := validatePodCliqueSetWithBackend(ctx, pcs); err != nil {
@@ -101,8 +101,8 @@ func (h *Handler) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Obj
 	v := newPCSValidator(newPCS, admissionv1.Update, h.tasConfig, h.schedulerConfig)
 	warnings, errs := v.validate()
 
-	// Validate MNNVL annotation immutability
-	errs = append(errs, mnnvl.ValidateMetadataOnUpdate(oldPCS, newPCS)...)
+	// Validate MNNVL annotation immutability on PCS metadata and spec (clique templates)
+	errs = append(errs, mnnvl.ValidatePCSOnUpdate(oldPCS, newPCS)...)
 
 	// Scheduler-backend-specific validation
 	if err := validatePodCliqueSetWithBackend(ctx, newPCS); err != nil {

--- a/operator/internal/webhook/admission/pcs/validation/handler_mnnvl_test.go
+++ b/operator/internal/webhook/admission/pcs/validation/handler_mnnvl_test.go
@@ -70,7 +70,6 @@ func TestValidateCreate_MNNVL(t *testing.T) {
 			autoMNNVLEnabled: false,
 			expectError:      false,
 		},
-		// mnnvl-group on PCS metadata
 		{
 			description:      "mnnvl-group on PCS + feature enabled -> no error",
 			pcs:              createValidPCSWithGPU(map[string]string{mnnvl.AnnotationMNNVLGroup: "workers"}),
@@ -101,20 +100,20 @@ func TestValidateCreate_MNNVL(t *testing.T) {
 		// mnnvl-group on clique template
 		{
 			description:      "mnnvl-group on clique + feature enabled -> no error",
-			pcs:              createValidPCSWithCliqueAnnotations(nil, map[string]string{mnnvl.AnnotationMNNVLGroup: "workers"}),
+			pcs:              createValidPCSWithCliqueAnnotations(map[string]string{mnnvl.AnnotationMNNVLGroup: "workers"}),
 			autoMNNVLEnabled: true,
 			expectError:      false,
 		},
 		{
 			description:      "invalid mnnvl-group on clique -> error",
-			pcs:              createValidPCSWithCliqueAnnotations(nil, map[string]string{mnnvl.AnnotationMNNVLGroup: "-bad"}),
+			pcs:              createValidPCSWithCliqueAnnotations(map[string]string{mnnvl.AnnotationMNNVLGroup: "-bad"}),
 			autoMNNVLEnabled: true,
 			expectError:      true,
 			errorContains:    "not a valid DNS-1123 label",
 		},
 		{
 			description:      "conflict on clique: disabled + group -> error",
-			pcs:              createValidPCSWithCliqueAnnotations(nil, map[string]string{mnnvl.AnnotationAutoMNNVL: mnnvl.AnnotationAutoMNNVLDisabled, mnnvl.AnnotationMNNVLGroup: "training"}),
+			pcs:              createValidPCSWithCliqueAnnotations(map[string]string{mnnvl.AnnotationAutoMNNVL: mnnvl.AnnotationAutoMNNVLDisabled, mnnvl.AnnotationMNNVLGroup: "training"}),
 			autoMNNVLEnabled: true,
 			expectError:      true,
 			errorContains:    "contradictory",
@@ -205,7 +204,6 @@ func TestValidateUpdate_MNNVL(t *testing.T) {
 			newPCS:      createValidPCSWithGPU(nil),
 			expectError: false,
 		},
-		// mnnvl-group immutability on PCS metadata
 		{
 			description: "mnnvl-group unchanged -> no error",
 			oldPCS:      createValidPCSWithGPU(map[string]string{mnnvl.AnnotationMNNVLGroup: "workers"}),
@@ -229,14 +227,14 @@ func TestValidateUpdate_MNNVL(t *testing.T) {
 		// mnnvl-group immutability on clique template
 		{
 			description: "clique mnnvl-group unchanged -> no error",
-			oldPCS:      createValidPCSWithCliqueAnnotations(nil, map[string]string{mnnvl.AnnotationMNNVLGroup: "training"}),
-			newPCS:      createValidPCSWithCliqueAnnotations(nil, map[string]string{mnnvl.AnnotationMNNVLGroup: "training"}),
+			oldPCS:      createValidPCSWithCliqueAnnotations(map[string]string{mnnvl.AnnotationMNNVLGroup: "training"}),
+			newPCS:      createValidPCSWithCliqueAnnotations(map[string]string{mnnvl.AnnotationMNNVLGroup: "training"}),
 			expectError: false,
 		},
 		{
 			description:   "clique mnnvl-group changed -> error",
-			oldPCS:        createValidPCSWithCliqueAnnotations(nil, map[string]string{mnnvl.AnnotationMNNVLGroup: "training"}),
-			newPCS:        createValidPCSWithCliqueAnnotations(nil, map[string]string{mnnvl.AnnotationMNNVLGroup: "inference"}),
+			oldPCS:        createValidPCSWithCliqueAnnotations(map[string]string{mnnvl.AnnotationMNNVLGroup: "training"}),
+			newPCS:        createValidPCSWithCliqueAnnotations(map[string]string{mnnvl.AnnotationMNNVLGroup: "inference"}),
 			expectError:   true,
 			errorContains: "immutable",
 		},
@@ -379,11 +377,10 @@ func createValidPCSWithGPU(annotations map[string]string) *grovecorev1alpha1.Pod
 		Build()
 }
 
-// createValidPCSWithCliqueAnnotations creates a fully valid PCS with PCS-level
-// and clique-level annotations for testing spec-level validation.
-func createValidPCSWithCliqueAnnotations(pcsAnnotations, cliqueAnnotations map[string]string) *grovecorev1alpha1.PodCliqueSet {
+// createValidPCSWithCliqueAnnotations creates a fully valid PCS with
+// clique-level annotations for testing spec-level validation.
+func createValidPCSWithCliqueAnnotations(cliqueAnnotations map[string]string) *grovecorev1alpha1.PodCliqueSet {
 	return testutils.NewPodCliqueSetBuilder("test-pcs", "default", "").
-		WithAnnotations(pcsAnnotations).
 		WithCliqueStartupType(ptr.To(grovecorev1alpha1.CliqueStartupTypeAnyOrder)).
 		WithTerminationDelay(4 * time.Hour).
 		WithPodCliqueTemplateSpec(

--- a/operator/internal/webhook/admission/pcs/validation/handler_mnnvl_test.go
+++ b/operator/internal/webhook/admission/pcs/validation/handler_mnnvl_test.go
@@ -70,6 +70,55 @@ func TestValidateCreate_MNNVL(t *testing.T) {
 			autoMNNVLEnabled: false,
 			expectError:      false,
 		},
+		// mnnvl-group on PCS metadata
+		{
+			description:      "mnnvl-group on PCS + feature enabled -> no error",
+			pcs:              createValidPCSWithGPU(map[string]string{mnnvl.AnnotationMNNVLGroup: "workers"}),
+			autoMNNVLEnabled: true,
+			expectError:      false,
+		},
+		{
+			description:      "mnnvl-group on PCS + feature disabled -> error",
+			pcs:              createValidPCSWithGPU(map[string]string{mnnvl.AnnotationMNNVLGroup: "workers"}),
+			autoMNNVLEnabled: false,
+			expectError:      true,
+			errorContains:    "MNNVL is not enabled",
+		},
+		{
+			description:      "invalid mnnvl-group on PCS -> error",
+			pcs:              createValidPCSWithGPU(map[string]string{mnnvl.AnnotationMNNVLGroup: "INVALID"}),
+			autoMNNVLEnabled: true,
+			expectError:      true,
+			errorContains:    "not a valid DNS-1123 label",
+		},
+		{
+			description:      "conflict: auto-mnnvl disabled + mnnvl-group on PCS -> error",
+			pcs:              createValidPCSWithGPU(map[string]string{mnnvl.AnnotationAutoMNNVL: mnnvl.AnnotationAutoMNNVLDisabled, mnnvl.AnnotationMNNVLGroup: "training"}),
+			autoMNNVLEnabled: true,
+			expectError:      true,
+			errorContains:    "contradictory",
+		},
+		// mnnvl-group on clique template
+		{
+			description:      "mnnvl-group on clique + feature enabled -> no error",
+			pcs:              createValidPCSWithCliqueAnnotations(nil, map[string]string{mnnvl.AnnotationMNNVLGroup: "workers"}),
+			autoMNNVLEnabled: true,
+			expectError:      false,
+		},
+		{
+			description:      "invalid mnnvl-group on clique -> error",
+			pcs:              createValidPCSWithCliqueAnnotations(nil, map[string]string{mnnvl.AnnotationMNNVLGroup: "-bad"}),
+			autoMNNVLEnabled: true,
+			expectError:      true,
+			errorContains:    "not a valid DNS-1123 label",
+		},
+		{
+			description:      "conflict on clique: disabled + group -> error",
+			pcs:              createValidPCSWithCliqueAnnotations(nil, map[string]string{mnnvl.AnnotationAutoMNNVL: mnnvl.AnnotationAutoMNNVLDisabled, mnnvl.AnnotationMNNVLGroup: "training"}),
+			autoMNNVLEnabled: true,
+			expectError:      true,
+			errorContains:    "contradictory",
+		},
 	}
 
 	for _, tt := range tests {
@@ -155,6 +204,41 @@ func TestValidateUpdate_MNNVL(t *testing.T) {
 			oldPCS:      createValidPCSWithGPU(nil),
 			newPCS:      createValidPCSWithGPU(nil),
 			expectError: false,
+		},
+		// mnnvl-group immutability on PCS metadata
+		{
+			description: "mnnvl-group unchanged -> no error",
+			oldPCS:      createValidPCSWithGPU(map[string]string{mnnvl.AnnotationMNNVLGroup: "workers"}),
+			newPCS:      createValidPCSWithGPU(map[string]string{mnnvl.AnnotationMNNVLGroup: "workers"}),
+			expectError: false,
+		},
+		{
+			description:   "mnnvl-group added -> error",
+			oldPCS:        createValidPCSWithGPU(nil),
+			newPCS:        createValidPCSWithGPU(map[string]string{mnnvl.AnnotationMNNVLGroup: "workers"}),
+			expectError:   true,
+			errorContains: "cannot be added",
+		},
+		{
+			description:   "mnnvl-group changed -> error",
+			oldPCS:        createValidPCSWithGPU(map[string]string{mnnvl.AnnotationMNNVLGroup: "workers"}),
+			newPCS:        createValidPCSWithGPU(map[string]string{mnnvl.AnnotationMNNVLGroup: "training"}),
+			expectError:   true,
+			errorContains: "immutable",
+		},
+		// mnnvl-group immutability on clique template
+		{
+			description: "clique mnnvl-group unchanged -> no error",
+			oldPCS:      createValidPCSWithCliqueAnnotations(nil, map[string]string{mnnvl.AnnotationMNNVLGroup: "training"}),
+			newPCS:      createValidPCSWithCliqueAnnotations(nil, map[string]string{mnnvl.AnnotationMNNVLGroup: "training"}),
+			expectError: false,
+		},
+		{
+			description:   "clique mnnvl-group changed -> error",
+			oldPCS:        createValidPCSWithCliqueAnnotations(nil, map[string]string{mnnvl.AnnotationMNNVLGroup: "training"}),
+			newPCS:        createValidPCSWithCliqueAnnotations(nil, map[string]string{mnnvl.AnnotationMNNVLGroup: "inference"}),
+			expectError:   true,
+			errorContains: "immutable",
 		},
 	}
 
@@ -279,7 +363,7 @@ func TestMNNVL_WebhookPipeline_LegacyPCSUpdate(t *testing.T) {
 	}
 }
 
-// createValidPCSWithGPU creates a fully valid PCS with GPU for validation tests.
+// createValidPCSWithGPU creates a fully valid PCS with GPU and PCS-level annotations.
 func createValidPCSWithGPU(annotations map[string]string) *grovecorev1alpha1.PodCliqueSet {
 	return testutils.NewPodCliqueSetBuilder("test-pcs", "default", "").
 		WithAnnotations(annotations).
@@ -289,6 +373,24 @@ func createValidPCSWithGPU(annotations map[string]string) *grovecorev1alpha1.Pod
 			testutils.NewPodCliqueTemplateSpecBuilder("worker").
 				WithRoleName("worker").
 				WithMinAvailable(1).
+				WithContainer(testutils.NewGPUContainer("train", "nvidia/cuda:latest", 8)).
+				Build(),
+		).
+		Build()
+}
+
+// createValidPCSWithCliqueAnnotations creates a fully valid PCS with PCS-level
+// and clique-level annotations for testing spec-level validation.
+func createValidPCSWithCliqueAnnotations(pcsAnnotations, cliqueAnnotations map[string]string) *grovecorev1alpha1.PodCliqueSet {
+	return testutils.NewPodCliqueSetBuilder("test-pcs", "default", "").
+		WithAnnotations(pcsAnnotations).
+		WithCliqueStartupType(ptr.To(grovecorev1alpha1.CliqueStartupTypeAnyOrder)).
+		WithTerminationDelay(4 * time.Hour).
+		WithPodCliqueTemplateSpec(
+			testutils.NewPodCliqueTemplateSpecBuilder("worker").
+				WithRoleName("worker").
+				WithMinAvailable(1).
+				WithAnnotations(cliqueAnnotations).
 				WithContainer(testutils.NewGPUContainer("train", "nvidia/cuda:latest", 8)).
 				Build(),
 		).

--- a/operator/test/utils/pclqTemplate.go
+++ b/operator/test/utils/pclqTemplate.go
@@ -69,6 +69,12 @@ func (b *PodCliqueTemplateSpecBuilder) WithLabels(labels map[string]string) *Pod
 	return b
 }
 
+// WithAnnotations sets the annotations for the PodCliqueTemplateSpec.
+func (b *PodCliqueTemplateSpecBuilder) WithAnnotations(annotations map[string]string) *PodCliqueTemplateSpecBuilder {
+	b.pclqTemplateSpec.Annotations = annotations
+	return b
+}
+
 // WithStartsAfter sets the StartsAfter field for the PodCliqueTemplateSpec.
 func (b *PodCliqueTemplateSpecBuilder) WithStartsAfter(startsAfter []string) *PodCliqueTemplateSpecBuilder {
 	b.pclqTemplateSpec.Spec.StartsAfter = startsAfter


### PR DESCRIPTION
…TemplateSpec level

/kind feature


#### What this PR does / why we need it:

Introduce grove.io/mnnvl-group annotation support with DNS-1123 label validation, conflict detection (auto-mnnvl: disabled + mnnvl-group), and immutability enforcement. 
Extend MNNVL webhook validation from PCS metadata to the full spec hierarchy (PCS → template → clique).

#### Which issue(s) this PR fixes:
Refs #417 


```release-note
NONE
```

