### PR TITLE
Fix gang termination when scheduled replicas regress below MinAvailable

### DIFF
--- a/operator/api/common/constants/constants.go
+++ b/operator/api/common/constants/constants.go
@@ -135,6 +135,12 @@ const (
 	ConditionReasonSufficientScheduledPods = "SufficientScheduledPods"
 	// ConditionReasonInsufficientScheduledPCSGReplicas indicates that the number of scheduled replicas in the PodCliqueScalingGroup is below the PodCliqueScalingGroupSpec.MinAvailable.
 	ConditionReasonInsufficientScheduledPCSGReplicas = "InsufficientScheduledPodCliqueScalingGroupReplicas"
+	// ConditionReasonScheduledReplicasRegressed indicates that the number of scheduled replicas dropped
+	// below MinAvailable after previously meeting it (e.g. a node was cordoned or failed and the
+	// replacement pods could not be scheduled). Under gang scheduling, a partial scheduled state
+	// (0 < scheduled < MinAvailable) is structurally unreachable from initial startup and so is treated
+	// as a regression and a MinAvailableBreach.
+	ConditionReasonScheduledReplicasRegressed = "ScheduledReplicasRegressed"
 	// ConditionReasonInsufficientAvailablePCSGReplicas indicates that the number of ready replicas in the PodCliqueScalingGroup is below the PodCliqueScalingGroupSpec.MinAvailable.
 	ConditionReasonInsufficientAvailablePCSGReplicas = "InsufficientAvailablePodCliqueScalingGroupReplicas"
 	// ConditionReasonSufficientAvailablePCSGReplicas indicates that the number of ready replicas in the PodCliqueScalingGroup is greater than or equal to the PodCliqueScalingGroupSpec.MinAvailable.

--- a/operator/api/common/constants/constants.go
+++ b/operator/api/common/constants/constants.go
@@ -135,12 +135,8 @@ const (
 	ConditionReasonSufficientScheduledPods = "SufficientScheduledPods"
 	// ConditionReasonInsufficientScheduledPCSGReplicas indicates that the number of scheduled replicas in the PodCliqueScalingGroup is below the PodCliqueScalingGroupSpec.MinAvailable.
 	ConditionReasonInsufficientScheduledPCSGReplicas = "InsufficientScheduledPodCliqueScalingGroupReplicas"
-	// ConditionReasonScheduledReplicasRegressed indicates that the number of scheduled replicas dropped
-	// below MinAvailable after previously meeting it (e.g. a node was cordoned or failed and the
-	// replacement pods could not be scheduled). Under gang scheduling, a partial scheduled state
-	// (0 < scheduled < MinAvailable) is structurally unreachable from initial startup and so is treated
-	// as a regression and a MinAvailableBreach.
-	ConditionReasonScheduledReplicasRegressed = "ScheduledReplicasRegressed"
+	// ConditionReasonScheduledReplicasBelowMinAvailable indicates that scheduledReplicas is below MinAvailable but greater than zero.
+	ConditionReasonScheduledReplicasBelowMinAvailable = "ScheduledReplicasBelowMinAvailable"
 	// ConditionReasonInsufficientAvailablePCSGReplicas indicates that the number of ready replicas in the PodCliqueScalingGroup is below the PodCliqueScalingGroupSpec.MinAvailable.
 	ConditionReasonInsufficientAvailablePCSGReplicas = "InsufficientAvailablePodCliqueScalingGroupReplicas"
 	// ConditionReasonSufficientAvailablePCSGReplicas indicates that the number of ready replicas in the PodCliqueScalingGroup is greater than or equal to the PodCliqueScalingGroupSpec.MinAvailable.

--- a/operator/internal/constants/constants.go
+++ b/operator/internal/constants/constants.go
@@ -59,6 +59,9 @@ const (
 	ReasonPodCliqueDeleteSuccessful = "PodCliqueDeleteSuccessful"
 	// ReasonPodCliqueDeleteFailed is an event reason which represents that the deletion of a PodClique failed.
 	ReasonPodCliqueDeleteFailed = "PodCliqueDeleteFailed"
+	// ReasonAllScheduledReplicasLost is an event reason emitted when scheduled replicas drop from non-zero to zero.
+	// Gang termination is suppressed in this state to avoid a churn loop, so the event is the only signal that the workload is fully down.
+	ReasonAllScheduledReplicasLost = "AllScheduledReplicasLost"
 )
 
 // constants for PodCliqueScalingGroup lifecycle events

--- a/operator/internal/controller/podclique/reconcilestatus.go
+++ b/operator/internal/controller/podclique/reconcilestatus.go
@@ -78,14 +78,7 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 		mutateMinAvailableBreachedCondition(pclq,
 			len(podCategories[k8sutils.PodHasAtleastOneContainerWithNonZeroExitCode]),
 			len(podCategories[k8sutils.PodStartedButNotReady]))
-		// Emit a Warning when scheduledReplicas drops from non-zero to zero. Gang termination is
-		// suppressed in this state to avoid a churn loop, so this event is the only signal that a
-		// previously-running workload is fully down.
-		if originalStatus.ScheduledReplicas > 0 && pclq.Status.ScheduledReplicas == 0 {
-			r.eventRecorder.Eventf(pclq, corev1.EventTypeWarning, internalconstants.ReasonAllScheduledReplicasLost,
-				"All scheduled pods lost (was %d). Gang termination is suppressed to avoid recreating Pending pods against the same cluster state; investigate node availability or capacity.",
-				originalStatus.ScheduledReplicas)
-		}
+		r.emitAllScheduledReplicasLostIfNeeded(pclq, originalStatus.ScheduledReplicas)
 	}
 
 	// mutate the selector that will be used by an autoscaler.
@@ -189,6 +182,18 @@ func mutateSelector(pcsName string, pclq *grovecorev1alpha1.PodClique) error {
 	}
 	pclq.Status.Selector = ptr.To(selector.String())
 	return nil
+}
+
+// emitAllScheduledReplicasLostIfNeeded emits a Warning event when ScheduledReplicas drops from
+// non-zero to zero. Gang termination is suppressed in this state (recreating the PodGang would
+// just produce the same Pending pods) so this event is the only explicit signal that a
+// previously-running workload is now fully down.
+func (r *Reconciler) emitAllScheduledReplicasLostIfNeeded(pclq *grovecorev1alpha1.PodClique, originalScheduled int32) {
+	if originalScheduled > 0 && pclq.Status.ScheduledReplicas == 0 {
+		r.eventRecorder.Eventf(pclq, corev1.EventTypeWarning, internalconstants.ReasonAllScheduledReplicasLost,
+			"All scheduled pods lost (was %d). Gang termination is suppressed to avoid recreating Pending pods against the same cluster state; investigate node availability or capacity.",
+			originalScheduled)
+	}
 }
 
 // mutateMinAvailableBreachedCondition updates the MinAvailableBreached condition based on pod availability

