### PR TITLE
feat: add Prometheus reconcile metrics to Grove operator controllers

### DIFF
--- a/operator/go.mod
+++ b/operator/go.mod
@@ -4,13 +4,13 @@ go 1.26.1
 
 require (
 	github.com/ai-dynamo/grove/operator/api v0.0.0
-	github.com/ai-dynamo/grove/operator/client v0.0.0-00010101000000-000000000000
 	github.com/ai-dynamo/grove/scheduler/api v0.0.0
 	github.com/docker/docker v28.3.3+incompatible
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/zapr v1.3.0
 	github.com/kai-scheduler/KAI-scheduler v0.14.0
 	github.com/open-policy-agent/cert-controller v0.14.0
+	github.com/prometheus/client_golang v1.23.2
 	github.com/samber/lo v1.52.0
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
@@ -87,6 +87,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/lib/pq v1.10.9 // indirect
@@ -113,7 +114,6 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect

--- a/operator/internal/controller/podclique/reconciler.go
+++ b/operator/internal/controller/podclique/reconciler.go
@@ -28,6 +28,7 @@ import (
 	pclqcomponent "github.com/ai-dynamo/grove/operator/internal/controller/podclique/components"
 	ctrlutils "github.com/ai-dynamo/grove/operator/internal/controller/utils"
 	"github.com/ai-dynamo/grove/operator/internal/expect"
+	grovemetrics "github.com/ai-dynamo/grove/operator/internal/metrics"
 	"github.com/ai-dynamo/grove/operator/internal/scheduler"
 
 	"k8s.io/client-go/tools/record"
@@ -83,8 +84,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return r.triggerDeletionFlow(ctx, logger, pclq).Result()
 	}
 
+	doneSpec := grovemetrics.StartOperation(controllerName, "reconcile_spec")
 	reconcileSpecFlowResult := r.reconcileSpec(ctx, logger, pclq)
-	if statusReconcileResult := r.reconcileStatus(ctx, logger, pclq); ctrlcommon.ShortCircuitReconcileFlow(statusReconcileResult) {
+	doneSpec()
+
+	doneStatus := grovemetrics.StartOperation(controllerName, "reconcile_status")
+	statusReconcileResult := r.reconcileStatus(ctx, logger, pclq)
+	doneStatus()
+
+	if ctrlcommon.ShortCircuitReconcileFlow(statusReconcileResult) {
 		return statusReconcileResult.Result()
 	}
 

--- a/operator/internal/controller/podclique/register.go
+++ b/operator/internal/controller/podclique/register.go
@@ -25,6 +25,7 @@ import (
 	componentutils "github.com/ai-dynamo/grove/operator/internal/controller/common/component/utils"
 	grovectrlutils "github.com/ai-dynamo/grove/operator/internal/controller/utils"
 	"github.com/ai-dynamo/grove/operator/internal/expect"
+	grovemetrics "github.com/ai-dynamo/grove/operator/internal/metrics"
 	"github.com/ai-dynamo/grove/operator/internal/utils"
 	k8sutils "github.com/ai-dynamo/grove/operator/internal/utils/kubernetes"
 
@@ -80,7 +81,7 @@ func (r *Reconciler) RegisterWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(mapPodGangToPCLQs()),
 			builder.WithPredicates(podGangPredicate()),
 		).
-		Complete(r)
+		Complete(grovemetrics.NewObservedReconciler(controllerName, r))
 }
 
 // managedPodCliquePredicate filters PodClique events to only process managed PodCliques owned by expected resources

--- a/operator/internal/controller/podcliquescalinggroup/reconciler.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconciler.go
@@ -27,6 +27,7 @@ import (
 	componentutils "github.com/ai-dynamo/grove/operator/internal/controller/common/component/utils"
 	pcsgcomponent "github.com/ai-dynamo/grove/operator/internal/controller/podcliquescalinggroup/components"
 	ctrlutils "github.com/ai-dynamo/grove/operator/internal/controller/utils"
+	grovemetrics "github.com/ai-dynamo/grove/operator/internal/metrics"
 
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -78,11 +79,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		dLog := logger.WithValues("operation", "delete")
 		deletionOrSpecReconcileFlowResult = r.triggerDeletionFlow(ctx, dLog, pcsg)
 	} else {
+		doneSpec := grovemetrics.StartOperation(controllerName, "reconcile_spec")
 		specLog := logger.WithValues("operation", "specReconcile")
 		deletionOrSpecReconcileFlowResult = r.reconcileSpec(ctx, specLog, pcsg)
+		doneSpec()
 	}
 
-	if statusReconcileResult := r.reconcileStatus(ctx, logger, ctrlclient.ObjectKeyFromObject(pcsg)); ctrlcommon.ShortCircuitReconcileFlow(statusReconcileResult) {
+	doneStatus := grovemetrics.StartOperation(controllerName, "reconcile_status")
+	statusReconcileResult := r.reconcileStatus(ctx, logger, ctrlclient.ObjectKeyFromObject(pcsg))
+	doneStatus()
+
+	if ctrlcommon.ShortCircuitReconcileFlow(statusReconcileResult) {
 		return statusReconcileResult.Result()
 	}
 

--- a/operator/internal/controller/podcliquescalinggroup/register.go
+++ b/operator/internal/controller/podcliquescalinggroup/register.go
@@ -24,6 +24,7 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	componentutils "github.com/ai-dynamo/grove/operator/internal/controller/common/component/utils"
 	ctrlutils "github.com/ai-dynamo/grove/operator/internal/controller/utils"
+	grovemetrics "github.com/ai-dynamo/grove/operator/internal/metrics"
 	"github.com/ai-dynamo/grove/operator/internal/utils"
 
 	"github.com/samber/lo"
@@ -64,7 +65,7 @@ func (r *Reconciler) RegisterWithManager(mgr manager.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(mapPCLQToPCSG()),
 			builder.WithPredicates(podCliquePredicate()),
 		).
-		Complete(r)
+		Complete(grovemetrics.NewObservedReconciler(controllerName, r))
 }
 
 // podCliqueScalingGroupUpdatePredicate filters PodCliqueScalingGroup events to only process Grove-managed resources owned by PodCliqueSet

--- a/operator/internal/controller/podcliqueset/reconciler.go
+++ b/operator/internal/controller/podcliqueset/reconciler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ai-dynamo/grove/operator/internal/controller/common/component"
 	pcscomponent "github.com/ai-dynamo/grove/operator/internal/controller/podcliqueset/components"
 	ctrlutils "github.com/ai-dynamo/grove/operator/internal/controller/utils"
+	grovemetrics "github.com/ai-dynamo/grove/operator/internal/metrics"
 	"github.com/ai-dynamo/grove/operator/internal/scheduler"
 
 	"github.com/go-logr/logr"
@@ -73,8 +74,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return result.Result()
 	}
 
