### PR TITLE
make linear complexity instead of embedded loops

### DIFF
--- a/operator/internal/controller/common/component/utils/lookups.go
+++ b/operator/internal/controller/common/component/utils/lookups.go
@@ -1,0 +1,55 @@
+// /*
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package utils
+
+import (
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+
+	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
+)
+
+// Reusable name-keyed views over the common Grove resource slices. Each function builds a
+// fresh map (or set) — call once per sync context and pass the result around. Callers that
+// only need membership checks should prefer the *NameSet variants.
+
+// PodCliqueByName builds a name-keyed map for O(1) PodClique lookups.
+func PodCliqueByName(pclqs []grovecorev1alpha1.PodClique) map[string]grovecorev1alpha1.PodClique {
+	return MapBy(pclqs, func(pclq grovecorev1alpha1.PodClique) (string, grovecorev1alpha1.PodClique) {
+		return pclq.Name, pclq
+	})
+}
+
+// PodCliqueNameSet builds a set of PodClique names for O(1) membership checks.
+func PodCliqueNameSet(pclqs []grovecorev1alpha1.PodClique) Set[string] {
+	return NewSetBy(pclqs, func(pclq grovecorev1alpha1.PodClique) string {
+		return pclq.Name
+	})
+}
+
+// PCSGByName builds a name-keyed map for O(1) PodCliqueScalingGroup lookups.
+func PCSGByName(pcsgs []grovecorev1alpha1.PodCliqueScalingGroup) map[string]grovecorev1alpha1.PodCliqueScalingGroup {
+	return MapBy(pcsgs, func(pcsg grovecorev1alpha1.PodCliqueScalingGroup) (string, grovecorev1alpha1.PodCliqueScalingGroup) {
+		return pcsg.Name, pcsg
+	})
+}
+
+// PodGangByName builds a name-keyed map for O(1) PodGang lookups.
+func PodGangByName(podGangs []groveschedulerv1alpha1.PodGang) map[string]groveschedulerv1alpha1.PodGang {
+	return MapBy(podGangs, func(podGang groveschedulerv1alpha1.PodGang) (string, groveschedulerv1alpha1.PodGang) {
+		return podGang.Name, podGang
+	})
+}

--- a/operator/internal/controller/common/component/utils/sets.go
+++ b/operator/internal/controller/common/component/utils/sets.go
@@ -1,0 +1,57 @@
+// /*
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package utils
+
+// Set represents unique values with O(1) membership checks. Use it where callers only need
+// to test whether an element is present; use a plain map[K]V (built via MapBy) where callers
+// also need to retrieve the value associated with the key.
+type Set[T comparable] map[T]struct{}
+
+// NewSet converts a slice into a set for O(1) membership checks.
+func NewSet[T comparable](values []T) Set[T] {
+	return NewSetBy(values, func(value T) T {
+		return value
+	})
+}
+
+// NewSetBy converts a slice into a set using keyFunc to derive the key.
+func NewSetBy[T any, K comparable](values []T, keyFunc func(T) K) Set[K] {
+	set := make(Set[K], len(values))
+	for _, value := range values {
+		set[keyFunc(value)] = struct{}{}
+	}
+	return set
+}
+
+// Has returns true if the set contains value. The Set type uses a sentinel struct{} value, so
+// callers cannot use the comma-ok idiom directly; this method gives them an equivalent.
+func (s Set[T]) Has(value T) bool {
+	_, exists := s[value]
+	return exists
+}
+
+// MapBy converts a slice into a name-keyed map using mapFunc to derive each key and value.
+// Last-write-wins on duplicate keys: callers should ensure inputs are unique by key, otherwise
+// only the last entry per key survives.
+func MapBy[T any, K comparable, V any](values []T, mapFunc func(T) (K, V)) map[K]V {
+	byKey := make(map[K]V, len(values))
+	for _, value := range values {
+		key, mappedValue := mapFunc(value)
+		byKey[key] = mappedValue
+	}
+	return byKey
+}

