### PR TITLE
Fix decode test error for operator config defaults

### DIFF
--- a/.github/workflows/build-check-test.yaml
+++ b/.github/workflows/build-check-test.yaml
@@ -57,7 +57,13 @@ jobs:
         with:
           go-version: "1.26.1"
           cache: true
-          cache-dependency-path: operator/go.sum
+          cache-dependency-path: |
+            operator/go.sum
+            operator/api/go.sum
+            operator/client/go.sum
+            scheduler/api/go.sum
+            scheduler/client/go.sum
+            cli-plugin/go.sum
       - name: test-unit
         run: make test-unit
   build:

--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,22 @@ generate-api-docs: $(CRD_REF_DOCS)
 # Runs unit tests for the entire codebase (all modules)
 .PHONY: test-unit
 test-unit:
+	@echo "> Running tests for operator/api"
+	@cd operator/api && go test ./...
 	@echo "> Running tests for operator"
 	@make --directory=operator test-unit
+	@echo "> Running tests for operator/client"
+	@cd operator/client && go test ./...
+	@echo "> Running tests for scheduler/api"
+	@cd scheduler/api && go test ./...
+	@echo "> Running tests for scheduler/client"
+	@cd scheduler/client && go test ./...
+	@echo "> Running tests for cli-plugin"
+	@if [ -n "$$(cd cli-plugin && go list ./... 2>/dev/null)" ]; then \
+		cd cli-plugin && go test ./...; \
+	else \
+		echo "> Skipping cli-plugin (no Go packages)"; \
+	fi
 
 .PHONY: test-cover
 test-cover:

--- a/operator/api/config/v1alpha1/decode_test.go
+++ b/operator/api/config/v1alpha1/decode_test.go
@@ -67,11 +67,11 @@ kind: OperatorConfiguration
 				assert.InDelta(t, float32(100), cfg.ClientConnection.QPS, 0.01)
 				assert.Equal(t, 120, cfg.ClientConnection.Burst)
 				require.NotNil(t, cfg.Controllers.PodCliqueSet.ConcurrentSyncs)
-				assert.Equal(t, 1, *cfg.Controllers.PodCliqueSet.ConcurrentSyncs)
+				assert.Equal(t, 10, *cfg.Controllers.PodCliqueSet.ConcurrentSyncs)
 				require.NotNil(t, cfg.Controllers.PodCliqueScalingGroup.ConcurrentSyncs)
-				assert.Equal(t, 1, *cfg.Controllers.PodCliqueScalingGroup.ConcurrentSyncs)
+				assert.Equal(t, 5, *cfg.Controllers.PodCliqueScalingGroup.ConcurrentSyncs)
 				require.NotNil(t, cfg.Controllers.PodClique.ConcurrentSyncs)
-				assert.Equal(t, 1, *cfg.Controllers.PodClique.ConcurrentSyncs)
+				assert.Equal(t, 10, *cfg.Controllers.PodClique.ConcurrentSyncs)
 			},
 		},
 		{


### PR DESCRIPTION
Fix https://github.com/ai-dynamo/grove/issues/580

Issue #580 

```
--- FAIL: TestDecodeOperatorConfig (0.00s)
    --- FAIL: TestDecodeOperatorConfig/defaults_applied_for_minimal_YAML (0.00s)
        decode_test.go:70: 
            	Error Trace:	/Users/admin/work/go/src/github.com/ai-dynamo/grove/operator/api/config/v1alpha1/decode_test.go:70
            	            				/Users/admin/work/go/src/github.com/ai-dynamo/grove/operator/api/config/v1alpha1/decode_test.go:117
            	Error:      	Not equal: 
            	            	expected: 1
            	            	actual  : 10
            	Test:       	TestDecodeOperatorConfig/defaults_applied_for_minimal_YAML
        decode_test.go:72: 
            	Error Trace:	/Users/admin/work/go/src/github.com/ai-dynamo/grove/operator/api/config/v1alpha1/decode_test.go:72
            	            				/Users/admin/work/go/src/github.com/ai-dynamo/grove/operator/api/config/v1alpha1/decode_test.go:117
            	Error:      	Not equal: 
            	            	expected: 1
            	            	actual  : 5
            	Test:       	TestDecodeOperatorConfig/defaults_applied_for_minimal_YAML
        decode_test.go:74: 
            	Error Trace:	/Users/admin/work/go/src/github.com/ai-dynamo/grove/operator/api/config/v1alpha1/decode_test.go:74
            	            				/Users/admin/work/go/src/github.com/ai-dynamo/grove/operator/api/config/v1alpha1/decode_test.go:117
            	Error:      	Not equal: 
            	            	expected: 1
            	            	actual  : 10
            	Test:       	TestDecodeOperatorConfig/defaults_applied_for_minimal_YAML
FAIL
FAIL	github.com/ai-dynamo/grove/operator/api/config/v1alpha1	0.472s
FAIL

```