### PR TITLE
fix: cascade-delete PCS/PCSG/PC via Kubernetes GC

### DIFF
--- a/operator/internal/controller/podclique/reconciledelete.go
+++ b/operator/internal/controller/podclique/reconciledelete.go
@@ -24,19 +24,22 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	ctrlcommon "github.com/ai-dynamo/grove/operator/internal/controller/common"
 	ctrlutils "github.com/ai-dynamo/grove/operator/internal/controller/utils"
-	"github.com/ai-dynamo/grove/operator/internal/utils"
+	"github.com/ai-dynamo/grove/operator/internal/expect"
 
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// triggerDeletionFlow handles the deletion of a PodClique and its managed resources
+// triggerDeletionFlow handles the deletion of a PodClique. Owned Pods (and any
+// PCLQ-scoped ResourceClaims) carry a controller owner reference back to this
+// PodClique, so removing the finalizer hands the cascade off to the Kubernetes
+// garbage collector. Local in-memory state (the expectations store) is the only
+// thing the controller still has to clean up itself.
 func (r *Reconciler) triggerDeletionFlow(ctx context.Context, logger logr.Logger, pclq *grovecorev1alpha1.PodClique) ctrlcommon.ReconcileStepResult {
 	dLog := logger.WithValues("operation", "delete")
 	deleteStepFns := []ctrlcommon.ReconcileStepFn[grovecorev1alpha1.PodClique]{
-		r.deletePodCliqueResources,
-		r.verifyNoResourcesAwaitsCleanup,
+		r.clearPodCliqueExpectations,
 		r.removeFinalizer,
 	}
 	for _, fn := range deleteStepFns {
@@ -44,34 +47,21 @@ func (r *Reconciler) triggerDeletionFlow(ctx context.Context, logger logr.Logger
 			return stepResult
 		}
 	}
-	dLog.Info("PodClique deleted successfully")
+	dLog.Info("PodClique finalizer removed; Kubernetes garbage collector will cascade-delete owned Pods")
 	return ctrlcommon.DoNotRequeue()
 }
 
