### PR TITLE
docs: document immutable operator ConfigMap

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -150,6 +150,18 @@ make deploy
 kubectl logs -l app.kubernetes.io/name=grove-operator
 ```
 
+#### `kubectl edit cm grove-operator-cm-*` fails with `field is immutable`
+
+**Cause:** The operator ConfigMap is rendered with `immutable: true` by design and cannot be edited in place.
+
+**Solution:** Change configuration via `helm upgrade`; a new ConfigMap is created and the operator rolls automatically.
+
+```bash
+helm upgrade grove oci://ghcr.io/ai-dynamo/grove/grove-charts \
+  --version <version> \
+  --set config.network.autoMNNVLEnabled=false
+```
+
 ### Runtime Issues
 
 #### Pods stuck in `Pending` state


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Documents that the operator ConfigMap is immutable and configuration changes should use `helm upgrade`.

#### Which issue(s) this PR fixes:
Fixes #415

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a API change?
```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```