### PR TITLE
feat(chart): Allow setting security context in Helm

### DIFF
--- a/operator/charts/templates/_helpers.tpl
+++ b/operator/charts/templates/_helpers.tpl
@@ -122,11 +122,15 @@ release: "{{ .Release.Name }}"
 {{- end }}
 {{- end -}}
 
-{{- define "operator.service.labels" -}}
-{{- include "common.chart.labels" . }}
+{{- define "operator.service.matchLabels" -}}
 {{- range $key, $val := .Values.service.labels }}
 {{ $key }}: {{ $val }}
 {{- end }}
+{{- end -}}
+
+{{- define "operator.service.labels" -}}
+{{- include "common.chart.labels" . }}
+{{- include "operator.service.matchLabels" . }}
 {{- end -}}
 
 {{- define "operator.servicemonitor.labels" -}}

--- a/operator/charts/templates/_helpers.tpl
+++ b/operator/charts/templates/_helpers.tpl
@@ -135,7 +135,7 @@ release: "{{ .Release.Name }}"
 
 {{- define "operator.servicemonitor.labels" -}}
 {{- include "common.chart.labels" . }}
-{{- range $key, $val := .Values.serviceMonitor.labels }}
+{{- range $key, $val := .Values.metrics.serviceMonitor.labels }}
 {{ $key }}: {{ $val }}
 {{- end }}
 {{- end -}}

--- a/operator/charts/templates/_helpers.tpl
+++ b/operator/charts/templates/_helpers.tpl
@@ -129,6 +129,13 @@ release: "{{ .Release.Name }}"
 {{- end }}
 {{- end -}}
 
+{{- define "operator.servicemonitor.labels" -}}
+{{- include "common.chart.labels" . }}
+{{- range $key, $val := .Values.serviceMonitor.labels }}
+{{ $key }}: {{ $val }}
+{{- end }}
+{{- end -}}
+
 {{- define "operator.clusterrole.labels" -}}
 {{- include "common.chart.labels" . }}
 {{- range $key, $val := .Values.clusterRole.labels }}

