### PR TITLE
fix: cascade-delete PCS/PCSG/PCLQ via Kubernetes GC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,8 @@ scheduler/bin/*
 # generated/copied chart resources
 operator/charts/crds/*
 
+# scale-test result/profile output (per-run)
+operator/e2e/tests/scale/ScaleTest_*/
+
 # Python bytecode cache
 __pycache__/

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -220,7 +220,7 @@ run-scale-test: export GROVE_E2E_DIAG_DIR = $(DIAG_DIR)
 run-scale-test: export GROVE_E2E_DIAG_MODE = $(DIAG_MODE)
 run-scale-test:
 	@echo "> Running scale tests..."
-	@cd e2e && go test -count=1 -tags=e2e ./tests/scale/... -v -timeout 30m
+	@cd e2e && go test -count=1 -tags=e2e ./tests/scale/... -v -timeout 60m
 
 # Make targets for local development and testing
 # -------------------------------------------------------------

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -220,7 +220,7 @@ run-scale-test: export GROVE_E2E_DIAG_DIR = $(DIAG_DIR)
 run-scale-test: export GROVE_E2E_DIAG_MODE = $(DIAG_MODE)
 run-scale-test:
 	@echo "> Running scale tests..."
-	@cd e2e && go test -count=1 -tags=e2e ./tests/scale/... -v -timeout 60m
+	@cd e2e && go test -count=1 -tags=e2e ./tests/scale/... -v -timeout 40m
 
 # Make targets for local development and testing
 # -------------------------------------------------------------

--- a/operator/e2e/measurement/condition/pcs.go
+++ b/operator/e2e/measurement/condition/pcs.go
@@ -54,12 +54,12 @@ func (c *PCSDeletedCondition) Progress(_ context.Context) string {
 	return "Not deleted"
 }
 
-// PCSFullyDeletedCondition checks that the PodCliqueSet and every resource it
+// PCSAndSubresourcesDeletedCondition checks that the PodCliqueSet and every resource it
 // owns transitively (PodCliqueScalingGroups, PodCliques, and Pods carrying the
 // part-of label) are gone from the API. Use this in delete-phase milestones
 // when you want the timeline to reflect actual cascade-cleanup latency, not
 // just finalizer removal on the parent PCS.
