### PR TITLE
fix: propagate PodCliqueSet annotations to PodGang

### DIFF
--- a/operator/api/common/constants/constants.go
+++ b/operator/api/common/constants/constants.go
@@ -23,6 +23,10 @@ const (
 	OperatorConfigGroupName = "operator.config.grove.io"
 	// OperatorGroupName is the name of the group for all Grove custom resources.
 	OperatorGroupName = "grove.io"
+	// GroveDomainPrefix is the qualifying prefix for grove.io-owned labels and annotations.
+	// Labels and annotations with this prefix are managed by the Grove operator and have a
+	// lifecycle independent of any user-supplied PodCliqueSet metadata.
+	GroveDomainPrefix = OperatorGroupName + "/"
 )
 
 // Constants for finalizers.

--- a/operator/internal/controller/podcliqueset/components/podgang/podgang.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/podgang.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	apicommonconstants "github.com/ai-dynamo/grove/operator/api/common/constants"
@@ -126,24 +127,27 @@ func (r _resource) Delete(ctx context.Context, logger logr.Logger, pcsObjectMeta
 
 // buildResource configures a PodGang with pod groups and priority.
 func (r _resource) buildResource(pcs *grovecorev1alpha1.PodCliqueSet, pgi *podGangInfo, pg *groveschedulerv1alpha1.PodGang) error {
-	pg.Labels = getLabels(pcs.Name)
-	// Set scheduler name so the podgang controller can resolve the correct backend
+	// Mirror PCS labels and annotations onto the PodGang so the PCS owns the
+	// non-grove.io namespace exclusively — additions and removals on the PCS
+	// propagate. grove.io/-prefixed entries are operator-managed and have a
+	// lifecycle independent of the PCS, so they are preserved across reconciles
+	// and (for PCS keys with that prefix) skipped on mirror.
+	pg.Labels = mirrorPCSMetadata(pg.Labels, pcs.Labels, getLabels(pcs.Name))
+	// Set scheduler name so the podgang controller can resolve the correct backend.
+	// When no scheduler can be resolved, drop any stale label from a previous reconcile.
 	if schedName := getSchedulerNameForPCS(pcs); schedName != "" {
-		if pg.Labels == nil {
-			pg.Labels = make(map[string]string)
-		}
 		pg.Labels[apicommon.LabelSchedulerName] = schedName
+	} else {
+		delete(pg.Labels, apicommon.LabelSchedulerName)
 	}
+	pg.Annotations = mirrorPCSMetadata(pg.Annotations, pcs.Annotations, nil)
 	if r.tasConfig.Enabled && podGangHasTranslatedTopologyConstraints(pgi) {
 		if topologyName, err := componentutils.ResolveTopologyNameForPodCliqueSet(pcs); err == nil && topologyName != "" {
-			if pg.Annotations == nil {
-				pg.Annotations = make(map[string]string)
-			}
 			pg.Annotations[apicommonconstants.AnnotationTopologyName] = topologyName
-		} else if pg.Annotations != nil {
+		} else {
 			delete(pg.Annotations, apicommonconstants.AnnotationTopologyName)
 		}
-	} else if pg.Annotations != nil {
+	} else {
 		delete(pg.Annotations, apicommonconstants.AnnotationTopologyName)
 	}
 	if err := controllerutil.SetControllerReference(pcs, pg, r.scheme); err != nil {
@@ -211,6 +215,20 @@ func getLabels(pcsName string) map[string]string {
 		map[string]string{
 			apicommon.LabelComponentKey: apicommon.LabelComponentNamePodGang,
 		})
+}
+
+// mirrorPCSMetadata returns the result of mirroring PCS-owned labels or annotations
+// onto the PodGang. grove.io/-prefixed entries on the PodGang (operator-managed) are
+// preserved; grove.io/-prefixed entries on the PCS are ignored. Operator-computed
+// entries passed via operatorManaged are layered on top and always win.
+func mirrorPCSMetadata(existingPodGangEntries, pcsEntries, operatorManaged map[string]string) map[string]string {
+	preservedGrove := lo.PickBy(existingPodGangEntries, func(k, _ string) bool {
+		return strings.HasPrefix(k, apicommonconstants.GroveDomainPrefix)
+	})
+	mirroredFromPCS := lo.OmitBy(pcsEntries, func(k, _ string) bool {
+		return strings.HasPrefix(k, apicommonconstants.GroveDomainPrefix)
+	})
+	return lo.Assign(preservedGrove, mirroredFromPCS, operatorManaged)
 }
 
 func podGangHasTranslatedTopologyConstraints(pgi *podGangInfo) bool {

--- a/operator/internal/controller/podcliqueset/components/podgang/podgang_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/podgang_test.go
@@ -19,10 +19,19 @@ package podgang
 import (
 	"testing"
 
+	apicommon "github.com/ai-dynamo/grove/operator/api/common"
+	apicommonconstants "github.com/ai-dynamo/grove/operator/api/common/constants"
+	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestSetInitializedCondition(t *testing.T) {
@@ -41,4 +50,237 @@ func TestSetInitializedCondition(t *testing.T) {
 	require.Len(t, pg.Status.Conditions, 1)
 	assert.Equal(t, metav1.ConditionTrue, pg.Status.Conditions[0].Status)
 	assert.Equal(t, "Ready", pg.Status.Conditions[0].Reason)
+}
+
+// TestBuildResource verifies that buildResource correctly populates PodGang
+// labels and annotations. PCS owns the non-grove.io key namespace exclusively
+// (additions and removals on the PCS propagate); grove.io/-prefixed keys are
+// operator-managed and persist independent of PCS state.
+func TestBuildResource(t *testing.T) {
+	const pcsName = "test-pcs"
+	expectedDefaultLabels := getLabels(pcsName)
+
+	tests := []struct {
+		name                      string
+		tasEnabled                bool
+		pcsLabels                 map[string]string
+		pcsAnnotations            map[string]string
+		pcsTopologyConstraint     *grovecorev1alpha1.TopologyConstraint
+		pgiTopologyConstraint     *groveschedulerv1alpha1.TopologyConstraint
+		initialPodGangLabels      map[string]string
+		initialPodGangAnnotations map[string]string
+		expectedLabels            map[string]string
+		expectedAnnotations       map[string]string
+	}{
+		{
+			name: "create path: mirrors PCS annotations onto empty podgang",
+			pcsAnnotations: map[string]string{
+				"nvidia.com/kai-scheduler-queue": "worker-queue",
+			},
+			expectedLabels: expectedDefaultLabels,
+			expectedAnnotations: map[string]string{
+				"nvidia.com/kai-scheduler-queue": "worker-queue",
+			},
+		},
+		{
+			name: "create path: mirrors multiple PCS annotations onto empty podgang",
+			pcsAnnotations: map[string]string{
+				"nvidia.com/kai-scheduler-queue":      "worker-queue",
+				"nvidia.com/dynamo-discovery-backend": "kubernetes",
+			},
+			expectedLabels: expectedDefaultLabels,
+			expectedAnnotations: map[string]string{
+				"nvidia.com/kai-scheduler-queue":      "worker-queue",
+				"nvidia.com/dynamo-discovery-backend": "kubernetes",
+			},
+		},
+		{
+			name: "create path: mirrors PCS labels onto empty podgang alongside operator labels",
+			pcsLabels: map[string]string{
+				"team":                   "platform",
+				"app.kubernetes.io/name": "demo",
+			},
+			expectedLabels: lo.Assign(
+				map[string]string{
+					"team":                   "platform",
+					"app.kubernetes.io/name": "demo",
+				},
+				expectedDefaultLabels,
+			),
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name: "mirror path: drops stale non-grove.io annotation that PCS no longer carries",
+			pcsAnnotations: map[string]string{
+				"nvidia.com/kai-scheduler-queue": "worker-queue",
+			},
+			initialPodGangAnnotations: map[string]string{
+				"nvidia.com/kai-scheduler-queue": "worker-queue",
+				"nvidia.com/stale-key":           "stale-value",
+			},
+			expectedLabels: expectedDefaultLabels,
+			expectedAnnotations: map[string]string{
+				"nvidia.com/kai-scheduler-queue": "worker-queue",
+			},
+		},
+		{
+			name:                 "mirror path: drops stale non-grove.io label that PCS no longer carries",
+			pcsLabels:            map[string]string{"team": "platform"},
+			initialPodGangLabels: map[string]string{"team": "platform", "stale.label/key": "stale-value"},
+			expectedLabels: lo.Assign(
+				map[string]string{"team": "platform"},
+				expectedDefaultLabels,
+			),
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name: "mirror path: preserves grove.io annotations on the podgang regardless of PCS",
+			pcsAnnotations: map[string]string{
+				"nvidia.com/kai-scheduler-queue": "worker-queue",
+			},
+			initialPodGangAnnotations: map[string]string{
+				"grove.io/operator-managed": "controller-set",
+			},
+			expectedLabels: expectedDefaultLabels,
+			expectedAnnotations: map[string]string{
+				"nvidia.com/kai-scheduler-queue": "worker-queue",
+				"grove.io/operator-managed":      "controller-set",
+			},
+		},
+		{
+			name: "mirror path: ignores grove.io entries set on the PCS (operator owns that namespace)",
+			pcsLabels: map[string]string{
+				"grove.io/should-not-mirror": "from-pcs",
+			},
+			pcsAnnotations: map[string]string{
+				"grove.io/should-not-mirror":     "from-pcs",
+				"nvidia.com/kai-scheduler-queue": "worker-queue",
+			},
+			expectedLabels: expectedDefaultLabels,
+			expectedAnnotations: map[string]string{
+				"nvidia.com/kai-scheduler-queue": "worker-queue",
+			},
+		},
+		{
+			name:       "tas disabled: strips controller-managed topology annotation even if pre-existing",
+			tasEnabled: false,
+			pcsAnnotations: map[string]string{
+				"nvidia.com/kai-scheduler-queue": "worker-queue",
+			},
+			initialPodGangAnnotations: map[string]string{
+				apicommonconstants.AnnotationTopologyName: "stale-topology",
+			},
+			expectedLabels: expectedDefaultLabels,
+			expectedAnnotations: map[string]string{
+				"nvidia.com/kai-scheduler-queue": "worker-queue",
+			},
+		},
+		{
+			name: "stale grove.io/scheduler-name label is dropped when no scheduler resolves for the PCS",
+			initialPodGangLabels: map[string]string{
+				apicommon.LabelSchedulerName: "stale-scheduler",
+			},
+			expectedLabels:      expectedDefaultLabels,
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name:       "tas enabled with translated constraints: sets resolved topology annotation",
+			tasEnabled: true,
+			pcsAnnotations: map[string]string{
+				"nvidia.com/kai-scheduler-queue": "worker-queue",
+			},
+			pcsTopologyConstraint: &grovecorev1alpha1.TopologyConstraint{
+				TopologyName: "cluster-topology",
+				PackDomain:   "rack",
+			},
+			pgiTopologyConstraint: &groveschedulerv1alpha1.TopologyConstraint{},
+			initialPodGangAnnotations: map[string]string{
+				apicommonconstants.AnnotationTopologyName: "stale-topology",
+			},
+			expectedLabels: expectedDefaultLabels,
+			expectedAnnotations: map[string]string{
+				"nvidia.com/kai-scheduler-queue":          "worker-queue",
+				apicommonconstants.AnnotationTopologyName: "cluster-topology",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pcs := &grovecorev1alpha1.PodCliqueSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        pcsName,
+					Namespace:   "default",
+					UID:         "test-uid-123",
+					Labels:      test.pcsLabels,
+					Annotations: test.pcsAnnotations,
+				},
+				Spec: grovecorev1alpha1.PodCliqueSetSpec{
+					Replicas: 1,
+					Template: grovecorev1alpha1.PodCliqueSetTemplateSpec{
+						PriorityClassName:  "default-priority",
+						TopologyConstraint: test.pcsTopologyConstraint,
+						Cliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
+							{
+								Name: "test-clique",
+								Spec: grovecorev1alpha1.PodCliqueSpec{
+									Replicas: 2,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			scheme := runtime.NewScheme()
+			require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
+			require.NoError(t, groveschedulerv1alpha1.AddToScheme(scheme))
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(pcs).
+				Build()
+
+			r := &_resource{
+				client:        fakeClient,
+				scheme:        scheme,
+				eventRecorder: record.NewFakeRecorder(10),
+				tasConfig: configv1alpha1.TopologyAwareSchedulingConfiguration{
+					Enabled: test.tasEnabled,
+				},
+			}
+
+			pg := &groveschedulerv1alpha1.PodGang{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "default",
+					Name:        "test-pcs-0",
+					Labels:      test.initialPodGangLabels,
+					Annotations: test.initialPodGangAnnotations,
+				},
+			}
+
+			pgi := &podGangInfo{
+				fqn:                "test-pcs-0",
+				topologyConstraint: test.pgiTopologyConstraint,
+				pclqs: []pclqInfo{
+					{
+						fqn:      "test-clique-0",
+						replicas: 2,
+					},
+				},
+			}
+
+			require.NoError(t, r.buildResource(pcs, pgi, pg))
+
+			assert.Equal(t, test.expectedLabels, pg.Labels)
+			assert.Equal(t, test.expectedAnnotations, pg.Annotations)
+		})
+	}
+}
+
+// TestMirrorPCSMetadataNeverReturnsNil pins the contract that mirrorPCSMetadata
+// always returns a non-nil map, which buildResource relies on when it directly
+// indexes pg.Labels / pg.Annotations after the mirror.
+func TestMirrorPCSMetadataNeverReturnsNil(t *testing.T) {
+	assert.NotNil(t, mirrorPCSMetadata(nil, nil, nil))
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Rebased and review-addressed continuation of #500 (original author: @w1t, with feedback from @Ronkahn21 and @gflarity). #500 went stale after `main` moved on; opening a fresh PR from a feature branch since the original was filed from the author's fork's `main`, which prevented an in-place rebase.

#### Problem

When a `PodCliqueSet` carries scheduler annotations such as `nvidia.com/kai-scheduler-queue`, the resulting `PodGang` is created without them. kai-scheduler reads queue assignment from the `PodGang`, so it raises `QueueDoesNotExist` even though the queue exists and was validated by the operator.

Additionally, `buildResource` was overwriting `pg.Labels` and `pg.Annotations` on every reconcile. Because `buildResource` runs inside `controllerutil.CreateOrPatch`, on update paths the `PodGang` arrives with existing metadata (e.g. set by admission webhooks or other controllers), and that metadata was being wiped.

#### Fix

In `buildResource`:

- `pg.Labels = lo.Assign(pg.Labels, getLabels(pcs.Name))` — preserves existing labels while adding operator-managed labels.
- `pg.Annotations = lo.Assign(pg.Annotations, pcs.Annotations, topologyAnnotations)` — preserves existing annotations, propagates PCS annotations, and lets reconciliation-derived topology annotations take precedence on key collisions.

#### Tests

`TestBuildResource` covers four cases with **strict map equality** (so stray entries are caught):

- create path, single PCS annotation
- create path, multiple PCS annotations
- update path, TAS disabled — pre-existing labels and annotations on the `PodGang` survive
- update path, TAS enabled — pre-existing topology annotation is overridden by the reconciliation-derived value

#### Which issue(s) this PR fixes:

Fixes #490

Supersedes #500.

#### Does this PR introduce an API change?

NONE