### PR TITLE
Use embedded etcd for scale test cluster

### DIFF
--- a/operator/hack/infra_manager/cluster.py
+++ b/operator/hack/infra_manager/cluster.py
@@ -258,6 +258,12 @@ def create_cluster(cfg: ClusterConfig) -> None:
             f"{cfg.lb_port}@loadbalancer",
             "--registry-create",
             f"registry:0.0.0.0:{cfg.registry_port}",
+            # Scale CI creates enough pod/status churn that the default k3s
+            # sqlite/kine datastore can lag and stall watch/list calls. This
+            # keeps a single-server cluster, but bootstraps k3s with embedded
+            # etcd as the datastore instead of sqlite through kine.
+            "--k3s-arg",
+            "--cluster-init@server:0",
             "--k3s-arg",
             f"--node-taint={E2E_NODE_ROLE_KEY}=agent:NoSchedule@agent:*",
             "--k3s-node-label",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This updates the k3d cluster created by the e2e infra manager to start the single k3s server with embedded etcd:

```text
--k3s-arg --cluster-init@server:0
```

The scale test creates enough pod and status churn that the default single-server k3s datastore, sqlite through kine, can lag under CI load. In the failed scale CI runs, the API server showed symptoms such as stale resource versions, compacted revisions, handler timeouts, and list/watch calls stalling while the scale test waited for pods to become ready.

`--cluster-init@server:0` keeps the same single-server k3d topology, but bootstraps the k3s server with embedded etcd as the datastore instead of sqlite/kine. This gives the scale test a datastore path that handles the high watch/list/update churn more reliably.

#### Which issue(s) this PR fixes:

Related to #550

#### Special notes for your reviewer:

This is intentionally scoped to cluster creation. It does not change the scale test workload, node count, controller settings, or workflow behavior.

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
