### PR TITLE
fix: avoid Docker Hub rate limits using GHCR registry image

### DIFF
--- a/.github/workflows/build-check-test.yaml
+++ b/.github/workflows/build-check-test.yaml
@@ -52,6 +52,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
@@ -64,6 +69,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
@@ -78,6 +88,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
@@ -139,6 +154,12 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: E2E Setup
         uses: ./.github/actions/e2e-setup

--- a/.github/workflows/build-check-test.yaml
+++ b/.github/workflows/build-check-test.yaml
@@ -55,8 +55,8 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
@@ -72,8 +72,8 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
@@ -91,8 +91,8 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
@@ -158,8 +158,8 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: E2E Setup
         uses: ./.github/actions/e2e-setup

--- a/.github/workflows/build-check-test.yaml
+++ b/.github/workflows/build-check-test.yaml
@@ -52,11 +52,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
-          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
@@ -69,11 +64,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
-          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
@@ -88,11 +78,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
-          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
@@ -155,11 +140,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
-          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+      - name: Pull registry image from GHCR to avoid Docker Hub rate limits
+        run: |
+          docker pull ghcr.io/distribution/distribution:3.1.0
+          docker tag ghcr.io/distribution/distribution:3.1.0 registry:2
 
       - name: E2E Setup
         uses: ./.github/actions/e2e-setup

--- a/.github/workflows/push-artifacts.yaml
+++ b/.github/workflows/push-artifacts.yaml
@@ -60,8 +60,8 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/push-artifacts.yaml
+++ b/.github/workflows/push-artifacts.yaml
@@ -57,12 +57,6 @@ jobs:
         with:
           go-version: '1.26.1'
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
-          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/push-artifacts.yaml
+++ b/.github/workflows/push-artifacts.yaml
@@ -57,6 +57,12 @@ jobs:
         with:
           go-version: '1.26.1'
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Problem

E2E CI was failing intermittently with:

```
docker failed to pull image 'docker.io/library/registry:2': You have reached your unauthenticated pull rate limit.
```

When k3d creates its local registry container it pulls `registry:2` from Docker Hub. The self-hosted runner hits the 100 pulls/6hr unauthenticated limit.

## Solution

Pre-pull the equivalent image from GHCR before k3d runs and tag it as `registry:2`:

```yaml
- name: Pull registry image from GHCR to avoid Docker Hub rate limits
  run: |
    docker pull ghcr.io/distribution/distribution:3.1.0
    docker tag ghcr.io/distribution/distribution:3.1.0 registry:2
```

`ghcr.io/distribution/distribution` is published by the same upstream project ([distribution/distribution](https://github.com/distribution/distribution/pkgs/container/distribution)) and has no pull rate limits. When k3d runs, Docker finds `registry:2` already cached locally and skips the Docker Hub pull entirely.

No secrets or credentials required.

## Changes

- **e2e job**: pre-pull `ghcr.io/distribution/distribution:3.1.0` and tag as `registry:2` before k3d runs

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)