### PR TITLE
docs: use --version flag for helm install/upgrade

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,7 +11,7 @@ Locate the [release tag](https://github.com/ai-dynamo/grove/releases) to install
 Set the `KUBECONFIG` in your shell session, and run the following:
 
 ```bash
-helm upgrade -i grove oci://ghcr.io/ai-dynamo/grove/grove-charts:<tag>
+helm upgrade -i grove oci://ghcr.io/ai-dynamo/grove/grove-charts --version <version>
 ```
 
 ## Build and install Grove from source (*for developers*)

--- a/docs/user-guide/auto-mnnvl.md
+++ b/docs/user-guide/auto-mnnvl.md
@@ -41,7 +41,7 @@ config:
 Deploy or upgrade Grove with this configuration:
 
 ```bash
-helm upgrade -i grove oci://ghcr.io/ai-dynamo/grove/grove-charts:<tag> \
+helm upgrade -i grove oci://ghcr.io/ai-dynamo/grove/grove-charts --version <version> \
   --set config.network.autoMNNVLEnabled=true
 ```
 

--- a/docs/user-guide/certificate-management.md
+++ b/docs/user-guide/certificate-management.md
@@ -22,7 +22,7 @@ By default, Grove's built-in cert-controller automatically:
 This mode requires no additional configuration. Simply deploy Grove:
 
 ```bash
-helm upgrade -i grove oci://ghcr.io/ai-dynamo/grove/grove-charts:<tag>
+helm upgrade -i grove oci://ghcr.io/ai-dynamo/grove/grove-charts --version <version>
 ```
 
 ### How It Works
@@ -183,7 +183,7 @@ webhooks:
 #### Step 5: Deploy Grove
 
 ```bash
-helm upgrade -i grove oci://ghcr.io/ai-dynamo/grove/grove-charts:<tag> \
+helm upgrade -i grove oci://ghcr.io/ai-dynamo/grove/grove-charts --version <version> \
   --set config.server.webhooks.certProvisionMode=manual \
   --set webhooks.podCliqueSetValidationWebhook.annotations."cert-manager\.io/inject-ca-from"="<namespace>/grove-webhook-cert" \
   --set webhooks.podCliqueSetDefaultingWebhook.annotations."cert-manager\.io/inject-ca-from"="<namespace>/grove-webhook-cert" \
@@ -193,7 +193,7 @@ helm upgrade -i grove oci://ghcr.io/ai-dynamo/grove/grove-charts:<tag> \
 Or create a `values.yaml` file with the configuration shown above and deploy:
 
 ```bash
-helm upgrade -i grove oci://ghcr.io/ai-dynamo/grove/grove-charts:<tag> -f values.yaml
+helm upgrade -i grove oci://ghcr.io/ai-dynamo/grove/grove-charts --version <version> -f values.yaml
 ```
 
 ### Manual Certificate Management
@@ -253,7 +253,7 @@ kubectl create secret generic grove-webhook-server-cert \
 ```bash
 CA_BUNDLE=$(cat ca.crt | base64 | tr -d '\n')
 
-helm upgrade -i grove oci://ghcr.io/ai-dynamo/grove/grove-charts:<tag> \
+helm upgrade -i grove oci://ghcr.io/ai-dynamo/grove/grove-charts --version <version> \
   --set config.server.webhooks.certProvisionMode=manual \
   --set webhooks.caBundle="${CA_BUNDLE}"
 ```
@@ -267,7 +267,7 @@ helm upgrade -i grove oci://ghcr.io/ai-dynamo/grove/grove-charts:<tag> \
 3. Upgrade the Grove deployment
 
 ```bash
-helm upgrade grove oci://ghcr.io/ai-dynamo/grove/grove-charts:<tag> \
+helm upgrade grove oci://ghcr.io/ai-dynamo/grove/grove-charts --version <version> \
   --set config.server.webhooks.certProvisionMode=manual \
   --set webhooks.caBundle="${CA_BUNDLE}"
 ```
@@ -279,7 +279,7 @@ helm upgrade grove oci://ghcr.io/ai-dynamo/grove/grove-charts:<tag> \
 3. Upgrade the Grove deployment
 
 ```bash
-helm upgrade grove oci://ghcr.io/ai-dynamo/grove/grove-charts:<tag> \
+helm upgrade grove oci://ghcr.io/ai-dynamo/grove/grove-charts --version <version> \
   --set config.server.webhooks.certProvisionMode=auto \
   --set webhooks.caBundle=""
 ```


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The `oci://.../grove-charts:<tag>` form in our docs doesn't work consistently across Helm versions. Helm's [official OCI docs](https://helm.sh/docs/topics/registries/) use `--version <version>` instead.

Update all `helm install`/`upgrade` examples in `docs/` accordingly.

#### Which issue(s) this PR fixes:

Fixes #461

#### Special notes for your reviewer:

Docs-only.

Tested with `v0.1.0-alpha.8`:
- `helm show chart oci://ghcr.io/ai-dynamo/grove/grove-charts --version v0.1.0-alpha.8`
- `helm template grove oci://ghcr.io/ai-dynamo/grove/grove-charts --version v0.1.0-alpha.8`
- Representative `helm template` commands with the documented Auto MNNVL and manual certificate values.

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs

```