-// deletePodCliqueResources triggers concurrent deletion of all resources managed by the PodClique operators
-func (r *Reconciler) deletePodCliqueResources(ctx context.Context, logger logr.Logger, pclq *grovecorev1alpha1.PodClique) ctrlcommon.ReconcileStepResult {
-	operators := r.operatorRegistry.GetAllOperators()
-	deleteTasks := make([]utils.Task, 0, len(operators))
-	for kind, operator := range operators {
-		deleteTasks = append(deleteTasks, utils.Task{
-			Name: fmt.Sprintf("delete-%s", kind),
-			Fn: func(ctx context.Context) error {
-				return operator.Delete(ctx, logger, pclq.ObjectMeta)
-			},
-		})
+// clearPodCliqueExpectations drops the in-memory expectations entry for this
+// PodClique so the store does not retain stale UIDs after the object is gone.
+func (r *Reconciler) clearPodCliqueExpectations(_ context.Context, logger logr.Logger, pclq *grovecorev1alpha1.PodClique) ctrlcommon.ReconcileStepResult {
+	key, err := expect.ControlleeKeyFunc(pclq)
+	if err != nil {
+		return ctrlcommon.ReconcileWithErrors("error building expectations store key", fmt.Errorf("failed to build expectations store key for PodClique %v: %w", client.ObjectKeyFromObject(pclq), err))
 	}
-	logger.Info("Triggering delete of PodClique resources")
-	if runResult := utils.RunConcurrently(ctx, logger, deleteTasks); runResult.HasErrors() {
-		deletionErr := runResult.GetAggregatedError()
-		logger.Error(deletionErr, "Error deleting managed resources", "summary", runResult.GetSummary())
-		return ctrlcommon.ReconcileWithErrors("error deleting managed resources", deletionErr)
+	if err := r.expectationsStore.DeleteExpectations(logger, key); err != nil {
+		return ctrlcommon.ReconcileWithErrors("error clearing expectations", err)
 	}
 	return ctrlcommon.ContinueReconcile()
-}
-
-// verifyNoResourcesAwaitsCleanup ensures all managed resources have been fully deleted before allowing finalizer removal
-func (r *Reconciler) verifyNoResourcesAwaitsCleanup(ctx context.Context, logger logr.Logger, pclq *grovecorev1alpha1.PodClique) ctrlcommon.ReconcileStepResult {
-	return ctrlutils.VerifyNoResourceAwaitsCleanup(ctx, logger, r.operatorRegistry, pclq.ObjectMeta)
 }
 
 // removeFinalizer removes the PodClique finalizer to allow Kubernetes to complete the deletion

--- a/operator/internal/controller/podclique/reconciledelete_test.go
+++ b/operator/internal/controller/podclique/reconciledelete_test.go
@@ -18,14 +18,11 @@ package podclique
 
 import (
 	"context"
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/ai-dynamo/grove/operator/api/common/constants"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
-	ctrlcommon "github.com/ai-dynamo/grove/operator/internal/controller/common"
-	"github.com/ai-dynamo/grove/operator/internal/controller/common/component"
+	"github.com/ai-dynamo/grove/operator/internal/expect"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
@@ -33,27 +30,24 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-// TestTriggerDeletionFlow tests the deletion flow for PodClique
+// TestTriggerDeletionFlow verifies the cascade-delete flow: the controller
+// clears in-memory expectations and removes the finalizer, leaving the actual
+// child cleanup to the Kubernetes garbage collector via owner references.
 func TestTriggerDeletionFlow(t *testing.T) {
 	tests := []struct {
-		// Test case description
-		name string
-		// pclq is the PodClique being deleted
-		pclq *grovecorev1alpha1.PodClique
-		// existingResources are resources that exist in the cluster
-		existingResources []client.Object
-		// mockSetup sets up mock behavior
-		mockSetup func(*mockOperatorRegistry)
-		// expectedResult is the expected reconcile result
-		expectedResult ctrlcommon.ReconcileStepResult
+		name              string
+		pclq              *grovecorev1alpha1.PodClique
+		expectFinalizer   bool
+		expectRequeue     bool
+		expectErrors      bool
+		seedExpectationOf string
 	}{
 		{
-			// Tests successful deletion flow
-			name: "successful_deletion",
+			name: "removes_finalizer_and_completes",
 			pclq: &grovecorev1alpha1.PodClique{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-pclq",
@@ -61,157 +55,65 @@ func TestTriggerDeletionFlow(t *testing.T) {
 					Finalizers: []string{constants.FinalizerPodClique},
 				},
 			},
-			mockSetup: func(registry *mockOperatorRegistry) {
-				// Mock pod operator
-				podOp := &mockOperator{
-					deleteFunc: func(_ context.Context, _ logr.Logger, _ metav1.ObjectMeta) error {
-						return nil
-					},
-					getExistingResourceNamesFunc: func(_ context.Context, _ logr.Logger, _ metav1.ObjectMeta) ([]string, error) {
-						return []string{}, nil // No resources left
-					},
-				}
-				registry.operators[component.KindPod] = podOp
-			},
-			expectedResult: ctrlcommon.DoNotRequeue(),
+			seedExpectationOf: "default/test-pclq",
+			expectFinalizer:   false,
+			expectRequeue:     false,
+			expectErrors:      false,
 		},
 		{
-			// Tests deletion with resources still present
-			name: "deletion_with_resources_awaiting_cleanup",
+			name: "no_finalizer_is_a_noop",
 			pclq: &grovecorev1alpha1.PodClique{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test-pclq",
-					Namespace:  "default",
-					Finalizers: []string{constants.FinalizerPodClique},
+					Name:      "test-pclq",
+					Namespace: "default",
 				},
 			},
-			mockSetup: func(registry *mockOperatorRegistry) {
-				// Mock pod operator
-				podOp := &mockOperator{
-					deleteFunc: func(_ context.Context, _ logr.Logger, _ metav1.ObjectMeta) error {
-						return nil
-					},
-					getExistingResourceNamesFunc: func(_ context.Context, _ logr.Logger, _ metav1.ObjectMeta) ([]string, error) {
-						return []string{"pod-1", "pod-2"}, nil // Resources still exist
-					},
-				}
-				registry.operators[component.KindPod] = podOp
-			},
-			expectedResult: ctrlcommon.ReconcileAfter(5*time.Second, "Resources are still awaiting cleanup. Skipping removal of finalizer"),
-		},
-		{
-			// Tests deletion with error during resource deletion
-			name: "deletion_with_error",
-			pclq: &grovecorev1alpha1.PodClique{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test-pclq",
-					Namespace:  "default",
-					Finalizers: []string{constants.FinalizerPodClique},
-				},
-			},
-			mockSetup: func(registry *mockOperatorRegistry) {
-				// Mock pod operator
-				podOp := &mockOperator{
-					deleteFunc: func(_ context.Context, _ logr.Logger, _ metav1.ObjectMeta) error {
-						return fmt.Errorf("failed to delete pod")
-					},
-				}
-				registry.operators[component.KindPod] = podOp
-			},
-			expectedResult: ctrlcommon.ReconcileWithErrors("error deleting managed resources", fmt.Errorf("failed to delete pod")),
+			expectFinalizer: false,
+			expectRequeue:   false,
+			expectErrors:    false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// Setup scheme
 			scheme := runtime.NewScheme()
 			require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
 			require.NoError(t, corev1.AddToScheme(scheme))
 
-			// Build runtime objects
-			runtimeObjs := []client.Object{tc.pclq}
-			runtimeObjs = append(runtimeObjs, tc.existingResources...)
-
-			// Create fake client
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
-				WithObjects(runtimeObjs...).
+				WithObjects(tc.pclq).
 				Build()
 
-			// Create mock registry
-			mockRegistry := &mockOperatorRegistry{
-				operators: make(map[component.Kind]component.Operator[grovecorev1alpha1.PodClique]),
-			}
-			if tc.mockSetup != nil {
-				tc.mockSetup(mockRegistry)
+			expectationsStore := expect.NewExpectationsStore()
+			if tc.seedExpectationOf != "" {
+				require.NoError(t, expectationsStore.ExpectCreations(logr.Discard(), tc.seedExpectationOf, "uid-1"))
 			}
 
-			// Create reconciler
 			r := &Reconciler{
-				client:           fakeClient,
-				operatorRegistry: mockRegistry,
+				client:            fakeClient,
+				expectationsStore: expectationsStore,
 			}
 
-			// Execute deletion flow
-			ctx := context.Background()
-			logger := logr.Discard()
-			result := r.triggerDeletionFlow(ctx, logger, tc.pclq)
+			result := r.triggerDeletionFlow(context.Background(), logr.Discard(), tc.pclq)
 
-			// Verify result
-			assert.Equal(t, tc.expectedResult.NeedsRequeue(), result.NeedsRequeue())
-			if tc.expectedResult.HasErrors() {
-				assert.True(t, result.HasErrors())
+			assert.Equal(t, tc.expectRequeue, result.NeedsRequeue())
+			assert.Equal(t, tc.expectErrors, result.HasErrors())
+
+			if tc.seedExpectationOf != "" {
+				_, exists, err := expectationsStore.GetExpectations(tc.seedExpectationOf)
+				require.NoError(t, err)
+				assert.False(t, exists, "expectations entry should have been cleared")
+			}
+
+			fetched := &grovecorev1alpha1.PodClique{}
+			err := fakeClient.Get(context.Background(), types.NamespacedName{Name: tc.pclq.Name, Namespace: tc.pclq.Namespace}, fetched)
+			require.NoError(t, err)
+			if tc.expectFinalizer {
+				assert.Contains(t, fetched.Finalizers, constants.FinalizerPodClique)
+			} else {
+				assert.NotContains(t, fetched.Finalizers, constants.FinalizerPodClique)
 			}
 		})
 	}
-}
-
-// mockOperator is a mock implementation of component.Operator
-type mockOperator struct {
-	deleteFunc                   func(ctx context.Context, logger logr.Logger, objMeta metav1.ObjectMeta) error
-	syncFunc                     func(ctx context.Context, logger logr.Logger, obj *grovecorev1alpha1.PodClique) error
-	getExistingResourceNamesFunc func(ctx context.Context, logger logr.Logger, objMeta metav1.ObjectMeta) ([]string, error)
-}
-
-func (m *mockOperator) Delete(ctx context.Context, logger logr.Logger, objMeta metav1.ObjectMeta) error {
-	if m.deleteFunc != nil {
-		return m.deleteFunc(ctx, logger, objMeta)
-	}
-	return nil
-}
-
-func (m *mockOperator) Sync(ctx context.Context, logger logr.Logger, obj *grovecorev1alpha1.PodClique) error {
-	if m.syncFunc != nil {
-		return m.syncFunc(ctx, logger, obj)
-	}
-	return nil
-}
-
-func (m *mockOperator) GetExistingResourceNames(ctx context.Context, logger logr.Logger, objMeta metav1.ObjectMeta) ([]string, error) {
-	if m.getExistingResourceNamesFunc != nil {
-		return m.getExistingResourceNamesFunc(ctx, logger, objMeta)
-	}
-	return []string{}, nil
-}
-
-// mockOperatorRegistry is a mock implementation of OperatorRegistry
-type mockOperatorRegistry struct {
-	operators map[component.Kind]component.Operator[grovecorev1alpha1.PodClique]
-}
-
-func (m *mockOperatorRegistry) Register(kind component.Kind, operator component.Operator[grovecorev1alpha1.PodClique]) {
-	m.operators[kind] = operator
-}
-
-func (m *mockOperatorRegistry) GetOperator(kind component.Kind) (component.Operator[grovecorev1alpha1.PodClique], error) {
-	op, ok := m.operators[kind]
-	if !ok {
-		return nil, fmt.Errorf("operator not found for kind: %s", kind)
-	}
-	return op, nil
-}
-
-func (m *mockOperatorRegistry) GetAllOperators() map[component.Kind]component.Operator[grovecorev1alpha1.PodClique] {
-	return m.operators
 }

--- a/operator/internal/controller/podcliquescalinggroup/reconciledelete.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconciledelete.go
@@ -24,53 +24,21 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	ctrlcommon "github.com/ai-dynamo/grove/operator/internal/controller/common"
 	ctrlutils "github.com/ai-dynamo/grove/operator/internal/controller/utils"
-	"github.com/ai-dynamo/grove/operator/internal/utils"
 
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// triggerDeletionFlow handles the deletion of a PodCliqueScalingGroup and its managed resources
+// triggerDeletionFlow handles the deletion of a PodCliqueScalingGroup.
+// Child PodCliques carry a controller owner reference to this PCSG, so finalizer
+// removal hands the cascade off to the Kubernetes garbage collector.
 func (r *Reconciler) triggerDeletionFlow(ctx context.Context, logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup) ctrlcommon.ReconcileStepResult {
-	deleteStepFns := []ctrlcommon.ReconcileStepFn[grovecorev1alpha1.PodCliqueScalingGroup]{
-		r.deletePodCliqueScalingGroupResources,
-		r.verifyNoResourcesAwaitsCleanup,
-		r.removeFinalizer,
+	if stepResult := r.removeFinalizer(ctx, logger, pcsg); ctrlcommon.ShortCircuitReconcileFlow(stepResult) {
+		return stepResult
 	}
-	for _, fn := range deleteStepFns {
-		if stepResult := fn(ctx, logger, pcsg); ctrlcommon.ShortCircuitReconcileFlow(stepResult) {
-			return stepResult
-		}
-	}
-	logger.Info("PodCliqueScalingGroup deleted successfully")
+	logger.Info("PodCliqueScalingGroup finalizer removed; Kubernetes garbage collector will cascade-delete owned PodCliques")
 	return ctrlcommon.DoNotRequeue()
-}
-
-// deletePodCliqueScalingGroupResources triggers concurrent deletion of all resources managed by the PodCliqueScalingGroup operators
-func (r *Reconciler) deletePodCliqueScalingGroupResources(ctx context.Context, logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup) ctrlcommon.ReconcileStepResult {
-	operators := r.operatorRegistry.GetAllOperators()
-	deleteTasks := make([]utils.Task, 0, len(operators))
-	for kind, operator := range operators {
-		deleteTasks = append(deleteTasks, utils.Task{
-			Name: fmt.Sprintf("delete-%s", kind),
-			Fn: func(ctx context.Context) error {
-				return operator.Delete(ctx, logger, pcsg.ObjectMeta)
-			},
-		})
-	}
-	logger.Info("Triggering delete of PodCliqueScalingGroup resources")
-	if runResult := utils.RunConcurrently(ctx, logger, deleteTasks); runResult.HasErrors() {
-		deletionErr := runResult.GetAggregatedError()
-		logger.Error(deletionErr, "Error deleting managed resources", "summary", runResult.GetSummary())
-		return ctrlcommon.ReconcileWithErrors("error deleting managed resources", deletionErr)
-	}
-	return ctrlcommon.ContinueReconcile()
-}
-
-// verifyNoResourcesAwaitsCleanup ensures all managed resources have been fully deleted before allowing finalizer removal
-func (r *Reconciler) verifyNoResourcesAwaitsCleanup(ctx context.Context, logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup) ctrlcommon.ReconcileStepResult {
-	return ctrlutils.VerifyNoResourceAwaitsCleanup(ctx, logger, r.operatorRegistry, pcsg.ObjectMeta)
 }
 
 // removeFinalizer removes the PodCliqueScalingGroup finalizer to allow Kubernetes to complete the deletion

--- a/operator/internal/controller/podcliqueset/reconciledelete.go
+++ b/operator/internal/controller/podcliqueset/reconciledelete.go
@@ -24,53 +24,24 @@ import (
 	"github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	ctrlcommon "github.com/ai-dynamo/grove/operator/internal/controller/common"
 	ctrlutils "github.com/ai-dynamo/grove/operator/internal/controller/utils"
-	"github.com/ai-dynamo/grove/operator/internal/utils"
 
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// triggerDeletionFlow handles the deletion of a PodCliqueSet and its managed resources
+// triggerDeletionFlow handles the deletion of a PodCliqueSet.
+// Owned resources (PodCliqueScalingGroup, PodClique, Service, ServiceAccount, Role,
+// RoleBinding, HPA, PodGang, ResourceClaim, etc.) carry a controller owner reference
+// to the PodCliqueSet, so removing the finalizer hands cleanup to the Kubernetes
+// garbage collector — which cascades the entire subtree without per-resource
+// reconcile work in this controller.
 func (r *Reconciler) triggerDeletionFlow(ctx context.Context, logger logr.Logger, pcs *v1alpha1.PodCliqueSet) ctrlcommon.ReconcileStepResult {
-	deleteStepFns := []ctrlcommon.ReconcileStepFn[v1alpha1.PodCliqueSet]{
-		r.deletePodCliqueSetResources,
-		r.verifyNoResourcesAwaitsCleanup,
-		r.removeFinalizer,
+	if stepResult := r.removeFinalizer(ctx, logger, pcs); ctrlcommon.ShortCircuitReconcileFlow(stepResult) {
+		return r.recordIncompleteDeletion(ctx, logger, pcs, &stepResult)
 	}
-	for _, fn := range deleteStepFns {
-		if stepResult := fn(ctx, logger, pcs); ctrlcommon.ShortCircuitReconcileFlow(stepResult) {
-			return r.recordIncompleteDeletion(ctx, logger, pcs, &stepResult)
-		}
-	}
-	logger.Info("PodCliqueSet deleted successfully")
+	logger.Info("PodCliqueSet finalizer removed; Kubernetes garbage collector will cascade-delete owned resources")
 	return ctrlcommon.DoNotRequeue()
-}
-
-// deletePodCliqueSetResources triggers concurrent deletion of all managed resources for the PodCliqueSet.
-func (r *Reconciler) deletePodCliqueSetResources(ctx context.Context, logger logr.Logger, pcs *v1alpha1.PodCliqueSet) ctrlcommon.ReconcileStepResult {
-	operators := r.operatorRegistry.GetAllOperators()
-	deleteTasks := make([]utils.Task, 0, len(operators))
-	for kind, operator := range operators {
-		deleteTasks = append(deleteTasks, utils.Task{
-			Name: fmt.Sprintf("delete-%s", kind),
-			Fn: func(ctx context.Context) error {
-				return operator.Delete(ctx, logger, pcs.ObjectMeta)
-			},
-		})
-	}
-	logger.Info("Triggering delete of PodCliqueSet resources")
-	if runResult := utils.RunConcurrently(ctx, logger, deleteTasks); runResult.HasErrors() {
-		deletionErr := runResult.GetAggregatedError()
-		logger.Error(deletionErr, "Error deleting managed resources", "summary", runResult.GetSummary())
-		return ctrlcommon.ReconcileWithErrors("error deleting managed resources", deletionErr)
-	}
-	return ctrlcommon.ContinueReconcile()
-}
-
-// verifyNoResourcesAwaitsCleanup ensures all managed resources have been cleaned up before finalizer removal.
-func (r *Reconciler) verifyNoResourcesAwaitsCleanup(ctx context.Context, logger logr.Logger, pcs *v1alpha1.PodCliqueSet) ctrlcommon.ReconcileStepResult {
-	return ctrlutils.VerifyNoResourceAwaitsCleanup(ctx, logger, r.operatorRegistry, pcs.ObjectMeta)
 }
 
 // removeFinalizer removes the PodCliqueSet finalizer if present.


### PR DESCRIPTION
## Summary
- Replaces the manual *delete-children → poll-until-clean → remove-finalizer* flow in the PCS, PCSG, and PodClique reconcilers with immediate finalizer removal, letting the Kubernetes garbage collector cascade through the existing owner-reference chain (PCS → PCSG → PC → Pod, plus the PCS-owned siblings).
- The PodClique reconciler still clears its in-memory expectations entry on delete, since that state lives outside the API server.
- Targets #423: at 5k PodCliques the old serialized flow took ~20 minutes; finalizer removal is a single patch per object, so deletion now proceeds at GC speed.

## Tradeoffs
- The parent object disappears from the API as soon as its finalizer is gone, even while children are still terminating. Anyone scripting around "PCS gone = workload gone" should switch to watching pods.
- Status no longer reports per-step deletion progress; the live cluster state is the source of truth.
- We are now fully reliant on owner refs being correctly wired on every component. Audited the existing components — all set `controllerutil.SetControllerReference()` on their owned objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)