--- a/operator/internal/controller/common/component/utils/sets_test.go
+++ b/operator/internal/controller/common/component/utils/sets_test.go
@@ -1,0 +1,92 @@
+// /*
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSet(t *testing.T) {
+	t.Run("empty input → empty set", func(t *testing.T) {
+		got := NewSet[string](nil)
+		assert.Equal(t, Set[string]{}, got)
+	})
+	t.Run("populated input", func(t *testing.T) {
+		got := NewSet([]string{"a", "b", "c"})
+		assert.True(t, got.Has("a"))
+		assert.True(t, got.Has("b"))
+		assert.True(t, got.Has("c"))
+		assert.False(t, got.Has("d"))
+		assert.Len(t, got, 3)
+	})
+	t.Run("duplicates collapse to a single entry", func(t *testing.T) {
+		got := NewSet([]string{"a", "a", "b"})
+		assert.Len(t, got, 2)
+		assert.True(t, got.Has("a"))
+		assert.True(t, got.Has("b"))
+	})
+}
+
+func TestNewSetBy(t *testing.T) {
+	type item struct {
+		key  string
+		junk int
+	}
+	t.Run("keyFunc applied to each element", func(t *testing.T) {
+		got := NewSetBy([]item{{"a", 1}, {"b", 2}}, func(i item) string { return i.key })
+		assert.Equal(t, Set[string]{"a": {}, "b": {}}, got)
+	})
+	t.Run("duplicate keys collapse", func(t *testing.T) {
+		got := NewSetBy([]item{{"a", 1}, {"a", 2}}, func(i item) string { return i.key })
+		assert.Len(t, got, 1)
+		assert.True(t, got.Has("a"))
+	})
+}
+
+func TestSetHas(t *testing.T) {
+	s := Set[string]{"present": {}}
+	assert.True(t, s.Has("present"))
+	assert.False(t, s.Has("absent"))
+	t.Run("zero-value type", func(t *testing.T) {
+		// Zero value of int is 0; verify Has works with the zero value as a real entry.
+		zeroSet := Set[int]{0: {}}
+		assert.True(t, zeroSet.Has(0))
+		assert.False(t, zeroSet.Has(1))
+	})
+}
+
+func TestMapBy(t *testing.T) {
+	type item struct {
+		name  string
+		value int
+	}
+	t.Run("empty input → empty map", func(t *testing.T) {
+		got := MapBy[item, string, int](nil, func(i item) (string, int) { return i.name, i.value })
+		assert.Equal(t, map[string]int{}, got)
+	})
+	t.Run("populated input", func(t *testing.T) {
+		got := MapBy([]item{{"a", 1}, {"b", 2}}, func(i item) (string, int) { return i.name, i.value })
+		assert.Equal(t, map[string]int{"a": 1, "b": 2}, got)
+	})
+	t.Run("duplicate keys: last write wins", func(t *testing.T) {
+		// Documented semantic — callers should pre-dedup if they need stricter behavior.
+		got := MapBy([]item{{"a", 1}, {"a", 99}}, func(i item) (string, int) { return i.name, i.value })
+		assert.Equal(t, map[string]int{"a": 99}, got)
+	})
+}