--- a/operator/internal/controller/podclique/reconcilestatus.go
+++ b/operator/internal/controller/podclique/reconcilestatus.go
@@ -206,14 +206,36 @@ func computeMinAvailableBreachedCondition(pclq *grovecorev1alpha1.PodClique, num
 	scheduledReplicas := int(pclq.Status.ScheduledReplicas)
 	now := metav1.Now()
 
-	// If the number of scheduled pods is less than the minimum available, then minAvailable is not considered as breached.
-	// Consider a case where none of the PodCliques have been scheduled yet, then it should not cause the PodGang to be recreated all the time.
+	// Handle the under-scheduled cases:
+	//   - scheduledReplicas == 0: either initial startup (no pods admitted yet) or a full
+	//     regression where every running pod has been lost. In both cases, gang termination
+	//     would only recreate the same Pending pods against the same cluster state and would
+	//     produce a churn loop, so we suppress the breach. If the cluster state actually
+	//     changes the next reconcile picks it up.
+	//   - 0 < scheduledReplicas < minAvailable: under gang scheduling this state is
+	//     structurally unreachable from initial startup — the gang scheduler admits
+	//     MinAvailable pods atomically. So observing it implies pods were healthy and
+	//     have since regressed (e.g. node cordon/failure with replacements pending).
+	//     Treat as a breach. The downstream gang-termination flow still waits the full
+	//     TerminationDelay before acting, and the pod-creation path is unaffected, so
+	//     the controller keeps trying to schedule replacements throughout the wait.
+	//     On non-gang schedulers a brief partial-scheduled flicker can occur during
+	//     staged startup; TerminationDelay (default 4h) absorbs it.
 	if scheduledReplicas < minAvailable {
+		if scheduledReplicas == 0 {
+			return metav1.Condition{
+				Type:               constants.ConditionTypeMinAvailableBreached,
+				Status:             metav1.ConditionFalse,
+				Reason:             constants.ConditionReasonInsufficientScheduledPods,
+				Message:            fmt.Sprintf("Insufficient scheduled pods. expected at least: %d, found: %d", minAvailable, scheduledReplicas),
+				LastTransitionTime: now,
+			}
+		}
 		return metav1.Condition{
 			Type:               constants.ConditionTypeMinAvailableBreached,
-			Status:             metav1.ConditionFalse,
-			Reason:             constants.ConditionReasonInsufficientScheduledPods,
-			Message:            fmt.Sprintf("Insufficient scheduled pods. expected at least: %d, found: %d", minAvailable, scheduledReplicas),
+			Status:             metav1.ConditionTrue,
+			Reason:             constants.ConditionReasonScheduledReplicasRegressed,
+			Message:            fmt.Sprintf("Scheduled replicas regressed below MinAvailable. expected at least: %d, found: %d", minAvailable, scheduledReplicas),
 			LastTransitionTime: now,
 		}
 	}

--- a/operator/internal/controller/podclique/reconcilestatus.go
+++ b/operator/internal/controller/podclique/reconcilestatus.go
@@ -23,6 +23,7 @@ import (
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	"github.com/ai-dynamo/grove/operator/api/common/constants"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	internalconstants "github.com/ai-dynamo/grove/operator/internal/constants"
 	ctrlcommon "github.com/ai-dynamo/grove/operator/internal/controller/common"
 	componentutils "github.com/ai-dynamo/grove/operator/internal/controller/common/component/utils"
 	k8sutils "github.com/ai-dynamo/grove/operator/internal/utils/kubernetes"
@@ -77,6 +78,14 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 		mutateMinAvailableBreachedCondition(pclq,
 			len(podCategories[k8sutils.PodHasAtleastOneContainerWithNonZeroExitCode]),
 			len(podCategories[k8sutils.PodStartedButNotReady]))
+		// Emit a Warning when scheduledReplicas drops from non-zero to zero. Gang termination is
+		// suppressed in this state to avoid a churn loop, so this event is the only signal that a
+		// previously-running workload is fully down.
+		if originalStatus.ScheduledReplicas > 0 && pclq.Status.ScheduledReplicas == 0 {
+			r.eventRecorder.Eventf(pclq, corev1.EventTypeWarning, internalconstants.ReasonAllScheduledReplicasLost,
+				"All scheduled pods lost (was %d). Gang termination is suppressed to avoid recreating Pending pods against the same cluster state; investigate node availability or capacity.",
+				originalStatus.ScheduledReplicas)
+		}
 	}
 
 	// mutate the selector that will be used by an autoscaler.
@@ -206,36 +215,27 @@ func computeMinAvailableBreachedCondition(pclq *grovecorev1alpha1.PodClique, num
 	scheduledReplicas := int(pclq.Status.ScheduledReplicas)
 	now := metav1.Now()
 
-	// Handle the under-scheduled cases:
-	//   - scheduledReplicas == 0: either initial startup (no pods admitted yet) or a full
-	//     regression where every running pod has been lost. In both cases, gang termination
-	//     would only recreate the same Pending pods against the same cluster state and would
-	//     produce a churn loop, so we suppress the breach. If the cluster state actually
-	//     changes the next reconcile picks it up.
-	//   - 0 < scheduledReplicas < minAvailable: under gang scheduling this state is
-	//     structurally unreachable from initial startup — the gang scheduler admits
-	//     MinAvailable pods atomically. So observing it implies pods were healthy and
-	//     have since regressed (e.g. node cordon/failure with replacements pending).
-	//     Treat as a breach. The downstream gang-termination flow still waits the full
-	//     TerminationDelay before acting, and the pod-creation path is unaffected, so
-	//     the controller keeps trying to schedule replacements throughout the wait.
-	//     On non-gang schedulers a brief partial-scheduled flicker can occur during
-	//     staged startup; TerminationDelay (default 4h) absorbs it.
+	// scheduledReplicas == 0: either initial startup or every running pod has been lost.
+	// Recreating the PodGang would just produce the same Pending pods, so suppress to avoid
+	// a churn loop.
+	// 0 < scheduledReplicas < MinAvailable: with a gang scheduler this implies regression
+	// after a healthy state and breaches. On non-gang schedulers it can flicker briefly
+	// during staged startup; TerminationDelay (default 4h) absorbs the flicker.
 	if scheduledReplicas < minAvailable {
 		if scheduledReplicas == 0 {
 			return metav1.Condition{
 				Type:               constants.ConditionTypeMinAvailableBreached,
 				Status:             metav1.ConditionFalse,
 				Reason:             constants.ConditionReasonInsufficientScheduledPods,
-				Message:            fmt.Sprintf("Insufficient scheduled pods. expected at least: %d, found: %d", minAvailable, scheduledReplicas),
+				Message:            fmt.Sprintf("Scheduled replicas (%d) below MinAvailable (%d)", scheduledReplicas, minAvailable),
 				LastTransitionTime: now,
 			}
 		}
 		return metav1.Condition{
 			Type:               constants.ConditionTypeMinAvailableBreached,
 			Status:             metav1.ConditionTrue,
-			Reason:             constants.ConditionReasonScheduledReplicasRegressed,
-			Message:            fmt.Sprintf("Scheduled replicas regressed below MinAvailable. expected at least: %d, found: %d", minAvailable, scheduledReplicas),
+			Reason:             constants.ConditionReasonScheduledReplicasBelowMinAvailable,
+			Message:            fmt.Sprintf("Scheduled replicas (%d) below MinAvailable (%d)", scheduledReplicas, minAvailable),
 			LastTransitionTime: now,
 		}
 	}

--- a/operator/internal/controller/podclique/reconcilestatus.go
+++ b/operator/internal/controller/podclique/reconcilestatus.go
@@ -227,7 +227,7 @@ func computeMinAvailableBreachedCondition(pclq *grovecorev1alpha1.PodClique, num
 				Type:               constants.ConditionTypeMinAvailableBreached,
 				Status:             metav1.ConditionFalse,
 				Reason:             constants.ConditionReasonInsufficientScheduledPods,
-				Message:            fmt.Sprintf("Scheduled replicas (%d) below MinAvailable (%d)", scheduledReplicas, minAvailable),
+				Message:            fmt.Sprintf("Scheduled replicas 0 (MinAvailable %d); gang termination suppressed to avoid recreating Pending pods against the same cluster state", minAvailable),
 				LastTransitionTime: now,
 			}
 		}

--- a/operator/internal/controller/podclique/reconcilestatus_test.go
+++ b/operator/internal/controller/podclique/reconcilestatus_test.go
@@ -197,15 +197,10 @@ func createPodWithHash(name string, templateHash string) *corev1.Pod {
 
 // TestComputeMinAvailableBreachedConditionPartialScheduleRegression covers the
 // behaviour where MinAvailableBreached must flip True when scheduled replicas
-// regress below MinAvailable from a previously healthy state.
-//
-// Under gang scheduling, 0 < scheduledReplicas < minAvailable is structurally
-// unreachable from a fresh start (the gang scheduler admits MinAvailable atomically),
-// so observing it implies regression — for example a node hosting running pods is
-// cordoned or fails and the replacement pods cannot be scheduled. Breaching in
-// that case lets gang termination recreate the PodGang. scheduledReplicas == 0
-// stays suppressed: gang termination would only recreate the same Pending pods
-// against the same cluster state.
+// drop below MinAvailable but stay above zero. With a gang scheduler this can
+// only happen by regression after a healthy state. scheduledReplicas == 0 stays
+// suppressed regardless of history: recreating the PodGang would just produce
+// the same Pending pods against the same cluster state (churn loop).
 func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testing.T) {
 	pastTransition := metav1.NewTime(time.Now().Add(-10 * time.Minute))
 
@@ -215,9 +210,10 @@ func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testin
 		numPodsHavingAtleastOneContainerWithNonZeroExitCode int
 		numPodsStartedButNotReady                           int
 		wantStatus                                          metav1.ConditionStatus
+		wantReason                                          string
 	}{
 		{
-			name: "healthy then node cordoned: scheduled replicas drop below minAvailable",
+			name: "0 < scheduled < MinAvailable breaches",
 			pclq: &grovecorev1alpha1.PodClique{
 				Spec: grovecorev1alpha1.PodCliqueSpec{
 					Replicas:     3,
@@ -230,7 +226,6 @@ func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testin
 					ReadyReplicas:      1,
 					Conditions: []metav1.Condition{
 						{
-							// PCLQ was healthy before the regression.
 							Type:               constants.ConditionTypePodCliqueScheduled,
 							Status:             metav1.ConditionTrue,
 							Reason:             constants.ConditionReasonSufficientScheduledPods,
@@ -246,12 +241,13 @@ func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testin
 				},
 			},
 			wantStatus: metav1.ConditionTrue,
+			wantReason: constants.ConditionReasonScheduledReplicasBelowMinAvailable,
 		},
 		{
-			// Even after a full regression to zero scheduled, gang termination has
-			// no useful action — recreating the PodGang would just produce the same
-			// Pending pods. The fix should keep this case suppressed to avoid a
-			// churn loop. (Captured as a sanity-pin so a fix doesn't over-correct.)
+			// Sanity-pin: scheduled == 0 must NOT breach even when the PCLQ was
+			// previously healthy. Gang termination has no useful action here
+			// (would re-create the same Pending pods) and the suppression has
+			// to win to avoid a churn loop.
 			name: "previously-healthy PCLQ loses all scheduled pods — must NOT breach",
 			pclq: &grovecorev1alpha1.PodClique{
 				Spec: grovecorev1alpha1.PodCliqueSpec{
@@ -274,10 +270,11 @@ func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testin
 				},
 			},
 			wantStatus: metav1.ConditionFalse,
+			wantReason: constants.ConditionReasonInsufficientScheduledPods,
 		},
 		{
-			// Sanity case that the fix must preserve: a freshly-created PCLQ that has
-			// not yet scheduled any pods MUST NOT be considered breached.
+			// Sanity case that the fix must preserve: a freshly-created PCLQ
+			// that has not yet scheduled any pods MUST NOT be considered breached.
 			name: "fresh PCLQ never scheduled — must not breach",
 			pclq: &grovecorev1alpha1.PodClique{
 				Spec: grovecorev1alpha1.PodCliqueSpec{
@@ -289,10 +286,10 @@ func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testin
 					Replicas:           3,
 					ScheduledReplicas:  0,
 					ReadyReplicas:      0,
-					// No prior PodCliqueScheduled=True history.
 				},
 			},
 			wantStatus: metav1.ConditionFalse,
+			wantReason: constants.ConditionReasonInsufficientScheduledPods,
 		},
 	}
 
@@ -302,8 +299,8 @@ func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testin
 				tt.numPodsHavingAtleastOneContainerWithNonZeroExitCode,
 				tt.numPodsStartedButNotReady)
 			assert.Equal(t, constants.ConditionTypeMinAvailableBreached, condition.Type)
-			assert.Equal(t, tt.wantStatus, condition.Status,
-				"MinAvailableBreached status should match expected post-fix behaviour")
+			assert.Equal(t, tt.wantStatus, condition.Status, "MinAvailableBreached status mismatch")
+			assert.Equal(t, tt.wantReason, condition.Reason, "MinAvailableBreached reason mismatch")
 		})
 	}
 }