+	doneSpec := grovemetrics.StartOperation(controllerName, "reconcile_spec")
 	reconcileSpecFlowResult := r.reconcileSpec(ctx, logger, pcs)
-	if statusReconcileResult := r.reconcileStatus(ctx, logger, pcs); ctrlcommon.ShortCircuitReconcileFlow(statusReconcileResult) {
+	doneSpec()
+
+	doneStatus := grovemetrics.StartOperation(controllerName, "reconcile_status")
+	statusReconcileResult := r.reconcileStatus(ctx, logger, pcs)
+	doneStatus()
+
+	if ctrlcommon.ShortCircuitReconcileFlow(statusReconcileResult) {
 		return statusReconcileResult.Result()
 	}
 

--- a/operator/internal/controller/podcliqueset/register.go
+++ b/operator/internal/controller/podcliqueset/register.go
@@ -24,6 +24,7 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	componentutils "github.com/ai-dynamo/grove/operator/internal/controller/common/component/utils"
 	grovectrlutils "github.com/ai-dynamo/grove/operator/internal/controller/utils"
+	grovemetrics "github.com/ai-dynamo/grove/operator/internal/metrics"
 	"github.com/ai-dynamo/grove/operator/internal/utils"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -65,7 +66,7 @@ func (r *Reconciler) RegisterWithManager(mgr manager.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(mapPodCliqueScaleGroupToPodCliqueSet()),
 			builder.WithPredicates(podCliqueScalingGroupPredicate()),
 		).
-		Complete(r)
+		Complete(grovemetrics.NewObservedReconciler(controllerName, r))
 }
 
 // mapPodCliqueToPodCliqueSet returns a function that maps PodClique events to their parent PodCliqueSet.

--- a/operator/internal/metrics/metrics.go
+++ b/operator/internal/metrics/metrics.go
@@ -1,0 +1,159 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+// Package metrics provides Prometheus metrics for Grove operator controllers.
+// All metrics use the grove_operator namespace prefix and are registered on
+// the controller-runtime global registry so they are served on the existing
+// metrics endpoint without additional configuration.
+package metrics
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const namespace = "grove_operator"
+
+var (
+	reconcileTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "reconcile_total",
+			Help:      "Total number of reconcile operations per controller, partitioned by result (success, error, requeue, requeue_after).",
+		},
+		[]string{"controller", "result"},
+	)
+
+	reconcileDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "reconcile_duration_seconds",
+			Help:      "Duration of each reconcile operation in seconds, per controller.",
+			Buckets:   []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0},
+		},
+		[]string{"controller"},
+	)
+
+	inFlightReconciles = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "in_flight_reconciles",
+			Help:      "Number of currently executing reconcile operations, per controller.",
+		},
+		[]string{"controller"},
+	)
+
+	operationDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "operation_duration_seconds",
+			Help:      "Duration of named sub-operations within a reconcile loop (e.g. reconcile_spec, reconcile_status), per controller.",
+			Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0},
+		},
+		[]string{"controller", "operation"},
+	)
+
+	conflictTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "conflict_total",
+			Help:      "Total number of 409 Conflict errors encountered per controller. High rates indicate concurrent modification contention.",
+		},
+		[]string{"controller"},
+	)
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(
+		reconcileTotal,
+		reconcileDuration,
+		inFlightReconciles,
+		operationDuration,
+		conflictTotal,
+	)
+}
+
+// ObservedReconciler wraps a reconcile.Reconciler with automatic Prometheus instrumentation.
+// It records reconcile duration, in-flight count, result totals, and 409 Conflict errors.
+type ObservedReconciler struct {
+	controller string
+	inner      reconcile.Reconciler
+}
+
+// NewObservedReconciler returns an ObservedReconciler that instruments the given reconciler
+// under the provided controller name label.
+func NewObservedReconciler(controller string, inner reconcile.Reconciler) *ObservedReconciler {
+	return &ObservedReconciler{controller: controller, inner: inner}
+}
+
+// Reconcile implements reconcile.Reconciler.
+func (o *ObservedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	start := time.Now()
+	inFlightReconciles.WithLabelValues(o.controller).Inc()
+	defer inFlightReconciles.WithLabelValues(o.controller).Dec()
+
+	result, err := o.inner.Reconcile(ctx, req)
+
+	reconcileDuration.WithLabelValues(o.controller).Observe(time.Since(start).Seconds())
+	reconcileTotal.WithLabelValues(o.controller, resultLabel(result, err)).Inc()
+
+	if err != nil && isConflict(err) {
+		conflictTotal.WithLabelValues(o.controller).Inc()
+	}
+
+	return result, err
+}
+
+// StartOperation begins timing a named sub-operation and returns a done function
+// that must be called when the operation completes to record the elapsed duration.
+//
+//	done := metrics.StartOperation(controllerName, "reconcile_spec")
+//	result := r.reconcileSpec(ctx, logger, obj)
+//	done()
+func StartOperation(controller, operation string) func() {
+	start := time.Now()
+	return func() {
+		operationDuration.WithLabelValues(controller, operation).Observe(time.Since(start).Seconds())
+	}
+}
+
+func resultLabel(result ctrl.Result, err error) string {
+	if err != nil {
+		return "error"
+	}
+	if result.RequeueAfter > 0 {
+		return "requeue_after"
+	}
+	if result.Requeue {
+		return "requeue"
+	}
+	return "success"
+}
+
+func isConflict(err error) bool {
+	var statusErr *apierrors.StatusError
+	if errors.As(err, &statusErr) {
+		return apierrors.IsConflict(statusErr)
+	}
+	return apierrors.IsConflict(err)
+}