--- a/operator/internal/controller/podclique/components/pod/rollingupdate.go
+++ b/operator/internal/controller/podclique/components/pod/rollingupdate.go
@@ -51,8 +51,9 @@ type updateWork struct {
 // getPodNamesPendingUpdate returns names of pods with old template hash that are not already being deleted
 func (w *updateWork) getPodNamesPendingUpdate(deletionExpectedPodUIDs []types.UID) []string {
 	allOldPods := lo.Union(w.oldTemplateHashPendingPods, w.oldTemplateHashUnhealthyPods, w.oldTemplateHashStartingPods, w.oldTemplateHashUncategorizedPods, w.oldTemplateHashReadyPods)
+	deletionExpectedPodUIDSet := componentutils.NewSet(deletionExpectedPodUIDs)
 	return lo.FilterMap(allOldPods, func(pod *corev1.Pod, _ int) (string, bool) {
-		if slices.Contains(deletionExpectedPodUIDs, pod.UID) {
+		if deletionExpectedPodUIDSet.Has(pod.UID) {
 			return "", false
 		}
 		return pod.Name, true

--- a/operator/internal/controller/podclique/components/pod/syncflow.go
+++ b/operator/internal/controller/podclique/components/pod/syncflow.go
@@ -89,6 +89,7 @@ func (r _resource) prepareSyncFlow(ctx context.Context, logger logr.Logger, pclq
 
 	// initialize the Pod names that are updated in the PodGang resource for this PCLQ.
 	sc.podNamesUpdatedInPCLQPodGangs = r.getPodNamesUpdatedInAssociatedPodGang(existingPodGang, pclq.Name)
+	sc.podNamesUpdatedInPCLQPodGangSet = componentutils.NewSet(sc.podNamesUpdatedInPCLQPodGangs)
 
 	// Get all existing pods for this PCLQ.
 	sc.existingPCLQPods, err = componentutils.GetPCLQPods(ctx, r.client, sc.pcs.Name, pclq)
@@ -268,10 +269,13 @@ func (r _resource) checkAndRemovePodSchedulingGates(sc *syncContext, logger logr
 		)
 	}
 
+	if sc.podNamesUpdatedInPCLQPodGangSet == nil {
+		sc.podNamesUpdatedInPCLQPodGangSet = componentutils.NewSet(sc.podNamesUpdatedInPCLQPodGangs)
+	}
 	for i, p := range sc.existingPCLQPods {
 		if hasPodGangSchedulingGate(p) {
 			podObjectKey := client.ObjectKeyFromObject(p)
-			if !slices.Contains(sc.podNamesUpdatedInPCLQPodGangs, p.Name) {
+			if !sc.podNamesUpdatedInPCLQPodGangSet.Has(p.Name) {
 				logger.Info("Pod has scheduling gate but it has not yet been updated in PodGang", "podObjectKey", podObjectKey)
 				skippedScheduleGatedPods = append(skippedScheduleGatedPods, p.Name)
 				continue
@@ -438,14 +442,15 @@ func (r _resource) createPods(ctx context.Context, logger logr.Logger, sc *syncC
 
 // syncContext holds the relevant state required during the sync flow run.
 type syncContext struct {
-	ctx                           context.Context
-	pcs                           *grovecorev1alpha1.PodCliqueSet
-	pclq                          *grovecorev1alpha1.PodClique
-	associatedPodGangName         string
-	existingPCLQPods              []*corev1.Pod
-	podNamesUpdatedInPCLQPodGangs []string
-	pclqExpectationsStoreKey      string
-	expectedPodTemplateHash       string
+	ctx                             context.Context
+	pcs                             *grovecorev1alpha1.PodCliqueSet
+	pclq                            *grovecorev1alpha1.PodClique
+	associatedPodGangName           string
+	existingPCLQPods                []*corev1.Pod
+	podNamesUpdatedInPCLQPodGangs   []string
+	podNamesUpdatedInPCLQPodGangSet componentutils.Set[string]
+	pclqExpectationsStoreKey        string
+	expectedPodTemplateHash         string
 }
 
 // syncFlowResult captures the result of a sync flow run.

--- a/operator/internal/controller/podcliquescalinggroup/components/podclique/sync.go
+++ b/operator/internal/controller/podcliquescalinggroup/components/podclique/sync.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"slices"
 	"strconv"
 	"time"
 
@@ -47,6 +46,7 @@ type syncContext struct {
 	pcsgConfig                     *grovecorev1alpha1.PodCliqueScalingGroupConfig
 	pcsReplicaIndex                int
 	existingPCLQs                  []grovecorev1alpha1.PodClique
+	existingPCLQNameSet            componentutils.Set[string]
 	pcsgIndicesToTerminate         []string
 	pcsgIndicesToRequeue           []string
 	expectedPCLQFQNsPerPCSGReplica map[int][]string
@@ -86,6 +86,7 @@ func (r _resource) prepareSyncContext(ctx context.Context, logger logr.Logger, p
 	if err != nil {
 		return nil, err
 	}
+	syncCtx.existingPCLQNameSet = componentutils.PodCliqueNameSet(syncCtx.existingPCLQs)
 
 	// compute the PCSG indices that have their MinAvailableBreached condition set to true. Segregated these into two
 	// pcsgIndicesToTerminate will have the indices for which the TerminationDelay has expired.
@@ -200,10 +201,9 @@ func computePCSGReplicasToDelete(existingReplicas, expectedReplicas int) []strin
 // createExpectedPCLQs creates any missing PodCliques needed to satisfy the desired PCSG replica configuration
 func (r _resource) createExpectedPCLQs(logger logr.Logger, sc *syncContext) error {
 	var tasks []utils.Task
-	existingPCLQFQNs := lo.Map(sc.existingPCLQs, func(pclq grovecorev1alpha1.PodClique, _ int) string { return pclq.Name })
 	for pcsgReplicaIndex, expectedPCLQNames := range sc.expectedPCLQFQNsPerPCSGReplica {
 		for _, pclqFQN := range expectedPCLQNames {
-			if slices.Contains(existingPCLQFQNs, pclqFQN) {
+			if sc.existingPCLQNameSet.Has(pclqFQN) {
 				continue
 			}
 			pclqObjectKey := client.ObjectKey{
@@ -233,14 +233,13 @@ func (r _resource) createExpectedPCLQs(logger logr.Logger, sc *syncContext) erro
 // This is used for the OnDelete update strategy where changes are applied in place rather than through recreation.
 func (r _resource) createOrUpdatePCLQs(logger logr.Logger, sc *syncContext) error {
 	var tasks []utils.Task
-	existingPCLQFQNs := lo.Map(sc.existingPCLQs, func(pclq grovecorev1alpha1.PodClique, _ int) string { return pclq.Name })
 	for pcsgReplicaIndex, expectedPCLQNames := range sc.expectedPCLQFQNsPerPCSGReplica {
 		for _, pclqFQN := range expectedPCLQNames {
 			pclqObjectKey := client.ObjectKey{
 				Name:      pclqFQN,
 				Namespace: sc.pcsg.Namespace,
 			}
-			pclqExists := slices.Contains(existingPCLQFQNs, pclqFQN)
+			pclqExists := sc.existingPCLQNameSet.Has(pclqFQN)
 			createOrUpdateTask := utils.Task{
 				Name: fmt.Sprintf("CreateOrUpdatePodClique-%s", pclqObjectKey),
 				Fn: func(ctx context.Context) error {
@@ -383,6 +382,7 @@ func (sc *syncContext) refreshExistingPCLQs(pcsg *grovecorev1alpha1.PodCliqueSca
 		}
 	}
 	sc.existingPCLQs = revisedExistingPCLQs
+	sc.existingPCLQNameSet = componentutils.PodCliqueNameSet(revisedExistingPCLQs)
 	return nil
 }
 

--- a/operator/internal/controller/podcliqueset/components/podclique/podclique.go
+++ b/operator/internal/controller/podcliqueset/components/podclique/podclique.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -130,6 +129,7 @@ func (r _resource) triggerDeletionOfExcessPCLQs(ctx context.Context, logger logr
 func (r _resource) createOrUpdatePCLQs(ctx context.Context, logger logr.Logger, pcs *grovecorev1alpha1.PodCliqueSet, existingPCLQFQNs []string) error {
 	expectedPCLQNames, _ := componentutils.GetExpectedPCLQNamesGroupByOwner(pcs)
 	tasks := make([]utils.Task, 0, len(expectedPCLQNames))
+	existingPCLQNameSet := componentutils.NewSet(existingPCLQFQNs)
 
 	for pcsReplica := range pcs.Spec.Replicas {
 		for _, expectedPCLQName := range expectedPCLQNames {
@@ -137,7 +137,7 @@ func (r _resource) createOrUpdatePCLQs(ctx context.Context, logger logr.Logger, 
 				Name:      apicommon.GeneratePodCliqueName(apicommon.ResourceNameReplica{Name: pcs.Name, Replica: int(pcsReplica)}, expectedPCLQName),
 				Namespace: pcs.Namespace,
 			}
-			pclqExists := slices.Contains(existingPCLQFQNs, pclqObjectKey.Name)
+			pclqExists := existingPCLQNameSet.Has(pclqObjectKey.Name)
 			createOrUpdateTask := utils.Task{
 				Name: fmt.Sprintf("CreateOrUpdatePodClique-%s", pclqObjectKey),
 				Fn: func(ctx context.Context) error {

--- a/operator/internal/controller/podcliqueset/components/podcliquescalinggroup/podcliquescalinggroup.go
+++ b/operator/internal/controller/podcliqueset/components/podcliquescalinggroup/podcliquescalinggroup.go
@@ -19,7 +19,6 @@ package podcliquescalinggroup
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strconv"
 
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
@@ -27,6 +26,7 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/ai-dynamo/grove/operator/internal/constants"
 	"github.com/ai-dynamo/grove/operator/internal/controller/common/component"
+	componentutils "github.com/ai-dynamo/grove/operator/internal/controller/common/component/utils"
 	groveerr "github.com/ai-dynamo/grove/operator/internal/errors"
 	"github.com/ai-dynamo/grove/operator/internal/mnnvl"
 	"github.com/ai-dynamo/grove/operator/internal/utils"
@@ -94,6 +94,7 @@ func (r _resource) Sync(ctx context.Context, logger logr.Logger, pcs *grovecorev
 	}
 
 	tasks := make([]utils.Task, 0, int(pcs.Spec.Replicas)*len(pcs.Spec.Template.PodCliqueScalingGroupConfigs))
+	existingPCSGNameSet := componentutils.NewSet(existingPCSGNames)
 	expectedPCSGNames := make([]string, 0, 20)
 	for pcsReplica := range pcs.Spec.Replicas {
 		for _, pcsgConfig := range pcs.Spec.Template.PodCliqueScalingGroupConfigs {
@@ -103,7 +104,7 @@ func (r _resource) Sync(ctx context.Context, logger logr.Logger, pcs *grovecorev
 				Name:      pcsgName,
 				Namespace: pcs.Namespace,
 			}
-			pcsgExists := slices.Contains(existingPCSGNames, pcsgName)
+			pcsgExists := existingPCSGNameSet.Has(pcsgName)
 			createOrUpdateTask := utils.Task{
 				Name: fmt.Sprintf("CreateOrUpdatePodCliqueScalingGroup-%s", pcsgObjectKey),
 				Fn: func(ctx context.Context) error {
@@ -114,9 +115,13 @@ func (r _resource) Sync(ctx context.Context, logger logr.Logger, pcs *grovecorev
 		}
 	}
 
-	excessPCSGNames := lo.Filter(existingPCSGNames, func(existingPCSGName string, _ int) bool {
-		return !slices.Contains(expectedPCSGNames, existingPCSGName)
-	})
+	expectedPCSGNameSet := componentutils.NewSet(expectedPCSGNames)
+	var excessPCSGNames []string
+	for _, existingPCSGName := range existingPCSGNames {
+		if !expectedPCSGNameSet.Has(existingPCSGName) {
+			excessPCSGNames = append(excessPCSGNames, existingPCSGName)
+		}
+	}
 	for _, excessPCSGName := range excessPCSGNames {
 		pcsgObjectKey := client.ObjectKey{
 			Namespace: pcs.Namespace,

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
@@ -61,6 +60,7 @@ func (r _resource) prepareSyncFlow(ctx context.Context, logger logr.Logger, pcs 
 			fmt.Sprintf("failed to list PodCliques for PodCliqueSet %v", pcsObjectKey),
 		)
 	}
+	sc.existingPCLQByName = componentutils.PodCliqueByName(sc.existingPCLQs)
 
 	sc.existingPCSGs, err = r.getExistingPCSGsForPCS(ctx, pcs)
 	if err != nil {
@@ -70,6 +70,7 @@ func (r _resource) prepareSyncFlow(ctx context.Context, logger logr.Logger, pcs 
 			fmt.Sprintf("failed to list PodCliqueScalingGroups for PodCliqueSet %v", pcsObjectKey),
 		)
 	}
+	sc.existingPCSGByName = componentutils.PCSGByName(sc.existingPCSGs)
 
 	sc.tasEnabled = r.tasConfig.Enabled
 	if r.tasConfig.Enabled && componentutils.HasAnyTopologyConstraint(pcs) {
@@ -102,6 +103,8 @@ func (r _resource) prepareSyncFlow(ctx context.Context, logger logr.Logger, pcs 
 			fmt.Sprintf("failed to compute existing PodGangs for PodCliqueSet %v", pcsObjectKey),
 		)
 	}
+	sc.expectedPodGangByName = podGangInfoByName(sc.expectedPodGangs)
+	sc.expectedPodGangNameSet = podGangInfoNameSet(sc.expectedPodGangs)
 
 	sc.existingPodGangs, err = componentutils.GetExistingPodGangs(ctx, r.client, pcs.ObjectMeta, pcs.Namespace)
 	if err != nil {
@@ -111,6 +114,7 @@ func (r _resource) prepareSyncFlow(ctx context.Context, logger logr.Logger, pcs 
 			fmt.Sprintf("Failed to get existing PodGangs for PodCliqueSet: %v", client.ObjectKeyFromObject(sc.pcs)),
 		)
 	}
+	sc.existingPodGangByName = componentutils.PodGangByName(sc.existingPodGangs)
 
 	sc.existingPCLQPods, err = r.getExistingPodsByPCLQForPCS(ctx, pcsObjectKey)
 	if err != nil {
@@ -375,9 +379,7 @@ func determinePodCliqueReplicas(sc *syncContext, pclqTemplateSpec *grovecorev1al
 	if belongsToPCSG || pclqTemplateSpec.Spec.ScaleConfig == nil {
 		return pclqTemplateSpec.Spec.Replicas
 	}
-	matchingPCLQ, found := lo.Find(sc.existingPCLQs, func(pclq grovecorev1alpha1.PodClique) bool {
-		return pclqFQN == pclq.Name
-	})
+	matchingPCLQ, found := sc.existingPCLQByName[pclqFQN]
 	if !found {
 		// PodClique resource not found - might be during initial creation
 		// Fall back to template replicas but log warning for visibility
@@ -551,12 +553,8 @@ func (r _resource) verifyAllPodsCreated(sc *syncContext, pgi *podGangInfo) error
 
 // getPodsForPodCliquesPendingCreation counts expected pods from non-existent PodCliques.
 func (r _resource) getPodsForPodCliquesPendingCreation(sc *syncContext, podGang *podGangInfo) int {
-	existingPCLQNames := lo.Map(sc.existingPCLQs, func(pclq grovecorev1alpha1.PodClique, _ int) string {
-		return pclq.Name
-	})
-
 	return lo.Reduce(podGang.pclqs, func(agg int, pclq pclqInfo, _ int) int {
-		if !slices.Contains(existingPCLQNames, pclq.fqn) {
+		if _, ok := sc.existingPCLQByName[pclq.fqn]; !ok {
 			return agg + int(pclq.replicas)
 		}
 		return agg
@@ -631,20 +629,29 @@ func (r _resource) createOrUpdatePodGang(ctx context.Context, sc *syncContext, p
 // Convenience types and methods on these types that are used during sync flow run.
 // ------------------------------------------------------------------------------------------------
 
-// syncContext holds the relevant state required during the sync flow run.
+// syncContext holds the relevant state required during the sync flow run. The *ByName / *NameSet
+// fields are O(1) views over their corresponding slices and are populated eagerly in
+// prepareSyncFlow. Callers must access them as fields, not via getters — there is no lazy
+// fallback because lazy mutation of syncContext would race the moment the struct is shared
+// across goroutines.
 type syncContext struct {
 	//ctx                  context.Context
-	pcs                  *grovecorev1alpha1.PodCliqueSet
-	logger               logr.Logger
-	expectedPodGangs     []*podGangInfo
-	existingPodGangs     []groveschedulerv1alpha1.PodGang
-	deletedPodGangNames  []string
-	existingPCLQPods     map[string][]corev1.Pod
-	existingPCLQs        []grovecorev1alpha1.PodClique
-	existingPCSGs        []grovecorev1alpha1.PodCliqueScalingGroup
-	unassignedPodsByPCLQ map[string][]corev1.Pod
-	tasEnabled           bool
-	topologyLevels       []grovecorev1alpha1.TopologyLevel
+	pcs                    *grovecorev1alpha1.PodCliqueSet
+	logger                 logr.Logger
+	expectedPodGangs       []*podGangInfo
+	existingPodGangs       []groveschedulerv1alpha1.PodGang
+	existingPodGangByName  map[string]groveschedulerv1alpha1.PodGang
+	deletedPodGangNames    []string
+	existingPCLQPods       map[string][]corev1.Pod
+	existingPCLQs          []grovecorev1alpha1.PodClique
+	existingPCLQByName     map[string]grovecorev1alpha1.PodClique
+	existingPCSGs          []grovecorev1alpha1.PodCliqueScalingGroup
+	existingPCSGByName     map[string]grovecorev1alpha1.PodCliqueScalingGroup
+	expectedPodGangByName  map[string]*podGangInfo
+	expectedPodGangNameSet componentutils.Set[string]
+	unassignedPodsByPCLQ   map[string][]corev1.Pod
+	tasEnabled             bool
+	topologyLevels         []grovecorev1alpha1.TopologyLevel
 }
 
 // getPodGangNamesPendingCreation identifies PodGangs not yet created.
@@ -655,18 +662,14 @@ func (sc *syncContext) getPodGangNamesPendingCreation() []string {
 }
 
 func (sc *syncContext) isExistingPodGang(podGangName string) bool {
-	return slices.ContainsFunc(sc.existingPodGangs, func(pg groveschedulerv1alpha1.PodGang) bool {
-		return podGangName == pg.Name
-	})
+	_, ok := sc.existingPodGangByName[podGangName]
+	return ok
 }
 
 func (sc *syncContext) getExcessPodGangNames() []string {
 	var excessPodGangNames []string
-	expectedPodGangNames := lo.Map(sc.expectedPodGangs, func(pg *podGangInfo, _ int) string {
-		return pg.fqn
-	})
 	for _, existingPodGang := range sc.existingPodGangs {
-		if !slices.Contains(expectedPodGangNames, existingPodGang.Name) {
+		if !sc.expectedPodGangNameSet.Has(existingPodGang.Name) {
 			excessPodGangNames = append(excessPodGangNames, existingPodGang.Name)
 		}
 	}
@@ -674,27 +677,24 @@ func (sc *syncContext) getExcessPodGangNames() []string {
 }
 
 func (sc *syncContext) isPodGangInitialized(podGangName string) bool {
-	foundPG, ok := lo.Find(sc.existingPodGangs, func(pg groveschedulerv1alpha1.PodGang) bool {
-		return podGangName == pg.Name
-	})
+	foundPG, ok := sc.existingPodGangByName[podGangName]
 	return ok && k8sutils.IsConditionTrue(foundPG.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeInitialized))
 }
 
 // initializeAssignedAndUnassignedPodsForPCS categorizes pods by PodGang assignment.
+// The lookup yields a *podGangInfo that aliases an entry in sc.expectedPodGangs (which stores
+// pointers). Mutations via refreshAssociatedPCLQPods therefore propagate back to the slice;
+// changing expectedPodGangs to a value-typed slice would silently break this aliasing.
 func (sc *syncContext) initializeAssignedAndUnassignedPodsForPCS() {
 	for pclqName, pods := range sc.existingPCLQPods {
 		for _, pod := range pods {
 			if metav1.HasLabel(pod.ObjectMeta, apicommon.LabelPodGang) {
 				podGangName := pod.GetLabels()[apicommon.LabelPodGang]
-				// Find the index to work with the original slice element, not a copy
-				pgiIndex := slices.IndexFunc(sc.expectedPodGangs, func(pgi *podGangInfo) bool {
-					return podGangName == pgi.fqn
-				})
-				if pgiIndex == -1 {
+				pgi, ok := sc.expectedPodGangByName[podGangName]
+				if !ok {
 					continue
 				}
-				// Work with the original element in the slice, not a copy
-				sc.expectedPodGangs[pgiIndex].refreshAssociatedPCLQPods(pclqName, pod.Name)
+				pgi.refreshAssociatedPCLQPods(pclqName, pod.Name)
 			} else {
 				sc.unassignedPodsByPCLQ[pclqName] = append(sc.unassignedPodsByPCLQ[pclqName], pod)
 			}
@@ -706,10 +706,8 @@ func (sc *syncContext) initializeAssignedAndUnassignedPodsForPCS() {
 func (sc *syncContext) getPodCliques(podGang *podGangInfo) []grovecorev1alpha1.PodClique {
 	constituentPCLQs := make([]grovecorev1alpha1.PodClique, 0, len(podGang.pclqs))
 	for _, podGangConstituentPCLQInfo := range podGang.pclqs {
-		for _, pclq := range sc.existingPCLQs {
-			if pclq.Name == podGangConstituentPCLQInfo.fqn {
-				constituentPCLQs = append(constituentPCLQs, pclq)
-			}
+		if pclq, ok := sc.existingPCLQByName[podGangConstituentPCLQInfo.fqn]; ok {
+			constituentPCLQs = append(constituentPCLQs, pclq)
 		}
 	}
 	return constituentPCLQs
@@ -719,13 +717,27 @@ func (sc *syncContext) getPodCliques(podGang *podGangInfo) []grovecorev1alpha1.P
 // If the PCSG exists then it will return the pcsg.Spec.Replicas value, else it will return the template replicas
 // as defined in grovecorev1alpha1.PodCliqueScalingGroupConfig.Replicas
 func (sc *syncContext) determinePCSGReplicas(pcsgFQN string, pcsgConfig grovecorev1alpha1.PodCliqueScalingGroupConfig) int {
-	foundExistingPCSG, ok := lo.Find(sc.existingPCSGs, func(pcsg grovecorev1alpha1.PodCliqueScalingGroup) bool {
-		return pcsg.Name == pcsgFQN
-	})
-	if ok {
+	if foundExistingPCSG, ok := sc.existingPCSGByName[pcsgFQN]; ok {
 		return int(foundExistingPCSG.Spec.Replicas)
 	}
 	return int(*pcsgConfig.Replicas)
+}
+
+// podGangInfoByName builds a name-keyed map for O(1) podGangInfo lookups. Kept local because
+// podGangInfo is package-private; the public PodCliqueByName/PCSGByName/PodGangByName helpers
+// in componentutils cover the cross-package equivalents.
+func podGangInfoByName(podGangs []*podGangInfo) map[string]*podGangInfo {
+	return componentutils.MapBy(podGangs, func(podGang *podGangInfo) (string, *podGangInfo) {
+		return podGang.fqn, podGang
+	})
+}
+
+// podGangInfoNameSet builds a Set of podGangInfo FQNs. Kept local for the same reason as
+// podGangInfoByName.
+func podGangInfoNameSet(podGangs []*podGangInfo) componentutils.Set[string] {
+	return componentutils.NewSetBy(podGangs, func(podGang *podGangInfo) string {
+		return podGang.fqn
+	})
 }
 
 // syncFlowResult captures the result of a sync flow run.

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow_test.go
@@ -278,9 +278,10 @@ func TestVerifyAllPodsCreated(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sc := &syncContext{
-				logger:           ctrllogger.FromContext(t.Context()).WithName("test"),
-				existingPCLQPods: tt.existingPods,
-				existingPCLQs:    tt.existingPCLQs,
+				logger:             ctrllogger.FromContext(t.Context()).WithName("test"),
+				existingPCLQPods:   tt.existingPods,
+				existingPCLQs:      tt.existingPCLQs,
+				existingPCLQByName: componentutils.PodCliqueByName(tt.existingPCLQs),
 			}
 			r := &_resource{}
 			err := r.verifyAllPodsCreated(sc, tt.podGang)
@@ -1548,7 +1549,8 @@ func TestDeterminePCSGReplicas(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			sc := &syncContext{
-				existingPCSGs: test.existingPCSGs,
+				existingPCSGs:      test.existingPCSGs,
+				existingPCSGByName: componentutils.PCSGByName(test.existingPCSGs),
 			}
 
 			actualReplicas := sc.determinePCSGReplicas(test.pcsgFQN, test.pcsgConfig)


### PR DESCRIPTION
#### What type of PR is this?      

  /kind cleanup                                                                                                                                                                                                                                                                             
   
  #### What this PR does / why we need it:                                                                                                                                                                                                                                                  
                  
  Linearizes nine O(N×M) loops in the operator's reconcile path by replacing per-element `slices.Contains` / `slices.IndexFunc` / `lo.Filter`-with-inner-`Contains` lookups with `map[string]struct{}` (or `map[string]T`) sets/lookups built once per sync context. Same shape across all  
  nine sites; no behavior change.
                                                                                                                                                                                                                                                                                            
  Affected call sites (each was O(M·E), is now O(M+E)):                                                                                                                                                                                                                                     
   
  | Hotspot | File | Function |                                                                                                                                                                                                                                                             
  |---|---|---|   
  | 1 | `controller/podcliqueset/components/podgang/syncflow.go` | `initializeAssignedAndUnassignedPodsForPCS` |
  | 2 | `controller/podclique/components/pod/syncflow.go` | `checkAndRemovePodSchedulingGates` |                                                                                                                                                                                            
  | 3 | `controller/podclique/components/pod/rollingupdate.go` | `getPodNamesPendingUpdate` |                                                                                                                                                                                               
  | 4 | `controller/podcliquescalinggroup/components/podclique/sync.go` | `createExpectedPCLQs`, `createOrUpdatePCLQs` |                                                                                                                                                                    
  | 5 | `controller/podcliqueset/components/podclique/podclique.go` | `createOrUpdatePCLQs` |                                                                                                                                                                                               
  | 6 | `controller/podcliqueset/components/podcliquescalinggroup/podcliquescalinggroup.go` | `Sync` (existence check + excess filter) |                                                                                                                                                    
  nine sites; no behavior change.

  Affected call sites (each was O(M·E), is now O(M+E)):

  | Hotspot | File | Function |
  |---|---|---|
  | 1 | `controller/podcliqueset/components/podgang/syncflow.go` | `initializeAssignedAndUnassignedPodsForPCS` |
  | 2 | `controller/podclique/components/pod/syncflow.go` | `checkAndRemovePodSchedulingGates` |
  | 3 | `controller/podclique/components/pod/rollingupdate.go` | `getPodNamesPendingUpdate` |
  | 4 | `controller/podcliquescalinggroup/components/podclique/sync.go` | `createExpectedPCLQs`, `createOrUpdatePCLQs` |
  | 5 | `controller/podcliqueset/components/podclique/podclique.go` | `createOrUpdatePCLQs` |
  | 6 | `controller/podcliqueset/components/podcliquescalinggroup/podcliquescalinggroup.go` | `Sync` (existence check + excess filter) |
  | 7 | `controller/podcliqueset/components/podgang/syncflow.go` | `getPodsForPodCliquesPendingCreation` |
  | 8 | `controller/podcliqueset/components/podgang/syncflow.go` | `getPodGangNamesPendingCreation`, `getExcessPodGangNames` |
  | 9 | `controller/podcliqueset/components/podgang/syncflow.go` | `getPodCliques`, `determinePodCliqueReplicas`, `determinePCSGReplicas` |

  Introduces a small generic utility at `internal/controller/common/component/utils/`:

  - `sets.go` — `Set[T]` / `NewSet` / `NewSetBy` / `Has` for membership-only lookups; `MapBy` returning `map[K]V` for value-retrieval lookups.
  - `lookups.go` — typed convenience helpers (`PodCliqueByName`, `PodCliqueNameSet`, `PCSGByName`, `PodGangByName`) over Grove's common resource slices, since these views are needed in multiple controllers.

  The fix matters at modest scale, not just at the upper bound: at ~1 000 Pods (well below Grove's ~10 000-Pod target) the PCLQ-heavy shape produces low-millions of comparisons per reconcile plus per-element slice allocations on every hot path. CPU and GC pressure don't show in
  dev/CI because dev clusters typically run at N≈10. At N=10 000 these patterns produce 10⁸-class per-reconcile work — the regime where reconcile latencies climb to seconds and watch-event storms cascade.

  #### Which issue(s) this PR fixes:
  Fixes #577

  #### Special notes for your reviewer:

  - **Mechanical refactor.** Each hotspot is the same pattern: hoist a `map[string]struct{}` (or `map[string]T`) out of the inner loop, do a single map lookup per element. No semantic changes.
  - **Eager init, no lazy fallback.** The `*ByName` / `*NameSet` fields on `syncContext` are populated up front in `prepareSyncFlow` (or `prepareSyncContext`). I deliberately did *not* add lazy-init getters — they would either be dead code (callers always go through
  `prepareSyncFlow`) or a latent data race (if `syncContext` is ever shared across goroutines). Two `syncflow_test.go` fixtures were updated to populate the new fields explicitly using the hoisted helpers — this is exactly the kind of mismatch the eager-only design is meant to
  surface.
  - **`Set[T]` keeps `.Has`, `map[K]V` doesn't get a wrapper.** `Set[T]` uses a sentinel `struct{}` value, so the `Has` method is genuinely useful. For `map[K]V` lookups, the natural `_, ok := m[k]` idiom is used everywhere — no `Lookup[K, V]` alias.
  - **Pointer aliasing.** `initializeAssignedAndUnassignedPodsForPCS` relies on `expectedPodGangs []*podGangInfo` being a slice of pointers — the `expectedPodGangByName` map values alias the same structs, so `pgi.refreshAssociatedPCLQPods(...)` mutates back into the slice. There's an
   inline comment documenting this; a future refactor that switches to value-typed entries would silently break it.
  - **Companion scale test.** `Test_ScaleTest_1000_PodHeavy` (1 PCS × 1 PCLQ × 1 000 pods) added to `e2e/tests/scale/`. Companion to the existing `Test_ScaleTest_1000` (500 PCLQs × 2 pods, PCLQ-heavy). The two together cover both hotspot axes: PCLQ-heavy hits hotspots 1, 4, 5, 7, 8,
  9; Pod-heavy hits 2, 3. Run with `make run-scale-test TEST_PATTERN=Test_ScaleTest_1000_PodHeavy` against `make scale-cluster-up`. Diff `scale-test-results.json` and the steady-state-reconcile pprof captures between baseline and this branch for the perf evidence.
  - **Tests.** `sets_test.go` covers `NewSet` (empty/populated/dups), `NewSetBy` (keyFunc + dedup), `Set.Has` (incl. zero-value), `MapBy` (empty/populated/last-write-wins). All existing controller tests pass. Full unit-test suite + `go vet` (default + `-tags=e2e`) + `make lint`
  clean.
  - **Suggested review focus.** `internal/controller/common/component/utils/sets.go`, `lookups.go` (the new abstraction), and `controller/podcliqueset/components/podgang/syncflow.go` (largest delta — 4 hotspots fixed in one file, syncContext shape changed). The rest are 5–10-line
  mechanical applications of the same pattern.

  #### Does this PR introduce a API change?

  ```release-note
  NONE

  Additional documentation e.g., enhancement proposals, usage docs, etc.: