### PR TITLE
controller: propagate preferred topology pack constraints

### DIFF
--- a/operator/e2e/tests/topology_test.go
+++ b/operator/e2e/tests/topology_test.go
@@ -1899,3 +1899,78 @@ func Test_TAS22_PodCliqueSetTopologyCELValidation(t *testing.T) {
 
 	Logger.Info("TAS22: PodCliqueSet topology CEL validation test completed successfully!")
 }
+
+// Test_TAS23_PreferredPackConstraintPropagation verifies that Grove preferred pack domains
+// are propagated to KAI PodGroup topology constraints. It does not assert placement because
+// preferred constraints are soft scheduling hints.
+func Test_TAS23_PreferredPackConstraintPropagation(t *testing.T) {
+	ctx := context.Background()
+
+	Logger.Info("1. Initialize a 28-node Grove cluster for preferred topology propagation testing")
+	expectedPods := 3 // 2 PCSG worker replicas + 1 standalone router
+	tc, cleanup := testctx.PrepareTest(ctx, t, 28,
+		testctx.WithWorkload(&testctx.WorkloadConfig{
+			Name:         "tas-preferred-pack",
+			YAMLPath:     "../yaml/tas-preferred-pack.yaml",
+			Namespace:    "default",
+			ExpectedPods: expectedPods,
+		}),
+	)
+	defer cleanup()
+	topologyVerifier := topology.NewTopologyVerifier(tc.Client, Logger)
+	podGroupVerifier := podgroup.NewPodGroupVerifier(tc.Client, Logger)
+
+	ensureGroveTopology(ctx, t, topologyVerifier)
+	Logger.Info("2. Deploy workload (TAS23: preferred topology pack constraints)")
+	if _, err := DeployWorkloadAndGetPods(tc, expectedPods); err != nil {
+		t.Fatalf("Setup failed: %v", err)
+	}
+
+	Logger.Info("3. Verify base KAI PodGroup required and preferred topology constraints")
+	basePodGroup := GetPodGroupOrFail(t, tc, podGroupVerifier, 0)
+
+	workersParent := podgroup.CreateExpectedPCSGParentSubGroup(tc.Workload.Name, 0, "workers", 0, "")
+	workersParent.PreferredTopologyLevel = setup.TopologyLabelHostname
+	router := podgroup.CreateExpectedStandalonePCLQSubGroup(tc.Workload.Name, 0, "router", 1, "")
+	router.PreferredTopologyLevel = setup.TopologyLabelHostname
+	expectedBaseSubGroups := []podgroup.ExpectedSubGroup{
+		workersParent,
+		podgroup.CreateExpectedPCLQInPCSGSubGroup(tc.Workload.Name, 0, "workers", 0, "worker", 1, ""),
+		router,
+	}
+	if err := podGroupVerifier.VerifyPodGroupTopology(basePodGroup, setup.TopologyLabelBlock, setup.TopologyLabelRack, expectedBaseSubGroups); err != nil {
+		t.Fatalf("Failed to verify base KAI PodGroup topology: %v", err)
+	}
+
+	Logger.Info("4. Verify scaled PCSG KAI PodGroup preferred topology constraint")
+	podGroups, err := podGroupVerifier.GetKAIPodGroupsForPCS(tc.Ctx, tc.Namespace, tc.Workload.Name)
+	if err != nil {
+		t.Fatalf("Failed to get KAI PodGroups: %v", err)
+	}
+	workersFQN := nameutils.GeneratePodCliqueScalingGroupName(
+		nameutils.ResourceNameReplica{Name: tc.Workload.Name, Replica: 0},
+		"workers",
+	)
+	scaledPodGangName := nameutils.CreatePodGangNameFromPCSGFQN(workersFQN, 0)
+	scaledPodGroup, err := podgroup.FilterPodGroupByOwner(podGroups, scaledPodGangName)
+	if err != nil {
+		t.Fatalf("Failed to find scaled PodGroup %s: %v", scaledPodGangName, err)
+	}
+	expectedScaledSubGroups := []podgroup.ExpectedSubGroup{
+		podgroup.CreateExpectedPCLQInPCSGSubGroupNoParent(tc.Workload.Name, 0, "workers", 1, "worker", 1, ""),
+	}
+	if err := podGroupVerifier.VerifyPodGroupTopology(scaledPodGroup, "", setup.TopologyLabelHostname, expectedScaledSubGroups); err != nil {
+		t.Fatalf("Failed to verify scaled KAI PodGroup topology: %v", err)
+	}
+
+	Logger.Info("5. Verify TopologyLevelsUnavailable = False")
+	if err := topologyVerifier.WaitForPCSCondition(ctx, "default", tc.Workload.Name,
+		apicommonconstants.ConditionTopologyLevelsUnavailable,
+		string(metav1.ConditionFalse),
+		apicommonconstants.ConditionReasonAllTopologyLevelsAvailable,
+		tc.Timeout, tc.Interval); err != nil {
+		t.Fatalf("Failed to verify TopologyLevelsUnavailable is False: %v", err)
+	}
+
+	Logger.Info("TAS23: Preferred Pack Constraint Propagation test completed successfully!")
+}

