### PR TITLE
fix: lower GetPodClique NotFound log to V(1) during expected cascade-delete

### DIFF
--- a/operator/internal/controller/utils/reconciler.go
+++ b/operator/internal/controller/utils/reconciler.go
@@ -45,11 +45,15 @@ func GetPodCliqueSet(ctx context.Context, cl client.Client, logger logr.Logger, 
 	return grovectrl.ContinueReconcile()
 }
 
-// GetPodClique gets the latest PodClique object. It will usually hit the informer cache. If the object is not found, it will log a message and return DoNotRequeue.
+// GetPodClique gets the latest PodClique object. It will usually hit the informer cache.
+// When ignoreNotFound is true the caller signals that a NotFound response is expected (e.g.
+// during a normal cascade-delete of the parent PodCliqueSet). In that case the log is emitted
+// at V(1) (verbose/debug) to avoid spamming info logs at scale. Unexpected NotFound responses
+// (ignoreNotFound=false) are still propagated as errors so the calling reconciler can surface them.
 func GetPodClique(ctx context.Context, cl client.Client, logger logr.Logger, objectKey client.ObjectKey, pclq *v1alpha1.PodClique, ignoreNotFound bool) grovectrl.ReconcileStepResult {
 	if err := cl.Get(ctx, objectKey, pclq); err != nil {
 		if ignoreNotFound && apierrors.IsNotFound(err) {
-			logger.Info("PodClique not found", "objectKey", objectKey)
+			logger.V(1).Info("PodClique not found (expected during cascade-delete)", "objectKey", objectKey)
 			return grovectrl.DoNotRequeue()
 		}
 		return grovectrl.ReconcileWithErrors("error getting PodClique", err)

--- a/operator/internal/controller/utils/reconciler_test.go
+++ b/operator/internal/controller/utils/reconciler_test.go
@@ -192,6 +192,26 @@ func TestGetPodClique(t *testing.T) {
 	}
 }
 
+// TestGetPodClique_IgnoreNotFoundFalse verifies that when ignoreNotFound is false and the
+// PodClique does not exist, GetPodClique propagates the error rather than returning DoNotRequeue.
+// This path covers unexpected missing PodCliques (not cascade-delete) and should surface the error.
+func TestGetPodClique_IgnoreNotFoundFalse(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	objectKey := types.NamespacedName{Name: "missing-pclq", Namespace: "default"}
+	pclq := &grovecorev1alpha1.PodClique{}
+	result := GetPodClique(ctx, fakeClient, logger, objectKey, pclq, false)
+
+	// Must not silently swallow the error or return DoNotRequeue — the caller
+	// should be aware the object is missing unexpectedly.
+	assert.True(t, result.NeedsRequeue() || result.HasErrors(), "expected error or requeue on unexpected NotFound with ignoreNotFound=false")
+}
+
 // TestGetPodCliqueScalingGroup tests the GetPodCliqueScalingGroup function
 func TestGetPodCliqueScalingGroup(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Problem

Resolves #622.

During normal `PodCliqueSet` cascade-delete, the `PodClique` controller receives reconcile requests for already-deleted `PodCliques` and logs at `info` level:

```json
{"level":"info","msg":"PodClique not found","objectKey":{"name":"...","namespace":"default"}}
```

At scale this produces one log line per deleted PodClique — pure noise with no actionable signal.

## Fix

`GetPodClique` already accepts an `ignoreNotFound bool` parameter to signal that the caller considers NotFound expected. Change the log level in that branch from `Info` to `V(1)` (verbose/debug). The log message is updated to clarify it is during cascade-delete.

Unexpected missing PodCliques (`ignoreNotFound=false`) still propagate as errors through `ReconcileWithErrors`, preserving visibility.

## Tests

Added `TestGetPodClique_IgnoreNotFoundFalse` to cover the error-propagation path — `ignoreNotFound=false` on a missing object must return an error result, not silently succeed.

## Before / After

**Before:** Every deleted PodClique during a cascade emits one `info` log.

**After:** Those logs appear only at `V(1)` (hidden unless verbose logging is enabled). Unexpected missing PodCliques still surface as errors.