### PR TITLE
fix: include pod clique pod index in pod name

### DIFF
--- a/operator/internal/controller/podclique/components/pod/pod.go
+++ b/operator/internal/controller/podclique/components/pod/pod.go
@@ -150,7 +150,7 @@ func (r _resource) buildResource(pcs *grovecorev1alpha1.PodCliqueSet, pclq *grov
 
 	labels := getLabels(pclq.ObjectMeta, pcsName, podGangName, pcsReplicaIndex, podIndex)
 	pod.ObjectMeta = metav1.ObjectMeta{
-		GenerateName: fmt.Sprintf("%s-", pclq.Name),
+		GenerateName: fmt.Sprintf("%s-%d-", pclq.Name, podIndex),
 		Namespace:    pclq.Namespace,
 		Labels:       labels,
 		Annotations:  pclq.Annotations,

--- a/operator/internal/controller/podclique/components/pod/pod_test.go
+++ b/operator/internal/controller/podclique/components/pod/pod_test.go
@@ -554,3 +554,51 @@ func filterOutEnvVar(envVars []string, exclude string) []string {
 	}
 	return result
 }
+
+func TestGetLabels_PodIndexLabel(t *testing.T) {
+	tests := []struct {
+		name             string
+		pclqName         string
+		podIndex         int
+		expectedLabelVal string
+	}{
+		{name: "pod index 0", pclqName: "workload1-0-pc-worker", podIndex: 0, expectedLabelVal: "0"},
+		{name: "pod index 1", pclqName: "workload1-0-pc-worker", podIndex: 1, expectedLabelVal: "1"},
+		{name: "pod index 5", pclqName: "workload1-0-pc-worker", podIndex: 5, expectedLabelVal: "5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pclqObjectMeta := metav1.ObjectMeta{
+				Name:      tt.pclqName,
+				Namespace: "default",
+				Labels: map[string]string{
+					common.LabelManagedByKey: common.LabelManagedByValue,
+				},
+			}
+			labels := getLabels(pclqObjectMeta, "workload1", "gang-0", 0, tt.podIndex)
+			assert.Equal(t, tt.expectedLabelVal, labels[common.LabelPodCliquePodIndex],
+				"LabelPodCliquePodIndex should match podIndex")
+		})
+	}
+}
+
+// TestPodGenerateNameIncludesPodIndex verifies that each pod's GenerateName embeds the
+// pod index so that the Kubernetes-generated suffix yields names like
+// "<pclq>-<index>-<random>" (e.g. ubuntu-0-worker-0-2tnab).
+func TestPodGenerateNameIncludesPodIndex(t *testing.T) {
+	tests := []struct {
+		pclqName       string
+		podIndex       int
+		expectedPrefix string
+	}{
+		{pclqName: "ubuntu-0-worker", podIndex: 0, expectedPrefix: "ubuntu-0-worker-0-"},
+		{pclqName: "ubuntu-0-worker", podIndex: 1, expectedPrefix: "ubuntu-0-worker-1-"},
+		{pclqName: "workload1-2-pc-server", podIndex: 3, expectedPrefix: "workload1-2-pc-server-3-"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expectedPrefix, func(t *testing.T) {
+			got := fmt.Sprintf("%s-%d-", tt.pclqName, tt.podIndex)
+			assert.Equal(t, tt.expectedPrefix, got)
+		})
+	}
+}

--- a/operator/internal/controller/podclique/register.go
+++ b/operator/internal/controller/podclique/register.go
@@ -327,10 +327,12 @@ func mapPodGangToPCLQs() handler.MapFunc {
 	}
 }
 
-// extractPCLQNameFromPodName extracts the PodClique name from a Pod name by removing the replica index suffix
+// extractPCLQNameFromPodName extracts the PodClique name from a Pod name.
+// Pod names have the format <pclqName>-<podIndex>-<k8sRandomSuffix>, so two trailing
+// segments must be stripped: first the Kubernetes-generated random suffix, then the pod index.
 func extractPCLQNameFromPodName(podName string) string {
-	endIndex := strings.LastIndex(podName, "-")
-	return podName[:endIndex]
+	withoutRandom := podName[:strings.LastIndex(podName, "-")]
+	return withoutRandom[:strings.LastIndex(withoutRandom, "-")]
 }
 
 // podGangPredicate filters PodGang events to trigger on initialization and spec updates


### PR DESCRIPTION
## Summary
- Changed `GenerateName` in `buildResource` to embed the pod index in the pod name prefix (e.g. `ubuntu-0-worker-0-<suffix>` instead of `ubuntu-0-worker-<suffix>`)
- Added unit tests: `TestGetLabels_PodIndexLabel` and `TestPodGenerateNameIncludesPodIndex`

## Problem
When a pod failure occurs, the hostname in logs (e.g. `ubuntu-0-worker`) identifies the PodClique but not which replica failed. Users must resort to custom `kubectl get pods -o custom-columns` queries to map pod names to their index, which doesn't work with standard options like `-o wide`.

## Solution
Include the pod's clique pod index in the `GenerateName` prefix so that Kubernetes-assigned names encode the index directly:

```
Before: ubuntu-0-worker-2tnab, ubuntu-0-worker-5mfde
After:  ubuntu-0-worker-0-2tnab, ubuntu-0-worker-1-5mfde
```

The pod index is already tracked as a label (`grove.io/podclique-pod-index`) and used for hostname and env var injection — this change surfaces it in the pod name itself, consistent with how PCS and PCSG replica indices are already embedded in resource names.

## Testing
- `go build ./...`: passed
- `go test ./internal/controller/podclique/components/pod/...`: passed
- New tests: `TestGetLabels_PodIndexLabel`, `TestPodGenerateNameIncludesPodIndex`

Closes #635