--- a/operator/charts/templates/deployment.yaml
+++ b/operator/charts/templates/deployment.yaml
@@ -25,9 +25,10 @@ spec:
       {{- end }}
       serviceAccountName: {{ required ".Values.serviceAccount.name is required" .Values.serviceAccount.name }}
       automountServiceAccountToken: false
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        seccompProfile:
-          type: RuntimeDefault
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -41,6 +42,14 @@ spec:
         - name: crd-installer
           image: {{ include "image" .Values.crdInstaller.image }}
           imagePullPolicy: {{ .Values.crdInstaller.image.pullPolicy }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: kube-api-access-grove
               mountPath: /var/run/secrets/kubernetes.io/serviceaccount
@@ -74,9 +83,13 @@ spec:
             initialDelaySeconds: 10
             timeoutSeconds: 5
           {{- end }}
-          {{- if .Values.resources }}
+          {{- with .Values.resources }}
           resources:
-{{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: operator-config

--- a/operator/charts/templates/service.yaml
+++ b/operator/charts/templates/service.yaml
@@ -4,7 +4,11 @@ metadata:
   name: {{ required ".Values.service.name is required" .Values.service.name }}
   namespace: {{ .Release.Namespace }}
   labels:
-{{- include "operator.service.labels" . | nindent 4 }}
+    {{- include "operator.service.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   selector:

--- a/operator/charts/templates/servicemonitor.yaml
+++ b/operator/charts/templates/servicemonitor.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.serviceMonitor.enable }}
+{{- if .Values.serviceMonitor.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Values.serviceMonitor.name }}
+  name: {{ required ".Values.serviceMonitor.name is required" .Values.serviceMonitor.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "operator.servicemonitor.labels" . | nindent 4 }}

--- a/operator/charts/templates/servicemonitor.yaml
+++ b/operator/charts/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceMonitor.enable }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: grove-operator-monitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{  include "operator.servicemonitor.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "operator.service.labels" . | nindent 6 }}
+  endpoints:
+  - port: metrics
+    path: /metrics
+    scheme: http
+{{- end }}

--- a/operator/charts/templates/servicemonitor.yaml
+++ b/operator/charts/templates/servicemonitor.yaml
@@ -3,14 +3,14 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: grove-operator-monitor
+  name: {{ .Values.serviceMonitor.name }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{  include "operator.servicemonitor.labels" . | nindent 4 }}
+    {{- include "operator.servicemonitor.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      {{- include "operator.service.labels" . | nindent 6 }}
+      {{- include "operator.service.matchLabels" . | nindent 6 }}
   endpoints:
   - port: metrics
     path: /metrics

--- a/operator/charts/templates/servicemonitor.yaml
+++ b/operator/charts/templates/servicemonitor.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- if .Values.metrics.serviceMonitor.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ required ".Values.serviceMonitor.name is required" .Values.serviceMonitor.name }}
+  name: {{ required ".Values.metrics.serviceMonitor.name is required" .Values.metrics.serviceMonitor.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "operator.servicemonitor.labels" . | nindent 4 }}

--- a/operator/charts/values.yaml
+++ b/operator/charts/values.yaml
@@ -20,6 +20,11 @@ resources:
     memory: 128Mi
     ephemeral-storage: 128Mi
 
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+securityContext: {}
+
 # Node selector to constrain the operator pod to nodes with matching labels.
 nodeSelector: {}
 

--- a/operator/charts/values.yaml
+++ b/operator/charts/values.yaml
@@ -149,11 +149,15 @@ service:
     app.kubernetes.io/component: operator-service
     app.kubernetes.io/name: grove-operator
     app.kubernetes.io/part-of: grove
+  # -- Annotations to add to the Grove Operator Service resource
   annotations: {}
 
 serviceMonitor:
+  # -- Enable the Prometheus ServiceMonitor resource
   enabled: false
+  # -- Name of the Prometheus ServiceMonitor resource
   name: grove-operator-monitor
+  # -- Labels for the Prometheus ServiceMonitor resource
   labels:
     app.kubernetes.io/component: operator-service-monitor
     app.kubernetes.io/name: grove-operator

--- a/operator/charts/values.yaml
+++ b/operator/charts/values.yaml
@@ -158,6 +158,8 @@ serviceMonitor:
     app.kubernetes.io/component: operator-service-monitor
     app.kubernetes.io/name: grove-operator
     app.kubernetes.io/part-of: grove
+    # If the Prometheus Operator requires the 'release' label, set this value:
+    # release: prometheus
 
 clusterRole:
   name: grove:system:grove-operator

--- a/operator/charts/values.yaml
+++ b/operator/charts/values.yaml
@@ -153,12 +153,12 @@ service:
 
 serviceMonitor:
   enable: false
+  name: grove-operator-monitor
   labels:
     app.kubernetes.io/component: operator-service-monitor
     app.kubernetes.io/name: grove-operator
     app.kubernetes.io/part-of: grove
     release: prometheus-stack
-
 
 clusterRole:
   name: grove:system:grove-operator

--- a/operator/charts/values.yaml
+++ b/operator/charts/values.yaml
@@ -149,6 +149,16 @@ service:
     app.kubernetes.io/component: operator-service
     app.kubernetes.io/name: grove-operator
     app.kubernetes.io/part-of: grove
+  annotations: {}
+
+serviceMonitor:
+  enable: false
+  labels:
+    app.kubernetes.io/component: operator-service-monitor
+    app.kubernetes.io/name: grove-operator
+    app.kubernetes.io/part-of: grove
+    release: prometheus-stack
+
 
 clusterRole:
   name: grove:system:grove-operator

--- a/operator/charts/values.yaml
+++ b/operator/charts/values.yaml
@@ -158,7 +158,6 @@ serviceMonitor:
     app.kubernetes.io/component: operator-service-monitor
     app.kubernetes.io/name: grove-operator
     app.kubernetes.io/part-of: grove
-    release: prometheus-stack
 
 clusterRole:
   name: grove:system:grove-operator

--- a/operator/charts/values.yaml
+++ b/operator/charts/values.yaml
@@ -152,7 +152,7 @@ service:
   annotations: {}
 
 serviceMonitor:
-  enable: false
+  enabled: false
   name: grove-operator-monitor
   labels:
     app.kubernetes.io/component: operator-service-monitor

--- a/operator/charts/values.yaml
+++ b/operator/charts/values.yaml
@@ -152,18 +152,19 @@ service:
   # -- Annotations to add to the Grove Operator Service resource
   annotations: {}
 
-serviceMonitor:
-  # -- Enable the Prometheus ServiceMonitor resource
-  enabled: false
-  # -- Name of the Prometheus ServiceMonitor resource
-  name: grove-operator-monitor
-  # -- Labels for the Prometheus ServiceMonitor resource
-  labels:
-    app.kubernetes.io/component: operator-service-monitor
-    app.kubernetes.io/name: grove-operator
-    app.kubernetes.io/part-of: grove
-    # If the Prometheus Operator requires the 'release' label, set this value:
-    # release: prometheus
+metrics:
+  serviceMonitor:
+    # -- Enable the Prometheus ServiceMonitor resource
+    enabled: false
+    # -- Name of the Prometheus ServiceMonitor resource
+    name: grove-operator-monitor
+    # -- Labels for the Prometheus ServiceMonitor resource
+    labels:
+      app.kubernetes.io/component: operator-service-monitor
+      app.kubernetes.io/name: grove-operator
+      app.kubernetes.io/part-of: grove
+      # If the Prometheus Operator requires the 'release' label, set this value:
+      # release: prometheus
 
 clusterRole:
   name: grove:system:grove-operator


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind api
-->
/kind feature

#### What this PR does / why we need it:

Allow setting security contexts so that it's possible to force the containers to run as non-root and specific UID/GID.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #647

#### Special notes for your reviewer:

#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- Allow setting `securityContext` and `podSecurityContext` for the Helm chart.
- Add optional serviceMonitor and allow annotations for service
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs

```