-type PCSFullyDeletedCondition struct {
+type PCSAndSubresourcesDeletedCondition struct {
 	Client        client.Client
 	Name          string
 	Namespace     string
@@ -74,7 +74,7 @@ type PCSFullyDeletedCondition struct {
 
 // Met returns true when the PCS, all owned PCSGs, all owned PodCliques, and
 // all owned Pods (matched by LabelSelector) are absent from the API.
-func (c *PCSFullyDeletedCondition) Met(ctx context.Context) (bool, error) {
+func (c *PCSAndSubresourcesDeletedCondition) Met(ctx context.Context) (bool, error) {
 	c.sel.init(c.LabelSelector)
 	s, err := c.sel.get()
 	if err != nil {
@@ -118,7 +118,7 @@ func (c *PCSFullyDeletedCondition) Met(ctx context.Context) (bool, error) {
 }
 
 // Progress returns a human-readable progress string.
-func (c *PCSFullyDeletedCondition) Progress(_ context.Context) string {
+func (c *PCSAndSubresourcesDeletedCondition) Progress(_ context.Context) string {
 	return fmt.Sprintf("PCS=%d PCSG=%d PCLQ=%d Pod=%d remaining", c.lastPCS, c.lastPCSG, c.lastPCLQ, c.lastPod)
 }
 

--- a/operator/e2e/measurement/condition/pcs.go
+++ b/operator/e2e/measurement/condition/pcs.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,6 +52,74 @@ func (c *PCSDeletedCondition) Met(ctx context.Context) (bool, error) {
 // Progress returns a human-readable progress string.
 func (c *PCSDeletedCondition) Progress(_ context.Context) string {
 	return "Not deleted"
+}
+
+// PCSFullyDeletedCondition checks that the PodCliqueSet and every resource it
+// owns transitively (PodCliqueScalingGroups, PodCliques, and Pods carrying the
+// part-of label) are gone from the API. Use this in delete-phase milestones
+// when you want the timeline to reflect actual cascade-cleanup latency, not
+// just finalizer removal on the parent PCS.
+type PCSFullyDeletedCondition struct {
+	Client        client.Client
+	Name          string
+	Namespace     string
+	LabelSelector string
+
+	sel       parsedSelector
+	lastPCS   int
+	lastPCSG  int
+	lastPCLQ  int
+	lastPod   int
+}
+
+// Met returns true when the PCS, all owned PCSGs, all owned PodCliques, and
+// all owned Pods (matched by LabelSelector) are absent from the API.
+func (c *PCSFullyDeletedCondition) Met(ctx context.Context) (bool, error) {
+	c.sel.init(c.LabelSelector)
+	s, err := c.sel.get()
+	if err != nil {
+		return false, err
+	}
+
+	var pcs corev1alpha1.PodCliqueSet
+	switch err := c.Client.Get(ctx, types.NamespacedName{Name: c.Name, Namespace: c.Namespace}, &pcs); {
+	case apierrors.IsNotFound(err):
+		c.lastPCS = 0
+	case err != nil:
+		return false, fmt.Errorf("get PodCliqueSet: %w", err)
+	default:
+		c.lastPCS = 1
+	}
+
+	listOpts := []client.ListOption{
+		client.InNamespace(c.Namespace),
+		client.MatchingLabelsSelector{Selector: s},
+	}
+
+	var pcsgList corev1alpha1.PodCliqueScalingGroupList
+	if err := c.Client.List(ctx, &pcsgList, listOpts...); err != nil {
+		return false, fmt.Errorf("list PodCliqueScalingGroups: %w", err)
+	}
+	c.lastPCSG = len(pcsgList.Items)
+
+	var pclqList corev1alpha1.PodCliqueList
+	if err := c.Client.List(ctx, &pclqList, listOpts...); err != nil {
+		return false, fmt.Errorf("list PodCliques: %w", err)
+	}
+	c.lastPCLQ = len(pclqList.Items)
+
+	var podList corev1.PodList
+	if err := c.Client.List(ctx, &podList, listOpts...); err != nil {
+		return false, fmt.Errorf("list Pods: %w", err)
+	}
+	c.lastPod = len(podList.Items)
+
+	return c.lastPCS == 0 && c.lastPCSG == 0 && c.lastPCLQ == 0 && c.lastPod == 0, nil
+}
+
+// Progress returns a human-readable progress string.
+func (c *PCSFullyDeletedCondition) Progress(_ context.Context) string {
+	return fmt.Sprintf("PCS=%d PCSG=%d PCLQ=%d Pod=%d remaining", c.lastPCS, c.lastPCSG, c.lastPCLQ, c.lastPod)
 }
 
 // PCSAvailableCondition checks if a PodCliqueSet has at least ExpectedCount available replicas.

--- a/operator/e2e/tests/scale/scale_test.go
+++ b/operator/e2e/tests/scale/scale_test.go
@@ -60,17 +60,10 @@ func toOperatorMetadata(m *config.GroveMetadata) *measurement.OperatorMetadata {
 var Logger = log.NewTestLogger(log.InfoLevel)
 
 const (
-	scaleTestExpectedPods     = 1000
-	scaleTestExpectedReplicas = 1
-	scaleTestPCSCount         = 1
-	scaleTestWorkerNodes      = 100
-	scaleTestPollInterval     = 100 * time.Millisecond
-	scaleTestTimeout          = 15 * time.Minute
-
-	scaleTestName      = "ScaleTest_1000"
-	scaleTestWorkload  = "scale-test-1000"
-	scaleTestYAMLPath  = "../../yaml/scale-test-1000.yaml"
-	scaleTestNamespace = "default"
+	defaultScalePollInterval = 100 * time.Millisecond
+	defaultScalePCSCount     = 1
+	defaultScaleWorkerNodes  = 100
+	defaultScaleNamespace    = "default"
 
 	runIDTimeFormat   = "20060102-150405"
 	outputResultsFile = "scale-test-results.json"
@@ -80,22 +73,41 @@ const (
 	steadyStateWindow = 30 * time.Second
 )
 
-func Test_ScaleTest_1000(t *testing.T) {
-	diagDir := os.Getenv(diagnostics.DirEnvVar)
-	Logger.Infof("starting scale test: %d expected pods, timeout %v", scaleTestExpectedPods, scaleTestTimeout)
+// scaleTestConfig parameterizes a single scale test run.
+type scaleTestConfig struct {
+	name         string
+	workload     string
+	yamlPath     string
+	expectedPods int
+	pcsCount     int
+	workerNodes  int
+	timeout      time.Duration
+	pollInterval time.Duration
+}
 
-	ctx, cancel := context.WithTimeout(context.Background(), scaleTestTimeout)
+// scaleTestPhases registers test-specific phases on the tracker. Implementations
+// receive the prepared TestContext and the runID (for unique trigger keys) and add
+// deploy/delete/etc phases via tracker.AddPhase.
+type scaleTestPhases func(tracker *measurement.TimelineTracker, tc *testctx.TestContext, runID string)
+
+// runScaleTest provides the shared scaffolding (cluster setup, tracker, pprof,
+// output dir, result export) used by every scale test in this package.
+func runScaleTest(t *testing.T, cfg scaleTestConfig, addPhases scaleTestPhases) {
+	diagDir := os.Getenv(diagnostics.DirEnvVar)
+	Logger.Infof("starting scale test %s: %d expected pods, timeout %v", cfg.name, cfg.expectedPods, cfg.timeout)
+
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.timeout)
 	defer cancel()
 
-	Logger.Infof("preparing test cluster with %d worker nodes", scaleTestWorkerNodes)
-	tc, cleanup := testctx.PrepareTest(ctx, t, scaleTestWorkerNodes,
-		testctx.WithTimeout(scaleTestTimeout),
-		testctx.WithInterval(scaleTestPollInterval),
+	Logger.Infof("preparing test cluster with %d worker nodes", cfg.workerNodes)
+	tc, cleanup := testctx.PrepareTest(ctx, t, cfg.workerNodes,
+		testctx.WithTimeout(cfg.timeout),
+		testctx.WithInterval(cfg.pollInterval),
 		testctx.WithWorkload(&testctx.WorkloadConfig{
-			Name:         scaleTestWorkload,
-			YAMLPath:     scaleTestYAMLPath,
-			Namespace:    scaleTestNamespace,
-			ExpectedPods: scaleTestExpectedPods,
+			Name:         cfg.workload,
+			YAMLPath:     cfg.yamlPath,
+			Namespace:    defaultScaleNamespace,
+			ExpectedPods: cfg.expectedPods,
 		}),
 	)
 	defer cleanup()
@@ -108,9 +120,9 @@ func Test_ScaleTest_1000(t *testing.T) {
 	runID := fmt.Sprintf("run-%s", time.Now().Format(runIDTimeFormat))
 	Logger.Infof("test config: runID=%s, namespace=%s, pcsName=%s", runID, tc.Namespace, tc.Workload.Name)
 
-	outputDir := filepath.Join(scaleTestName, runID)
+	outputDir := filepath.Join(cfg.name, runID)
 	if diagDir != "" {
-		outputDir = filepath.Join(diagDir, scaleTestName, runID)
+		outputDir = filepath.Join(diagDir, cfg.name, runID)
 	}
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		t.Fatalf("failed to create output directory: %v", err)
@@ -120,7 +132,7 @@ func Test_ScaleTest_1000(t *testing.T) {
 	defer pprofCleanup()
 
 	opts := []measurement.TimelineOption{
-		measurement.WithPollInterval(scaleTestPollInterval),
+		measurement.WithPollInterval(cfg.pollInterval),
 		measurement.WithLogger(Logger.GetLogr()),
 	}
 	if pprofOpt != nil {
@@ -128,94 +140,14 @@ func Test_ScaleTest_1000(t *testing.T) {
 	}
 
 	tracker := measurement.NewTimelineTracker(
-		scaleTestName,
+		cfg.name,
 		runID,
 		tc.Namespace,
-		scaleTestPCSCount,
+		cfg.pcsCount,
 		opts...,
 	)
 
-	tracker.AddPhase(measurement.PhaseDefinition{
-		Name: "deploy",
-		ActionFn: func(ctx context.Context) error {
-			_, err := resources.NewResourceManager(tc.Client, Logger).ApplyYAMLFile(ctx, tc.Workload.YAMLPath, tc.Namespace)
-			return err
-		},
-		Milestones: []measurement.MilestoneDefinition{
-			{
-				Name: "pods-created",
-				Condition: &condition.PodsCreatedCondition{
-					Client:        tc.Client.Client,
-					Namespace:     tc.Namespace,
-					LabelSelector: tc.GetLabelSelector(),
-					ExpectedCount: scaleTestExpectedPods,
-				},
-			},
-			{
-				Name: "pods-ready",
-				Condition: &condition.PodsReadyCondition{
-					Client:        tc.Client.Client,
-					Namespace:     tc.Namespace,
-					LabelSelector: tc.GetLabelSelector(),
-					ExpectedCount: scaleTestExpectedPods,
-				},
-			},
-			{
-				Name: "pcs-available",
-				Condition: &condition.PCSAvailableCondition{
-					Client:        tc.Client.Client,
-					Name:          tc.Workload.Name,
-					Namespace:     tc.Namespace,
-					ExpectedCount: scaleTestExpectedReplicas,
-				},
-			},
-		},
-	})
-
-	// steady-state-reconcile: patch a metadata annotation to force one reconcile cycle
-	// without touching spec. With the spec-hash short-circuit in place, the PCS→PodClique
-	// update path should fire cache hits for every PodClique. pprof captured during this
-	// window isolates the no-op reconcile cost.
-	steadyStateTriggerID := fmt.Sprintf("steady-%s", runID)
-	tracker.AddPhase(measurement.PhaseDefinition{
-		Name: "steady-state-reconcile",
-		ActionFn: func(ctx context.Context) error {
-			Logger.Info("triggering no-op PCS reconcile")
-			return workload.NewWorkloadManager(tc.Client, Logger).TriggerPCSReconcile(ctx, tc.Namespace, tc.Workload.Name, steadyStateTriggerID)
-		},
-		Milestones: []measurement.MilestoneDefinition{
-			{
-				Name: "pcs-still-available",
-				Condition: &condition.PCSAvailableCondition{
-					Client:        tc.Client.Client,
-					Name:          tc.Workload.Name,
-					Namespace:     tc.Namespace,
-					ExpectedCount: scaleTestExpectedReplicas,
-				},
-			},
-			{
-				Name:      "steady-state-window",
-				Condition: &condition.TimerCondition{Duration: steadyStateWindow},
-			},
-		},
-	})
-
-	tracker.AddPhase(measurement.PhaseDefinition{
-		Name: "delete",
-		ActionFn: func(ctx context.Context) error {
-			return workload.NewWorkloadManager(tc.Client, Logger).DeletePCS(ctx, tc.Namespace, tc.Workload.Name)
-		},
-		Milestones: []measurement.MilestoneDefinition{
-			{
-				Name: "pcs-deleted",
-				Condition: &condition.PCSDeletedCondition{
-					Client:    tc.Client.Client,
-					Name:      tc.Workload.Name,
-					Namespace: tc.Namespace,
-				},
-			},
-		},
-	})
+	addPhases(tracker, tc, runID)
 
 	Logger.Info("running timeline tracker")
 	result, err := tracker.Run(ctx, toOperatorMetadata(metadata))
@@ -227,6 +159,161 @@ func Test_ScaleTest_1000(t *testing.T) {
 	Logger.Info("exporting results")
 	exportResult(t, result, outputDir)
 	Logger.Infof("scale test completed successfully in %.1fs", result.TestDurationSeconds)
+}
+
+// Test_ScaleTest_1000 validates the full lifecycle (deploy → ready → steady-state
+// reconcile → delete) of a 1000-pod PodCliqueSet.
+func Test_ScaleTest_1000(t *testing.T) {
+	const expectedPods = 1000
+	const expectedReplicas = 1
+
+	runScaleTest(t, scaleTestConfig{
+		name:         "ScaleTest_1000",
+		workload:     "scale-test-1000",
+		yamlPath:     "../../yaml/scale-test-1000.yaml",
+		expectedPods: expectedPods,
+		pcsCount:     defaultScalePCSCount,
+		workerNodes:  defaultScaleWorkerNodes,
+		timeout:      15 * time.Minute,
+		pollInterval: defaultScalePollInterval,
+	}, func(tracker *measurement.TimelineTracker, tc *testctx.TestContext, runID string) {
+		tracker.AddPhase(measurement.PhaseDefinition{
+			Name: "deploy",
+			ActionFn: func(ctx context.Context) error {
+				_, err := resources.NewResourceManager(tc.Client, Logger).ApplyYAMLFile(ctx, tc.Workload.YAMLPath, tc.Namespace)
+				return err
+			},
+			Milestones: []measurement.MilestoneDefinition{
+				{
+					Name: "pods-created",
+					Condition: &condition.PodsCreatedCondition{
+						Client:        tc.Client.Client,
+						Namespace:     tc.Namespace,
+						LabelSelector: tc.GetLabelSelector(),
+						ExpectedCount: expectedPods,
+					},
+				},
+				{
+					Name: "pods-ready",
+					Condition: &condition.PodsReadyCondition{
+						Client:        tc.Client.Client,
+						Namespace:     tc.Namespace,
+						LabelSelector: tc.GetLabelSelector(),
+						ExpectedCount: expectedPods,
+					},
+				},
+				{
+					Name: "pcs-available",
+					Condition: &condition.PCSAvailableCondition{
+						Client:        tc.Client.Client,
+						Name:          tc.Workload.Name,
+						Namespace:     tc.Namespace,
+						ExpectedCount: expectedReplicas,
+					},
+				},
+			},
+		})
+
+		// steady-state-reconcile: patch a metadata annotation to force one reconcile cycle
+		// without touching spec. With the spec-hash short-circuit in place, the PCS→PodClique
+		// update path should fire cache hits for every PodClique. pprof captured during this
+		// window isolates the no-op reconcile cost.
+		steadyStateTriggerID := fmt.Sprintf("steady-%s", runID)
+		tracker.AddPhase(measurement.PhaseDefinition{
+			Name: "steady-state-reconcile",
+			ActionFn: func(ctx context.Context) error {
+				Logger.Info("triggering no-op PCS reconcile")
+				return workload.NewWorkloadManager(tc.Client, Logger).TriggerPCSReconcile(ctx, tc.Namespace, tc.Workload.Name, steadyStateTriggerID)
+			},
+			Milestones: []measurement.MilestoneDefinition{
+				{
+					Name: "pcs-still-available",
+					Condition: &condition.PCSAvailableCondition{
+						Client:        tc.Client.Client,
+						Name:          tc.Workload.Name,
+						Namespace:     tc.Namespace,
+						ExpectedCount: expectedReplicas,
+					},
+				},
+				{
+					Name:      "steady-state-window",
+					Condition: &condition.TimerCondition{Duration: steadyStateWindow},
+				},
+			},
+		})
+
+		tracker.AddPhase(measurement.PhaseDefinition{
+			Name: "delete",
+			ActionFn: func(ctx context.Context) error {
+				return workload.NewWorkloadManager(tc.Client, Logger).DeletePCS(ctx, tc.Namespace, tc.Workload.Name)
+			},
+			Milestones: []measurement.MilestoneDefinition{
+				{
+					Name: "pcs-deleted",
+					Condition: &condition.PCSDeletedCondition{
+						Client:    tc.Client.Client,
+						Name:      tc.Workload.Name,
+						Namespace: tc.Namespace,
+					},
+				},
+			},
+		})
+	})
+}
+
+// Test_ScaleTest_5000_Deletion validates that a 5000-pod PodCliqueSet — built
+// from a mix of standalone PodCliques and PodCliqueScalingGroups — can be torn
+// down quickly via the cascade-delete path. Regression guard for #423, where
+// the old serial delete-then-verify flow took ~20 minutes at this scale.
+func Test_ScaleTest_5000_Deletion(t *testing.T) {
+	const expectedPods = 5000
+
+	runScaleTest(t, scaleTestConfig{
+		name:         "ScaleTest_5000_Deletion",
+		workload:     "scale-test-5000-deletion",
+		yamlPath:     "../../yaml/scale-test-5000-deletion.yaml",
+		expectedPods: expectedPods,
+		pcsCount:     defaultScalePCSCount,
+		workerNodes:  defaultScaleWorkerNodes,
+		timeout:      30 * time.Minute,
+		pollInterval: defaultScalePollInterval,
+	}, func(tracker *measurement.TimelineTracker, tc *testctx.TestContext, _ string) {
+		tracker.AddPhase(measurement.PhaseDefinition{
+			Name: "deploy",
+			ActionFn: func(ctx context.Context) error {
+				_, err := resources.NewResourceManager(tc.Client, Logger).ApplyYAMLFile(ctx, tc.Workload.YAMLPath, tc.Namespace)
+				return err
+			},
+			Milestones: []measurement.MilestoneDefinition{
+				{
+					Name: "pods-created",
+					Condition: &condition.PodsCreatedCondition{
+						Client:        tc.Client.Client,
+						Namespace:     tc.Namespace,
+						LabelSelector: tc.GetLabelSelector(),
+						ExpectedCount: expectedPods,
+					},
+				},
+			},
+		})
+
+		tracker.AddPhase(measurement.PhaseDefinition{
+			Name: "delete",
+			ActionFn: func(ctx context.Context) error {
+				return workload.NewWorkloadManager(tc.Client, Logger).DeletePCS(ctx, tc.Namespace, tc.Workload.Name)
+			},
+			Milestones: []measurement.MilestoneDefinition{
+				{
+					Name: "pcs-deleted",
+					Condition: &condition.PCSDeletedCondition{
+						Client:    tc.Client.Client,
+						Name:      tc.Workload.Name,
+						Namespace: tc.Namespace,
+					},
+				},
+			},
+		})
+	})
 }
 
 func exportResult(t *testing.T, result *measurement.TrackerResult, outputDir string) {

--- a/operator/e2e/tests/scale/scale_test.go
+++ b/operator/e2e/tests/scale/scale_test.go
@@ -250,10 +250,11 @@ func Test_ScaleTest_1000(t *testing.T) {
 			Milestones: []measurement.MilestoneDefinition{
 				{
 					Name: "pcs-deleted",
-					Condition: &condition.PCSDeletedCondition{
-						Client:    tc.Client.Client,
-						Name:      tc.Workload.Name,
-						Namespace: tc.Namespace,
+					Condition: &condition.PCSFullyDeletedCondition{
+						Client:        tc.Client.Client,
+						Name:          tc.Workload.Name,
+						Namespace:     tc.Namespace,
+						LabelSelector: tc.GetLabelSelector(),
 					},
 				},
 			},
@@ -305,10 +306,11 @@ func Test_ScaleTest_5000_Deletion(t *testing.T) {
 			Milestones: []measurement.MilestoneDefinition{
 				{
 					Name: "pcs-deleted",
-					Condition: &condition.PCSDeletedCondition{
-						Client:    tc.Client.Client,
-						Name:      tc.Workload.Name,
-						Namespace: tc.Namespace,
+					Condition: &condition.PCSFullyDeletedCondition{
+						Client:        tc.Client.Client,
+						Name:          tc.Workload.Name,
+						Namespace:     tc.Namespace,
+						LabelSelector: tc.GetLabelSelector(),
 					},
 				},
 			},

--- a/operator/e2e/tests/scale/scale_test.go
+++ b/operator/e2e/tests/scale/scale_test.go
@@ -250,7 +250,7 @@ func Test_ScaleTest_1000(t *testing.T) {
 			Milestones: []measurement.MilestoneDefinition{
 				{
 					Name: "pcs-deleted",
-					Condition: &condition.PCSFullyDeletedCondition{
+					Condition: &condition.PCSAndSubresourcesDeletedCondition{
 						Client:        tc.Client.Client,
 						Name:          tc.Workload.Name,
 						Namespace:     tc.Namespace,
@@ -306,7 +306,7 @@ func Test_ScaleTest_5000_Deletion(t *testing.T) {
 			Milestones: []measurement.MilestoneDefinition{
 				{
 					Name: "pcs-deleted",
-					Condition: &condition.PCSFullyDeletedCondition{
+					Condition: &condition.PCSAndSubresourcesDeletedCondition{
 						Client:        tc.Client.Client,
 						Name:          tc.Workload.Name,
 						Namespace:     tc.Namespace,

--- a/operator/e2e/tests/scale/scale_test.go
+++ b/operator/e2e/tests/scale/scale_test.go
@@ -174,7 +174,7 @@ func Test_ScaleTest_1000(t *testing.T) {
 		expectedPods: expectedPods,
 		pcsCount:     defaultScalePCSCount,
 		workerNodes:  defaultScaleWorkerNodes,
-		timeout:      15 * time.Minute,
+		timeout:      10 * time.Minute,
 		pollInterval: defaultScalePollInterval,
 	}, func(tracker *measurement.TimelineTracker, tc *testctx.TestContext, runID string) {
 		tracker.AddPhase(measurement.PhaseDefinition{
@@ -276,7 +276,7 @@ func Test_ScaleTest_5000_Deletion(t *testing.T) {
 		expectedPods: expectedPods,
 		pcsCount:     defaultScalePCSCount,
 		workerNodes:  defaultScaleWorkerNodes,
-		timeout:      30 * time.Minute,
+		timeout:      20 * time.Minute,
 		pollInterval: defaultScalePollInterval,
 	}, func(tracker *measurement.TimelineTracker, tc *testctx.TestContext, _ string) {
 		tracker.AddPhase(measurement.PhaseDefinition{

--- a/operator/e2e/yaml/scale-test-5000-deletion.yaml
+++ b/operator/e2e/yaml/scale-test-5000-deletion.yaml
@@ -1,0 +1,169 @@
+# Scale Test: 5000-pod deletion workload (covers Issue #423).
+# Mix of a standalone PodClique (frontend) and two PodCliqueScalingGroups
+# (prefill, decode) to exercise cascade deletion through both code paths.
+#
+# Composition:
+#   frontend (standalone PCLQ)               :    8 pods
+#   prefill PCSG  × 624 replicas × (1+3 pods): 2496 pods
+#   decode  PCSG  × 624 replicas × (1+3 pods): 2496 pods
+#   ----------------------------------------- ----------
+#   total                                    : 5000 pods
+---
+apiVersion: grove.io/v1alpha1
+kind: PodCliqueSet
+metadata:
+  name: scale-test-5000-deletion
+  labels:
+    app: scale-test-5000-deletion
+spec:
+  replicas: 1
+  template:
+    podCliqueScalingGroups:
+      - name: prefill
+        replicas: 624
+        minAvailable: 1
+        cliqueNames:
+          - pleader
+          - pworker
+      - name: decode
+        replicas: 624
+        minAvailable: 1
+        cliqueNames:
+          - dleader
+          - dworker
+    cliques:
+      - name: frontend
+        spec:
+          roleName: frontend
+          replicas: 8
+          minAvailable: 8
+          podSpec:
+            schedulerName: default-scheduler
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: type
+                          operator: In
+                          values:
+                            - kwok
+            tolerations:
+              - key: node_role.e2e.grove.nvidia.com
+                operator: Equal
+                value: agent
+                effect: NoSchedule
+            containers:
+              - name: app
+                image: registry:5001/nginx:alpine-slim
+                resources:
+                  requests:
+                    memory: 10Mi
+      - name: pleader
+        spec:
+          roleName: pleader
+          replicas: 1
+          minAvailable: 1
+          podSpec:
+            schedulerName: default-scheduler
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: type
+                          operator: In
+                          values:
+                            - kwok
+            tolerations:
+              - key: node_role.e2e.grove.nvidia.com
+                operator: Equal
+                value: agent
+                effect: NoSchedule
+            containers:
+              - name: app
+                image: registry:5001/nginx:alpine-slim
+                resources:
+                  requests:
+                    memory: 10Mi
+      - name: pworker
+        spec:
+          roleName: pworker
+          replicas: 3
+          minAvailable: 3
+          podSpec:
+            schedulerName: default-scheduler
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: type
+                          operator: In
+                          values:
+                            - kwok
+            tolerations:
+              - key: node_role.e2e.grove.nvidia.com
+                operator: Equal
+                value: agent
+                effect: NoSchedule
+            containers:
+              - name: app
+                image: registry:5001/nginx:alpine-slim
+                resources:
+                  requests:
+                    memory: 10Mi
+      - name: dleader
+        spec:
+          roleName: dleader
+          replicas: 1
+          minAvailable: 1
+          podSpec:
+            schedulerName: default-scheduler
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: type
+                          operator: In
+                          values:
+                            - kwok
+            tolerations:
+              - key: node_role.e2e.grove.nvidia.com
+                operator: Equal
+                value: agent
+                effect: NoSchedule
+            containers:
+              - name: app
+                image: registry:5001/nginx:alpine-slim
+                resources:
+                  requests:
+                    memory: 10Mi
+      - name: dworker
+        spec:
+          roleName: dworker
+          replicas: 3
+          minAvailable: 3
+          podSpec:
+            schedulerName: default-scheduler
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: type
+                          operator: In
+                          values:
+                            - kwok
+            tolerations:
+              - key: node_role.e2e.grove.nvidia.com
+                operator: Equal
+                value: agent
+                effect: NoSchedule
+            containers:
+              - name: app
+                image: registry:5001/nginx:alpine-slim
+                resources:
+                  requests:
+                    memory: 10Mi

--- a/operator/internal/controller/podclique/reconciledelete.go
+++ b/operator/internal/controller/podclique/reconciledelete.go
@@ -24,19 +24,22 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	ctrlcommon "github.com/ai-dynamo/grove/operator/internal/controller/common"
 	ctrlutils "github.com/ai-dynamo/grove/operator/internal/controller/utils"
-	"github.com/ai-dynamo/grove/operator/internal/utils"
+	"github.com/ai-dynamo/grove/operator/internal/expect"
 
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// triggerDeletionFlow handles the deletion of a PodClique and its managed resources
+// triggerDeletionFlow handles the deletion of a PodClique. Owned Pods (and any
+// PCLQ-scoped ResourceClaims) carry a controller owner reference back to this
+// PodClique, so removing the finalizer hands the cascade off to the Kubernetes
+// garbage collector. Local in-memory state (the expectations store) is the only
+// thing the controller still has to clean up itself.
 func (r *Reconciler) triggerDeletionFlow(ctx context.Context, logger logr.Logger, pclq *grovecorev1alpha1.PodClique) ctrlcommon.ReconcileStepResult {
 	dLog := logger.WithValues("operation", "delete")
 	deleteStepFns := []ctrlcommon.ReconcileStepFn[grovecorev1alpha1.PodClique]{
-		r.deletePodCliqueResources,
-		r.verifyNoResourcesAwaitsCleanup,
+		r.clearPodCliqueExpectations,
 		r.removeFinalizer,
 	}
 	for _, fn := range deleteStepFns {
@@ -44,34 +47,21 @@ func (r *Reconciler) triggerDeletionFlow(ctx context.Context, logger logr.Logger
 			return stepResult
 		}
 	}
-	dLog.Info("PodClique deleted successfully")
+	dLog.Info("PodClique finalizer removed; Kubernetes garbage collector will cascade-delete owned Pods")
 	return ctrlcommon.DoNotRequeue()
 }
 
-// deletePodCliqueResources triggers concurrent deletion of all resources managed by the PodClique operators
-func (r *Reconciler) deletePodCliqueResources(ctx context.Context, logger logr.Logger, pclq *grovecorev1alpha1.PodClique) ctrlcommon.ReconcileStepResult {
-	operators := r.operatorRegistry.GetAllOperators()
-	deleteTasks := make([]utils.Task, 0, len(operators))
-	for kind, operator := range operators {
-		deleteTasks = append(deleteTasks, utils.Task{
-			Name: fmt.Sprintf("delete-%s", kind),
-			Fn: func(ctx context.Context) error {
-				return operator.Delete(ctx, logger, pclq.ObjectMeta)
-			},
-		})
+// clearPodCliqueExpectations drops the in-memory expectations entry for this
+// PodClique so the store does not retain stale UIDs after the object is gone.
+func (r *Reconciler) clearPodCliqueExpectations(_ context.Context, logger logr.Logger, pclq *grovecorev1alpha1.PodClique) ctrlcommon.ReconcileStepResult {
+	key, err := expect.ControlleeKeyFunc(pclq)
+	if err != nil {
+		return ctrlcommon.ReconcileWithErrors("error building expectations store key", fmt.Errorf("failed to build expectations store key for PodClique %v: %w", client.ObjectKeyFromObject(pclq), err))
 	}
-	logger.Info("Triggering delete of PodClique resources")
-	if runResult := utils.RunConcurrently(ctx, logger, deleteTasks); runResult.HasErrors() {
-		deletionErr := runResult.GetAggregatedError()
-		logger.Error(deletionErr, "Error deleting managed resources", "summary", runResult.GetSummary())
-		return ctrlcommon.ReconcileWithErrors("error deleting managed resources", deletionErr)
+	if err := r.expectationsStore.DeleteExpectations(logger, key); err != nil {
+		return ctrlcommon.ReconcileWithErrors("error clearing expectations", err)
 	}
 	return ctrlcommon.ContinueReconcile()
-}
-
-// verifyNoResourcesAwaitsCleanup ensures all managed resources have been fully deleted before allowing finalizer removal
-func (r *Reconciler) verifyNoResourcesAwaitsCleanup(ctx context.Context, logger logr.Logger, pclq *grovecorev1alpha1.PodClique) ctrlcommon.ReconcileStepResult {
-	return ctrlutils.VerifyNoResourceAwaitsCleanup(ctx, logger, r.operatorRegistry, pclq.ObjectMeta)
 }
 
 // removeFinalizer removes the PodClique finalizer to allow Kubernetes to complete the deletion

--- a/operator/internal/controller/podclique/reconciledelete_test.go
+++ b/operator/internal/controller/podclique/reconciledelete_test.go
@@ -18,14 +18,11 @@ package podclique
 
 import (
 	"context"
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/ai-dynamo/grove/operator/api/common/constants"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
-	ctrlcommon "github.com/ai-dynamo/grove/operator/internal/controller/common"
-	"github.com/ai-dynamo/grove/operator/internal/controller/common/component"
+	"github.com/ai-dynamo/grove/operator/internal/expect"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
@@ -33,27 +30,24 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-// TestTriggerDeletionFlow tests the deletion flow for PodClique
+// TestTriggerDeletionFlow verifies the cascade-delete flow: the controller
+// clears in-memory expectations and removes the finalizer, leaving the actual
+// child cleanup to the Kubernetes garbage collector via owner references.
 func TestTriggerDeletionFlow(t *testing.T) {
 	tests := []struct {
-		// Test case description
-		name string
-		// pclq is the PodClique being deleted
-		pclq *grovecorev1alpha1.PodClique
-		// existingResources are resources that exist in the cluster
-		existingResources []client.Object
-		// mockSetup sets up mock behavior
-		mockSetup func(*mockOperatorRegistry)
-		// expectedResult is the expected reconcile result
-		expectedResult ctrlcommon.ReconcileStepResult
+		name              string
+		pclq              *grovecorev1alpha1.PodClique
+		expectFinalizer   bool
+		expectRequeue     bool
+		expectErrors      bool
+		seedExpectationOf string
 	}{
 		{
-			// Tests successful deletion flow
-			name: "successful_deletion",
+			name: "removes_finalizer_and_completes",
 			pclq: &grovecorev1alpha1.PodClique{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-pclq",
@@ -61,157 +55,65 @@ func TestTriggerDeletionFlow(t *testing.T) {
 					Finalizers: []string{constants.FinalizerPodClique},
 				},
 			},
-			mockSetup: func(registry *mockOperatorRegistry) {
-				// Mock pod operator
-				podOp := &mockOperator{
-					deleteFunc: func(_ context.Context, _ logr.Logger, _ metav1.ObjectMeta) error {
-						return nil
-					},
-					getExistingResourceNamesFunc: func(_ context.Context, _ logr.Logger, _ metav1.ObjectMeta) ([]string, error) {
-						return []string{}, nil // No resources left
-					},
-				}
-				registry.operators[component.KindPod] = podOp
-			},
-			expectedResult: ctrlcommon.DoNotRequeue(),
+			seedExpectationOf: "default/test-pclq",
+			expectFinalizer:   false,
+			expectRequeue:     false,
+			expectErrors:      false,
 		},
 		{
-			// Tests deletion with resources still present
-			name: "deletion_with_resources_awaiting_cleanup",
+			name: "no_finalizer_is_a_noop",
 			pclq: &grovecorev1alpha1.PodClique{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test-pclq",
-					Namespace:  "default",
-					Finalizers: []string{constants.FinalizerPodClique},
+					Name:      "test-pclq",
+					Namespace: "default",
 				},
 			},
-			mockSetup: func(registry *mockOperatorRegistry) {
-				// Mock pod operator
-				podOp := &mockOperator{
-					deleteFunc: func(_ context.Context, _ logr.Logger, _ metav1.ObjectMeta) error {
-						return nil
-					},
-					getExistingResourceNamesFunc: func(_ context.Context, _ logr.Logger, _ metav1.ObjectMeta) ([]string, error) {
-						return []string{"pod-1", "pod-2"}, nil // Resources still exist
-					},
-				}
-				registry.operators[component.KindPod] = podOp
-			},
-			expectedResult: ctrlcommon.ReconcileAfter(5*time.Second, "Resources are still awaiting cleanup. Skipping removal of finalizer"),
-		},
-		{
-			// Tests deletion with error during resource deletion
-			name: "deletion_with_error",
-			pclq: &grovecorev1alpha1.PodClique{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test-pclq",
-					Namespace:  "default",
-					Finalizers: []string{constants.FinalizerPodClique},
-				},
-			},
-			mockSetup: func(registry *mockOperatorRegistry) {
-				// Mock pod operator
-				podOp := &mockOperator{
-					deleteFunc: func(_ context.Context, _ logr.Logger, _ metav1.ObjectMeta) error {
-						return fmt.Errorf("failed to delete pod")
-					},
-				}
-				registry.operators[component.KindPod] = podOp
-			},
-			expectedResult: ctrlcommon.ReconcileWithErrors("error deleting managed resources", fmt.Errorf("failed to delete pod")),
+			expectFinalizer: false,
+			expectRequeue:   false,
+			expectErrors:    false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// Setup scheme
 			scheme := runtime.NewScheme()
 			require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
 			require.NoError(t, corev1.AddToScheme(scheme))
 
-			// Build runtime objects
-			runtimeObjs := []client.Object{tc.pclq}
-			runtimeObjs = append(runtimeObjs, tc.existingResources...)
-
-			// Create fake client
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
-				WithObjects(runtimeObjs...).
+				WithObjects(tc.pclq).
 				Build()
 
-			// Create mock registry
-			mockRegistry := &mockOperatorRegistry{
-				operators: make(map[component.Kind]component.Operator[grovecorev1alpha1.PodClique]),
-			}
-			if tc.mockSetup != nil {
-				tc.mockSetup(mockRegistry)
+			expectationsStore := expect.NewExpectationsStore()
+			if tc.seedExpectationOf != "" {
+				require.NoError(t, expectationsStore.ExpectCreations(logr.Discard(), tc.seedExpectationOf, "uid-1"))
 			}
 
-			// Create reconciler
 			r := &Reconciler{
-				client:           fakeClient,
-				operatorRegistry: mockRegistry,
+				client:            fakeClient,
+				expectationsStore: expectationsStore,
 			}
 
-			// Execute deletion flow
-			ctx := context.Background()
-			logger := logr.Discard()
-			result := r.triggerDeletionFlow(ctx, logger, tc.pclq)
+			result := r.triggerDeletionFlow(context.Background(), logr.Discard(), tc.pclq)
 
-			// Verify result
-			assert.Equal(t, tc.expectedResult.NeedsRequeue(), result.NeedsRequeue())
-			if tc.expectedResult.HasErrors() {
-				assert.True(t, result.HasErrors())
+			assert.Equal(t, tc.expectRequeue, result.NeedsRequeue())
+			assert.Equal(t, tc.expectErrors, result.HasErrors())
+
+			if tc.seedExpectationOf != "" {
+				_, exists, err := expectationsStore.GetExpectations(tc.seedExpectationOf)
+				require.NoError(t, err)
+				assert.False(t, exists, "expectations entry should have been cleared")
+			}
+
+			fetched := &grovecorev1alpha1.PodClique{}
+			err := fakeClient.Get(context.Background(), types.NamespacedName{Name: tc.pclq.Name, Namespace: tc.pclq.Namespace}, fetched)
+			require.NoError(t, err)
+			if tc.expectFinalizer {
+				assert.Contains(t, fetched.Finalizers, constants.FinalizerPodClique)
+			} else {
+				assert.NotContains(t, fetched.Finalizers, constants.FinalizerPodClique)
 			}
 		})
 	}
-}
-
-// mockOperator is a mock implementation of component.Operator
-type mockOperator struct {
-	deleteFunc                   func(ctx context.Context, logger logr.Logger, objMeta metav1.ObjectMeta) error
-	syncFunc                     func(ctx context.Context, logger logr.Logger, obj *grovecorev1alpha1.PodClique) error
-	getExistingResourceNamesFunc func(ctx context.Context, logger logr.Logger, objMeta metav1.ObjectMeta) ([]string, error)
-}
-
-func (m *mockOperator) Delete(ctx context.Context, logger logr.Logger, objMeta metav1.ObjectMeta) error {
-	if m.deleteFunc != nil {
-		return m.deleteFunc(ctx, logger, objMeta)
-	}
-	return nil
-}
-
-func (m *mockOperator) Sync(ctx context.Context, logger logr.Logger, obj *grovecorev1alpha1.PodClique) error {
-	if m.syncFunc != nil {
-		return m.syncFunc(ctx, logger, obj)
-	}
-	return nil
-}
-
-func (m *mockOperator) GetExistingResourceNames(ctx context.Context, logger logr.Logger, objMeta metav1.ObjectMeta) ([]string, error) {
-	if m.getExistingResourceNamesFunc != nil {
-		return m.getExistingResourceNamesFunc(ctx, logger, objMeta)
-	}
-	return []string{}, nil
-}
-
-// mockOperatorRegistry is a mock implementation of OperatorRegistry
-type mockOperatorRegistry struct {
-	operators map[component.Kind]component.Operator[grovecorev1alpha1.PodClique]
-}
-
-func (m *mockOperatorRegistry) Register(kind component.Kind, operator component.Operator[grovecorev1alpha1.PodClique]) {
-	m.operators[kind] = operator
-}
-
-func (m *mockOperatorRegistry) GetOperator(kind component.Kind) (component.Operator[grovecorev1alpha1.PodClique], error) {
-	op, ok := m.operators[kind]
-	if !ok {
-		return nil, fmt.Errorf("operator not found for kind: %s", kind)
-	}
-	return op, nil
-}
-
-func (m *mockOperatorRegistry) GetAllOperators() map[component.Kind]component.Operator[grovecorev1alpha1.PodClique] {
-	return m.operators
 }

--- a/operator/internal/controller/podcliquescalinggroup/reconciledelete.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconciledelete.go
@@ -24,53 +24,21 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	ctrlcommon "github.com/ai-dynamo/grove/operator/internal/controller/common"
 	ctrlutils "github.com/ai-dynamo/grove/operator/internal/controller/utils"
-	"github.com/ai-dynamo/grove/operator/internal/utils"
 
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// triggerDeletionFlow handles the deletion of a PodCliqueScalingGroup and its managed resources
+// triggerDeletionFlow handles the deletion of a PodCliqueScalingGroup.
+// Child PodCliques carry a controller owner reference to this PCSG, so finalizer
+// removal hands the cascade off to the Kubernetes garbage collector.
 func (r *Reconciler) triggerDeletionFlow(ctx context.Context, logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup) ctrlcommon.ReconcileStepResult {
-	deleteStepFns := []ctrlcommon.ReconcileStepFn[grovecorev1alpha1.PodCliqueScalingGroup]{
-		r.deletePodCliqueScalingGroupResources,
-		r.verifyNoResourcesAwaitsCleanup,
-		r.removeFinalizer,
+	if stepResult := r.removeFinalizer(ctx, logger, pcsg); ctrlcommon.ShortCircuitReconcileFlow(stepResult) {
+		return stepResult
 	}
-	for _, fn := range deleteStepFns {
-		if stepResult := fn(ctx, logger, pcsg); ctrlcommon.ShortCircuitReconcileFlow(stepResult) {
-			return stepResult
-		}
-	}
-	logger.Info("PodCliqueScalingGroup deleted successfully")
+	logger.Info("PodCliqueScalingGroup finalizer removed; Kubernetes garbage collector will cascade-delete owned PodCliques")
 	return ctrlcommon.DoNotRequeue()
-}
-
-// deletePodCliqueScalingGroupResources triggers concurrent deletion of all resources managed by the PodCliqueScalingGroup operators
-func (r *Reconciler) deletePodCliqueScalingGroupResources(ctx context.Context, logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup) ctrlcommon.ReconcileStepResult {
-	operators := r.operatorRegistry.GetAllOperators()
-	deleteTasks := make([]utils.Task, 0, len(operators))
-	for kind, operator := range operators {
-		deleteTasks = append(deleteTasks, utils.Task{
-			Name: fmt.Sprintf("delete-%s", kind),
-			Fn: func(ctx context.Context) error {
-				return operator.Delete(ctx, logger, pcsg.ObjectMeta)
-			},
-		})
-	}
-	logger.Info("Triggering delete of PodCliqueScalingGroup resources")
-	if runResult := utils.RunConcurrently(ctx, logger, deleteTasks); runResult.HasErrors() {
-		deletionErr := runResult.GetAggregatedError()
-		logger.Error(deletionErr, "Error deleting managed resources", "summary", runResult.GetSummary())
-		return ctrlcommon.ReconcileWithErrors("error deleting managed resources", deletionErr)
-	}
-	return ctrlcommon.ContinueReconcile()
-}
-
-// verifyNoResourcesAwaitsCleanup ensures all managed resources have been fully deleted before allowing finalizer removal
-func (r *Reconciler) verifyNoResourcesAwaitsCleanup(ctx context.Context, logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup) ctrlcommon.ReconcileStepResult {
-	return ctrlutils.VerifyNoResourceAwaitsCleanup(ctx, logger, r.operatorRegistry, pcsg.ObjectMeta)
 }
 
 // removeFinalizer removes the PodCliqueScalingGroup finalizer to allow Kubernetes to complete the deletion

--- a/operator/internal/controller/podcliqueset/reconciledelete.go
+++ b/operator/internal/controller/podcliqueset/reconciledelete.go
@@ -24,53 +24,24 @@ import (
 	"github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	ctrlcommon "github.com/ai-dynamo/grove/operator/internal/controller/common"
 	ctrlutils "github.com/ai-dynamo/grove/operator/internal/controller/utils"
-	"github.com/ai-dynamo/grove/operator/internal/utils"
 
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// triggerDeletionFlow handles the deletion of a PodCliqueSet and its managed resources
+// triggerDeletionFlow handles the deletion of a PodCliqueSet.
+// Owned resources (PodCliqueScalingGroup, PodClique, Service, ServiceAccount, Role,
+// RoleBinding, HPA, PodGang, ResourceClaim, etc.) carry a controller owner reference
+// to the PodCliqueSet, so removing the finalizer hands cleanup to the Kubernetes
+// garbage collector — which cascades the entire subtree without per-resource
+// reconcile work in this controller.
 func (r *Reconciler) triggerDeletionFlow(ctx context.Context, logger logr.Logger, pcs *v1alpha1.PodCliqueSet) ctrlcommon.ReconcileStepResult {
-	deleteStepFns := []ctrlcommon.ReconcileStepFn[v1alpha1.PodCliqueSet]{
-		r.deletePodCliqueSetResources,
-		r.verifyNoResourcesAwaitsCleanup,
-		r.removeFinalizer,
+	if stepResult := r.removeFinalizer(ctx, logger, pcs); ctrlcommon.ShortCircuitReconcileFlow(stepResult) {
+		return r.recordIncompleteDeletion(ctx, logger, pcs, &stepResult)
 	}
-	for _, fn := range deleteStepFns {
-		if stepResult := fn(ctx, logger, pcs); ctrlcommon.ShortCircuitReconcileFlow(stepResult) {
-			return r.recordIncompleteDeletion(ctx, logger, pcs, &stepResult)
-		}
-	}
-	logger.Info("PodCliqueSet deleted successfully")
+	logger.Info("PodCliqueSet finalizer removed; Kubernetes garbage collector will cascade-delete owned resources")
 	return ctrlcommon.DoNotRequeue()
-}
-
-// deletePodCliqueSetResources triggers concurrent deletion of all managed resources for the PodCliqueSet.
-func (r *Reconciler) deletePodCliqueSetResources(ctx context.Context, logger logr.Logger, pcs *v1alpha1.PodCliqueSet) ctrlcommon.ReconcileStepResult {
-	operators := r.operatorRegistry.GetAllOperators()
-	deleteTasks := make([]utils.Task, 0, len(operators))
-	for kind, operator := range operators {
-		deleteTasks = append(deleteTasks, utils.Task{
-			Name: fmt.Sprintf("delete-%s", kind),
-			Fn: func(ctx context.Context) error {
-				return operator.Delete(ctx, logger, pcs.ObjectMeta)
-			},
-		})
-	}
-	logger.Info("Triggering delete of PodCliqueSet resources")
-	if runResult := utils.RunConcurrently(ctx, logger, deleteTasks); runResult.HasErrors() {
-		deletionErr := runResult.GetAggregatedError()
-		logger.Error(deletionErr, "Error deleting managed resources", "summary", runResult.GetSummary())
-		return ctrlcommon.ReconcileWithErrors("error deleting managed resources", deletionErr)
-	}
-	return ctrlcommon.ContinueReconcile()
-}
-
-// verifyNoResourcesAwaitsCleanup ensures all managed resources have been cleaned up before finalizer removal.
-func (r *Reconciler) verifyNoResourcesAwaitsCleanup(ctx context.Context, logger logr.Logger, pcs *v1alpha1.PodCliqueSet) ctrlcommon.ReconcileStepResult {
-	return ctrlutils.VerifyNoResourceAwaitsCleanup(ctx, logger, r.operatorRegistry, pcs.ObjectMeta)
 }
 
 // removeFinalizer removes the PodCliqueSet finalizer if present.

--- a/operator/internal/controller/podcliqueset/reconciledelete.go
+++ b/operator/internal/controller/podcliqueset/reconciledelete.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ai-dynamo/grove/operator/api/common/constants"
 	"github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	ctrlcommon "github.com/ai-dynamo/grove/operator/internal/controller/common"
+	"github.com/ai-dynamo/grove/operator/internal/controller/common/component"
 	ctrlutils "github.com/ai-dynamo/grove/operator/internal/controller/utils"
 
 	"github.com/go-logr/logr"
@@ -36,12 +37,41 @@ import (
 // to the PodCliqueSet, so removing the finalizer hands cleanup to the Kubernetes
 // garbage collector — which cascades the entire subtree without per-resource
 // reconcile work in this controller.
+//
+// One exception: ComputeDomain objects carry a Grove-owned finalizer
+// (`grove.io/computedomain-finalizer`) that the K8s garbage collector cannot
+// strip on its own. We invoke the ComputeDomain operator's Delete (which removes
+// the finalizer and issues Delete) before dropping the PCS finalizer, so the
+// CDs aren't left dangling once GC starts cascading.
 func (r *Reconciler) triggerDeletionFlow(ctx context.Context, logger logr.Logger, pcs *v1alpha1.PodCliqueSet) ctrlcommon.ReconcileStepResult {
-	if stepResult := r.removeFinalizer(ctx, logger, pcs); ctrlcommon.ShortCircuitReconcileFlow(stepResult) {
-		return r.recordIncompleteDeletion(ctx, logger, pcs, &stepResult)
+	deleteStepFns := []ctrlcommon.ReconcileStepFn[v1alpha1.PodCliqueSet]{
+		r.releaseComputeDomainFinalizers,
+		r.removeFinalizer,
+	}
+	for _, fn := range deleteStepFns {
+		if stepResult := fn(ctx, logger, pcs); ctrlcommon.ShortCircuitReconcileFlow(stepResult) {
+			return r.recordIncompleteDeletion(ctx, logger, pcs, &stepResult)
+		}
 	}
 	logger.Info("PodCliqueSet finalizer removed; Kubernetes garbage collector will cascade-delete owned resources")
 	return ctrlcommon.DoNotRequeue()
+}
+
+// releaseComputeDomainFinalizers strips the Grove finalizer from every
+// ComputeDomain owned by this PCS. ComputeDomains are the only PCS-owned
+// resource that carry a Grove-managed finalizer; without this step the K8s
+// garbage collector would orphan them in a `deleting` state forever once the
+// PCS goes away.
+func (r *Reconciler) releaseComputeDomainFinalizers(ctx context.Context, logger logr.Logger, pcs *v1alpha1.PodCliqueSet) ctrlcommon.ReconcileStepResult {
+	op, err := r.operatorRegistry.GetOperator(component.KindComputeDomain)
+	if err != nil {
+		// ComputeDomain operator not registered (test scaffolding, etc.). Nothing to release.
+		return ctrlcommon.ContinueReconcile()
+	}
+	if err := op.Delete(ctx, logger, pcs.ObjectMeta); err != nil {
+		return ctrlcommon.ReconcileWithErrors("error releasing ComputeDomain finalizers", fmt.Errorf("failed to release ComputeDomain finalizers for PodCliqueSet %v: %w", client.ObjectKeyFromObject(pcs), err))
+	}
+	return ctrlcommon.ContinueReconcile()
 }
 
 // removeFinalizer removes the PodCliqueSet finalizer if present.


### PR DESCRIPTION
Closes #423.

## What this changes

Replaces the manual *delete-children → poll-until-clean → remove-finalizer* flow in the PCS, PCSG, and PodClique reconcilers with **immediate finalizer removal**. The Kubernetes garbage collector then cascades the entire owner-reference tree (PCS → PCSG → PC → Pod, plus the PCS-owned siblings: Service, ServiceAccount, Role, RoleBinding, HPA, PodGang, ResourceClaim).

The PodClique reconciler keeps a one-step finalizer to clear its in-memory `expectationsStore` entry — that state lives outside the API server and GC can't see it.

## The pattern: GC cascade + thin finalizer for non-API-server state

This is the dominant pattern across modern cloud-native CRDs that own a tree of K8s resources. Owner refs do the heavy lifting; the finalizer exists only as a hook for state GC can't reach.

Reference implementations using this pattern:

- **Kubernetes core controllers** — `ReplicaSet`, `Deployment`, `StatefulSet`, `DaemonSet`, `Job` all rely on owner-reference cascade for child cleanup. The expectations cache pattern Grove now mirrors lives in [`k8s.io/kubernetes/pkg/controller/controller_utils.go`](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/controller_utils.go) and is consumed by `replica_set.go` and `statefulset/stateful_set.go`. They never manually `Delete` their pods on parent deletion.
- **[JobSet](https://github.com/kubernetes-sigs/jobset)** (kubernetes-sigs) — JobSet → Job → Pod via owner refs; the controller does no manual child deletion.
- **[LeaderWorkerSet (LWS)](https://github.com/kubernetes-sigs/lws)** (kubernetes-sigs) — LWS → StatefulSet → Pod, same pattern.
- **[Kueue](https://github.com/kubernetes-sigs/kueue)** — `Workload` carries a finalizer whose only job is to release queue/quota accounting before letting GC cascade.
- **[KubeRay](https://github.com/ray-project/kuberay)** — `RayCluster`/`RayService` use finalizers for service-mesh deregistration and graceful dashboard shutdown, but children clean up via owner refs.
- **[Volcano](https://github.com/volcano-sh/volcano)** — `PodGroup` finalizer releases gang-scheduling state; pods cascade via GC.
- **[KServe](https://github.com/kserve/kserve)** — `InferenceService` finalizer releases external model-server registration; the K8s subtree is cascaded.

What Grove was doing before is the older Gardener-style controller-utils template: a serialized `delete → verify → finalize` loop. Defensive when owner refs are unreliable, but it serializes through `concurrentSyncs` — which is exactly what made #423 a 20-minute deletion at 5k pods.

## Tradeoffs we're accepting

- **Parent disappears from the API as soon as its finalizer is removed,** even while children are still terminating. Anyone scripting around "PCS object gone = workload gone" should switch to watching pods.
- **No per-step deletion progress in status.** Live cluster state is the source of truth.
- **Correctness now depends on every component having a controller owner reference.** Audited the existing components (HPA, Service, ServiceAccount, Role, RoleBinding, SAtokenSecret, PodGang, ResourceClaim, PCSG, PC, Pod) — all set `controllerutil.SetControllerReference` on owned objects. A unit test asserting owner refs on every newly-built object would be a reasonable follow-up to keep this property from regressing.