### PR TITLE
fix: initc panic on pod update after termination

### DIFF
--- a/operator/initc/internal/wait.go
+++ b/operator/initc/internal/wait.go
@@ -103,7 +103,7 @@ func newPodCliqueStateWithInfo(podCliqueDependencies map[string]int, namespace, 
 		podGang:               podGang,
 		pclqFQNToMinAvailable: podCliqueDependencies,
 		currentPCLQReadyPods:  currentlyReadyPods,
-		allReadyCh:            make(chan struct{}, len(podCliqueDependencies)),
+		allReadyCh:            make(chan struct{}, 1),
 	}
 }
 
@@ -131,7 +131,6 @@ func (c *ParentPodCliqueDependencies) WaitForReady(ctx context.Context, log logr
 	}
 
 	eventHandlerContext, cancel := context.WithCancel(ctx)
-	defer cancel() // Cancel the context used by the informers if the wait is successful, or an err occurs.
 
 	// Create informer factory to watch pods matching the PodGang label
 	factory := informers.NewSharedInformerFactoryWithOptions(
@@ -140,9 +139,13 @@ func (c *ParentPodCliqueDependencies) WaitForReady(ctx context.Context, log logr
 		informers.WithNamespace(c.namespace),
 		informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
 			opts.LabelSelector = selector.String()
-		},
-		),
+		}),
 	)
+	defer func() {
+		cancel() // Cancel the context used by the informers if the wait is successful, or an err occurs.
+		factory.Shutdown()
+	}()
+
 	if err := c.registerEventHandler(factory, log); err != nil {
 		return groveerr.WrapError(
 			err,
@@ -199,9 +202,7 @@ func (c *ParentPodCliqueDependencies) registerEventHandler(factory informers.Sha
 			}
 
 			c.refreshReadyPodsOfPodClique(pod, false)
-			if c.checkAllParentsReady() {
-				c.allReadyCh <- struct{}{}
-			}
+			c.notifyIfAllParentsReady()
 		},
 		UpdateFunc: func(_, newObj any) {
 			c.mutex.Lock()
@@ -212,9 +213,7 @@ func (c *ParentPodCliqueDependencies) registerEventHandler(factory informers.Sha
 			}
 
 			c.refreshReadyPodsOfPodClique(pod, false)
-			if c.checkAllParentsReady() {
-				c.allReadyCh <- struct{}{}
-			}
+			c.notifyIfAllParentsReady()
 		},
 		DeleteFunc: func(obj any) {
 			c.mutex.Lock()
@@ -228,9 +227,7 @@ func (c *ParentPodCliqueDependencies) registerEventHandler(factory informers.Sha
 			}
 
 			c.refreshReadyPodsOfPodClique(pod, true)
-			if c.checkAllParentsReady() {
-				c.allReadyCh <- struct{}{}
-			}
+			c.notifyIfAllParentsReady()
 		},
 	}, cache.HandlerOptions{Logger: &log})
 	return err
@@ -264,14 +261,18 @@ func (c *ParentPodCliqueDependencies) refreshReadyPodsOfPodClique(pod *corev1.Po
 	}
 }
 
-// checkAllParentsReady returns true when all parent PodCliques have met their minimum ready pod requirements.
-func (c *ParentPodCliqueDependencies) checkAllParentsReady() bool {
+// notifyIfAllParentsReady will notify consumers if all PCLQ pods are ready.
+func (c *ParentPodCliqueDependencies) notifyIfAllParentsReady() {
 	for cliqueName, readyPods := range c.currentPCLQReadyPods {
 		if len(readyPods) < c.pclqFQNToMinAvailable[cliqueName] {
-			return false
+			return
 		}
 	}
-	return true
+
+	select {
+	case c.allReadyCh <- struct{}{}:
+	default: // already notified
+	}
 }
 
 // getLabelSelectorForPods returns the label selector to filter pods belonging to the specified PodGang.

--- a/operator/initc/internal/wait_test.go
+++ b/operator/initc/internal/wait_test.go
@@ -157,9 +157,18 @@ func TestCheckAllParentsReady(t *testing.T) {
 			deps := &ParentPodCliqueDependencies{
 				pclqFQNToMinAvailable: tt.pclqFQNToMinAvailable,
 				currentPCLQReadyPods:  tt.currentPCLQReadyPods,
+				allReadyCh:            make(chan struct{}, 1),
 			}
 
-			result := deps.checkAllParentsReady()
+			deps.notifyIfAllParentsReady()
+
+			result := false
+			select {
+			case <-deps.allReadyCh:
+				result = true
+			default:
+			}
+
 			assert.Equal(t, tt.expected, result, "Readiness check should match expected result")
 		})
 	}
