### PR TITLE
fix(initc): drain informer goroutines before closing allReadyCh

### DIFF
--- a/operator/initc/internal/wait.go
+++ b/operator/initc/internal/wait.go
@@ -109,7 +109,11 @@ func newPodCliqueStateWithInfo(podCliqueDependencies map[string]int, namespace, 
 
 // WaitForReady waits for all upstream start-up dependencies to be ready.
 func (c *ParentPodCliqueDependencies) WaitForReady(ctx context.Context, log logr.Logger) error {
-	defer close(c.allReadyCh) // Close the channel the informers write to *after* the context they use is cancelled.
+	// Close allReadyCh last: informer event handlers write to it, so we must
+	// wait for their goroutines to drain (via factory.Shutdown below) before
+	// closing the channel. Otherwise a pod Add/Update/Delete event firing
+	// after we return can trigger "send on closed channel". See #548.
+	defer close(c.allReadyCh)
 
 	log.Info("Parent PodClique(s) being waited on", "pclqFQNToMinAvailable", c.pclqFQNToMinAvailable)
 
@@ -131,7 +135,6 @@ func (c *ParentPodCliqueDependencies) WaitForReady(ctx context.Context, log logr
 	}
 
 	eventHandlerContext, cancel := context.WithCancel(ctx)
-	defer cancel() // Cancel the context used by the informers if the wait is successful, or an err occurs.
 
 	// Create informer factory to watch pods matching the PodGang label
 	factory := informers.NewSharedInformerFactoryWithOptions(
@@ -143,6 +146,14 @@ func (c *ParentPodCliqueDependencies) WaitForReady(ctx context.Context, log logr
 		},
 		),
 	)
+	// Cancel the informers' context when we return, then block until their
+	// goroutines have terminated. factory.Shutdown drains the listener
+	// goroutines spawned by factory.Start so that no handler can race with
+	// the deferred close(c.allReadyCh) above.
+	defer func() {
+		cancel()
+		factory.Shutdown()
+	}()
 	if err := c.registerEventHandler(factory, log); err != nil {
 		return groveerr.WrapError(
 			err,


### PR DESCRIPTION
Closes #548.

## Root cause

\`ParentPodCliqueDependencies.WaitForReady\` deferred \`close(c.allReadyCh)\` unconditionally on return. The stack trace on #548 shows the panic firing from \`registerEventHandler.func1\` (the \`AddFunc\`) running inside \`processorListener.run\` — i.e. after \`WaitForReady\` had already returned and closed the channel, but while the shared-informer listener goroutine was still draining pending events.

The existing code relied on the deferred \`cancel()\` of the informer's context being enough to stop dispatch. It isn't: \`k8s.io/client-go\` spawns its listener goroutines via \`wait.(*Group).Start.func1\`, and nothing waits for them to terminate before the outer function returns. Any \`Add\` / \`Update\` / \`Delete\` event that races past the cancel drops into a handler that does

\`\`\`go
c.allReadyCh <- struct{}{}
\`\`\`

…on a closed channel, and panics. The stack in the bug report shows exactly that.

## Fix

Call \`factory.Shutdown()\` before closing the channel. \`Shutdown\` blocks until every informer goroutine has terminated, so once it returns no handler can still be in flight.

Defer ordering (LIFO):

\`\`\`go
defer close(c.allReadyCh)                 // last: channel close
...
defer func() {                            // middle: drain informers first
    cancel()
    factory.Shutdown()
}()
\`\`\`

I updated the comment on the \`close\` defer so the next reader knows *why* it has to be last.

## Testing

- \`go build ./initc/...\`
- \`go vet ./initc/...\`
- \`go test -race -count=1 ./initc/internal/...\` — ok

A deterministic regression test for this race requires spinning up a fake clientset + informer and racing the Shutdown against a final pod event, which the existing unit test file doesn't set up. Happy to add one if you'd prefer — wanted to keep this minimal so the fix can ship.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>