--- a/operator/internal/controller/podclique/reconcilestatus_test.go
+++ b/operator/internal/controller/podclique/reconcilestatus_test.go
@@ -195,29 +195,26 @@ func createPodWithHash(name string, templateHash string) *corev1.Pod {
 	}
 }
 
-// TestComputeMinAvailableBreachedCondition_Issue277 covers the gang-termination
-// regression fix from https://github.com/ai-dynamo/grove/issues/277.
-//
-// Before the fix, the early-return at scheduledReplicas < minAvailable suppressed
-// the breach in two distinct situations: (a) genuine initial startup where no pods
-// had been admitted yet, and (b) regression after a healthy state where a node was
-// cordoned/failed and the replacement pods couldn't be scheduled. Suppressing (b)
-// meant gang termination never fired and the workload was stuck.
+// TestComputeMinAvailableBreachedConditionPartialScheduleRegression covers the
+// behaviour where MinAvailableBreached must flip True when scheduled replicas
+// regress below MinAvailable from a previously healthy state.
 //
 // Under gang scheduling, 0 < scheduledReplicas < minAvailable is structurally
 // unreachable from a fresh start (the gang scheduler admits MinAvailable atomically),
-// so observing it implies regression. The fix breaches in that case while still
-// suppressing scheduledReplicas == 0 (no useful work for gang termination — recreating
-// the PodGang would just produce the same Pending pods).
-func TestComputeMinAvailableBreachedCondition_Issue277(t *testing.T) {
+// so observing it implies regression — for example a node hosting running pods is
+// cordoned or fails and the replacement pods cannot be scheduled. Breaching in
+// that case lets gang termination recreate the PodGang. scheduledReplicas == 0
+// stays suppressed: gang termination would only recreate the same Pending pods
+// against the same cluster state.
+func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testing.T) {
 	pastTransition := metav1.NewTime(time.Now().Add(-10 * time.Minute))
 
 	tests := []struct {
-		name                                                 string
-		pclq                                                 *grovecorev1alpha1.PodClique
-		numPodsHavingAtleastOneContainerWithNonZeroExitCode  int
-		numPodsStartedButNotReady                            int
-		wantStatus                                           metav1.ConditionStatus
+		name                                                string
+		pclq                                                *grovecorev1alpha1.PodClique
+		numPodsHavingAtleastOneContainerWithNonZeroExitCode int
+		numPodsStartedButNotReady                           int
+		wantStatus                                          metav1.ConditionStatus
 	}{
 		{
 			name: "healthy then node cordoned: scheduled replicas drop below minAvailable",

--- a/operator/internal/controller/podclique/reconcilestatus_test.go
+++ b/operator/internal/controller/podclique/reconcilestatus_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
+	"github.com/ai-dynamo/grove/operator/api/common/constants"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 
 	"github.com/stretchr/testify/assert"
@@ -193,3 +194,120 @@ func createPodWithHash(name string, templateHash string) *corev1.Pod {
 		},
 	}
 }
+
+// TestComputeMinAvailableBreachedCondition_Issue277 covers the gang-termination
+// regression fix from https://github.com/ai-dynamo/grove/issues/277.
+//
+// Before the fix, the early-return at scheduledReplicas < minAvailable suppressed
+// the breach in two distinct situations: (a) genuine initial startup where no pods
+// had been admitted yet, and (b) regression after a healthy state where a node was
+// cordoned/failed and the replacement pods couldn't be scheduled. Suppressing (b)
+// meant gang termination never fired and the workload was stuck.
+//
+// Under gang scheduling, 0 < scheduledReplicas < minAvailable is structurally
+// unreachable from a fresh start (the gang scheduler admits MinAvailable atomically),
+// so observing it implies regression. The fix breaches in that case while still
+// suppressing scheduledReplicas == 0 (no useful work for gang termination — recreating
+// the PodGang would just produce the same Pending pods).
+func TestComputeMinAvailableBreachedCondition_Issue277(t *testing.T) {
+	pastTransition := metav1.NewTime(time.Now().Add(-10 * time.Minute))
+
+	tests := []struct {
+		name                                                 string
+		pclq                                                 *grovecorev1alpha1.PodClique
+		numPodsHavingAtleastOneContainerWithNonZeroExitCode  int
+		numPodsStartedButNotReady                            int
+		wantStatus                                           metav1.ConditionStatus
+	}{
+		{
+			name: "healthy then node cordoned: scheduled replicas drop below minAvailable",
+			pclq: &grovecorev1alpha1.PodClique{
+				Spec: grovecorev1alpha1.PodCliqueSpec{
+					Replicas:     3,
+					MinAvailable: ptr.To(int32(3)),
+				},
+				Status: grovecorev1alpha1.PodCliqueStatus{
+					ObservedGeneration: ptr.To(int64(1)),
+					Replicas:           3,
+					ScheduledReplicas:  1,
+					ReadyReplicas:      1,
+					Conditions: []metav1.Condition{
+						{
+							// PCLQ was healthy before the regression.
+							Type:               constants.ConditionTypePodCliqueScheduled,
+							Status:             metav1.ConditionTrue,
+							Reason:             constants.ConditionReasonSufficientScheduledPods,
+							LastTransitionTime: pastTransition,
+						},
+						{
+							Type:               constants.ConditionTypeMinAvailableBreached,
+							Status:             metav1.ConditionFalse,
+							Reason:             constants.ConditionReasonSufficientReadyPods,
+							LastTransitionTime: pastTransition,
+						},
+					},
+				},
+			},
+			wantStatus: metav1.ConditionTrue,
+		},
+		{
+			// Even after a full regression to zero scheduled, gang termination has
+			// no useful action — recreating the PodGang would just produce the same
+			// Pending pods. The fix should keep this case suppressed to avoid a
+			// churn loop. (Captured as a sanity-pin so a fix doesn't over-correct.)
+			name: "previously-healthy PCLQ loses all scheduled pods — must NOT breach",
+			pclq: &grovecorev1alpha1.PodClique{
+				Spec: grovecorev1alpha1.PodCliqueSpec{
+					Replicas:     2,
+					MinAvailable: ptr.To(int32(2)),
+				},
+				Status: grovecorev1alpha1.PodCliqueStatus{
+					ObservedGeneration: ptr.To(int64(1)),
+					Replicas:           2,
+					ScheduledReplicas:  0,
+					ReadyReplicas:      0,
+					Conditions: []metav1.Condition{
+						{
+							Type:               constants.ConditionTypePodCliqueScheduled,
+							Status:             metav1.ConditionTrue,
+							Reason:             constants.ConditionReasonSufficientScheduledPods,
+							LastTransitionTime: pastTransition,
+						},
+					},
+				},
+			},
+			wantStatus: metav1.ConditionFalse,
+		},
+		{
+			// Sanity case that the fix must preserve: a freshly-created PCLQ that has
+			// not yet scheduled any pods MUST NOT be considered breached.
+			name: "fresh PCLQ never scheduled — must not breach",
+			pclq: &grovecorev1alpha1.PodClique{
+				Spec: grovecorev1alpha1.PodCliqueSpec{
+					Replicas:     3,
+					MinAvailable: ptr.To(int32(3)),
+				},
+				Status: grovecorev1alpha1.PodCliqueStatus{
+					ObservedGeneration: ptr.To(int64(1)),
+					Replicas:           3,
+					ScheduledReplicas:  0,
+					ReadyReplicas:      0,
+					// No prior PodCliqueScheduled=True history.
+				},
+			},
+			wantStatus: metav1.ConditionFalse,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			condition := computeMinAvailableBreachedCondition(tt.pclq,
+				tt.numPodsHavingAtleastOneContainerWithNonZeroExitCode,
+				tt.numPodsStartedButNotReady)
+			assert.Equal(t, constants.ConditionTypeMinAvailableBreached, condition.Type)
+			assert.Equal(t, tt.wantStatus, condition.Status,
+				"MinAvailableBreached status should match expected post-fix behaviour")
+		})
+	}
+}
+

--- a/operator/internal/controller/podclique/reconcilestatus_test.go
+++ b/operator/internal/controller/podclique/reconcilestatus_test.go
@@ -23,10 +23,12 @@ import (
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	"github.com/ai-dynamo/grove/operator/api/common/constants"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	internalconstants "github.com/ai-dynamo/grove/operator/internal/constants"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 )
 
@@ -195,6 +197,50 @@ func createPodWithHash(name string, templateHash string) *corev1.Pod {
 	}
 }
 
+// TestEmitAllScheduledReplicasLostIfNeeded covers the only explicit signal users have when a
+// previously-running PodClique loses every scheduled pod. Gang termination is suppressed in
+// that state, so this event must fire on the non-zero → zero transition (and only on that
+// transition) for the regression to remain observable.
+func TestEmitAllScheduledReplicasLostIfNeeded(t *testing.T) {
+	tests := []struct {
+		name              string
+		originalScheduled int32
+		nowScheduled      int32
+		wantEvent         bool
+	}{
+		{name: "non-zero to zero emits event", originalScheduled: 3, nowScheduled: 0, wantEvent: true},
+		{name: "zero to zero stays silent (initial startup)", originalScheduled: 0, nowScheduled: 0, wantEvent: false},
+		{name: "non-zero to non-zero stays silent (partial regression handled by breach)", originalScheduled: 3, nowScheduled: 2, wantEvent: false},
+		{name: "zero to non-zero stays silent (recovery)", originalScheduled: 0, nowScheduled: 3, wantEvent: false},
+		{name: "stable non-zero stays silent (steady state)", originalScheduled: 3, nowScheduled: 3, wantEvent: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := record.NewFakeRecorder(2)
+			r := &Reconciler{eventRecorder: recorder}
+			pclq := &grovecorev1alpha1.PodClique{
+				Status: grovecorev1alpha1.PodCliqueStatus{ScheduledReplicas: tt.nowScheduled},
+			}
+
+			r.emitAllScheduledReplicasLostIfNeeded(pclq, tt.originalScheduled)
+
+			select {
+			case ev := <-recorder.Events:
+				if !tt.wantEvent {
+					t.Fatalf("unexpected event: %s", ev)
+				}
+				assert.Contains(t, ev, "Warning", "event type should be Warning")
+				assert.Contains(t, ev, internalconstants.ReasonAllScheduledReplicasLost, "event reason mismatch")
+			default:
+				if tt.wantEvent {
+					t.Fatal("expected an event, got none")
+				}
+			}
+		})
+	}
+}
+
 // TestComputeMinAvailableBreachedConditionPartialScheduleRegression covers the
 // behaviour where MinAvailableBreached must flip True when scheduled replicas
 // drop below MinAvailable but stay above zero. With a gang scheduler this can
@@ -304,4 +350,3 @@ func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testin
 		})
 	}
 }
-

