### PR TITLE
Retry KWOK Stage CRD wait

### DIFF
--- a/operator/hack/infra_manager/kwok.py
+++ b/operator/hack/infra_manager/kwok.py
@@ -134,17 +134,25 @@ def _apply_kwok_manifest(base_url: str, manifest: str) -> None:
 def _wait_for_stage_crd(timeout: int) -> None:
     """Wait until the KWOK Stage CRD is established and visible via discovery."""
     console.print("[yellow]\u2139\ufe0f  Waiting for KWOK Stage CRD to be established...[/yellow]")
-    ok, _, stderr = run_kubectl(
-        [
-            "wait",
-            "--for=condition=Established",
-            f"crd/{KWOK_STAGE_CRD}",
-            f"--timeout={timeout}s",
-        ],
-        timeout=timeout + 10,
-    )
-    if not ok:
-        raise RuntimeError(f"KWOK Stage CRD not established after {timeout}s: {stderr[:500]}")
+    deadline = time.monotonic() + timeout
+    last_error = ""
+    while time.monotonic() < deadline:
+        wait_timeout = max(1, min(10, int(deadline - time.monotonic())))
+        ok, _, stderr = run_kubectl(
+            [
+                "wait",
+                "--for=condition=Established",
+                f"crd/{KWOK_STAGE_CRD}",
+                f"--timeout={wait_timeout}s",
+            ],
+            timeout=wait_timeout + 5,
+        )
+        if ok:
+            break
+        last_error = stderr
+        time.sleep(2)
+    else:
+        raise RuntimeError(f"KWOK Stage CRD not established after {timeout}s: {last_error[:500]}")
 
     deadline = time.monotonic() + timeout
     last_error = ""


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The scale-test CI hit a transient `kubectl wait` failure while waiting for the KWOK `Stage` CRD:

```
.status.conditions accessor error: <nil> is of the type <nil>, expected []interface{}
```

This PR keeps using `kubectl wait`, but runs it in short retry loops up to the existing timeout. That lets the CRD object finish populating status/discovery before setup fails.

#### Which issue(s) this PR fixes:

Fixes #550

#### Special notes for your reviewer:

This is a follow-up to #611. The previous PR made `stage-fast.yaml` mandatory; this one makes the CRD readiness wait tolerate the short window where the CRD exists but `.status.conditions` is not populated yet.

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```