### PR TITLE
Skip scheduled scale tests in forks

### DIFF
--- a/.github/workflows/scale-test-ci.yaml
+++ b/.github/workflows/scale-test-ci.yaml
@@ -14,6 +14,8 @@ env:
 
 jobs:
   run-scale-test:
+    # Run the weekly schedule only in the main repo, while keeping manual runs available in forks.
+    if: github.event_name != 'schedule' || github.repository == 'ai-dynamo/grove'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This prevents the scheduled scale test workflow from running automatically in forks.

The workflow can still be triggered manually with `workflow_dispatch` from a fork, which keeps local/fork debugging possible. Only the weekly scheduled run is restricted to `ai-dynamo/grove`.

#### Which issue(s) this PR fixes:

Related to #550

#### Special notes for your reviewer:

This avoids consuming GitHub Actions minutes on fork-owned scheduled runs while preserving manual testability in forks.

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
