### PR TITLE
Fix: Prevent potential test environment pollution in shared scale clusters

### DIFF
--- a/operator/e2e/tests/scale/main_test.go
+++ b/operator/e2e/tests/scale/main_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/ai-dynamo/grove/operator/e2e/k8s/k8sclient"
 	"github.com/ai-dynamo/grove/operator/e2e/measurement"
@@ -63,6 +64,15 @@ func TestMain(m *testing.M) {
 	}
 
 	code := m.Run()
+
+	// Perform a final cascading cleanup before tearing down the cluster to prevent
+	// resource leakage when the cluster is reused for subsequent tests.
+	// We use a 5-minute timeout as a safe upper bound; internal operations have their own stricter timeouts.
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	if err := sharedCluster.CleanupWorkloads(cleanupCtx, true); err != nil {
+		Logger.Errorf("Final cascading cleanup failed: %v", err)
+	}
 
 	sharedCluster.Teardown()
 


### PR DESCRIPTION
…ster pollution

#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:

Issue Summary

 Running scale tests (e.g., make run-scale-test) against a persistent or reused Kubernetes cluster.

In  PR #621, WithSkipCleanupWait() was intentionally introduced in operator/e2e/tests/scale/scale_test.go to measure only the PodCliqueSet deletion latency without waiting for the slow Kubernetes API server and GC to delete all sub-resources (Pods) .  
However, an oversight occurred: no thorough final cleanup was enforced at the suite level. Consequently, the test suite exits without ever waiting for the cascading deletion to  complete.
A large number of Terminating resources may  remain in the cluster for seconds after the scale tests finish. 

When the same cluster is reused for subsequent test runs, these leftover resources pollute the environment, leading to scheduling conflicts, test misjudgments, and resource exhaustion.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs

```