--- a/operator/internal/metrics/metrics_test.go
+++ b/operator/internal/metrics/metrics_test.go
@@ -1,0 +1,125 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type fakeReconciler struct {
+	result ctrl.Result
+	err    error
+}
+
+func (f *fakeReconciler) Reconcile(_ context.Context, _ reconcile.Request) (ctrl.Result, error) {
+	return f.result, f.err
+}
+
+func TestObservedReconciler_Success(t *testing.T) {
+	ctrlName := "t-success"
+	observed := NewObservedReconciler(ctrlName, &fakeReconciler{result: ctrl.Result{}})
+
+	_, err := observed.Reconcile(context.Background(), reconcile.Request{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := testutil.ToFloat64(reconcileTotal.WithLabelValues(ctrlName, "success")); got != 1 {
+		t.Errorf("reconcile_total{result=success} = %v, want 1", got)
+	}
+	// in-flight gauge must be zero after the reconcile completes.
+	if got := testutil.ToFloat64(inFlightReconciles.WithLabelValues(ctrlName)); got != 0 {
+		t.Errorf("in_flight_reconciles = %v, want 0", got)
+	}
+}
+
+func TestObservedReconciler_Error(t *testing.T) {
+	ctrlName := "t-error"
+	observed := NewObservedReconciler(ctrlName, &fakeReconciler{err: fmt.Errorf("inner error")})
+
+	_, _ = observed.Reconcile(context.Background(), reconcile.Request{})
+
+	if got := testutil.ToFloat64(reconcileTotal.WithLabelValues(ctrlName, "error")); got != 1 {
+		t.Errorf("reconcile_total{result=error} = %v, want 1", got)
+	}
+}
+
+func TestObservedReconciler_Conflict(t *testing.T) {
+	ctrlName := "t-conflict"
+	conflictErr := apierrors.NewConflict(
+		schema.GroupResource{Group: "core.grove.io", Resource: "podcliqueset"},
+		"my-pcs",
+		fmt.Errorf("object modified"),
+	)
+	observed := NewObservedReconciler(ctrlName, &fakeReconciler{err: conflictErr})
+
+	_, _ = observed.Reconcile(context.Background(), reconcile.Request{})
+
+	if got := testutil.ToFloat64(conflictTotal.WithLabelValues(ctrlName)); got != 1 {
+		t.Errorf("conflict_total = %v, want 1", got)
+	}
+	// conflicts are also counted as errors in reconcile_total.
+	if got := testutil.ToFloat64(reconcileTotal.WithLabelValues(ctrlName, "error")); got != 1 {
+		t.Errorf("reconcile_total{result=error} = %v, want 1 for conflict", got)
+	}
+}
+
+func TestObservedReconciler_Requeue(t *testing.T) {
+	ctrlName := "t-requeue"
+	observed := NewObservedReconciler(ctrlName, &fakeReconciler{result: ctrl.Result{Requeue: true}})
+
+	_, _ = observed.Reconcile(context.Background(), reconcile.Request{})
+
+	if got := testutil.ToFloat64(reconcileTotal.WithLabelValues(ctrlName, "requeue")); got != 1 {
+		t.Errorf("reconcile_total{result=requeue} = %v, want 1", got)
+	}
+}
+
+func TestObservedReconciler_RequeueAfter(t *testing.T) {
+	ctrlName := "t-requeue-after"
+	observed := NewObservedReconciler(ctrlName, &fakeReconciler{result: ctrl.Result{RequeueAfter: 5 * time.Second}})
+
+	_, _ = observed.Reconcile(context.Background(), reconcile.Request{})
+
+	if got := testutil.ToFloat64(reconcileTotal.WithLabelValues(ctrlName, "requeue_after")); got != 1 {
+		t.Errorf("reconcile_total{result=requeue_after} = %v, want 1", got)
+	}
+}
+
+func TestStartOperation_PopulatesHistogram(t *testing.T) {
+	// CollectAndCount returns the number of series present in the histogram vec.
+	// Before calling StartOperation with a fresh label combo the count is 0.
+	before := testutil.CollectAndCount(operationDuration)
+
+	done := StartOperation("t-op-ctrl", "reconcile_spec")
+	time.Sleep(time.Millisecond)
+	done()
+
+	after := testutil.CollectAndCount(operationDuration)
+	if after <= before {
+		t.Errorf("operation_duration_seconds count did not increase: before=%d after=%d", before, after)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a new `internal/metrics` package with five `grove_operator_*` Prometheus metrics covering reconcile duration, count, in-flight concurrency, sub-operation latency, and 409 Conflict rates
- Introduces an `ObservedReconciler` wrapper wired into all three controllers (PodCliqueSet, PodClique, PodCliqueScalingGroup) via their `Complete()` call — zero change to reconciliation logic
- Adds `StartOperation` timing around `reconcile_spec` and `reconcile_status` phases in each controller's `Reconcile` method

## Problem

Grove currently exposes zero custom Prometheus metrics, providing no visibility into reconcile duration, sub-operation latency, error categorisation, or 409 Conflict rates during large-scale inference graph deployments (e.g. 5 services × 10 replicas → 50+ PodClique Pods).

## Solution

**Metrics added (all under `grove_operator_` namespace):**

| Metric | Type | Labels |
|---|---|---|
| `grove_operator_reconcile_total` | Counter | `controller`, `result` (success/error/requeue/requeue_after) |
| `grove_operator_reconcile_duration_seconds` | Histogram | `controller` |
| `grove_operator_in_flight_reconciles` | Gauge | `controller` |
| `grove_operator_operation_duration_seconds` | Histogram | `controller`, `operation` (reconcile_spec/reconcile_status) |
| `grove_operator_conflict_total` | Counter | `controller` |

All metrics are registered on the controller-runtime global Prometheus registry (`sigs.k8s.io/controller-runtime/pkg/metrics`), served on the existing `/metrics` endpoint with no configuration changes required.

The `ObservedReconciler` wrapper handles the per-reconcile instrumentation (duration, in-flight gauge, result counter, conflict detection) purely at the `Complete()` boundary. Sub-operation timing uses explicit `done := StartOperation(...)` / `done()` call pairs — no deferred logic that could obscure early returns.

## Testing
- `go build ./...`: passed
- `go test ./internal/metrics/... -v`: 6/6 tests passed (success, error, conflict, requeue, requeue_after, histogram population)
- `go test ./internal/... -short`: all existing unit tests continue to pass

Closes #498