### PR TITLE
use lodash func

### DIFF
--- a/operator/internal/controller/common/component/utils/lookups.go
+++ b/operator/internal/controller/common/component/utils/lookups.go
@@ -20,6 +20,7 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
+	"github.com/samber/lo"
 )
 
 // Reusable name-keyed views over the common Grove resource slices. Each function builds a
@@ -28,7 +29,7 @@ import (
 
 // PodCliqueByName builds a name-keyed map for O(1) PodClique lookups.
 func PodCliqueByName(pclqs []grovecorev1alpha1.PodClique) map[string]grovecorev1alpha1.PodClique {
-	return MapBy(pclqs, func(pclq grovecorev1alpha1.PodClique) (string, grovecorev1alpha1.PodClique) {
+	return lo.SliceToMap(pclqs, func(pclq grovecorev1alpha1.PodClique) (string, grovecorev1alpha1.PodClique) {
 		return pclq.Name, pclq
 	})
 }
@@ -42,14 +43,14 @@ func PodCliqueNameSet(pclqs []grovecorev1alpha1.PodClique) Set[string] {
 
 // PCSGByName builds a name-keyed map for O(1) PodCliqueScalingGroup lookups.
 func PCSGByName(pcsgs []grovecorev1alpha1.PodCliqueScalingGroup) map[string]grovecorev1alpha1.PodCliqueScalingGroup {
-	return MapBy(pcsgs, func(pcsg grovecorev1alpha1.PodCliqueScalingGroup) (string, grovecorev1alpha1.PodCliqueScalingGroup) {
+	return lo.SliceToMap(pcsgs, func(pcsg grovecorev1alpha1.PodCliqueScalingGroup) (string, grovecorev1alpha1.PodCliqueScalingGroup) {
 		return pcsg.Name, pcsg
 	})
 }
 
 // PodGangByName builds a name-keyed map for O(1) PodGang lookups.
 func PodGangByName(podGangs []groveschedulerv1alpha1.PodGang) map[string]groveschedulerv1alpha1.PodGang {
-	return MapBy(podGangs, func(podGang groveschedulerv1alpha1.PodGang) (string, groveschedulerv1alpha1.PodGang) {
+	return lo.SliceToMap(podGangs, func(podGang groveschedulerv1alpha1.PodGang) (string, groveschedulerv1alpha1.PodGang) {
 		return podGang.Name, podGang
 	})
 }

--- a/operator/internal/controller/common/component/utils/podcliqueset.go
+++ b/operator/internal/controller/common/component/utils/podcliqueset.go
@@ -56,14 +56,14 @@ func GetPodCliqueFQNsForPCSReplicaNotInPCSG(pcs *grovecorev1alpha1.PodCliqueSet,
 
 // isStandalonePCLQ checks if the PodClique is managed by PodCliqueSet or not
 func isStandalonePCLQ(pcs *grovecorev1alpha1.PodCliqueSet, pclqName string) bool {
-	return !lo.Reduce(pcs.Spec.Template.PodCliqueScalingGroupConfigs, func(agg bool, pcsgConfig grovecorev1alpha1.PodCliqueScalingGroupConfig, _ int) bool {
-		return agg || slices.Contains(pcsgConfig.CliqueNames, pclqName)
-	}, false)
+	return !lo.SomeBy(pcs.Spec.Template.PodCliqueScalingGroupConfigs, func(pcsgConfig grovecorev1alpha1.PodCliqueScalingGroupConfig) bool {
+		return slices.Contains(pcsgConfig.CliqueNames, pclqName)
+	})
 }
 
 // pcsCacheKey is a context key for per-reconcile memoization of GetPodCliqueSet results.
 // In the PodClique reconcile flow alone we Get the same PCS up to 4 times (reconcileSpec,
-// reconcileStatus, pod.prepareSyncFlow, resourceclaim) — each DeepCopying the full template.
+// reconcileStatus, pod.prepareSyncFlow, resourceClaim) — each DeepCopying the full template.
 type pcsCacheKey struct{}
 
 // pcsCache holds one slot keyed by "namespace/name".

--- a/operator/internal/controller/common/component/utils/sets.go
+++ b/operator/internal/controller/common/component/utils/sets.go
@@ -17,8 +17,8 @@
 package utils
 
 // Set represents unique values with O(1) membership checks. Use it where callers only need
-// to test whether an element is present; use a plain map[K]V (built via MapBy) where callers
-// also need to retrieve the value associated with the key.
+// to test whether an element is present; use a plain map[K]V (built via lo.SliceToMap) where
+// callers also need to retrieve the value associated with the key.
 type Set[T comparable] map[T]struct{}
 
 // NewSet converts a slice into a set for O(1) membership checks.
@@ -42,16 +42,4 @@ func NewSetBy[T any, K comparable](values []T, keyFunc func(T) K) Set[K] {
 func (s Set[T]) Has(value T) bool {
 	_, exists := s[value]
 	return exists
-}
-
-// MapBy converts a slice into a name-keyed map using mapFunc to derive each key and value.
-// Last-write-wins on duplicate keys: callers should ensure inputs are unique by key, otherwise
-// only the last entry per key survives.
-func MapBy[T any, K comparable, V any](values []T, mapFunc func(T) (K, V)) map[K]V {
-	byKey := make(map[K]V, len(values))
-	for _, value := range values {
-		key, mappedValue := mapFunc(value)
-		byKey[key] = mappedValue
-	}
-	return byKey
 }

--- a/operator/internal/controller/common/component/utils/sets_test.go
+++ b/operator/internal/controller/common/component/utils/sets_test.go
@@ -70,4 +70,3 @@ func TestSetHas(t *testing.T) {
 		assert.False(t, zeroSet.Has(1))
 	})
 }
-

--- a/operator/internal/controller/common/component/utils/sets_test.go
+++ b/operator/internal/controller/common/component/utils/sets_test.go
@@ -71,22 +71,3 @@ func TestSetHas(t *testing.T) {
 	})
 }
 
-func TestMapBy(t *testing.T) {
-	type item struct {
-		name  string
-		value int
-	}
-	t.Run("empty input → empty map", func(t *testing.T) {
-		got := MapBy[item, string, int](nil, func(i item) (string, int) { return i.name, i.value })
-		assert.Equal(t, map[string]int{}, got)
-	})
-	t.Run("populated input", func(t *testing.T) {
-		got := MapBy([]item{{"a", 1}, {"b", 2}}, func(i item) (string, int) { return i.name, i.value })
-		assert.Equal(t, map[string]int{"a": 1, "b": 2}, got)
-	})
-	t.Run("duplicate keys: last write wins", func(t *testing.T) {
-		// Documented semantic — callers should pre-dedup if they need stricter behavior.
-		got := MapBy([]item{{"a", 1}, {"a", 99}}, func(i item) (string, int) { return i.name, i.value })
-		assert.Equal(t, map[string]int{"a": 99}, got)
-	})
-}

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
@@ -727,7 +727,7 @@ func (sc *syncContext) determinePCSGReplicas(pcsgFQN string, pcsgConfig grovecor
 // podGangInfo is package-private; the public PodCliqueByName/PCSGByName/PodGangByName helpers
 // in componentutils cover the cross-package equivalents.
 func podGangInfoByName(podGangs []*podGangInfo) map[string]*podGangInfo {
-	return componentutils.MapBy(podGangs, func(podGang *podGangInfo) (string, *podGangInfo) {
+	return lo.SliceToMap(podGangs, func(podGang *podGangInfo) (string, *podGangInfo) {
 		return podGang.fqn, podGang
 	})
 }


### PR DESCRIPTION
 /kind cleanup

  #### What this PR does / why we need it:

  Replaces two custom helpers in `operator/internal/controller/common/component/utils` with their direct `samber/lo` equivalents:

  - Deletes `MapBy` (and its tests) in favor of `lo.SliceToMap`. `MapBy` was a one-to-one re-implementation; callers in `lookups.go` and `podgang/syncflow.go` now use `lo.SliceToMap`
  directly.
  - Replaces the `lo.Reduce(..., agg || …, false)` fold in `isStandalonePCLQ` with `lo.SomeBy`. Same semantics, but `SomeBy` short-circuits on the first match instead of walking the full
  slice, and the intent ("does any config contain this clique?") is expressed directly.

  No behavior change. Pure refactor to lean on the upstream library and shrink the local utils surface.

  #### Which issue(s) this PR fixes:

  Fixes #567
  
  #### Special notes for your reviewer:

  - `NewSet` / `NewSetBy` were left in place: they return the package's `Set[T] = map[T]struct{}` typedef with a `Has` method, and lo has no equivalent set type — swapping them in would
  lose the named type and method.
  - `groupPCLQsByLabel` / `groupPCSGsByLabel` were also left alone: they filter items missing the label *and* group, so a one-to-one swap to `lo.GroupBy` isn't possible (would require
  `lo.GroupBy(lo.Filter(…), …)`, a composite rather than a direct replacement).

  #### Does this PR introduce a API change?
  
  ```release-note
  NONE

  Additional documentation e.g., enhancement proposals, usage docs, etc.: