### PR TITLE
fix: PodCliqueSet webhook crashes on unknown scheduler name

### DIFF
--- a/operator/internal/webhook/admission/pcs/validation/handler.go
+++ b/operator/internal/webhook/admission/pcs/validation/handler.go
@@ -134,6 +134,9 @@ func (h *Handler) validatePodCliqueSetWithBackend(ctx context.Context, pcs *v1al
 	}
 
 	backend := h.schedRegistry.GetOrDefault(schedulerName)
+	if backend == nil {
+		return fmt.Errorf("schedulerName %q is not a supported backend", schedulerName)
+	}
 	return backend.ValidatePodCliqueSet(ctx, pcs)
 }
 

--- a/operator/internal/webhook/admission/pcs/validation/handler_test.go
+++ b/operator/internal/webhook/admission/pcs/validation/handler_test.go
@@ -116,6 +116,41 @@ func TestValidateCreate(t *testing.T) {
 			expectError:   true,
 			errorContains: "failed to cast object to PodCliqueSet",
 		},
+		{
+			name: "unknown scheduler name returns error without panic",
+			obj: &grovecorev1alpha1.PodCliqueSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pcs",
+					Namespace: "default",
+				},
+				Spec: grovecorev1alpha1.PodCliqueSetSpec{
+					Replicas: 1,
+					Template: grovecorev1alpha1.PodCliqueSetTemplateSpec{
+						TerminationDelay: ptr.To(metav1.Duration{Duration: 4 * time.Hour}),
+						StartupType:      ptr.To(grovecorev1alpha1.CliqueStartupTypeAnyOrder),
+						Cliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
+							{
+								Name: "test-pclq",
+								Spec: grovecorev1alpha1.PodCliqueSpec{
+									RoleName:     "test-role",
+									Replicas:     1,
+									MinAvailable: ptr.To(int32(1)),
+									PodSpec: corev1.PodSpec{
+										SchedulerName: "unknown-scheduler",
+										Containers: []corev1.Container{{
+											Name:  "test",
+											Image: "test",
+										}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError:   true,
+			errorContains: "schedulerName must be an enabled scheduler backend",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

  In a PodCliqueSet YAML, users set spec.template.cliques[].spec.podSpec.schedulerName to choose the scheduler backend. Valid values are "default-scheduler" and "kai-scheduler". 
This field  is plain corev1.PodSpec.SchedulerName (a string) — it has no CRD-level enum constraint, so the API server does not reject unknown values like "volcano" at the schema layer.

 If a user mistakenly sets this to an unsupported value or typo , the validating webhook runs validateSchedulerNames, which detects the mismatch and records a validation error. However,  validateSchedulerNames only accumulates errors into a field.ErrorList; it does not return early or prevent the handler from continuing. validatePodCliqueSetWithBackend is called
  unconditionally immediately after. 

Inside that function, GetOrDefault("kaikai-scheduler") or GetOrDefault("volcano")  returns nil because the name is non-empty but not in the registry, and the subsequent  backend.ValidatePodCliqueSet() dereferences nil, panicking the webhook process before it can return the recorded validation error to the user. 

In short: the webhook does validate the  name, but that validation does not stop the code from reaching the nil-deref site.


#### Which issue(s) this PR fixes:

Fixes #619 
#### Special notes for your reviewer:

#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs

```
