### PR TITLE
fix: tolerate missing ResourceClaim API during PCLQ reconcile and delete

### DIFF
--- a/operator/internal/controller/podclique/components/resourceclaim/resourceclaim.go
+++ b/operator/internal/controller/podclique/components/resourceclaim/resourceclaim.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/go-logr/logr"
 	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -64,6 +65,9 @@ func (r _resource) GetExistingResourceNames(ctx context.Context, _ logr.Logger, 
 		client.InNamespace(pclqObjMeta.Namespace),
 		client.MatchingLabels(pclqResourceClaimLabels(pclqObjMeta)),
 	); err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil, nil
+		}
 		return nil, groveerr.WrapError(err,
 			errSyncPCLQLevelRC,
 			component.OperationGetExistingResourceNames,
@@ -188,12 +192,16 @@ func pclqResourceClaimLabels(pclqObjMeta metav1.ObjectMeta) map[string]string {
 // This is required because the PCLQ finalizer's verifyNoResourcesAwaitsCleanup
 // blocks finalizer removal until all owned resources are gone; relying solely on
 // GC would create a deadlock since GC only fires after the PCLQ is fully deleted.
-func (r _resource) Delete(ctx context.Context, _ logr.Logger, pclqObjMeta metav1.ObjectMeta) error {
+func (r _resource) Delete(ctx context.Context, logger logr.Logger, pclqObjMeta metav1.ObjectMeta) error {
 	labels := pclqResourceClaimLabels(pclqObjMeta)
 	if err := r.client.DeleteAllOf(ctx, &resourcev1.ResourceClaim{},
 		client.InNamespace(pclqObjMeta.Namespace),
 		client.MatchingLabels(labels),
 	); err != nil {
+		if meta.IsNoMatchError(err) {
+			logger.V(1).Info("ResourceClaim API not served by cluster, skipping delete", "namespace", pclqObjMeta.Namespace, "podClique", pclqObjMeta.Name, "err", err.Error())
+			return nil
+		}
 		return groveerr.WrapError(err,
 			errDeletePCLQLevelRC,
 			component.OperationDelete,

--- a/operator/internal/controller/podclique/components/resourceclaim/resourceclaim_test.go
+++ b/operator/internal/controller/podclique/components/resourceclaim/resourceclaim_test.go
@@ -26,11 +26,26 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
+
+// noResourceClaimAPIInterceptor simulates a cluster whose apiserver does not
+// serve resource.k8s.io ResourceClaim by returning a NoKindMatchError.
+var noResourceClaimAPIInterceptor = interceptor.Funcs{
+	List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+		return &meta.NoKindMatchError{GroupKind: schema.GroupKind{Group: resourcev1.GroupName, Kind: "ResourceClaim"}}
+	},
+	DeleteAllOf: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteAllOfOption) error {
+		return &meta.NoKindMatchError{GroupKind: schema.GroupKind{Group: resourcev1.GroupName, Kind: "ResourceClaim"}}
+	},
+}
 
 func newTestScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
@@ -190,6 +205,15 @@ func TestGetExistingResourceNames(t *testing.T) {
 		names, err := r.GetExistingResourceNames(context.Background(), logr.Discard(), pclqMeta)
 		require.NoError(t, err)
 		assert.Equal(t, []string{pclqName + "-all-gpu-mps"}, names)
+	})
+
+	t.Run("returns empty when ResourceClaim API is not served", func(t *testing.T) {
+		cl := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(noResourceClaimAPIInterceptor).Build()
+		r := _resource{client: cl, scheme: scheme}
+
+		names, err := r.GetExistingResourceNames(context.Background(), logr.Discard(), pclqMeta)
+		require.NoError(t, err)
+		assert.Empty(t, names)
 	})
 }
 
@@ -382,6 +406,19 @@ func TestDelete(t *testing.T) {
 			Labels:    map[string]string{apicommon.LabelPartOfKey: pcsName},
 		}
 		cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+		r := _resource{client: cl, scheme: scheme}
+
+		err := r.Delete(context.Background(), logr.Discard(), pclqMeta)
+		require.NoError(t, err)
+	})
+
+	t.Run("no-op when ResourceClaim API is not served", func(t *testing.T) {
+		pclqMeta := metav1.ObjectMeta{
+			Name:      pclqName,
+			Namespace: namespace,
+			Labels:    map[string]string{apicommon.LabelPartOfKey: pcsName},
+		}
+		cl := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(noResourceClaimAPIInterceptor).Build()
 		r := _resource{client: cl, scheme: scheme}
 
 		err := r.Delete(context.Background(), logr.Discard(), pclqMeta)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

PodClique reconcile and delete now treat `meta.IsNoMatchError` from ResourceClaim list/delete as "nothing to do" instead of a hard failure, so cleanup is not blocked on clusters that do not serve the `resource.k8s.io` ResourceClaim API.

#### Which issue(s) this PR fixes:
Fixes #609

#### Special notes for your reviewer:

If the API is absent there can be no ResourceClaim objects to reconcile or delete, so skipping is safe. Added regression tests using an interceptor that returns `NoKindMatchError`.

#### Does this PR introduce a API change?
```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs

```