@@ -365,10 +374,6 @@ func TestNewPodCliqueStateWithInfo(t *testing.T) {
 				assert.True(t, exists, "Ready pods set should exist for dependency %s", depName)
 				assert.Equal(t, 0, readySet.Len(), "Ready pods set should be empty initially for %s", depName)
 			}
-
-			// Verify channel is created with correct buffer size
-			assert.NotNil(t, result.allReadyCh, "Channel should be initialized")
-			assert.Equal(t, len(tt.dependencies), cap(result.allReadyCh), "Channel buffer size should match dependency count")
 		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

```
grove-initc panic: send on closed channel [recovered, repanicked]
grove-initc
grove-initc goroutine 201 [running]:
grove-initc k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x17d8688, 0xc0006f18f0}, {0x137e620, 0x17baf30}, {0x0, 0x0, 0x2?})
grove-initc 	/go/pkg/mod/k8s.io/apimachinery@v0.34.2/pkg/util/runtime/runtime.go:114 +0x1a9
grove-initc k8s.io/apimachinery/pkg/util/runtime.HandleCrashWithLogger({{0x17db960?, 0xc0006ab380?}, 0xc000935c38?}, {0x0, 0x0, 0x0})
grove-initc 	/go/pkg/mod/k8s.io/apimachinery@v0.34.2/pkg/util/runtime/runtime.go:91 +0x115
grove-initc panic({0x137e620?, 0x17baf30?})
grove-initc 	/usr/local/go/src/runtime/panic.go:783 +0x132
grove-initc github.com/ai-dynamo/grove/operator/initc/internal.(*ParentPodCliqueDependencies).registerEventHandler.func1({0x15b5f20?, 0xc0008e1208?})
grove-initc 	/go/src/github.com/ai-dynamo/grove/operator/initc/internal/wait.go:203 +0x186
grove-initc k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnAdd(...)
grove-initc 	/go/pkg/mod/k8s.io/client-go@v0.34.2/tools/cache/controller.go:259
grove-initc k8s.io/client-go/tools/cache.(*processorListener).run.func1(0xc000545f5f, 0xc0006f6820, {0x142b900?, 0xc0003ba468?})
grove-initc 	/go/pkg/mod/k8s.io/client-go@v0.34.2/tools/cache/shared_informer.go:1076 +0xd1
grove-initc k8s.io/client-go/tools/cache.(*processorListener).run(0xc0006f6820)
grove-initc 	/go/pkg/mod/k8s.io/client-go@v0.34.2/tools/cache/shared_informer.go:1086 +0x3c
grove-initc k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
grove-initc 	/go/pkg/mod/k8s.io/apimachinery@v0.34.2/pkg/util/wait/wait.go:72 +0x4c
grove-initc created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 292
grove-initc 	/go/pkg/mod/k8s.io/apimachinery@v0.34.2/pkg/util/wait/wait.go:70 +0x73
```

If `WaitForReady` returns and `allReadyCh` is closed, but, before the process exits, a shared informer event happens that indicates a podclique is ready, it'll attempt to send on a closed channel.

I've gone the route of closing the factory, but we could also just not close `allReadyCh` and the process exit will clean everything up.


#### Which issue(s) this PR fixes:

Fixes: #548.

#### Special notes for your reviewer:

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
