### PR TITLE
feat(mnnvl): add group-aware MNNVL injection into PodSpec

### DIFF
--- a/operator/internal/controller/podcliquescalinggroup/components/podclique/podclique.go
+++ b/operator/internal/controller/podcliquescalinggroup/components/podclique/podclique.go
@@ -332,9 +332,13 @@ func (r _resource) buildResource(logger logr.Logger, pcs *grovecorev1alpha1.PodC
 	}
 	pclq.Spec.StartsAfter = dependentPCLQNames
 
-	// Inject MNNVL resourceClaims if enabled on PCSG (propagated from PCS)
-	if mnnvl.IsAutoMNNVLEnabled(pcsg.Annotations) {
-		mnnvl.InjectMNNVLIntoPodSpec(logger, &pclq.Spec.PodSpec, apicommon.ResourceNameReplica{Name: pcs.Name, Replica: pcsReplicaIndex})
+	// Inject MNNVL resourceClaims: clique annotations take priority over PCSG
+	groupName, mnnvlEnabled := mnnvl.ResolveGroupName(pclqTemplateSpec.Annotations)
+	if !mnnvlEnabled {
+		groupName, mnnvlEnabled = mnnvl.ResolveGroupName(pcsg.Annotations)
+	}
+	if mnnvlEnabled {
+		mnnvl.InjectMNNVLIntoPodSpec(logger, &pclq.Spec.PodSpec, apicommon.ResourceNameReplica{Name: pcs.Name, Replica: pcsReplicaIndex}, groupName)
 	}
 
 	return nil

--- a/operator/internal/controller/podcliquescalinggroup/components/podclique/podclique.go
+++ b/operator/internal/controller/podcliquescalinggroup/components/podclique/podclique.go
@@ -332,11 +332,10 @@ func (r _resource) buildResource(logger logr.Logger, pcs *grovecorev1alpha1.PodC
 	}
 	pclq.Spec.StartsAfter = dependentPCLQNames
 
-	// Inject MNNVL resourceClaims: clique annotations take priority over PCSG
-	groupName, mnnvlEnabled := mnnvl.ResolveGroupName(pclqTemplateSpec.Annotations)
-	if !mnnvlEnabled {
-		groupName, mnnvlEnabled = mnnvl.ResolveGroupName(pcsg.Annotations)
-	}
+	// Inject MNNVL resourceClaims: resolve group hierarchically (PCLQ → PCSG).
+	// PCS-level annotations are already propagated onto the PCSG by the PCS
+	// controller via propagateMNNVLAnnotations, so a two-layer check suffices.
+	groupName, mnnvlEnabled := mnnvl.ResolveGroupNameHierarchically(pclqTemplateSpec.Annotations, pcsg.Annotations)
 	if mnnvlEnabled {
 		mnnvl.InjectMNNVLIntoPodSpec(logger, &pclq.Spec.PodSpec, apicommon.ResourceNameReplica{Name: pcs.Name, Replica: pcsReplicaIndex}, groupName)
 	}

--- a/operator/internal/controller/podcliquescalinggroup/components/podclique/podclique_test.go
+++ b/operator/internal/controller/podcliquescalinggroup/components/podclique/podclique_test.go
@@ -754,6 +754,7 @@ func TestBuildResource_MNNVLInjection(t *testing.T) {
 	tests := []struct {
 		description                         string
 		pcsgAnnotations                     map[string]string
+		cliqueAnnotations                   map[string]string
 		containers                          []corev1.Container
 		initContainers                      []corev1.Container
 		expectedContainersWithClaims        []string
@@ -889,6 +890,69 @@ func TestBuildResource_MNNVLInjection(t *testing.T) {
 			expectedContainersWithoutClaims: []string{"gpu-worker"},
 			expectPodLevelClaim:             false,
 		},
+		{
+			description: "mnnvl-group on PCSG — RCT name includes group",
+			pcsgAnnotations: map[string]string{
+				mnnvl.AnnotationMNNVLGroup: "workers",
+			},
+			containers: []corev1.Container{
+				{
+					Name: "gpu-worker",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							constants.GPUResourceName: resource.MustParse("8"),
+						},
+					},
+				},
+			},
+			expectedContainersWithClaims:    []string{"gpu-worker"},
+			expectedContainersWithoutClaims: []string{},
+			expectPodLevelClaim:             true,
+			expectedRCTName:                 "test-pcs-0-workers",
+		},
+		{
+			description: "mnnvl-group on clique overrides PCSG auto-mnnvl",
+			pcsgAnnotations: map[string]string{
+				mnnvl.AnnotationAutoMNNVL: mnnvl.AnnotationAutoMNNVLEnabled,
+			},
+			cliqueAnnotations: map[string]string{
+				mnnvl.AnnotationMNNVLGroup: "encoders",
+			},
+			containers: []corev1.Container{
+				{
+					Name: "gpu-worker",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							constants.GPUResourceName: resource.MustParse("8"),
+						},
+					},
+				},
+			},
+			expectedContainersWithClaims:    []string{"gpu-worker"},
+			expectedContainersWithoutClaims: []string{},
+			expectPodLevelClaim:             true,
+			expectedRCTName:                 "test-pcs-0-encoders",
+		},
+		{
+			description: "mnnvl-group on clique only — no PCSG annotation",
+			cliqueAnnotations: map[string]string{
+				mnnvl.AnnotationMNNVLGroup: "training",
+			},
+			containers: []corev1.Container{
+				{
+					Name: "gpu-worker",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							constants.GPUResourceName: resource.MustParse("8"),
+						},
+					},
+				},
+			},
+			expectedContainersWithClaims:    []string{"gpu-worker"},
+			expectedContainersWithoutClaims: []string{},
+			expectPodLevelClaim:             true,
+			expectedRCTName:                 "test-pcs-0-training",
+		},
 	}
 
 	for _, tc := range tests {
@@ -910,7 +974,8 @@ func TestBuildResource_MNNVLInjection(t *testing.T) {
 						StartupType: ptr.To(grovecorev1alpha1.CliqueStartupTypeAnyOrder),
 						Cliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
 							{
-								Name: pclqTemplateName,
+								Name:        pclqTemplateName,
+								Annotations: tc.cliqueAnnotations,
 								Spec: grovecorev1alpha1.PodCliqueSpec{
 									Replicas:     1,
 									MinAvailable: ptr.To(int32(1)),

--- a/operator/internal/controller/podcliqueset/components/podclique/podclique.go
+++ b/operator/internal/controller/podcliqueset/components/podclique/podclique.go
@@ -321,9 +321,13 @@ func (r _resource) buildResource(logger logr.Logger, pclq *grovecorev1alpha1.Pod
 	}
 	pclq.Spec.StartsAfter = dependentPclqNames
 
-	// Inject MNNVL resourceClaims if enabled on PCS
-	if mnnvl.IsAutoMNNVLEnabled(pcs.Annotations) {
-		mnnvl.InjectMNNVLIntoPodSpec(logger, &pclq.Spec.PodSpec, apicommon.ResourceNameReplica{Name: pcs.Name, Replica: pcsReplica})
+	// Inject MNNVL resourceClaims: clique annotations take priority over PCS
+	groupName, mnnvlEnabled := mnnvl.ResolveGroupName(pclqTemplateSpec.Annotations)
+	if !mnnvlEnabled {
+		groupName, mnnvlEnabled = mnnvl.ResolveGroupName(pcs.Annotations)
+	}
+	if mnnvlEnabled {
+		mnnvl.InjectMNNVLIntoPodSpec(logger, &pclq.Spec.PodSpec, apicommon.ResourceNameReplica{Name: pcs.Name, Replica: pcsReplica}, groupName)
 	}
 
 	return nil

--- a/operator/internal/controller/podcliqueset/components/podclique/podclique.go
+++ b/operator/internal/controller/podcliqueset/components/podclique/podclique.go
@@ -321,11 +321,8 @@ func (r _resource) buildResource(logger logr.Logger, pclq *grovecorev1alpha1.Pod
 	}
 	pclq.Spec.StartsAfter = dependentPclqNames
 
-	// Inject MNNVL resourceClaims: clique annotations take priority over PCS
-	groupName, mnnvlEnabled := mnnvl.ResolveGroupName(pclqTemplateSpec.Annotations)
-	if !mnnvlEnabled {
-		groupName, mnnvlEnabled = mnnvl.ResolveGroupName(pcs.Annotations)
-	}
+	// Inject MNNVL resourceClaims: resolve group hierarchically (PCLQ → PCS).
+	groupName, mnnvlEnabled := mnnvl.ResolveGroupNameHierarchically(pclqTemplateSpec.Annotations, pcs.Annotations)
 	if mnnvlEnabled {
 		mnnvl.InjectMNNVLIntoPodSpec(logger, &pclq.Spec.PodSpec, apicommon.ResourceNameReplica{Name: pcs.Name, Replica: pcsReplica}, groupName)
 	}

--- a/operator/internal/controller/podcliqueset/components/podclique/podclique_test.go
+++ b/operator/internal/controller/podcliqueset/components/podclique/podclique_test.go
@@ -219,6 +219,7 @@ func TestBuildResource_MNNVLInjection(t *testing.T) {
 	tests := []struct {
 		description                         string
 		pcsAnnotations                      map[string]string
+		cliqueAnnotations                   map[string]string
 		containers                          []corev1.Container
 		initContainers                      []corev1.Container
 		expectedContainersWithClaims        []string
@@ -354,6 +355,69 @@ func TestBuildResource_MNNVLInjection(t *testing.T) {
 			expectedContainersWithoutClaims: []string{"gpu-worker"},
 			expectPodLevelClaim:             false,
 		},
+		{
+			description: "mnnvl-group on PCS — RCT name includes group",
+			pcsAnnotations: map[string]string{
+				mnnvl.AnnotationMNNVLGroup: "workers",
+			},
+			containers: []corev1.Container{
+				{
+					Name: "gpu-worker",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							constants.GPUResourceName: resource.MustParse("8"),
+						},
+					},
+				},
+			},
+			expectedContainersWithClaims:    []string{"gpu-worker"},
+			expectedContainersWithoutClaims: []string{},
+			expectPodLevelClaim:             true,
+			expectedRCTName:                 "coyote-0-workers",
+		},
+		{
+			description: "mnnvl-group on clique overrides PCS auto-mnnvl",
+			pcsAnnotations: map[string]string{
+				mnnvl.AnnotationAutoMNNVL: mnnvl.AnnotationAutoMNNVLEnabled,
+			},
+			cliqueAnnotations: map[string]string{
+				mnnvl.AnnotationMNNVLGroup: "encoders",
+			},
+			containers: []corev1.Container{
+				{
+					Name: "gpu-worker",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							constants.GPUResourceName: resource.MustParse("8"),
+						},
+					},
+				},
+			},
+			expectedContainersWithClaims:    []string{"gpu-worker"},
+			expectedContainersWithoutClaims: []string{},
+			expectPodLevelClaim:             true,
+			expectedRCTName:                 "coyote-0-encoders",
+		},
+		{
+			description: "mnnvl-group on clique only — no PCS annotation",
+			cliqueAnnotations: map[string]string{
+				mnnvl.AnnotationMNNVLGroup: "training",
+			},
+			containers: []corev1.Container{
+				{
+					Name: "gpu-worker",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							constants.GPUResourceName: resource.MustParse("8"),
+						},
+					},
+				},
+			},
+			expectedContainersWithClaims:    []string{"gpu-worker"},
+			expectedContainersWithoutClaims: []string{},
+			expectPodLevelClaim:             true,
+			expectedRCTName:                 "coyote-0-training",
+		},
 	}
 
 	for _, tc := range tests {
@@ -367,8 +431,10 @@ func TestBuildResource_MNNVLInjection(t *testing.T) {
 				WithCliqueStartupType(ptr.To(grovecorev1alpha1.CliqueStartupTypeAnyOrder)).
 				WithAnnotations(tc.pcsAnnotations)
 
-			// Create PodCliqueTemplateSpec with containers
-			pclqTemplateSpec := testutils.NewPodCliqueTemplateSpecBuilder(pclqTemplateName).Build()
+			// Create PodCliqueTemplateSpec with containers and optional annotations
+			pclqTemplateSpec := testutils.NewPodCliqueTemplateSpecBuilder(pclqTemplateName).
+				WithAnnotations(tc.cliqueAnnotations).
+				Build()
 			pclqTemplateSpec.Spec.PodSpec.Containers = tc.containers
 			pclqTemplateSpec.Spec.PodSpec.InitContainers = tc.initContainers
 			pcsBuilder.WithPodCliqueTemplateSpec(pclqTemplateSpec)

--- a/operator/internal/mnnvl/computedomain/computedomain.go
+++ b/operator/internal/mnnvl/computedomain/computedomain.go
@@ -383,23 +383,9 @@ func collectDistinctGroups(pcs *grovecorev1alpha1.PodCliqueSet) map[string]struc
 
 // addGroupFromAnnotation extracts the MNNVL group from annotations and adds it to the set.
 func addGroupFromAnnotation(groups map[string]struct{}, annotations map[string]string) {
-	if group, ok := resolveGroupName(annotations); ok {
+	if group, ok := mnnvl.ResolveGroupName(annotations); ok {
 		groups[group] = struct{}{}
 	}
-}
-
-// resolveGroupName extracts the MNNVL group from a single annotation set.
-// Returns (group, true) when mnnvl-group is set.
-// Returns ("", true) when auto-mnnvl is enabled without a group (default group).
-// Returns ("", false) when MNNVL is not requested.
-func resolveGroupName(annotations map[string]string) (string, bool) {
-	if group, hasGroup := annotations[mnnvl.AnnotationMNNVLGroup]; hasGroup {
-		return group, true
-	}
-	if mnnvl.IsAutoMNNVLEnabled(annotations) {
-		return "", true
-	}
-	return "", false
 }
 
 // generateComputeDomainName creates the CD name for a replica.

--- a/operator/internal/mnnvl/computedomain/computedomain_test.go
+++ b/operator/internal/mnnvl/computedomain/computedomain_test.go
@@ -233,59 +233,6 @@ func TestGetRequiredCDNames(t *testing.T) {
 	}
 }
 
-func TestResolveGroupName(t *testing.T) {
-	testCases := []struct {
-		description   string
-		annotations   map[string]string
-		expectedGroup string
-		expectedOk    bool
-	}{
-		{
-			description:   "auto-mnnvl enabled only — default group",
-			annotations:   map[string]string{mnnvl.AnnotationAutoMNNVL: mnnvl.AnnotationAutoMNNVLEnabled},
-			expectedGroup: "",
-			expectedOk:    true,
-		},
-		{
-			description:   "mnnvl-group only — named group",
-			annotations:   map[string]string{mnnvl.AnnotationMNNVLGroup: "workers"},
-			expectedGroup: "workers",
-			expectedOk:    true,
-		},
-		{
-			description: "both — group takes precedence",
-			annotations: map[string]string{
-				mnnvl.AnnotationAutoMNNVL:  mnnvl.AnnotationAutoMNNVLEnabled,
-				mnnvl.AnnotationMNNVLGroup: "training",
-			},
-			expectedGroup: "training",
-			expectedOk:    true,
-		},
-		{
-			description: "auto-mnnvl disabled — not enrolled",
-			annotations: map[string]string{mnnvl.AnnotationAutoMNNVL: mnnvl.AnnotationAutoMNNVLDisabled},
-			expectedOk:  false,
-		},
-		{
-			description: "no annotations — not enrolled",
-			annotations: nil,
-			expectedOk:  false,
-		},
-	}
-
-	t.Parallel()
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
-			group, ok := resolveGroupName(tc.annotations)
-			assert.Equal(t, tc.expectedOk, ok)
-			if ok {
-				assert.Equal(t, tc.expectedGroup, group)
-			}
-		})
-	}
-}
-
 func TestTriageCDs(t *testing.T) {
 	testCases := []struct {
 		description      string

--- a/operator/internal/mnnvl/helpers.go
+++ b/operator/internal/mnnvl/helpers.go
@@ -66,6 +66,20 @@ func DetectMNNVLConflict(annotations map[string]string) error {
 	return nil
 }
 
+// ResolveGroupName extracts the MNNVL group from a single annotation set.
+// Returns (group, true) when mnnvl-group is set.
+// Returns ("", true) when auto-mnnvl is enabled without a group (default group).
+// Returns ("", false) when MNNVL is not requested.
+func ResolveGroupName(annotations map[string]string) (string, bool) {
+	if group, hasGroup := annotations[AnnotationMNNVLGroup]; hasGroup {
+		return group, true
+	}
+	if IsAutoMNNVLEnabled(annotations) {
+		return "", true
+	}
+	return "", false
+}
+
 // GenerateRCTName creates the ResourceClaimTemplate name for a PCS replica.
 // Without a group: {pcs-name}-{replica-index} (default CD).
 // With a group: {pcs-name}-{replica-index}-{group-name}.

--- a/operator/internal/mnnvl/helpers.go
+++ b/operator/internal/mnnvl/helpers.go
@@ -80,6 +80,21 @@ func ResolveGroupName(annotations map[string]string) (string, bool) {
 	return "", false
 }
 
+// ResolveGroupNameHierarchically resolves the MNNVL group from multiple
+// annotation layers, ordered from most specific to least specific
+// (e.g., PCLQ → PCSG/PCS). The first layer that requests MNNVL wins —
+// this lets a child layer intentionally override its parent's group,
+// including escaping a named group back to the default group by setting
+// only auto-mnnvl: enabled without mnnvl-group.
+func ResolveGroupNameHierarchically(annotationLayers ...map[string]string) (string, bool) {
+	for _, annotations := range annotationLayers {
+		if group, ok := ResolveGroupName(annotations); ok {
+			return group, true
+		}
+	}
+	return "", false
+}
+
 // GenerateRCTName creates the ResourceClaimTemplate name for a PCS replica.
 // Without a group: {pcs-name}-{replica-index} (default CD).
 // With a group: {pcs-name}-{replica-index}-{group-name}.

--- a/operator/internal/mnnvl/helpers_test.go
+++ b/operator/internal/mnnvl/helpers_test.go
@@ -136,6 +136,73 @@ func TestResolveGroupName(t *testing.T) {
 	}
 }
 
+func TestResolveGroupNameHierarchically(t *testing.T) {
+	tests := []struct {
+		description   string
+		layers        []map[string]string
+		expectedGroup string
+		expectedOk    bool
+	}{
+		{
+			description:   "PCLQ has group — parent ignored",
+			layers:        []map[string]string{{AnnotationMNNVLGroup: "pclq-group"}, {AnnotationMNNVLGroup: "parent-group"}},
+			expectedGroup: "pclq-group",
+			expectedOk:    true,
+		},
+		{
+			description:   "PCLQ has auto-mnnvl enabled — parent group ignored (escape to default)",
+			layers:        []map[string]string{{AnnotationAutoMNNVL: AnnotationAutoMNNVLEnabled}, {AnnotationMNNVLGroup: "parent-group"}},
+			expectedGroup: "",
+			expectedOk:    true,
+		},
+		{
+			description:   "PCLQ has nothing — falls back to parent group",
+			layers:        []map[string]string{{}, {AnnotationMNNVLGroup: "parent-group"}},
+			expectedGroup: "parent-group",
+			expectedOk:    true,
+		},
+		{
+			description:   "PCLQ has nothing — falls back to parent auto-mnnvl",
+			layers:        []map[string]string{nil, {AnnotationAutoMNNVL: AnnotationAutoMNNVLEnabled}},
+			expectedGroup: "",
+			expectedOk:    true,
+		},
+		{
+			description:   "PCLQ has group — nil parent is safe",
+			layers:        []map[string]string{{AnnotationMNNVLGroup: "pclq-group"}, nil},
+			expectedGroup: "pclq-group",
+			expectedOk:    true,
+		},
+		{
+			description: "PCLQ empty — nil parent is safe",
+			layers:      []map[string]string{{}, nil},
+			expectedOk:  false,
+		},
+		{
+			description: "no layers have MNNVL — not enrolled",
+			layers:      []map[string]string{{}, {}},
+			expectedOk:  false,
+		},
+		{
+			description: "no layers at all — not enrolled",
+			layers:      nil,
+			expectedOk:  false,
+		},
+	}
+
+	t.Parallel()
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+			group, ok := ResolveGroupNameHierarchically(tc.layers...)
+			assert.Equal(t, tc.expectedOk, ok)
+			if ok {
+				assert.Equal(t, tc.expectedGroup, group)
+			}
+		})
+	}
+}
+
 func TestGenerateRCTName(t *testing.T) {
 	tests := []struct {
 		description    string

--- a/operator/internal/mnnvl/helpers_test.go
+++ b/operator/internal/mnnvl/helpers_test.go
@@ -83,6 +83,59 @@ func TestIsAutoMNNVLEnabled(t *testing.T) {
 	}
 }
 
+func TestResolveGroupName(t *testing.T) {
+	testCases := []struct {
+		description   string
+		annotations   map[string]string
+		expectedGroup string
+		expectedOk    bool
+	}{
+		{
+			description:   "auto-mnnvl enabled only — default group",
+			annotations:   map[string]string{AnnotationAutoMNNVL: AnnotationAutoMNNVLEnabled},
+			expectedGroup: "",
+			expectedOk:    true,
+		},
+		{
+			description:   "mnnvl-group only — named group",
+			annotations:   map[string]string{AnnotationMNNVLGroup: "workers"},
+			expectedGroup: "workers",
+			expectedOk:    true,
+		},
+		{
+			description: "both — group takes precedence",
+			annotations: map[string]string{
+				AnnotationAutoMNNVL:  AnnotationAutoMNNVLEnabled,
+				AnnotationMNNVLGroup: "training",
+			},
+			expectedGroup: "training",
+			expectedOk:    true,
+		},
+		{
+			description: "auto-mnnvl disabled — not enrolled",
+			annotations: map[string]string{AnnotationAutoMNNVL: AnnotationAutoMNNVLDisabled},
+			expectedOk:  false,
+		},
+		{
+			description: "no annotations — not enrolled",
+			annotations: nil,
+			expectedOk:  false,
+		},
+	}
+
+	t.Parallel()
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+			group, ok := ResolveGroupName(tc.annotations)
+			assert.Equal(t, tc.expectedOk, ok)
+			if ok {
+				assert.Equal(t, tc.expectedGroup, group)
+			}
+		})
+	}
+}
+
 func TestGenerateRCTName(t *testing.T) {
 	tests := []struct {
 		description    string

--- a/operator/internal/mnnvl/injection.go
+++ b/operator/internal/mnnvl/injection.go
@@ -26,13 +26,13 @@ import (
 // InjectMNNVLIntoPodSpec injects MNNVL resourceClaims into the PodSpec if it has GPU requirements.
 // It adds a PodResourceClaim referencing the generated RCT name, and adds claim references to each
 // container that requests GPU resources. The operation is idempotent.
-// Should only be called when MNNVL is enabled (check IsAutoMNNVLEnabled first).
-func InjectMNNVLIntoPodSpec(logger logr.Logger, podSpec *corev1.PodSpec, pcsNameReplica apicommon.ResourceNameReplica) {
+// groupName identifies the MNNVL group; pass "" for the default (ungrouped) CD.
+func InjectMNNVLIntoPodSpec(logger logr.Logger, podSpec *corev1.PodSpec, pcsNameReplica apicommon.ResourceNameReplica, groupName string) {
 	if podSpec == nil {
 		return
 	}
 
-	rctName := GenerateRCTName(pcsNameReplica, "")
+	rctName := GenerateRCTName(pcsNameReplica, groupName)
 
 	// Check if already injected (idempotent)
 	for _, claim := range podSpec.ResourceClaims {

--- a/operator/internal/mnnvl/injection_test.go
+++ b/operator/internal/mnnvl/injection_test.go
@@ -34,6 +34,7 @@ func TestInjectMNNVLIntoPodSpec(t *testing.T) {
 		description                         string
 		podSpec                             *corev1.PodSpec
 		pcsNameReplica                      apicommon.ResourceNameReplica
+		groupName                           string
 		callTwice                           bool     // for idempotency testing
 		expectedContainersWithClaims        []string // container names that should have claims
 		expectedContainersWithoutClaims     []string // container names that should NOT have claims
@@ -64,6 +65,26 @@ func TestInjectMNNVLIntoPodSpec(t *testing.T) {
 			expectedContainersWithClaims:    []string{"gpu-container"},
 			expectedContainersWithoutClaims: []string{},
 			expectedRCTName:                 "my-pcs-0",
+		},
+		{
+			description: "named group — RCT name includes group",
+			podSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "gpu-container",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								constants.GPUResourceName: resource.MustParse("8"),
+							},
+						},
+					},
+				},
+			},
+			pcsNameReplica:                  apicommon.ResourceNameReplica{Name: "my-pcs", Replica: 1},
+			groupName:                       "workers",
+			expectedContainersWithClaims:    []string{"gpu-container"},
+			expectedContainersWithoutClaims: []string{},
+			expectedRCTName:                 "my-pcs-1-workers",
 		},
 		{
 			description: "injects claims into init container with GPU",
@@ -181,12 +202,10 @@ func TestInjectMNNVLIntoPodSpec(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
-			// Call the function
-			InjectMNNVLIntoPodSpec(logr.Discard(), tc.podSpec, tc.pcsNameReplica)
+			InjectMNNVLIntoPodSpec(logr.Discard(), tc.podSpec, tc.pcsNameReplica, tc.groupName)
 
-			// Call twice for idempotency test
 			if tc.callTwice {
-				InjectMNNVLIntoPodSpec(logr.Discard(), tc.podSpec, tc.pcsNameReplica)
+				InjectMNNVLIntoPodSpec(logr.Discard(), tc.podSpec, tc.pcsNameReplica, tc.groupName)
 			}
 
 			// Skip remaining checks for nil PodSpec


### PR DESCRIPTION
## Summary

- When injecting MNNVL into a PodSpec, the controller now uses the correct RCT name for the target MNNVL group
- Controllers resolve the MNNVL group from annotations hierarchically — clique annotations take priority over PCS/PCSG annotations
- Export `ResolveGroupName` from the `mnnvl` package and add `groupName` parameter to `InjectMNNVLIntoPodSpec`

## Key changes

- Move `resolveGroupName` to `mnnvl.ResolveGroupName` (exported)
- Add `groupName` parameter to `InjectMNNVLIntoPodSpec`
- Update PCS and PCSG controllers with hierarchical group resolution
- Add group-aware test cases for both PCS and PCSG injection

## Which issue(s) this PR fixes

Ref #417

## Test plan

- [x] Unit tests for `ResolveGroupName` in `helpers_test.go`
- [x] Unit tests for `InjectMNNVLIntoPodSpec` with named groups in `injection_test.go`
- [x] PCS controller `TestBuildResource_MNNVLInjection` — group on PCS, clique override, clique-only
- [x] PCSG controller `TestBuildResource_MNNVLInjection` — group on PCSG, clique override, clique-only
- [x] `make check` passes (no dirty tree)


Made with [Cursor](https://cursor.com)