--- a/operator/e2e/yaml/tas-preferred-pack.yaml
+++ b/operator/e2e/yaml/tas-preferred-pack.yaml
@@ -1,0 +1,94 @@
+# Workload: Preferred Topology Pack Constraints
+# Test scenario: PCS required+preferred, PCSG preferred-only, standalone PCLQ preferred-only
+---
+apiVersion: grove.io/v1alpha1
+kind: PodCliqueSet
+metadata:
+  name: tas-preferred-pack
+  labels:
+    app: tas-preferred-pack
+spec:
+  replicas: 1
+  template:
+    topologyConstraint:
+      topologyName: grove-topology
+      pack:
+        required: block
+        preferred: rack
+    podCliqueScalingGroups:
+      - name: workers
+        replicas: 2
+        minAvailable: 1
+        topologyConstraint:
+          topologyName: grove-topology
+          pack:
+            preferred: host
+        cliqueNames:
+          - worker
+    cliques:
+      - name: worker
+        labels:
+          kai.scheduler/queue: test
+        spec:
+          roleName: worker
+          replicas: 1
+          minAvailable: 1
+          podSpec:
+            terminationGracePeriodSeconds: 5
+            schedulerName: kai-scheduler
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node_role.e2e.grove.nvidia.com
+                          operator: In
+                          values:
+                            - agent
+            tolerations:
+              - key: node_role.e2e.grove.nvidia.com
+                operator: Equal
+                value: agent
+                effect: NoSchedule
+            containers:
+              - name: worker
+                image: registry:5001/busybox:latest
+                command: ["sleep", "infinity"]
+                resources:
+                  requests:
+                    memory: 10Mi
+      - name: router
+        labels:
+          kai.scheduler/queue: test
+        topologyConstraint:
+          topologyName: grove-topology
+          pack:
+            preferred: host
+        spec:
+          roleName: router
+          replicas: 1
+          minAvailable: 1
+          podSpec:
+            terminationGracePeriodSeconds: 5
+            schedulerName: kai-scheduler
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node_role.e2e.grove.nvidia.com
+                          operator: In
+                          values:
+                            - agent
+            tolerations:
+              - key: node_role.e2e.grove.nvidia.com
+                operator: Equal
+                value: agent
+                effect: NoSchedule
+            containers:
+              - name: router
+                image: registry:5001/busybox:latest
+                command: ["sleep", "infinity"]
+                resources:
+                  requests:
+                    memory: 10Mi

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
@@ -350,29 +350,35 @@ func buildPodCliqueInfo(sc *syncContext, pclqTemplateSpec *grovecorev1alpha1.Pod
 
 // createTopologyPackConstraint creates a TopologyPackConstraint based on the sync context and provided parameters for a resource.
 // PackConstraints are defined at multiple levels (PodCliqueSet, PodCliqueScalingGroup, PodClique). This function helps create a TopologyPackConstraint for any of these levels.
-func createTopologyPackConstraint(sc *syncContext, nsName types.NamespacedName, requiredTopologyConstraint *grovecorev1alpha1.TopologyConstraint) *groveschedulerv1alpha1.TopologyConstraint {
+func createTopologyPackConstraint(sc *syncContext, nsName types.NamespacedName, topologyConstraint *grovecorev1alpha1.TopologyConstraint) *groveschedulerv1alpha1.TopologyConstraint {
 	// If Topology aware scheduling is disabled, return nil even if TopologyConstraint is specified.
-	if !sc.tasEnabled || requiredTopologyConstraint == nil {
+	if !sc.tasEnabled || topologyConstraint == nil {
 		return nil
 	}
-	var pgPackConstraint *groveschedulerv1alpha1.TopologyPackConstraint
-	// If requiredTopologyConstraint is specified, set the required topology key accordingly.
-	requiredDomain := requiredTopologyConstraint.RequiredDomain()
-	requiredTopologyLevel, found := lo.Find(sc.topologyLevels, func(topologyLevel grovecorev1alpha1.TopologyLevel) bool {
-		return topologyLevel.Domain == requiredDomain
+
+	pgPackConstraint := &groveschedulerv1alpha1.TopologyPackConstraint{}
+	pgPackConstraint.Required = topologyLevelKeyForPackDomain(sc, nsName, topologyConstraint, topologyConstraint.RequiredDomain(), "required")
+	pgPackConstraint.Preferred = topologyLevelKeyForPackDomain(sc, nsName, topologyConstraint, topologyConstraint.PreferredDomain(), "preferred")
+
+	if pgPackConstraint.Required == nil && pgPackConstraint.Preferred == nil {
+		return nil
+	}
+	return &groveschedulerv1alpha1.TopologyConstraint{PackConstraint: pgPackConstraint}
+}
+
+func topologyLevelKeyForPackDomain(sc *syncContext, nsName types.NamespacedName, topologyConstraint *grovecorev1alpha1.TopologyConstraint, topologyDomain grovecorev1alpha1.TopologyDomain, packConstraintType string) *string {
+	if topologyDomain == "" {
+		return nil
+	}
+	topologyLevel, found := lo.Find(sc.topologyLevels, func(topologyLevel grovecorev1alpha1.TopologyLevel) bool {
+		return topologyLevel.Domain == topologyDomain
 	})
 	if !found {
-		// This can only happen if the ClusterTopologyBinding CR has been updated and no longer contains a topology level
-		// that is being referenced by the resource's TopologyConstraint.
-		// In the current version it's been decided to log this occurrence and skip setting the required constraint which is equivalent
-		// to nullifying the required constraint.
-		sc.logger.Info("required topology domain not found in cluster topology levels, skipping setting required pack constraint", "namespacedName", nsName, "requiredTopologyConstraint", *requiredTopologyConstraint)
-	} else {
-		pgPackConstraint = &groveschedulerv1alpha1.TopologyPackConstraint{
-			Required: ptr.To(requiredTopologyLevel.Key),
-		}
+		// This can happen if the ClusterTopologyBinding CR has changed after the resource was admitted.
+		sc.logger.Info(packConstraintType+" topology domain not found in cluster topology levels, skipping setting "+packConstraintType+" pack constraint", "namespacedName", nsName, "topologyDomain", topologyDomain, "topologyConstraint", *topologyConstraint)
+		return nil
 	}
-	return lo.Ternary(pgPackConstraint != nil, &groveschedulerv1alpha1.TopologyConstraint{PackConstraint: pgPackConstraint}, nil)
+	return ptr.To(topologyLevel.Key)
 }
 
 // determinePodCliqueReplicas determines replica count considering HPA mutations.

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow_test.go
@@ -962,10 +962,15 @@ func TestComputeExpectedPodGangs(t *testing.T) {
 }
 
 type expectedPodGangTopologyConstraints struct {
-	fqn             string
-	topologyLevel   *grovecorev1alpha1.TopologyLevel
-	pclqConstraints map[string]grovecorev1alpha1.TopologyLevel
-	pcsgConstraints map[string]grovecorev1alpha1.TopologyLevel
+	fqn                    string
+	topologyPackConstraint *expectedTopologyPackConstraint
+	pclqPackConstraints    map[string]expectedTopologyPackConstraint
+	pcsgPackConstraints    map[string]expectedTopologyPackConstraint
+}
+
+type expectedTopologyPackConstraint struct {
+	requiredKey  string
+	preferredKey string
 }
 
 // TestComputeExpectedPodGangsWithTopologyConstraints tests computeExpectedPodGangs with topology constraints.
@@ -986,6 +991,7 @@ func TestComputeExpectedPodGangsWithTopologyConstraints(t *testing.T) {
 		name                               string
 		tasEnabled                         bool
 		pcsTopologyLevel                   *grovecorev1alpha1.TopologyLevel
+		pcsTopologyConstraint              *grovecorev1alpha1.TopologyConstraint
 		pclqTemplateSpecs                  []*grovecorev1alpha1.PodCliqueTemplateSpec
 		pcsgConfigs                        []grovecorev1alpha1.PodCliqueScalingGroupConfig
 		expectedNumPodGangs                int
@@ -1021,8 +1027,64 @@ func TestComputeExpectedPodGangsWithTopologyConstraints(t *testing.T) {
 			expectedNumPodGangs: 1,
 			expectedPodGangTopologyConstraints: []expectedPodGangTopologyConstraints{
 				{
-					fqn:           "test-pcs-0",
-					topologyLevel: &grovecorev1alpha1.TopologyLevel{Domain: "zone", Key: "topology.kubernetes.io/zone"},
+					fqn: "test-pcs-0",
+					topologyPackConstraint: &expectedTopologyPackConstraint{
+						requiredKey: topologyLevelZone.Key,
+					},
+				},
+			},
+		},
+		{
+			name:       "PCS with preferred-only topology constraint at PCS level",
+			tasEnabled: true,
+			pcsTopologyConstraint: &grovecorev1alpha1.TopologyConstraint{
+				Pack: &grovecorev1alpha1.TopologyPackConstraint{PreferredDomain: "host"},
+			},
+			pclqTemplateSpecs: []*grovecorev1alpha1.PodCliqueTemplateSpec{
+				{
+					Name: "worker",
+					Spec: grovecorev1alpha1.PodCliqueSpec{
+						Replicas:     3,
+						MinAvailable: ptr.To(int32(2)),
+					},
+				},
+			},
+			expectedNumPodGangs: 1,
+			expectedPodGangTopologyConstraints: []expectedPodGangTopologyConstraints{
+				{
+					fqn: "test-pcs-0",
+					topologyPackConstraint: &expectedTopologyPackConstraint{
+						preferredKey: topologyLevelHost.Key,
+					},
+				},
+			},
+		},
+		{
+			name:       "PCS with required and preferred topology constraints at PCS level",
+			tasEnabled: true,
+			pcsTopologyConstraint: &grovecorev1alpha1.TopologyConstraint{
+				Pack: &grovecorev1alpha1.TopologyPackConstraint{
+					RequiredDomain:  "zone",
+					PreferredDomain: "host",
+				},
+			},
+			pclqTemplateSpecs: []*grovecorev1alpha1.PodCliqueTemplateSpec{
+				{
+					Name: "worker",
+					Spec: grovecorev1alpha1.PodCliqueSpec{
+						Replicas:     3,
+						MinAvailable: ptr.To(int32(2)),
+					},
+				},
+			},
+			expectedNumPodGangs: 1,
+			expectedPodGangTopologyConstraints: []expectedPodGangTopologyConstraints{
+				{
+					fqn: "test-pcs-0",
+					topologyPackConstraint: &expectedTopologyPackConstraint{
+						requiredKey:  topologyLevelZone.Key,
+						preferredKey: topologyLevelHost.Key,
+					},
 				},
 			},
 		},
@@ -1051,10 +1113,41 @@ func TestComputeExpectedPodGangsWithTopologyConstraints(t *testing.T) {
 			expectedNumPodGangs: 1,
 			expectedPodGangTopologyConstraints: []expectedPodGangTopologyConstraints{
 				{
-					fqn:           "test-pcs-0",
-					topologyLevel: nil,
-					pclqConstraints: map[string]grovecorev1alpha1.TopologyLevel{
-						"test-pcs-0-worker": topologyLevelHost,
+					fqn: "test-pcs-0",
+					pclqPackConstraints: map[string]expectedTopologyPackConstraint{
+						"test-pcs-0-worker": {requiredKey: topologyLevelHost.Key},
+					},
+				},
+			},
+		},
+		{
+			name:       "PCS with preferred-only topology constraint on standalone PCLQ",
+			tasEnabled: true,
+			pclqTemplateSpecs: []*grovecorev1alpha1.PodCliqueTemplateSpec{
+				{
+					Name: "router",
+					Spec: grovecorev1alpha1.PodCliqueSpec{
+						Replicas:     3,
+						MinAvailable: ptr.To(int32(2)),
+					},
+				},
+				{
+					Name: "worker",
+					TopologyConstraint: &grovecorev1alpha1.TopologyConstraint{
+						Pack: &grovecorev1alpha1.TopologyPackConstraint{PreferredDomain: "host"},
+					},
+					Spec: grovecorev1alpha1.PodCliqueSpec{
+						Replicas:     2,
+						MinAvailable: ptr.To(int32(1)),
+					},
+				},
+			},
+			expectedNumPodGangs: 1,
+			expectedPodGangTopologyConstraints: []expectedPodGangTopologyConstraints{
+				{
+					fqn: "test-pcs-0",
+					pclqPackConstraints: map[string]expectedTopologyPackConstraint{
+						"test-pcs-0-worker": {preferredKey: topologyLevelHost.Key},
 					},
 				},
 			},
@@ -1084,11 +1177,13 @@ func TestComputeExpectedPodGangsWithTopologyConstraints(t *testing.T) {
 			expectedNumPodGangs: 1,
 			expectedPodGangTopologyConstraints: []expectedPodGangTopologyConstraints{
 				{
-					fqn:           "test-pcs-0",
-					topologyLevel: &topologyLevelZone,
-					pclqConstraints: map[string]grovecorev1alpha1.TopologyLevel{
-						"test-pcs-0-worker": topologyLevelHost,
-						"test-pcs-0-router": topologyLevelZone,
+					fqn: "test-pcs-0",
+					topologyPackConstraint: &expectedTopologyPackConstraint{
+						requiredKey: topologyLevelZone.Key,
+					},
+					pclqPackConstraints: map[string]expectedTopologyPackConstraint{
+						"test-pcs-0-worker": {requiredKey: topologyLevelHost.Key},
+						"test-pcs-0-router": {requiredKey: topologyLevelZone.Key},
 					},
 				},
 			},
@@ -1127,22 +1222,72 @@ func TestComputeExpectedPodGangsWithTopologyConstraints(t *testing.T) {
 			expectedNumPodGangs: 2,
 			expectedPodGangTopologyConstraints: []expectedPodGangTopologyConstraints{
 				{
-					fqn:           "test-pcs-0",
-					topologyLevel: &topologyLevelZone,
-					pclqConstraints: map[string]grovecorev1alpha1.TopologyLevel{
-						"test-pcs-0-scaling-group-0-decode-leader": topologyLevelHost,
-						"test-pcs-0-scaling-group-0-decode-worker": topologyLevelHost,
+					fqn: "test-pcs-0",
+					topologyPackConstraint: &expectedTopologyPackConstraint{
+						requiredKey: topologyLevelZone.Key,
 					},
-					pcsgConstraints: map[string]grovecorev1alpha1.TopologyLevel{
-						"test-pcs-0-scaling-group-0": topologyLevelRack,
+					pclqPackConstraints: map[string]expectedTopologyPackConstraint{
+						"test-pcs-0-scaling-group-0-decode-leader": {requiredKey: topologyLevelHost.Key},
+						"test-pcs-0-scaling-group-0-decode-worker": {requiredKey: topologyLevelHost.Key},
+					},
+					pcsgPackConstraints: map[string]expectedTopologyPackConstraint{
+						"test-pcs-0-scaling-group-0": {requiredKey: topologyLevelRack.Key},
 					},
 				},
 				{
-					fqn:           "test-pcs-0-scaling-group-0",
-					topologyLevel: &topologyLevelRack,
-					pclqConstraints: map[string]grovecorev1alpha1.TopologyLevel{
-						"test-pcs-0-scaling-group-1-decode-leader": topologyLevelHost,
-						"test-pcs-0-scaling-group-1-decode-worker": topologyLevelHost,
+					fqn: "test-pcs-0-scaling-group-0",
+					topologyPackConstraint: &expectedTopologyPackConstraint{
+						requiredKey: topologyLevelRack.Key,
+					},
+					pclqPackConstraints: map[string]expectedTopologyPackConstraint{
+						"test-pcs-0-scaling-group-1-decode-leader": {requiredKey: topologyLevelHost.Key},
+						"test-pcs-0-scaling-group-1-decode-worker": {requiredKey: topologyLevelHost.Key},
+					},
+				},
+			},
+		},
+		{
+			name:       "PCS with preferred-only topology constraint on PCSG",
+			tasEnabled: true,
+			pclqTemplateSpecs: []*grovecorev1alpha1.PodCliqueTemplateSpec{
+				{
+					Name: "decode-leader",
+					Spec: grovecorev1alpha1.PodCliqueSpec{
+						Replicas:     1,
+						MinAvailable: ptr.To(int32(1)),
+					},
+				},
+				{
+					Name: "decode-worker",
+					Spec: grovecorev1alpha1.PodCliqueSpec{
+						Replicas:     5,
+						MinAvailable: ptr.To(int32(1)),
+					},
+				},
+			},
+			pcsgConfigs: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
+				{
+					Name:         "scaling-group",
+					Replicas:     ptr.To(int32(2)),
+					MinAvailable: ptr.To(int32(1)),
+					CliqueNames:  []string{"decode-leader", "decode-worker"},
+					TopologyConstraint: &grovecorev1alpha1.TopologyConstraint{
+						Pack: &grovecorev1alpha1.TopologyPackConstraint{PreferredDomain: "rack"},
+					},
+				},
+			},
+			expectedNumPodGangs: 2,
+			expectedPodGangTopologyConstraints: []expectedPodGangTopologyConstraints{
+				{
+					fqn: "test-pcs-0",
+					pcsgPackConstraints: map[string]expectedTopologyPackConstraint{
+						"test-pcs-0-scaling-group-0": {preferredKey: topologyLevelRack.Key},
+					},
+				},
+				{
+					fqn: "test-pcs-0-scaling-group-0",
+					topologyPackConstraint: &expectedTopologyPackConstraint{
+						preferredKey: topologyLevelRack.Key,
 					},
 				},
 			},
@@ -1189,23 +1334,27 @@ func TestComputeExpectedPodGangsWithTopologyConstraints(t *testing.T) {
 			expectedNumPodGangs: 2,
 			expectedPodGangTopologyConstraints: []expectedPodGangTopologyConstraints{
 				{
-					fqn:           "test-pcs-0",
-					topologyLevel: &topologyLevelZone,
-					pclqConstraints: map[string]grovecorev1alpha1.TopologyLevel{
-						"test-pcs-0-router":                        topologyLevelZone,
-						"test-pcs-0-scaling-group-0-decode-leader": topologyLevelHost,
-						"test-pcs-0-scaling-group-0-decode-worker": topologyLevelHost,
+					fqn: "test-pcs-0",
+					topologyPackConstraint: &expectedTopologyPackConstraint{
+						requiredKey: topologyLevelZone.Key,
 					},
-					pcsgConstraints: map[string]grovecorev1alpha1.TopologyLevel{
-						"test-pcs-0-scaling-group-0": topologyLevelRack,
+					pclqPackConstraints: map[string]expectedTopologyPackConstraint{
+						"test-pcs-0-router":                        {requiredKey: topologyLevelZone.Key},
+						"test-pcs-0-scaling-group-0-decode-leader": {requiredKey: topologyLevelHost.Key},
+						"test-pcs-0-scaling-group-0-decode-worker": {requiredKey: topologyLevelHost.Key},
+					},
+					pcsgPackConstraints: map[string]expectedTopologyPackConstraint{
+						"test-pcs-0-scaling-group-0": {requiredKey: topologyLevelRack.Key},
 					},
 				},
 				{
-					fqn:           "test-pcs-0-scaling-group-0",
-					topologyLevel: &topologyLevelRack,
-					pclqConstraints: map[string]grovecorev1alpha1.TopologyLevel{
-						"test-pcs-0-scaling-group-1-decode-leader": topologyLevelHost,
-						"test-pcs-0-scaling-group-1-decode-worker": topologyLevelHost,
+					fqn: "test-pcs-0-scaling-group-0",
+					topologyPackConstraint: &expectedTopologyPackConstraint{
+						requiredKey: topologyLevelRack.Key,
+					},
+					pclqPackConstraints: map[string]expectedTopologyPackConstraint{
+						"test-pcs-0-scaling-group-1-decode-leader": {requiredKey: topologyLevelHost.Key},
+						"test-pcs-0-scaling-group-1-decode-worker": {requiredKey: topologyLevelHost.Key},
 					},
 				},
 			},
@@ -1285,19 +1434,23 @@ func TestComputeExpectedPodGangsWithTopologyConstraints(t *testing.T) {
 			expectedNumPodGangs: 2,
 			expectedPodGangTopologyConstraints: []expectedPodGangTopologyConstraints{
 				{
-					fqn:           "test-pcs-0",
-					topologyLevel: &topologyLevelZone,
-					pclqConstraints: map[string]grovecorev1alpha1.TopologyLevel{
-						"test-pcs-0-scaling-group-0-decode-leader": topologyLevelHost,
-						"test-pcs-0-scaling-group-0-decode-worker": topologyLevelHost,
+					fqn: "test-pcs-0",
+					topologyPackConstraint: &expectedTopologyPackConstraint{
+						requiredKey: topologyLevelZone.Key,
+					},
+					pclqPackConstraints: map[string]expectedTopologyPackConstraint{
+						"test-pcs-0-scaling-group-0-decode-leader": {requiredKey: topologyLevelHost.Key},
+						"test-pcs-0-scaling-group-0-decode-worker": {requiredKey: topologyLevelHost.Key},
 					},
 				},
 				{
-					fqn:           "test-pcs-0-scaling-group-0",
-					topologyLevel: &topologyLevelZone,
-					pclqConstraints: map[string]grovecorev1alpha1.TopologyLevel{
-						"test-pcs-0-scaling-group-1-decode-leader": topologyLevelHost,
-						"test-pcs-0-scaling-group-1-decode-worker": topologyLevelHost,
+					fqn: "test-pcs-0-scaling-group-0",
+					topologyPackConstraint: &expectedTopologyPackConstraint{
+						requiredKey: topologyLevelZone.Key,
+					},
+					pclqPackConstraints: map[string]expectedTopologyPackConstraint{
+						"test-pcs-0-scaling-group-1-decode-leader": {requiredKey: topologyLevelHost.Key},
+						"test-pcs-0-scaling-group-1-decode-worker": {requiredKey: topologyLevelHost.Key},
 					},
 				},
 			},
@@ -1308,7 +1461,9 @@ func TestComputeExpectedPodGangsWithTopologyConstraints(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup
 			var pcsTopologyConstraint *grovecorev1alpha1.TopologyConstraint
-			if tc.pcsTopologyLevel != nil {
+			if tc.pcsTopologyConstraint != nil {
+				pcsTopologyConstraint = tc.pcsTopologyConstraint
+			} else if tc.pcsTopologyLevel != nil {
 				pcsTopologyConstraint = &grovecorev1alpha1.TopologyConstraint{
 					PackDomain: tc.pcsTopologyLevel.Domain,
 				}
@@ -1356,6 +1511,10 @@ func TestComputeExpectedPodGangsWithTopologyConstraints(t *testing.T) {
 			if !tc.tasEnabled {
 				mustNotHaveAnyTopologyConstraints(t, sc.expectedPodGangs)
 			} else {
+				if len(tc.expectedPodGangTopologyConstraints) == 0 {
+					mustNotHaveAnyTopologyConstraints(t, sc.expectedPodGangs)
+					return
+				}
 				// Iterate over the expected pod gang topology constraints.
 				for _, expectedPGConstraint := range tc.expectedPodGangTopologyConstraints {
 					// find the computed pod gang
@@ -1367,38 +1526,27 @@ func TestComputeExpectedPodGangsWithTopologyConstraints(t *testing.T) {
 					// verify pod gang topology constraint. This is the top level topology constraint.
 					// For base pod gang it comes from PodCliqueSet.Spec.Template.TopologyConstraint.
 					// For scaled pod gangs it comes from PodCliqueScalingGroup.Spec.TopologyConstraint.
-					if expectedPGConstraint.topologyLevel == nil {
-						assert.Nil(t, computedPodGang.topologyConstraint)
-					} else {
-						// assert pod gang topology constraint is set correctly
-						assertRequiredTopologyConstraint(t, computedPodGang.topologyConstraint, expectedPGConstraint.topologyLevel.Key)
-					}
+					assertTopologyPackConstraint(t, computedPodGang.topologyConstraint, expectedPGConstraint.topologyPackConstraint)
 
 					// verify pclq topology constraints
 					for _, pclq := range computedPodGang.pclqs {
-						expectedPCLQConstraint, exists := expectedPGConstraint.pclqConstraints[pclq.fqn]
-						if !exists {
-							assert.Nil(t, pclq.topologyConstraint)
-						} else {
-							// assert pclq topology constraint is set correctly
-							assertRequiredTopologyConstraint(t, pclq.topologyConstraint, expectedPCLQConstraint.Key)
-						}
+						expectedPCLQConstraint := expectedPCLQPackConstraint(expectedPGConstraint, pclq.fqn)
+						assertTopologyPackConstraint(t, pclq.topologyConstraint, expectedPCLQConstraint)
 					}
 
-					// iterate over expected PCSG Constraints and verify computed pcsg topology constraints
-					for pcsgFQN, expectedPCSGTC := range expectedPGConstraint.pcsgConstraints {
+					// iterate over expected PCSG pack constraints and verify computed pcsg topology constraints
+					for pcsgFQN, expectedPCSGTC := range expectedPGConstraint.pcsgPackConstraints {
 						actualPCSGTC, found := lo.Find(computedPodGang.pcsgTopologyConstraints, func(pcsgTC groveschedulerv1alpha1.TopologyConstraintGroupConfig) bool {
 							return pcsgTC.Name == pcsgFQN
 						})
-						assert.True(t, found, "Expected PCSG topology constraint for %s not found", pcsgFQN)
-						// assert pcsg topology constraint is set correctly
-						assertRequiredTopologyConstraint(t, actualPCSGTC.TopologyConstraint, expectedPCSGTC.Key)
+						require.True(t, found, "Expected PCSG topology constraint for %s not found", pcsgFQN)
+						assertTopologyPackConstraint(t, actualPCSGTC.TopologyConstraint, &expectedPCSGTC)
 					}
 
 					// iterate over computed PCSG topology constraints to ensure that expectations are properly defined.
 					// This ensures that developer mistakes are caught when defining the topology constraint expectations.
 					for _, actualPCSGTC := range computedPodGang.pcsgTopologyConstraints {
-						_, exists := expectedPGConstraint.pcsgConstraints[actualPCSGTC.Name]
+						_, exists := expectedPGConstraint.pcsgPackConstraints[actualPCSGTC.Name]
 						if !exists {
 							t.Errorf("Unexpected PCSG topology constraint for %s found in PodGang %s", actualPCSGTC.Name, computedPodGang.fqn)
 						}
@@ -1407,6 +1555,13 @@ func TestComputeExpectedPodGangsWithTopologyConstraints(t *testing.T) {
 			}
 		})
 	}
+}
+
+func expectedPCLQPackConstraint(expected expectedPodGangTopologyConstraints, pclqFQN string) *expectedTopologyPackConstraint {
+	if expectedPCLQConstraint, exists := expected.pclqPackConstraints[pclqFQN]; exists {
+		return &expectedPCLQConstraint
+	}
+	return nil
 }
 
 func mustNotHaveAnyTopologyConstraints(t *testing.T, podGangs []*podGangInfo) {
@@ -1420,12 +1575,25 @@ func mustNotHaveAnyTopologyConstraints(t *testing.T, podGangs []*podGangInfo) {
 	}
 }
 
-func assertRequiredTopologyConstraint(t *testing.T, got *groveschedulerv1alpha1.TopologyConstraint, wantedKey string) {
-	assert.NotNil(t, got)
-	assert.NotNil(t, got.PackConstraint)
-	assert.Nil(t, got.PackConstraint.Preferred)
-	assert.NotNil(t, got.PackConstraint.Required)
-	assert.Equal(t, wantedKey, *got.PackConstraint.Required)
+func assertTopologyPackConstraint(t *testing.T, got *groveschedulerv1alpha1.TopologyConstraint, expected *expectedTopologyPackConstraint) {
+	if expected == nil {
+		assert.Nil(t, got)
+		return
+	}
+	require.NotNil(t, got)
+	require.NotNil(t, got.PackConstraint)
+	if expected.requiredKey == "" {
+		assert.Nil(t, got.PackConstraint.Required)
+	} else {
+		require.NotNil(t, got.PackConstraint.Required)
+		assert.Equal(t, expected.requiredKey, *got.PackConstraint.Required)
+	}
+	if expected.preferredKey == "" {
+		assert.Nil(t, got.PackConstraint.Preferred)
+	} else {
+		require.NotNil(t, got.PackConstraint.Preferred)
+		assert.Equal(t, expected.preferredKey, *got.PackConstraint.Preferred)
+	}
 }
 
 // TestDeterminePCSGReplicas tests the determinePCSGReplicas method

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow_test.go
@@ -1089,6 +1089,62 @@ func TestComputeExpectedPodGangsWithTopologyConstraints(t *testing.T) {
 			},
 		},
 		{
+			name:       "PCS with stale preferred domain preserves required topology constraint",
+			tasEnabled: true,
+			pcsTopologyConstraint: &grovecorev1alpha1.TopologyConstraint{
+				Pack: &grovecorev1alpha1.TopologyPackConstraint{
+					RequiredDomain:  "rack",
+					PreferredDomain: "block",
+				},
+			},
+			pclqTemplateSpecs: []*grovecorev1alpha1.PodCliqueTemplateSpec{
+				{
+					Name: "worker",
+					Spec: grovecorev1alpha1.PodCliqueSpec{
+						Replicas:     3,
+						MinAvailable: ptr.To(int32(2)),
+					},
+				},
+			},
+			expectedNumPodGangs: 1,
+			expectedPodGangTopologyConstraints: []expectedPodGangTopologyConstraints{
+				{
+					fqn: "test-pcs-0",
+					topologyPackConstraint: &expectedTopologyPackConstraint{
+						requiredKey: topologyLevelRack.Key,
+					},
+				},
+			},
+		},
+		{
+			name:       "PCS with stale required domain preserves preferred topology constraint",
+			tasEnabled: true,
+			pcsTopologyConstraint: &grovecorev1alpha1.TopologyConstraint{
+				Pack: &grovecorev1alpha1.TopologyPackConstraint{
+					RequiredDomain:  "block",
+					PreferredDomain: "rack",
+				},
+			},
+			pclqTemplateSpecs: []*grovecorev1alpha1.PodCliqueTemplateSpec{
+				{
+					Name: "worker",
+					Spec: grovecorev1alpha1.PodCliqueSpec{
+						Replicas:     3,
+						MinAvailable: ptr.To(int32(2)),
+					},
+				},
+			},
+			expectedNumPodGangs: 1,
+			expectedPodGangTopologyConstraints: []expectedPodGangTopologyConstraints{
+				{
+					fqn: "test-pcs-0",
+					topologyPackConstraint: &expectedTopologyPackConstraint{
+						preferredKey: topologyLevelRack.Key,
+					},
+				},
+			},
+		},
+		{
 			name:       "PCS with single standalone PCLQ where topology constraints are set for one of the PCLQs",
 			tasEnabled: true,
 			pclqTemplateSpecs: []*grovecorev1alpha1.PodCliqueTemplateSpec{

--- a/operator/internal/controller/podcliqueset/reconcilestatus_test.go
+++ b/operator/internal/controller/podcliqueset/reconcilestatus_test.go
@@ -454,6 +454,25 @@ func TestMutateTopologyLevelUnavailableConditions(t *testing.T) {
 			wantMsgContain: "available",
 		},
 		{
+			name:       "TAS enabled, required and preferred domains available - False/AllClusterTopologyLevelsAvailable",
+			tasEnabled: true,
+			setupPCS: func() *grovecorev1alpha1.PodCliqueSet {
+				pcs := basePCS("my-topology")
+				pcs.Spec.Template.TopologyConstraint.PackDomain = ""
+				pcs.Spec.Template.TopologyConstraint.Pack = &grovecorev1alpha1.TopologyPackConstraint{
+					RequiredDomain:  grovecorev1alpha1.TopologyDomainRack,
+					PreferredDomain: grovecorev1alpha1.TopologyDomainZone,
+				}
+				return pcs
+			},
+			extraObjects: []client.Object{
+				clusterTopology("my-topology", standardLevels),
+			},
+			wantStatus:     metav1.ConditionFalse,
+			wantReason:     apicommonconstants.ConditionReasonAllTopologyLevelsAvailable,
+			wantMsgContain: "available",
+		},
+		{
 			name:       "TAS enabled, named ClusterTopologyBinding is used instead of another available topology",
 			tasEnabled: true,
 			setupPCS:   func() *grovecorev1alpha1.PodCliqueSet { return basePCS("selected-topology") },
@@ -486,6 +505,25 @@ func TestMutateTopologyLevelUnavailableConditions(t *testing.T) {
 			wantStatus:     metav1.ConditionTrue,
 			wantReason:     apicommonconstants.ConditionReasonTopologyLevelsUnavailable,
 			wantMsgContain: "Unavailable",
+		},
+		{
+			name:       "TAS enabled, preferred domain unavailable - True/ClusterTopologyLevelsUnavailable",
+			tasEnabled: true,
+			setupPCS: func() *grovecorev1alpha1.PodCliqueSet {
+				pcs := basePCS("my-topology")
+				pcs.Spec.Template.TopologyConstraint.PackDomain = ""
+				pcs.Spec.Template.TopologyConstraint.Pack = &grovecorev1alpha1.TopologyPackConstraint{
+					RequiredDomain:  grovecorev1alpha1.TopologyDomainRack,
+					PreferredDomain: grovecorev1alpha1.TopologyDomainHost,
+				}
+				return pcs
+			},
+			extraObjects: []client.Object{
+				clusterTopology("my-topology", standardLevels),
+			},
+			wantStatus:     metav1.ConditionTrue,
+			wantReason:     apicommonconstants.ConditionReasonTopologyLevelsUnavailable,
+			wantMsgContain: "host",
 		},
 		{
 			name:         "TAS enabled, topologyName set, CT not found — Unknown/ClusterTopologyNotFound",
@@ -632,6 +670,36 @@ func TestGetUniqueTopologyDomainsInPodCliqueSet(t *testing.T) {
 					tmpl.TopologyConstraint = &grovecorev1alpha1.TopologyConstraint{
 						TopologyName: "my-topology",
 						PackDomain:   grovecorev1alpha1.TopologyDomainRack,
+					}
+				})
+			},
+			wantDomains: []grovecorev1alpha1.TopologyDomain{grovecorev1alpha1.TopologyDomainRack},
+		},
+		{
+			name: "PCS-level required and preferred pack domains - both domains included",
+			setupPCS: func() *grovecorev1alpha1.PodCliqueSet {
+				return makePCS(func(tmpl *grovecorev1alpha1.PodCliqueSetTemplateSpec) {
+					tmpl.TopologyConstraint = &grovecorev1alpha1.TopologyConstraint{
+						TopologyName: "my-topology",
+						Pack: &grovecorev1alpha1.TopologyPackConstraint{
+							RequiredDomain:  grovecorev1alpha1.TopologyDomainRack,
+							PreferredDomain: grovecorev1alpha1.TopologyDomainHost,
+						},
+					}
+				})
+			},
+			wantDomains: []grovecorev1alpha1.TopologyDomain{grovecorev1alpha1.TopologyDomainRack, grovecorev1alpha1.TopologyDomainHost},
+		},
+		{
+			name: "PCS-level matching required and preferred pack domains - domain included once",
+			setupPCS: func() *grovecorev1alpha1.PodCliqueSet {
+				return makePCS(func(tmpl *grovecorev1alpha1.PodCliqueSetTemplateSpec) {
+					tmpl.TopologyConstraint = &grovecorev1alpha1.TopologyConstraint{
+						TopologyName: "my-topology",
+						Pack: &grovecorev1alpha1.TopologyPackConstraint{
+							RequiredDomain:  grovecorev1alpha1.TopologyDomainRack,
+							PreferredDomain: grovecorev1alpha1.TopologyDomainRack,
+						},
 					}
 				})
 			},


### PR DESCRIPTION
## Summary

- propagate `topologyConstraint.pack.preferred` to scheduler PodGang pack constraints
- keep required-domain behavior, including `pack.required` and deprecated `packDomain` fallback
- add controller/status unit coverage for preferred topology domains
- add TAS23 e2e coverage for PCS required+preferred, PCSG preferred-only, standalone PCLQ preferred-only, and scaled PCSG preferred propagation

## Testing

- `GOCACHE=/private/tmp/grove-go-build-cache GOTOOLCHAIN=auto go test ./internal/controller/podcliqueset/components/podgang`
- `GOCACHE=/private/tmp/grove-go-build-cache GOTOOLCHAIN=auto go test ./internal/controller/podcliqueset`
- `GOCACHE=/private/tmp/grove-go-build-cache GOTOOLCHAIN=auto go test ./internal/controller/common/component/utils`
- `GOCACHE=/private/tmp/grove-go-build-cache GOTOOLCHAIN=auto go test ./internal/controller/...`
- `GOCACHE=/private/tmp/grove-go-build-cache GOTOOLCHAIN=auto go test -c -tags=e2e ./e2e/tests -o /private/tmp/grove-e2e-tests.test`

Runtime e2e is intentionally not run by Codex; run manually with:

- `GOCACHE=/private/tmp/grove-go-build-cache GOTOOLCHAIN=auto make run-e2e TEST_PATTERN=Test_TAS23`

Related to #368