### PR TITLE
docs: add helm template / GitOps installation guidance

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -116,6 +116,31 @@ On clusters with NVIDIA MNNVL support, you can enable automatic Multi-Node NVLin
 
 Follow the instructions in the [quickstart guide](quickstart.md) to deploy a PodCliqueSet and validate your installation.
 
+## Advanced: `helm template` and GitOps
+
+`helm template` does not render the chart's `crds/` directory unless
+`--include-crds` is passed, so installs via `helm template | kubectl apply`,
+ArgoCD, Flux, or Kustomize fail with missing CRDs by default. Set
+`crdInstaller.enabled=true` to install and upgrade CRDs from an init
+container instead.
+
+In the same workflows you should also set `webhookServerSecret.enabled=false`:
+the chart otherwise renders an empty `grove-webhook-server-cert` Secret that
+overwrites the auto-generated TLS material on every re-apply or GitOps sync,
+breaking the webhook. With it disabled, the operator creates and manages the
+Secret itself.
+
+```bash
+helm template grove oci://ghcr.io/ai-dynamo/grove/grove-charts \
+  --version <version> \
+  --set crdInstaller.enabled=true \
+  --set webhookServerSecret.enabled=false \
+  | kubectl apply -f -
+```
+
+See [GREP-436](proposals/436-crd-upgrader/README.md#note-for-helm-template--gitops-users)
+for the CRD design details and the alternative `--include-crds` workflow.
+
 ## Troubleshooting
 
 ### Deployment Issues


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Adds a short "Advanced: helm template and GitOps" section to the installation guide, surfacing the recommended `crdInstaller.enabled=true` path from GREP-436 so users deploying via `helm template`, ArgoCD, Flux, or Kustomize don't hit a broken fresh install due to missing CRDs.

#### Which issue(s) this PR fixes:

Fixes #536

#### Special notes for your reviewer:

Kept the addition minimal and placed it after "Verify Installation" so it does not distract `helm install` users on the main path. Links to GREP-436 for the full design and the alternative `--include-crds` workflow.

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs

```