--- a/operator/internal/controller/podcliquescalinggroup/reconciler.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconciler.go
@@ -28,6 +28,7 @@ import (
 	pcsgcomponent "github.com/ai-dynamo/grove/operator/internal/controller/podcliquescalinggroup/components"
 	ctrlutils "github.com/ai-dynamo/grove/operator/internal/controller/utils"
 
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -38,6 +39,7 @@ import (
 type Reconciler struct {
 	config                  groveconfigv1alpha1.PodCliqueScalingGroupControllerConfiguration
 	client                  ctrlclient.Client
+	eventRecorder           record.EventRecorder
 	reconcileStatusRecorder ctrlcommon.ReconcileErrorRecorder
 	operatorRegistry        component.OperatorRegistry[grovecorev1alpha1.PodCliqueScalingGroup]
 }
@@ -49,6 +51,7 @@ func NewReconciler(mgr ctrl.Manager, controllerCfg groveconfigv1alpha1.PodClique
 	return &Reconciler{
 		config:                  controllerCfg,
 		client:                  client,
+		eventRecorder:           eventRecorder,
 		reconcileStatusRecorder: ctrlcommon.NewReconcileErrorRecorder(client),
 		operatorRegistry:        pcsgcomponent.CreateOperatorRegistry(mgr, eventRecorder),
 	}

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
@@ -239,7 +239,7 @@ func computeMinAvailableBreachedCondition(logger logr.Logger, pcsg *grovecorev1a
 				Type:    constants.ConditionTypeMinAvailableBreached,
 				Status:  metav1.ConditionFalse,
 				Reason:  constants.ConditionReasonInsufficientScheduledPCSGReplicas,
-				Message: fmt.Sprintf("Scheduled replicas (%d) below MinAvailable (%d)", scheduledReplicas, minAvailable),
+				Message: fmt.Sprintf("Scheduled replicas 0 (MinAvailable %d); gang termination suppressed to avoid recreating Pending pods against the same cluster state", minAvailable),
 			}
 		}
 		return metav1.Condition{

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
@@ -76,15 +76,7 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 	pclqsPerPCSGReplica = pruneStrayPCSGPCLQs(pcsg, pclqsPerPCSGReplica)
 	mutateReplicas(logger, pcs.Status.CurrentGenerationHash, pcsg, pclqsPerPCSGReplica)
 	mutateMinAvailableBreachedCondition(logger, pcsg, pclqsPerPCSGReplica)
-
-	// Emit a Warning when scheduledReplicas drops from non-zero to zero. Gang termination is
-	// suppressed in this state to avoid a churn loop, so this event is the only signal that a
-	// previously-running workload is fully down.
-	if originalStatus.ScheduledReplicas > 0 && pcsg.Status.ScheduledReplicas == 0 {
-		r.eventRecorder.Eventf(pcsg, corev1.EventTypeWarning, internalconstants.ReasonAllScheduledReplicasLost,
-			"All scheduled replicas lost (was %d). Gang termination is suppressed to avoid recreating Pending pods against the same cluster state; investigate node availability or capacity.",
-			originalStatus.ScheduledReplicas)
-	}
+	r.emitAllScheduledReplicasLostIfNeeded(pcsg, originalStatus.ScheduledReplicas)
 
 	if err = mutateSelector(pcs, pcsg); err != nil {
 		logger.Error(err, "failed to update selector for PodCliqueScalingGroup")
@@ -197,6 +189,18 @@ func computeReplicaStatus(logger logr.Logger, currentPCSGenerationHash *string, 
 			})
 	}
 	return
+}
+
+// emitAllScheduledReplicasLostIfNeeded emits a Warning event when ScheduledReplicas drops from
+// non-zero to zero. Gang termination is suppressed in this state (recreating the PodGang would
+// just produce the same Pending pods) so this event is the only explicit signal that a
+// previously-running workload is now fully down.
+func (r *Reconciler) emitAllScheduledReplicasLostIfNeeded(pcsg *grovecorev1alpha1.PodCliqueScalingGroup, originalScheduled int32) {
+	if originalScheduled > 0 && pcsg.Status.ScheduledReplicas == 0 {
+		r.eventRecorder.Eventf(pcsg, corev1.EventTypeWarning, internalconstants.ReasonAllScheduledReplicasLost,
+			"All scheduled replicas lost (was %d). Gang termination is suppressed to avoid recreating Pending pods against the same cluster state; investigate node availability or capacity.",
+			originalScheduled)
+	}
 }
 
 // mutateMinAvailableBreachedCondition updates the MinAvailableBreached condition based on replica availability

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
@@ -204,9 +204,18 @@ func mutateMinAvailableBreachedCondition(logger logr.Logger, pcsg *grovecorev1al
 // computeMinAvailableBreachedCondition computes the MinAvailableBreached condition for the PodCliqueScalingGroup.
 // If rolling update is under progress, then gang termination for this PCSG is disabled. This is achieved by marking the status to `Unknown`. This PCSG will not influence
 // the gang termination of PCS replica till its update has completed.
-// If the number of scheduled replicas is less than the MinAvailable, then it is too pre-mature to set the MinAvailableBreached condition to true.
-// If we set MinAvailableBreached condition to true, then it can result in pre-mature gang termination when the PodClique Pods are still starting.
-// If there are sufficient scheduled replicas (i.e. scheduledReplicas >= minAvailable), then we can compute the MinAvailableBreached condition based on the number of ready replicas.
+// Under-scheduled cases:
+//   - scheduledReplicas == 0: either initial startup (no replicas admitted yet) or a full regression where
+//     every scheduled replica has been lost. In both cases gang termination would only recreate the same
+//     Pending replicas against the same cluster state, so we suppress the breach to avoid a churn loop.
+//   - 0 < scheduledReplicas < MinAvailable: under gang scheduling this is structurally unreachable from
+//     initial startup, so it implies regression after a healthy state. Treat as a breach. The downstream
+//     gang-termination flow still waits the full TerminationDelay before acting and the controller keeps
+//     trying to schedule replacements throughout the wait. On non-gang schedulers a brief flicker can
+//     occur during staged startup; TerminationDelay (default 4h) absorbs it.
+//
+// If there are sufficient scheduled replicas (i.e. scheduledReplicas >= minAvailable), then we can compute
+// the MinAvailableBreached condition based on the number of ready replicas.
 func computeMinAvailableBreachedCondition(logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup, pclqsPerPCSGReplica map[string][]grovecorev1alpha1.PodClique) metav1.Condition {
 	if componentutils.IsPCSGUpdateInProgress(pcsg) {
 		return metav1.Condition{
@@ -220,11 +229,19 @@ func computeMinAvailableBreachedCondition(logger logr.Logger, pcsg *grovecorev1a
 	minAvailable := int(*pcsg.Spec.MinAvailable)
 	scheduledReplicas := int(pcsg.Status.ScheduledReplicas)
 	if scheduledReplicas < minAvailable {
+		if scheduledReplicas == 0 {
+			return metav1.Condition{
+				Type:    constants.ConditionTypeMinAvailableBreached,
+				Status:  metav1.ConditionFalse,
+				Reason:  constants.ConditionReasonInsufficientScheduledPCSGReplicas,
+				Message: fmt.Sprintf("Insufficient scheduled replicas. expected at least: %d, found: %d", minAvailable, scheduledReplicas),
+			}
+		}
 		return metav1.Condition{
 			Type:    constants.ConditionTypeMinAvailableBreached,
-			Status:  metav1.ConditionFalse,
-			Reason:  constants.ConditionReasonInsufficientScheduledPCSGReplicas,
-			Message: fmt.Sprintf("Insufficient scheduled replicas. expected at least: %d, found: %d", minAvailable, scheduledReplicas),
+			Status:  metav1.ConditionTrue,
+			Reason:  constants.ConditionReasonScheduledReplicasRegressed,
+			Message: fmt.Sprintf("Scheduled replicas regressed below MinAvailable. expected at least: %d, found: %d", minAvailable, scheduledReplicas),
 		}
 	}
 	minAvailableBreachedReplicas := computeMinAvailableBreachedReplicas(logger, pcsg, pclqsPerPCSGReplica)

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
@@ -25,6 +25,7 @@ import (
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	"github.com/ai-dynamo/grove/operator/api/common/constants"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	internalconstants "github.com/ai-dynamo/grove/operator/internal/constants"
 	ctrlcommon "github.com/ai-dynamo/grove/operator/internal/controller/common"
 	componentutils "github.com/ai-dynamo/grove/operator/internal/controller/common/component/utils"
 	ctrlutils "github.com/ai-dynamo/grove/operator/internal/controller/utils"
@@ -32,6 +33,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -74,6 +76,15 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 	pclqsPerPCSGReplica = pruneStrayPCSGPCLQs(pcsg, pclqsPerPCSGReplica)
 	mutateReplicas(logger, pcs.Status.CurrentGenerationHash, pcsg, pclqsPerPCSGReplica)
 	mutateMinAvailableBreachedCondition(logger, pcsg, pclqsPerPCSGReplica)
+
+	// Emit a Warning when scheduledReplicas drops from non-zero to zero. Gang termination is
+	// suppressed in this state to avoid a churn loop, so this event is the only signal that a
+	// previously-running workload is fully down.
+	if originalStatus.ScheduledReplicas > 0 && pcsg.Status.ScheduledReplicas == 0 {
+		r.eventRecorder.Eventf(pcsg, corev1.EventTypeWarning, internalconstants.ReasonAllScheduledReplicasLost,
+			"All scheduled replicas lost (was %d). Gang termination is suppressed to avoid recreating Pending pods against the same cluster state; investigate node availability or capacity.",
+			originalStatus.ScheduledReplicas)
+	}
 
 	if err = mutateSelector(pcs, pcsg); err != nil {
 		logger.Error(err, "failed to update selector for PodCliqueScalingGroup")
@@ -202,20 +213,14 @@ func mutateMinAvailableBreachedCondition(logger logr.Logger, pcsg *grovecorev1al
 }
 
 // computeMinAvailableBreachedCondition computes the MinAvailableBreached condition for the PodCliqueScalingGroup.
-// If rolling update is under progress, then gang termination for this PCSG is disabled. This is achieved by marking the status to `Unknown`. This PCSG will not influence
-// the gang termination of PCS replica till its update has completed.
-// Under-scheduled cases:
-//   - scheduledReplicas == 0: either initial startup (no replicas admitted yet) or a full regression where
-//     every scheduled replica has been lost. In both cases gang termination would only recreate the same
-//     Pending replicas against the same cluster state, so we suppress the breach to avoid a churn loop.
-//   - 0 < scheduledReplicas < MinAvailable: under gang scheduling this is structurally unreachable from
-//     initial startup, so it implies regression after a healthy state. Treat as a breach. The downstream
-//     gang-termination flow still waits the full TerminationDelay before acting and the controller keeps
-//     trying to schedule replacements throughout the wait. On non-gang schedulers a brief flicker can
-//     occur during staged startup; TerminationDelay (default 4h) absorbs it.
+// If rolling update is under progress, then gang termination for this PCSG is disabled. This is achieved by marking
+// the status to `Unknown`. This PCSG will not influence the gang termination of PCS replica till its update has completed.
 //
-// If there are sufficient scheduled replicas (i.e. scheduledReplicas >= minAvailable), then we can compute
-// the MinAvailableBreached condition based on the number of ready replicas.
+// scheduledReplicas == 0: either initial startup or every scheduled replica has been lost. Recreating the PodGang
+// would just produce the same Pending replicas, so suppress to avoid a churn loop.
+// 0 < scheduledReplicas < MinAvailable: with a gang scheduler this implies regression after a healthy state and
+// breaches. On non-gang schedulers it can flicker briefly during staged startup; TerminationDelay (default 4h)
+// absorbs the flicker.
 func computeMinAvailableBreachedCondition(logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup, pclqsPerPCSGReplica map[string][]grovecorev1alpha1.PodClique) metav1.Condition {
 	if componentutils.IsPCSGUpdateInProgress(pcsg) {
 		return metav1.Condition{
@@ -234,14 +239,14 @@ func computeMinAvailableBreachedCondition(logger logr.Logger, pcsg *grovecorev1a
 				Type:    constants.ConditionTypeMinAvailableBreached,
 				Status:  metav1.ConditionFalse,
 				Reason:  constants.ConditionReasonInsufficientScheduledPCSGReplicas,
-				Message: fmt.Sprintf("Insufficient scheduled replicas. expected at least: %d, found: %d", minAvailable, scheduledReplicas),
+				Message: fmt.Sprintf("Scheduled replicas (%d) below MinAvailable (%d)", scheduledReplicas, minAvailable),
 			}
 		}
 		return metav1.Condition{
 			Type:    constants.ConditionTypeMinAvailableBreached,
 			Status:  metav1.ConditionTrue,
-			Reason:  constants.ConditionReasonScheduledReplicasRegressed,
-			Message: fmt.Sprintf("Scheduled replicas regressed below MinAvailable. expected at least: %d, found: %d", minAvailable, scheduledReplicas),
+			Reason:  constants.ConditionReasonScheduledReplicasBelowMinAvailable,
+			Message: fmt.Sprintf("Scheduled replicas (%d) below MinAvailable (%d)", scheduledReplicas, minAvailable),
 		}
 	}
 	minAvailableBreachedReplicas := computeMinAvailableBreachedReplicas(logger, pcsg, pclqsPerPCSGReplica)

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus_test.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus_test.go
@@ -143,7 +143,7 @@ func TestComputeMinAvailableBreachedCondition(t *testing.T) {
 			available:    1,
 			pclqsMap:     make(map[string][]grovecorev1alpha1.PodClique),
 			wantStatus:   metav1.ConditionTrue,
-			wantReason:   "ScheduledReplicasRegressed",
+			wantReason:   "ScheduledReplicasBelowMinAvailable",
 		},
 		{
 			// scheduled == 0 stays suppressed: gang termination would only recreate
@@ -211,80 +211,103 @@ func TestComputeMinAvailableBreachedCondition(t *testing.T) {
 // TestComputeMinAvailableBreachedConditionPartialScheduleRegression covers the
 // regression-after-healthy-state behaviour at the PodCliqueScalingGroup level.
 // See the PodClique-level test for the full rationale.
+//
+// Several cases populate pclqsMap with breached PCLQs. That input is unread by
+// the under-scheduled branches today, but we keep it populated so that any
+// future refactor that drops the short-circuit and starts consulting pclqsMap
+// must continue to satisfy the assertions.
 func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testing.T) {
 	pastTransition := metav1.NewTime(time.Now().Add(-10 * time.Minute))
 
+	// breachedPCLQReplica is a single PCSG replica whose constituent PodCliques
+	// already report MinAvailableBreached=True. If a refactor accidentally
+	// consulted pclqsMap on the under-scheduled paths, these would inflate the
+	// breached count and could flip the answer — the assertions below must
+	// remain correct in that hypothetical world.
+	breachedPCLQReplica := map[string][]grovecorev1alpha1.PodClique{
+		"0": {{Status: grovecorev1alpha1.PodCliqueStatus{
+			Conditions: []metav1.Condition{{Type: constants.ConditionTypeMinAvailableBreached, Status: metav1.ConditionTrue}},
+		}}},
+	}
+
 	tests := []struct {
-		name         string
-		replicas     int32
-		minAvailable *int32
-		scheduled    int32
-		available    int32
-		conditions   []metav1.Condition
-		pclqsMap     map[string][]grovecorev1alpha1.PodClique
-		wantStatus   metav1.ConditionStatus
+		name           string
+		replicas       int32
+		minAvailable   *int32
+		scheduled      int32
+		available      int32
+		updateProgress *grovecorev1alpha1.PodCliqueScalingGroupUpdateProgress
+		conditions     []metav1.Condition
+		pclqsMap       map[string][]grovecorev1alpha1.PodClique
+		wantStatus     metav1.ConditionStatus
+		wantReason     string
 	}{
 		{
-			name:         "previously healthy PCSG: replicas regressed below minAvailable after node cordon/failure",
+			name:         "0 < scheduled < MinAvailable breaches",
 			replicas:     3,
 			minAvailable: ptr.To(int32(3)),
 			scheduled:    1,
 			available:    1,
-			conditions: []metav1.Condition{
-				{
-					Type:               constants.ConditionTypeMinAvailableBreached,
-					Status:             metav1.ConditionFalse,
-					Reason:             constants.ConditionReasonSufficientAvailablePCSGReplicas,
-					LastTransitionTime: pastTransition,
-				},
-			},
-			pclqsMap: map[string][]grovecorev1alpha1.PodClique{
-				"0": {
-					{
-						Status: grovecorev1alpha1.PodCliqueStatus{
-							Conditions: []metav1.Condition{
-								{
-									Type:   constants.ConditionTypeMinAvailableBreached,
-									Status: metav1.ConditionTrue,
-								},
-							},
-						},
-					},
-				},
-			},
+			conditions: []metav1.Condition{{
+				Type:               constants.ConditionTypeMinAvailableBreached,
+				Status:             metav1.ConditionFalse,
+				Reason:             constants.ConditionReasonSufficientAvailablePCSGReplicas,
+				LastTransitionTime: pastTransition,
+			}},
+			pclqsMap:   breachedPCLQReplica,
 			wantStatus: metav1.ConditionTrue,
+			wantReason: constants.ConditionReasonScheduledReplicasBelowMinAvailable,
 		},
 		{
-			// Sanity-pin: if all scheduled replicas are lost, gang terminating
-			// would recreate the PodGang into the same Pending state. Fix must
-			// keep this suppressed.
-			name:         "previously healthy PCSG: all scheduled replicas lost — must NOT breach",
+			// Sanity-pin: scheduled == 0 must NOT breach, even with PCLQs in the
+			// map already breached. The short-circuit on scheduled==0 has to
+			// take precedence over PCLQ-level breach signal — otherwise a stale
+			// PCLQ condition would push us into a churn loop.
+			name:         "scheduled == 0 with breached PCLQs in map — must NOT breach",
 			replicas:     2,
 			minAvailable: ptr.To(int32(2)),
 			scheduled:    0,
 			available:    0,
-			conditions: []metav1.Condition{
-				{
-					Type:               constants.ConditionTypeMinAvailableBreached,
-					Status:             metav1.ConditionFalse,
-					Reason:             constants.ConditionReasonSufficientAvailablePCSGReplicas,
-					LastTransitionTime: pastTransition,
-				},
-			},
-			pclqsMap:   map[string][]grovecorev1alpha1.PodClique{},
+			conditions: []metav1.Condition{{
+				Type:               constants.ConditionTypeMinAvailableBreached,
+				Status:             metav1.ConditionFalse,
+				Reason:             constants.ConditionReasonSufficientAvailablePCSGReplicas,
+				LastTransitionTime: pastTransition,
+			}},
+			pclqsMap:   breachedPCLQReplica,
 			wantStatus: metav1.ConditionFalse,
+			wantReason: constants.ConditionReasonInsufficientScheduledPCSGReplicas,
 		},
 		{
-			// Sanity: a fresh PCSG that has never scheduled any replica must NOT
-			// be reported as breached. Any fix must preserve this.
+			// A fresh PCSG that has never scheduled any replica must NOT be
+			// reported as breached.
 			name:         "fresh PCSG never scheduled — must not breach",
 			replicas:     3,
 			minAvailable: ptr.To(int32(3)),
 			scheduled:    0,
 			available:    0,
-			conditions:   nil,
 			pclqsMap:     map[string][]grovecorev1alpha1.PodClique{},
 			wantStatus:   metav1.ConditionFalse,
+			wantReason:   constants.ConditionReasonInsufficientScheduledPCSGReplicas,
+		},
+		{
+			// Pin branch ordering: when an update is in progress, the
+			// IsPCSGUpdateInProgress short-circuit must win over the regression
+			// breach branch. Otherwise a rolling update across a node cordon
+			// would falsely flip the breach to True and risk silent churn.
+			name:         "update in progress overrides partial-schedule breach",
+			replicas:     3,
+			minAvailable: ptr.To(int32(3)),
+			scheduled:    1,
+			available:    1,
+			updateProgress: &grovecorev1alpha1.PodCliqueScalingGroupUpdateProgress{
+				UpdateStartedAt:            pastTransition,
+				UpdateEndedAt:              nil, // active update
+				PodCliqueSetGenerationHash: "gen-hash-1",
+			},
+			pclqsMap:   breachedPCLQReplica,
+			wantStatus: metav1.ConditionUnknown,
+			wantReason: constants.ConditionReasonUpdateInProgress,
 		},
 	}
 
@@ -299,14 +322,15 @@ func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testin
 					ScheduledReplicas: tt.scheduled,
 					AvailableReplicas: tt.available,
 					Conditions:        tt.conditions,
+					UpdateProgress:    tt.updateProgress,
 				},
 			}
 
 			condition := computeMinAvailableBreachedCondition(logr.Discard(), pcsg, tt.pclqsMap)
 
 			assert.Equal(t, constants.ConditionTypeMinAvailableBreached, condition.Type)
-			assert.Equal(t, tt.wantStatus, condition.Status,
-				"MinAvailableBreached status should match expected post-fix behaviour")
+			assert.Equal(t, tt.wantStatus, condition.Status, "MinAvailableBreached status mismatch")
+			assert.Equal(t, tt.wantReason, condition.Reason, "MinAvailableBreached reason mismatch")
 		})
 	}
 }

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus_test.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus_test.go
@@ -135,7 +135,7 @@ func TestComputeMinAvailableBreachedCondition(t *testing.T) {
 		{
 			// 0 < scheduled < MinAvailable is structurally unreachable from initial
 			// startup under gang scheduling, so it is treated as a regression and
-			// breaches MinAvailable. See issue #277.
+			// breaches MinAvailable.
 			name:         "partially scheduled regression breaches",
 			replicas:     3,
 			minAvailable: ptr.To(int32(2)),
@@ -208,10 +208,10 @@ func TestComputeMinAvailableBreachedCondition(t *testing.T) {
 	}
 }
 
-// TestComputeMinAvailableBreachedCondition_Issue277 covers the gang-termination
-// regression fix from https://github.com/ai-dynamo/grove/issues/277 at the
-// PodCliqueScalingGroup level. See the PodClique-level test for the full rationale.
-func TestComputeMinAvailableBreachedCondition_Issue277(t *testing.T) {
+// TestComputeMinAvailableBreachedConditionPartialScheduleRegression covers the
+// regression-after-healthy-state behaviour at the PodCliqueScalingGroup level.
+// See the PodClique-level test for the full rationale.
+func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testing.T) {
 	pastTransition := metav1.NewTime(time.Now().Add(-10 * time.Minute))
 
 	tests := []struct {

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus_test.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ai-dynamo/grove/operator/api/common/constants"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	internalconstants "github.com/ai-dynamo/grove/operator/internal/constants"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
 	"github.com/go-logr/logr"
@@ -30,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -204,6 +206,50 @@ func TestComputeMinAvailableBreachedCondition(t *testing.T) {
 			assert.Equal(t, "MinAvailableBreached", condition.Type)
 			assert.Equal(t, tt.wantStatus, condition.Status)
 			assert.Equal(t, tt.wantReason, condition.Reason)
+		})
+	}
+}
+
+// TestEmitAllScheduledReplicasLostIfNeeded covers the only explicit signal users have when a
+// previously-running PodCliqueScalingGroup loses every scheduled replica. Gang termination is
+// suppressed in that state, so this event must fire on the non-zero → zero transition (and
+// only on that transition) for the regression to remain observable.
+func TestEmitAllScheduledReplicasLostIfNeeded(t *testing.T) {
+	tests := []struct {
+		name              string
+		originalScheduled int32
+		nowScheduled      int32
+		wantEvent         bool
+	}{
+		{name: "non-zero to zero emits event", originalScheduled: 3, nowScheduled: 0, wantEvent: true},
+		{name: "zero to zero stays silent (initial startup)", originalScheduled: 0, nowScheduled: 0, wantEvent: false},
+		{name: "non-zero to non-zero stays silent (partial regression handled by breach)", originalScheduled: 3, nowScheduled: 2, wantEvent: false},
+		{name: "zero to non-zero stays silent (recovery)", originalScheduled: 0, nowScheduled: 3, wantEvent: false},
+		{name: "stable non-zero stays silent (steady state)", originalScheduled: 3, nowScheduled: 3, wantEvent: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := record.NewFakeRecorder(2)
+			r := &Reconciler{eventRecorder: recorder}
+			pcsg := &grovecorev1alpha1.PodCliqueScalingGroup{
+				Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{ScheduledReplicas: tt.nowScheduled},
+			}
+
+			r.emitAllScheduledReplicasLostIfNeeded(pcsg, tt.originalScheduled)
+
+			select {
+			case ev := <-recorder.Events:
+				if !tt.wantEvent {
+					t.Fatalf("unexpected event: %s", ev)
+				}
+				assert.Contains(t, ev, "Warning", "event type should be Warning")
+				assert.Contains(t, ev, internalconstants.ReasonAllScheduledReplicasLost, "event reason mismatch")
+			default:
+				if tt.wantEvent {
+					t.Fatal("expected an event, got none")
+				}
+			}
 		})
 	}
 }

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus_test.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus_test.go
@@ -133,11 +133,26 @@ func TestComputeMinAvailableBreachedCondition(t *testing.T) {
 			wantReason:   "SufficientAvailablePodCliqueScalingGroupReplicas",
 		},
 		{
-			name:         "insufficient scheduled",
+			// 0 < scheduled < MinAvailable is structurally unreachable from initial
+			// startup under gang scheduling, so it is treated as a regression and
+			// breaches MinAvailable. See issue #277.
+			name:         "partially scheduled regression breaches",
 			replicas:     3,
 			minAvailable: ptr.To(int32(2)),
 			scheduled:    1,
 			available:    1,
+			pclqsMap:     make(map[string][]grovecorev1alpha1.PodClique),
+			wantStatus:   metav1.ConditionTrue,
+			wantReason:   "ScheduledReplicasRegressed",
+		},
+		{
+			// scheduled == 0 stays suppressed: gang termination would only recreate
+			// the same Pending replicas against the same cluster state.
+			name:         "zero scheduled does not breach",
+			replicas:     3,
+			minAvailable: ptr.To(int32(2)),
+			scheduled:    0,
+			available:    0,
 			pclqsMap:     make(map[string][]grovecorev1alpha1.PodClique),
 			wantStatus:   metav1.ConditionFalse,
 			wantReason:   "InsufficientScheduledPodCliqueScalingGroupReplicas",
@@ -189,6 +204,109 @@ func TestComputeMinAvailableBreachedCondition(t *testing.T) {
 			assert.Equal(t, "MinAvailableBreached", condition.Type)
 			assert.Equal(t, tt.wantStatus, condition.Status)
 			assert.Equal(t, tt.wantReason, condition.Reason)
+		})
+	}
+}
+
+// TestComputeMinAvailableBreachedCondition_Issue277 covers the gang-termination
+// regression fix from https://github.com/ai-dynamo/grove/issues/277 at the
+// PodCliqueScalingGroup level. See the PodClique-level test for the full rationale.
+func TestComputeMinAvailableBreachedCondition_Issue277(t *testing.T) {
+	pastTransition := metav1.NewTime(time.Now().Add(-10 * time.Minute))
+
+	tests := []struct {
+		name         string
+		replicas     int32
+		minAvailable *int32
+		scheduled    int32
+		available    int32
+		conditions   []metav1.Condition
+		pclqsMap     map[string][]grovecorev1alpha1.PodClique
+		wantStatus   metav1.ConditionStatus
+	}{
+		{
+			name:         "previously healthy PCSG: replicas regressed below minAvailable after node cordon/failure",
+			replicas:     3,
+			minAvailable: ptr.To(int32(3)),
+			scheduled:    1,
+			available:    1,
+			conditions: []metav1.Condition{
+				{
+					Type:               constants.ConditionTypeMinAvailableBreached,
+					Status:             metav1.ConditionFalse,
+					Reason:             constants.ConditionReasonSufficientAvailablePCSGReplicas,
+					LastTransitionTime: pastTransition,
+				},
+			},
+			pclqsMap: map[string][]grovecorev1alpha1.PodClique{
+				"0": {
+					{
+						Status: grovecorev1alpha1.PodCliqueStatus{
+							Conditions: []metav1.Condition{
+								{
+									Type:   constants.ConditionTypeMinAvailableBreached,
+									Status: metav1.ConditionTrue,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStatus: metav1.ConditionTrue,
+		},
+		{
+			// Sanity-pin: if all scheduled replicas are lost, gang terminating
+			// would recreate the PodGang into the same Pending state. Fix must
+			// keep this suppressed.
+			name:         "previously healthy PCSG: all scheduled replicas lost — must NOT breach",
+			replicas:     2,
+			minAvailable: ptr.To(int32(2)),
+			scheduled:    0,
+			available:    0,
+			conditions: []metav1.Condition{
+				{
+					Type:               constants.ConditionTypeMinAvailableBreached,
+					Status:             metav1.ConditionFalse,
+					Reason:             constants.ConditionReasonSufficientAvailablePCSGReplicas,
+					LastTransitionTime: pastTransition,
+				},
+			},
+			pclqsMap:   map[string][]grovecorev1alpha1.PodClique{},
+			wantStatus: metav1.ConditionFalse,
+		},
+		{
+			// Sanity: a fresh PCSG that has never scheduled any replica must NOT
+			// be reported as breached. Any fix must preserve this.
+			name:         "fresh PCSG never scheduled — must not breach",
+			replicas:     3,
+			minAvailable: ptr.To(int32(3)),
+			scheduled:    0,
+			available:    0,
+			conditions:   nil,
+			pclqsMap:     map[string][]grovecorev1alpha1.PodClique{},
+			wantStatus:   metav1.ConditionFalse,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pcsg := &grovecorev1alpha1.PodCliqueScalingGroup{
+				Spec: grovecorev1alpha1.PodCliqueScalingGroupSpec{
+					Replicas:     tt.replicas,
+					MinAvailable: tt.minAvailable,
+				},
+				Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{
+					ScheduledReplicas: tt.scheduled,
+					AvailableReplicas: tt.available,
+					Conditions:        tt.conditions,
+				},
+			}
+
+			condition := computeMinAvailableBreachedCondition(logr.Discard(), pcsg, tt.pclqsMap)
+
+			assert.Equal(t, constants.ConditionTypeMinAvailableBreached, condition.Type)
+			assert.Equal(t, tt.wantStatus, condition.Status,
+				"MinAvailableBreached status should match expected post-fix behaviour")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Closes #277.

The `MinAvailableBreached` condition was suppressed whenever `scheduledReplicas < MinAvailable`. That suppression conflated two situations:

1. **Initial startup** (correct to suppress) — no pods have been admitted yet, gang termination would be premature.
2. **Regression after a healthy state** (incorrectly suppressed) — e.g. a node hosting running pods is cordoned or fails and the replacement pod cannot be scheduled. `scheduledReplicas` falls below `MinAvailable`, but the breach never fires, so `gangterminate.go` never deletes the PCS replica's PodCliques, the PodGang is never recreated, and the workload is stuck. This is exactly the gap the new E2E gang-termination tests were exposing.

## Idea behind the fix

Split the under-scheduled branch on `scheduledReplicas == 0` vs `> 0`:

```go
if scheduledReplicas < minAvailable {
    if scheduledReplicas == 0 {
        // initial startup OR full regression — suppress (see below)
        return ConditionFalse, InsufficientScheduledPods
    }
    // 0 < scheduled < MinAvailable — must be regression, breach
    return ConditionTrue, ScheduledReplicasRegressed
}
```

**Why `0 < scheduled < MinAvailable` is unambiguously a regression.** Under gang scheduling the gang scheduler admits `MinAvailable` pods atomically — a partial-scheduled state is structurally unreachable from a fresh start. The only way to land there is to have been healthy and then lost pods. So we can breach immediately on observing the partial state.

**Why we keep `scheduled == 0` suppressed.** With nothing scheduled, gang termination has no useful work: recreating the PodGang produces the same Pending pods against the same cluster state. Suppressing avoids a churn loop. This matches KAI's behaviour: in general, if reaching `MinAvailable` legitimately takes longer than `TerminationDelay`, gang-terminating-and-recreating is the right move, and KAI's gang scheduler arrives at the same conclusion.

**Pod scheduling continues throughout.** The breach condition is consumed only by `gangterminate.go`, which still waits the full `TerminationDelay` (default 4h) before deleting. The pod-creation/replacement path in `podclique/components/pod/syncflow.go` and the PCLQ-creation path in `podcliquescalinggroup/components/podclique/sync.go` do not gate on the breach — replacement pods keep being created and re-scheduled while the timer runs. If they succeed, `scheduledReplicas` recovers, the condition flips back to False, and gang termination is never triggered.

## Behaviour on non-gang schedulers

On schedulers without gang admission (e.g. vanilla kube-scheduler), pods are admitted one at a time, so a brief `0 < scheduled < MinAvailable` flicker can occur during staged startup. The flicker is debounced by `TerminationDelay` (default 4h) — only pathological multi-hour rampups would see spurious gang termination, and in that case the existing `Spec.Template.TerminationDelay` knob is the remedy.

## Test plan

- [x] `go test ./...` passes (operator module)
- [x] `go vet ./...` clean, `go build ./...` clean
- [x] Reproducer tests in `reconcilestatus_test.go` for both PodClique and PodCliqueScalingGroup capture:
  - `0 < scheduled < MinAvailable` ⟹ breach (the bug fix)
  - `scheduled == 0` after regression ⟹ no breach (sanity-pin against over-correction / churn loop)
  - Fresh PCLQ/PCSG never scheduled ⟹ no breach (initial-startup sanity-pin)
- [x] Updated existing `TestComputeMinAvailableBreachedCondition / insufficient_scheduled` PCSG test, which had previously asserted the buggy behaviour, to assert the post-fix behaviour and added a paired `scheduled == 0` case.
- [x] E2E gang termination tests (referenced in the issue) should now pass.

## Open question for reviewers

The `scheduled == 0` suppression is a deliberate judgement call: it avoids a churn loop, but it does mean a fully-down PCS replica won't be gang-terminated (the controller keeps trying to schedule replacements forever). If there is a scenario where the *PodGang resource itself* gets into a bad shape that recreation would fix, we may want to revisit. Flagging for @renormalize / @unmarshall / @sanjaychatterjee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)