### PR TITLE
fix: shorten init-container SA token Secret name

### DIFF
--- a/operator/api/common/namegen.go
+++ b/operator/api/common/namegen.go
@@ -61,6 +61,14 @@ func GeneratePodServiceAccountName(pcsName string) string {
 // GenerateInitContainerSATokenSecretName generates a Secret name containing a service account token that will be mounted onto the init container
 // responsible for ensuring start-up order amongst PodCliques.
 func GenerateInitContainerSATokenSecretName(pcsName string) string {
+	return fmt.Sprintf("%s-ic-sat", pcsName)
+}
+
+// GenerateLegacyInitContainerSATokenSecretName generates the legacy init-container service account token
+// Secret name used before the suffix was shortened. Retained as a migration source and delete target.
+//
+// Deprecated: scheduled for removal three releases after the shortening (see https://github.com/ai-dynamo/grove/issues/658).
+func GenerateLegacyInitContainerSATokenSecretName(pcsName string) string {
 	return fmt.Sprintf("%s-initc-sa-token-secret", pcsName)
 }
 

--- a/operator/api/common/namegen.go
+++ b/operator/api/common/namegen.go
@@ -67,7 +67,9 @@ func GenerateInitContainerSATokenSecretName(pcsName string) string {
 // GenerateLegacyInitContainerSATokenSecretName generates the legacy init-container service account token
 // Secret name used before the suffix was shortened. Retained as a migration source and delete target.
 //
-// Deprecated: scheduled for removal three releases after the shortening (see https://github.com/ai-dynamo/grove/issues/658).
+// Deprecated: retained for migration after shortening the suffix to "-ic-sat".
+// Expected in v0.1.0-alpha.12; remove three releases later.
+// Track removal in https://github.com/ai-dynamo/grove/issues/658.
 func GenerateLegacyInitContainerSATokenSecretName(pcsName string) string {
 	return fmt.Sprintf("%s-initc-sa-token-secret", pcsName)
 }

--- a/operator/api/common/namegen_test.go
+++ b/operator/api/common/namegen_test.go
@@ -24,6 +24,11 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+func TestGenerateInitContainerSATokenSecretName(t *testing.T) {
+	assert.Equal(t, "test-pcs-ic-sat", GenerateInitContainerSATokenSecretName("test-pcs"))
+	assert.Equal(t, "test-pcs-initc-sa-token-secret", GenerateLegacyInitContainerSATokenSecretName("test-pcs"))
+}
+
 func TestExtractScalingGroupNameFromPCSGFQN(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/operator/internal/controller/podclique/components/pod/pod_test.go
+++ b/operator/internal/controller/podclique/components/pod/pod_test.go
@@ -18,6 +18,7 @@ package pod
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/ai-dynamo/grove/operator/api/common"
@@ -36,6 +37,26 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 )
+
+func TestAddServiceAccountTokenSecretVolumeUsesShortSecretName(t *testing.T) {
+	// 44 is the longest admitted PodCliqueSet name (the webhook caps combined
+	// resource name length at 45). The shortened "-ic-sat" suffix must keep the
+	// generated Secret name within the 63-byte label-value limit even at this bound.
+	pcsName := strings.Repeat("a", 44)
+	pod := &corev1.Pod{}
+
+	addServiceAccountTokenSecretVolume(pcsName, pod)
+
+	assert.Len(t, pod.Spec.Volumes, 1)
+	volume := pod.Spec.Volumes[0]
+	assert.Equal(t, serviceAccountTokenSecretVolumeName, volume.Name)
+	if assert.NotNil(t, volume.Secret) {
+		expectedSecretName := common.GenerateInitContainerSATokenSecretName(pcsName)
+		assert.Equal(t, expectedSecretName, volume.Secret.SecretName)
+		assert.NotEqual(t, common.GenerateLegacyInitContainerSATokenSecretName(pcsName), volume.Secret.SecretName)
+		assert.LessOrEqual(t, len(expectedSecretName), 63)
+	}
+}
 
 func TestBuildResourceWithLPXBackend(t *testing.T) {
 	const (

--- a/operator/internal/controller/podcliqueset/components/satokensecret/satokensecret.go
+++ b/operator/internal/controller/podcliqueset/components/satokensecret/satokensecret.go
@@ -36,6 +36,7 @@ import (
 
 const (
 	errCodeGetSecret              grovecorev1alpha1.ErrorCode = "ERR_GET_SECRET"
+	errCodeSecretConflict         grovecorev1alpha1.ErrorCode = "ERR_SECRET_CONFLICT"
 	errCodeSetControllerReference grovecorev1alpha1.ErrorCode = "ERR_SET_CONTROLLER_REFERENCE"
 	errCodeCreateSecret           grovecorev1alpha1.ErrorCode = "ERR_CREATE_SECRET"
 	errCodeDeleteSecret           grovecorev1alpha1.ErrorCode = "ERR_DELETE_SECRET"
@@ -92,7 +93,7 @@ func (r _resource) Sync(ctx context.Context, logger logr.Logger, pcs *grovecorev
 	if existingSecret != nil {
 		if !metav1.IsControlledBy(existingSecret, pcs) {
 			return groveerr.New(
-				errCodeGetSecret,
+				errCodeSecretConflict,
 				component.OperationSync,
 				fmt.Sprintf("Secret %v already exists but is not controlled by PodCliqueSet %v", objKey, pcsObjKey),
 			)
@@ -208,6 +209,8 @@ func (r _resource) cleanupLegacySecret(ctx context.Context, logger logr.Logger, 
 	if legacySecret == nil || !metav1.IsControlledBy(legacySecret, pcs) {
 		return nil
 	}
+	// Legacy cleanup is best-effort for Pods discoverable through current PCS-managed labels.
+	// Older Pods without these labels may keep the legacy Secret until they are replaced.
 	referencingPods, err := r.getPodsReferencingSecret(ctx, pcs, legacyObjKey.Name)
 	if err != nil {
 		return groveerr.WrapError(err,

--- a/operator/internal/controller/podcliqueset/components/satokensecret/satokensecret.go
+++ b/operator/internal/controller/podcliqueset/components/satokensecret/satokensecret.go
@@ -221,11 +221,9 @@ func (r _resource) cleanupLegacySecret(ctx context.Context, logger logr.Logger, 
 	}
 	if len(referencingPods) > 0 {
 		logger.Info("Skipping legacy Secret cleanup because Pods still reference it", "objectKey", legacyObjKey, "pods", referencingPods)
-		return groveerr.New(
-			groveerr.ErrCodeContinueReconcileAndRequeue,
-			component.OperationSync,
-			fmt.Sprintf("Secret %v is still referenced by Pods: %v", legacyObjKey, referencingPods),
-		)
+		// Cleanup is opportunistic on future reconciles or PodCliqueSet deletion.
+		// Referencing Pods may be long-lived, so do not poll while they remain.
+		return nil
 	}
 	if err = client.IgnoreNotFound(r.client.Delete(ctx, legacySecret)); err != nil {
 		return groveerr.WrapError(err,

--- a/operator/internal/controller/podcliqueset/components/satokensecret/satokensecret.go
+++ b/operator/internal/controller/podcliqueset/components/satokensecret/satokensecret.go
@@ -39,6 +39,7 @@ const (
 	errCodeSetControllerReference grovecorev1alpha1.ErrorCode = "ERR_SET_CONTROLLER_REFERENCE"
 	errCodeCreateSecret           grovecorev1alpha1.ErrorCode = "ERR_CREATE_SECRET"
 	errCodeDeleteSecret           grovecorev1alpha1.ErrorCode = "ERR_DELETE_SECRET"
+	errCodeListPods               grovecorev1alpha1.ErrorCode = "ERR_LIST_PODS"
 )
 
 type _resource struct {
@@ -107,17 +108,6 @@ func (r _resource) Sync(ctx context.Context, logger logr.Logger, pcs *grovecorev
 	}
 
 	secret := emptySecret(objKey)
-	legacySecret, err := r.getSecret(ctx, getLegacyObjectKey(pcs.ObjectMeta))
-	if err != nil {
-		return groveerr.WrapError(err,
-			errCodeGetSecret,
-			component.OperationSync,
-			fmt.Sprintf("Error getting legacy satokensecret for PodCliqueSet: %v", pcsObjKey),
-		)
-	}
-	if legacySecret != nil && metav1.IsControlledBy(legacySecret, pcs) {
-		secret.Data = copyMigratableSecretData(legacySecret.Data)
-	}
 	if err = r.buildResource(pcs, secret); err != nil {
 		return err
 	}
@@ -185,23 +175,6 @@ func hasServiceAccountToken(secret *corev1.Secret) bool {
 	return len(secret.Data[corev1.ServiceAccountTokenKey]) > 0
 }
 
-func copyMigratableSecretData(data map[string][]byte) map[string][]byte {
-	if len(data) == 0 {
-		return nil
-	}
-	copied := make(map[string][]byte, len(data))
-	for key, value := range data {
-		if key == corev1.ServiceAccountTokenKey {
-			continue
-		}
-		copied[key] = append([]byte(nil), value...)
-	}
-	if len(copied) == 0 {
-		return nil
-	}
-	return copied
-}
-
 func newWaitingForTokenError(objKey client.ObjectKey) error {
 	return groveerr.New(
 		groveerr.ErrCodeRequeueAfter,
@@ -235,6 +208,22 @@ func (r _resource) cleanupLegacySecret(ctx context.Context, logger logr.Logger, 
 	if legacySecret == nil || !metav1.IsControlledBy(legacySecret, pcs) {
 		return nil
 	}
+	referencingPods, err := r.getPodsReferencingSecret(ctx, pcs, legacyObjKey.Name)
+	if err != nil {
+		return groveerr.WrapError(err,
+			errCodeListPods,
+			component.OperationSync,
+			fmt.Sprintf("Error listing Pods referencing legacy satokensecret: %v for PodCliqueSet: %v", legacyObjKey, pcsObjKey),
+		)
+	}
+	if len(referencingPods) > 0 {
+		logger.Info("Skipping legacy Secret cleanup because Pods still reference it", "objectKey", legacyObjKey, "pods", referencingPods)
+		return groveerr.New(
+			groveerr.ErrCodeContinueReconcileAndRequeue,
+			component.OperationSync,
+			fmt.Sprintf("Secret %v is still referenced by Pods: %v", legacyObjKey, referencingPods),
+		)
+	}
 	if err = client.IgnoreNotFound(r.client.Delete(ctx, legacySecret)); err != nil {
 		return groveerr.WrapError(err,
 			errCodeDeleteSecret,
@@ -244,6 +233,34 @@ func (r _resource) cleanupLegacySecret(ctx context.Context, logger logr.Logger, 
 	}
 	logger.Info("Deleted legacy Secret after replacement Secret acquired token", "objectKey", legacyObjKey)
 	return nil
+}
+
+func (r _resource) getPodsReferencingSecret(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet, secretName string) ([]string, error) {
+	podList := &corev1.PodList{}
+	if err := r.client.List(ctx,
+		podList,
+		client.InNamespace(pcs.Namespace),
+		client.MatchingLabels(apicommon.GetDefaultLabelsForPodCliqueSetManagedResources(pcs.Name)),
+	); err != nil {
+		return nil, err
+	}
+
+	podNames := make([]string, 0, len(podList.Items))
+	for _, pod := range podList.Items {
+		if podReferencesSecret(pod, secretName) {
+			podNames = append(podNames, client.ObjectKeyFromObject(&pod).String())
+		}
+	}
+	return podNames, nil
+}
+
+func podReferencesSecret(pod corev1.Pod, secretName string) bool {
+	for _, volume := range pod.Spec.Volumes {
+		if volume.Secret != nil && volume.Secret.SecretName == secretName {
+			return true
+		}
+	}
+	return false
 }
 
 // getObjectKey constructs the object key for the ServiceAccount token Secret.

--- a/operator/internal/controller/podcliqueset/components/satokensecret/satokensecret.go
+++ b/operator/internal/controller/podcliqueset/components/satokensecret/satokensecret.go
@@ -56,21 +56,22 @@ func New(client client.Client, scheme *runtime.Scheme) component.Operator[grovec
 
 // GetExistingResourceNames returns the names of existing service account token secrets.
 func (r _resource) GetExistingResourceNames(ctx context.Context, _ logr.Logger, pcsObjMeta metav1.ObjectMeta) ([]string, error) {
-	secretNames := make([]string, 0, 1)
-	objKey := getObjectKey(pcsObjMeta)
-	partialObjMeta, err := k8sutils.GetExistingPartialObjectMetadata(ctx, r.client, corev1.SchemeGroupVersion.WithKind("Secret"), objKey)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return secretNames, nil
+	secretNames := make([]string, 0, 2)
+	for _, objKey := range getObjectKeys(pcsObjMeta) {
+		partialObjMeta, err := k8sutils.GetExistingPartialObjectMetadata(ctx, r.client, corev1.SchemeGroupVersion.WithKind("Secret"), objKey)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			return nil, groveerr.WrapError(err,
+				errCodeGetSecret,
+				component.OperationGetExistingResourceNames,
+				fmt.Sprintf("Error getting Secret: %v for PodCliqueSet: %v", objKey, k8sutils.GetObjectKeyFromObjectMeta(pcsObjMeta)),
+			)
 		}
-		return nil, groveerr.WrapError(err,
-			errCodeGetSecret,
-			component.OperationGetExistingResourceNames,
-			fmt.Sprintf("Error getting Secret: %v for PodCliqueSet: %v", objKey, k8sutils.GetObjectKeyFromObjectMeta(pcsObjMeta)),
-		)
-	}
-	if metav1.IsControlledBy(partialObjMeta, &pcsObjMeta) {
-		secretNames = append(secretNames, partialObjMeta.Name)
+		if metav1.IsControlledBy(partialObjMeta, &pcsObjMeta) {
+			secretNames = append(secretNames, partialObjMeta.Name)
+		}
 	}
 	return secretNames, nil
 }
@@ -78,24 +79,49 @@ func (r _resource) GetExistingResourceNames(ctx context.Context, _ logr.Logger, 
 // Sync creates the service account token secret if it doesn't exist.
 func (r _resource) Sync(ctx context.Context, logger logr.Logger, pcs *grovecorev1alpha1.PodCliqueSet) error {
 	pcsObjKey := client.ObjectKeyFromObject(pcs)
-	existingSecretNames, err := r.GetExistingResourceNames(ctx, logger, pcs.ObjectMeta)
+	objKey := getObjectKey(pcs.ObjectMeta)
+	existingSecret, err := r.getSecret(ctx, objKey)
 	if err != nil {
 		return groveerr.WrapError(err,
 			errCodeGetSecret,
 			component.OperationSync,
-			fmt.Sprintf("Error getting existing satokensecret names for PodCliqueSet: %v", pcsObjKey),
+			fmt.Sprintf("Error getting satokensecret: %v for PodCliqueSet: %v", objKey, pcsObjKey),
 		)
 	}
-	if len(existingSecretNames) > 0 {
-		logger.Info("Secret already exists, skipping creation", "existingSecret", existingSecretNames[0])
+	if existingSecret != nil {
+		if !metav1.IsControlledBy(existingSecret, pcs) {
+			return groveerr.New(
+				errCodeGetSecret,
+				component.OperationSync,
+				fmt.Sprintf("Secret %v already exists but is not controlled by PodCliqueSet %v", objKey, pcsObjKey),
+			)
+		}
+		if !hasServiceAccountToken(existingSecret) {
+			return newWaitingForTokenError(objKey)
+		}
+		if err = r.cleanupLegacySecret(ctx, logger, pcs); err != nil {
+			return err
+		}
+		logger.Info("Secret already exists, skipping creation", "existingSecret", client.ObjectKeyFromObject(existingSecret))
 		return nil
 	}
-	objKey := getObjectKey(pcs.ObjectMeta)
+
 	secret := emptySecret(objKey)
+	legacySecret, err := r.getSecret(ctx, getLegacyObjectKey(pcs.ObjectMeta))
+	if err != nil {
+		return groveerr.WrapError(err,
+			errCodeGetSecret,
+			component.OperationSync,
+			fmt.Sprintf("Error getting legacy satokensecret for PodCliqueSet: %v", pcsObjKey),
+		)
+	}
+	if legacySecret != nil && metav1.IsControlledBy(legacySecret, pcs) {
+		secret.Data = copyMigratableSecretData(legacySecret.Data)
+	}
 	if err = r.buildResource(pcs, secret); err != nil {
 		return err
 	}
-	if err = client.IgnoreAlreadyExists(r.client.Create(ctx, secret)); err != nil {
+	if err = r.client.Create(ctx, secret); err != nil {
 		return groveerr.WrapError(err,
 			errCodeCreateSecret,
 			component.OperationSync,
@@ -103,25 +129,26 @@ func (r _resource) Sync(ctx context.Context, logger logr.Logger, pcs *grovecorev
 		)
 	}
 	logger.Info("Created Secret", "objectKey", objKey)
-	return nil
+	return newWaitingForTokenError(objKey)
 }
 
 // Delete removes the service account token secret.
 func (r _resource) Delete(ctx context.Context, logger logr.Logger, pcsObjMeta metav1.ObjectMeta) error {
-	objectKey := getObjectKey(pcsObjMeta)
-	logger.Info("Triggering delete of Secret", "objectKey", objectKey)
-	if err := r.client.Delete(ctx, emptySecret(objectKey)); err != nil {
-		if errors.IsNotFound(err) {
-			logger.Info("Secret not found", "objectKey", objectKey)
-			return nil
+	for _, objectKey := range getObjectKeys(pcsObjMeta) {
+		logger.Info("Triggering delete of Secret", "objectKey", objectKey)
+		if err := r.client.Delete(ctx, emptySecret(objectKey)); err != nil {
+			if errors.IsNotFound(err) {
+				logger.Info("Secret not found", "objectKey", objectKey)
+				continue
+			}
+			return groveerr.WrapError(err,
+				errCodeDeleteSecret,
+				component.OperationDelete,
+				fmt.Sprintf("Error deleting satokensecret: %v for PodCliqueSet: %v", objectKey, k8sutils.GetObjectKeyFromObjectMeta(pcsObjMeta)),
+			)
 		}
-		return groveerr.WrapError(err,
-			errCodeDeleteSecret,
-			component.OperationDelete,
-			fmt.Sprintf("Error deleting satokensecret: %v for PodCliqueSet: %v", objectKey, k8sutils.GetObjectKeyFromObjectMeta(pcsObjMeta)),
-		)
+		logger.Info("Deleted Secret", "objectKey", objectKey)
 	}
-	logger.Info("Deleted Secret", "objectKey", objectKey)
 	return nil
 }
 
@@ -154,11 +181,90 @@ func getLabels(pcsName, secretName string) map[string]string {
 	)
 }
 
+func hasServiceAccountToken(secret *corev1.Secret) bool {
+	return len(secret.Data[corev1.ServiceAccountTokenKey]) > 0
+}
+
+func copyMigratableSecretData(data map[string][]byte) map[string][]byte {
+	if len(data) == 0 {
+		return nil
+	}
+	copied := make(map[string][]byte, len(data))
+	for key, value := range data {
+		if key == corev1.ServiceAccountTokenKey {
+			continue
+		}
+		copied[key] = append([]byte(nil), value...)
+	}
+	if len(copied) == 0 {
+		return nil
+	}
+	return copied
+}
+
+func newWaitingForTokenError(objKey client.ObjectKey) error {
+	return groveerr.New(
+		groveerr.ErrCodeRequeueAfter,
+		component.OperationSync,
+		fmt.Sprintf("Secret %v is waiting for service account token", objKey),
+	)
+}
+
+func (r _resource) getSecret(ctx context.Context, objKey client.ObjectKey) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	if err := r.client.Get(ctx, objKey, secret); err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return secret, nil
+}
+
+func (r _resource) cleanupLegacySecret(ctx context.Context, logger logr.Logger, pcs *grovecorev1alpha1.PodCliqueSet) error {
+	pcsObjKey := client.ObjectKeyFromObject(pcs)
+	legacyObjKey := getLegacyObjectKey(pcs.ObjectMeta)
+	legacySecret, err := r.getSecret(ctx, legacyObjKey)
+	if err != nil {
+		return groveerr.WrapError(err,
+			errCodeGetSecret,
+			component.OperationSync,
+			fmt.Sprintf("Error getting legacy satokensecret for PodCliqueSet: %v", pcsObjKey),
+		)
+	}
+	if legacySecret == nil || !metav1.IsControlledBy(legacySecret, pcs) {
+		return nil
+	}
+	if err = client.IgnoreNotFound(r.client.Delete(ctx, legacySecret)); err != nil {
+		return groveerr.WrapError(err,
+			errCodeDeleteSecret,
+			component.OperationSync,
+			fmt.Sprintf("Error deleting legacy satokensecret: %v for PodCliqueSet: %v", legacyObjKey, pcsObjKey),
+		)
+	}
+	logger.Info("Deleted legacy Secret after replacement Secret acquired token", "objectKey", legacyObjKey)
+	return nil
+}
+
 // getObjectKey constructs the object key for the ServiceAccount token Secret.
 func getObjectKey(pcsObjMeta metav1.ObjectMeta) client.ObjectKey {
 	return client.ObjectKey{
 		Name:      apicommon.GenerateInitContainerSATokenSecretName(pcsObjMeta.Name),
 		Namespace: pcsObjMeta.Namespace,
+	}
+}
+
+func getLegacyObjectKey(pcsObjMeta metav1.ObjectMeta) client.ObjectKey {
+	return client.ObjectKey{
+		Name:      apicommon.GenerateLegacyInitContainerSATokenSecretName(pcsObjMeta.Name),
+		Namespace: pcsObjMeta.Namespace,
+	}
+}
+
+func getObjectKeys(pcsObjMeta metav1.ObjectMeta) []client.ObjectKey {
+	return []client.ObjectKey{
+		getObjectKey(pcsObjMeta),
+		getLegacyObjectKey(pcsObjMeta),
 	}
 }
 

--- a/operator/internal/controller/podcliqueset/components/satokensecret/satokensecret_test.go
+++ b/operator/internal/controller/podcliqueset/components/satokensecret/satokensecret_test.go
@@ -254,7 +254,7 @@ func TestSync(t *testing.T) {
 		}
 	})
 
-	t.Run("copies owned legacy secret data except token when creating new secret", func(t *testing.T) {
+	t.Run("does not copy owned legacy secret data when creating new secret", func(t *testing.T) {
 		pcsUID := types.UID("pcs-uid-123")
 		legacySecretData := map[string][]byte{
 			corev1.ServiceAccountTokenKey:  []byte("legacy-token"),
@@ -299,13 +299,8 @@ func TestSync(t *testing.T) {
 		secretName := apicommon.GenerateInitContainerSATokenSecretName("test-pcs")
 		err = cl.Get(context.Background(), client.ObjectKey{Name: secretName, Namespace: "default"}, secret)
 		require.NoError(t, err)
-		assert.NotContains(t, secret.Data, corev1.ServiceAccountTokenKey)
-		assert.Equal(t, []byte("legacy-ca"), secret.Data[corev1.ServiceAccountRootCAKey])
-		assert.Equal(t, []byte("migrated"), secret.Data["migration-marker"])
+		assert.Empty(t, secret.Data)
 		assert.Equal(t, secretName, secret.Labels[apicommon.LabelAppNameKey])
-
-		legacySecretData["migration-marker"][0] = 'x'
-		assert.Equal(t, []byte("migrated"), secret.Data["migration-marker"])
 
 		remainingLegacySecret := &corev1.Secret{}
 		err = cl.Get(context.Background(), client.ObjectKey{Name: apicommon.GenerateLegacyInitContainerSATokenSecretName("test-pcs"), Namespace: "default"}, remainingLegacySecret)
@@ -443,7 +438,9 @@ func TestSync(t *testing.T) {
 	for _, tc := range []struct {
 		name               string
 		tokenReady         bool
+		referenceLegacy    bool
 		expectRequeue      bool
+		expectContinue     bool
 		expectLegacySecret bool
 	}{
 		{
@@ -453,6 +450,13 @@ func TestSync(t *testing.T) {
 		{
 			name:               "keeps owned legacy secret while new secret waits for token",
 			expectRequeue:      true,
+			expectLegacySecret: true,
+		},
+		{
+			name:               "keeps owned legacy secret while pods still reference it",
+			tokenReady:         true,
+			referenceLegacy:    true,
+			expectContinue:     true,
 			expectLegacySecret: true,
 		},
 	} {
@@ -472,9 +476,13 @@ func TestSync(t *testing.T) {
 			}
 			legacySecret := newOwnedSecret(apicommon.GenerateLegacyInitContainerSATokenSecretName(pcs.Name), pcs)
 
+			objects := []client.Object{secret, legacySecret}
+			if tc.referenceLegacy {
+				objects = append(objects, newPodReferencingSecret("test-pod", pcs, legacySecret.Name))
+			}
 			cl := fake.NewClientBuilder().
 				WithScheme(scheme).
-				WithObjects(secret, legacySecret).
+				WithObjects(objects...).
 				Build()
 			operator := New(cl, scheme)
 
@@ -482,6 +490,8 @@ func TestSync(t *testing.T) {
 
 			if tc.expectRequeue {
 				assertRequeueAfter(t, err)
+			} else if tc.expectContinue {
+				assertContinueReconcileAndRequeue(t, err)
 			} else {
 				require.NoError(t, err)
 			}
@@ -499,6 +509,14 @@ func TestSync(t *testing.T) {
 			}
 		})
 	}
+}
+
+func assertContinueReconcileAndRequeue(t *testing.T, err error) {
+	t.Helper()
+
+	var groveErr *groveerr.GroveError
+	require.True(t, errors.As(err, &groveErr))
+	assert.Equal(t, groveerr.ErrCodeContinueReconcileAndRequeue, groveErr.Code)
 }
 
 func assertRequeueAfter(t *testing.T, err error) {
@@ -521,6 +539,28 @@ func newOwnedSecret(name string, pcs *grovecorev1alpha1.PodCliqueSet) *corev1.Se
 					Name:       pcs.Name,
 					UID:        pcs.UID,
 					Controller: ptr.To(true),
+				},
+			},
+		},
+	}
+}
+
+func newPodReferencingSecret(name string, pcs *grovecorev1alpha1.PodCliqueSet, secretName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: pcs.Namespace,
+			Labels:    apicommon.GetDefaultLabelsForPodCliqueSetManagedResources(pcs.Name),
+		},
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{
+					Name: "sa-token-secret-vol",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: secretName,
+						},
+					},
 				},
 			},
 		},

--- a/operator/internal/controller/podcliqueset/components/satokensecret/satokensecret_test.go
+++ b/operator/internal/controller/podcliqueset/components/satokensecret/satokensecret_test.go
@@ -16,18 +16,23 @@ package satokensecret
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	groveerr "github.com/ai-dynamo/grove/operator/internal/errors"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -107,6 +112,43 @@ func TestGetExistingResourceNames(t *testing.T) {
 		assert.Equal(t, apicommon.GenerateInitContainerSATokenSecretName("test-pcs"), names[0])
 	})
 
+	t.Run("existing legacy owned secret", func(t *testing.T) {
+		pcsUID := types.UID("pcs-uid-123")
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      apicommon.GenerateLegacyInitContainerSATokenSecretName("test-pcs"),
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "grove.ai-dynamo.io/v1alpha1",
+						Kind:       "PodCliqueSet",
+						Name:       "test-pcs",
+						UID:        pcsUID,
+						Controller: ptr.To(true),
+					},
+				},
+			},
+		}
+
+		cl := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(secret).
+			Build()
+		operator := New(cl, scheme)
+
+		pcsObjMeta := metav1.ObjectMeta{
+			Name:      "test-pcs",
+			Namespace: "default",
+			UID:       pcsUID,
+		}
+
+		names, err := operator.GetExistingResourceNames(context.Background(), logr.Discard(), pcsObjMeta)
+
+		require.NoError(t, err)
+		assert.Len(t, names, 1)
+		assert.Equal(t, apicommon.GenerateLegacyInitContainerSATokenSecretName("test-pcs"), names[0])
+	})
+
 	// Test with existing secret not owned by this PCS
 	t.Run("existing not owned secret", func(t *testing.T) {
 		secret := &corev1.Secret{
@@ -166,7 +208,7 @@ func TestSync(t *testing.T) {
 
 		err := operator.Sync(context.Background(), logr.Discard(), pcs)
 
-		require.NoError(t, err)
+		assertRequeueAfter(t, err)
 
 		// Verify secret was created
 		secret := &corev1.Secret{}
@@ -176,9 +218,184 @@ func TestSync(t *testing.T) {
 		// Verify labels
 		assert.Equal(t, apicommon.LabelManagedByValue, secret.Labels[apicommon.LabelManagedByKey])
 		assert.Equal(t, "test-pcs", secret.Labels[apicommon.LabelPartOfKey])
+		assert.Equal(t, apicommon.GenerateInitContainerSATokenSecretName("test-pcs"), secret.Labels[apicommon.LabelAppNameKey])
 		// Verify type and annotations
 		assert.Equal(t, corev1.SecretTypeServiceAccountToken, secret.Type)
 		assert.Equal(t, apicommon.GeneratePodServiceAccountName("test-pcs"), secret.Annotations[corev1.ServiceAccountNameKey])
+	})
+
+	t.Run("creates secret with valid labels for long admitted pcs name", func(t *testing.T) {
+		cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+		operator := New(cl, scheme)
+		pcsName := strings.Repeat("a", 44)
+
+		pcs := &grovecorev1alpha1.PodCliqueSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pcsName,
+				Namespace: "default",
+				UID:       types.UID("pcs-uid-123"),
+			},
+		}
+
+		err := operator.Sync(context.Background(), logr.Discard(), pcs)
+
+		assertRequeueAfter(t, err)
+
+		secret := &corev1.Secret{}
+		secretName := apicommon.GenerateInitContainerSATokenSecretName(pcsName)
+		err = cl.Get(context.Background(), client.ObjectKey{Name: secretName, Namespace: "default"}, secret)
+		require.NoError(t, err)
+		require.Len(t, pcsName, 44)
+		require.LessOrEqual(t, len(secretName), 63)
+		assert.Equal(t, pcsName, secret.Labels[apicommon.LabelPartOfKey])
+		assert.Equal(t, secretName, secret.Labels[apicommon.LabelAppNameKey])
+		for _, value := range secret.Labels {
+			assert.Empty(t, k8svalidation.IsValidLabelValue(value))
+		}
+	})
+
+	t.Run("copies owned legacy secret data except token when creating new secret", func(t *testing.T) {
+		pcsUID := types.UID("pcs-uid-123")
+		legacySecretData := map[string][]byte{
+			corev1.ServiceAccountTokenKey:  []byte("legacy-token"),
+			corev1.ServiceAccountRootCAKey: []byte("legacy-ca"),
+			"migration-marker":             []byte("migrated"),
+		}
+		legacySecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      apicommon.GenerateLegacyInitContainerSATokenSecretName("test-pcs"),
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "grove.ai-dynamo.io/v1alpha1",
+						Kind:       "PodCliqueSet",
+						Name:       "test-pcs",
+						UID:        pcsUID,
+						Controller: ptr.To(true),
+					},
+				},
+			},
+			Data: legacySecretData,
+		}
+		cl := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(legacySecret).
+			Build()
+		operator := New(cl, scheme)
+
+		pcs := &grovecorev1alpha1.PodCliqueSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pcs",
+				Namespace: "default",
+				UID:       pcsUID,
+			},
+		}
+
+		err := operator.Sync(context.Background(), logr.Discard(), pcs)
+
+		assertRequeueAfter(t, err)
+
+		secret := &corev1.Secret{}
+		secretName := apicommon.GenerateInitContainerSATokenSecretName("test-pcs")
+		err = cl.Get(context.Background(), client.ObjectKey{Name: secretName, Namespace: "default"}, secret)
+		require.NoError(t, err)
+		assert.NotContains(t, secret.Data, corev1.ServiceAccountTokenKey)
+		assert.Equal(t, []byte("legacy-ca"), secret.Data[corev1.ServiceAccountRootCAKey])
+		assert.Equal(t, []byte("migrated"), secret.Data["migration-marker"])
+		assert.Equal(t, secretName, secret.Labels[apicommon.LabelAppNameKey])
+
+		legacySecretData["migration-marker"][0] = 'x'
+		assert.Equal(t, []byte("migrated"), secret.Data["migration-marker"])
+
+		remainingLegacySecret := &corev1.Secret{}
+		err = cl.Get(context.Background(), client.ObjectKey{Name: apicommon.GenerateLegacyInitContainerSATokenSecretName("test-pcs"), Namespace: "default"}, remainingLegacySecret)
+		require.NoError(t, err)
+	})
+
+	t.Run("does not copy legacy secret data without PCS ownership", func(t *testing.T) {
+		pcsUID := types.UID("pcs-uid-123")
+		legacySecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      apicommon.GenerateLegacyInitContainerSATokenSecretName("test-pcs"),
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "grove.ai-dynamo.io/v1alpha1",
+						Kind:       "PodCliqueSet",
+						Name:       "other-pcs",
+						UID:        types.UID("other-uid"),
+						Controller: ptr.To(true),
+					},
+				},
+			},
+			Data: map[string][]byte{
+				"migration-marker": []byte("do-not-copy"),
+			},
+		}
+		cl := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(legacySecret).
+			Build()
+		operator := New(cl, scheme)
+
+		pcs := &grovecorev1alpha1.PodCliqueSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pcs",
+				Namespace: "default",
+				UID:       pcsUID,
+			},
+		}
+
+		err := operator.Sync(context.Background(), logr.Discard(), pcs)
+
+		assertRequeueAfter(t, err)
+
+		secret := &corev1.Secret{}
+		secretName := apicommon.GenerateInitContainerSATokenSecretName("test-pcs")
+		err = cl.Get(context.Background(), client.ObjectKey{Name: secretName, Namespace: "default"}, secret)
+		require.NoError(t, err)
+		assert.Empty(t, secret.Data)
+		assert.Equal(t, secretName, secret.Labels[apicommon.LabelAppNameKey])
+	})
+
+	t.Run("errors when new secret already exists without PCS ownership", func(t *testing.T) {
+		pcsUID := types.UID("pcs-uid-123")
+		secretName := apicommon.GenerateInitContainerSATokenSecretName("test-pcs")
+		secretData := map[string][]byte{
+			"token": []byte("wrong-token"),
+		}
+		existingSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: "default",
+			},
+			Data: secretData,
+		}
+		cl := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(existingSecret).
+			Build()
+		operator := New(cl, scheme)
+
+		pcs := &grovecorev1alpha1.PodCliqueSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pcs",
+				Namespace: "default",
+				UID:       pcsUID,
+			},
+		}
+
+		err := operator.Sync(context.Background(), logr.Discard(), pcs)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists but is not controlled")
+		assert.Contains(t, err.Error(), secretName)
+
+		secret := &corev1.Secret{}
+		err = cl.Get(context.Background(), client.ObjectKey{Name: secretName, Namespace: "default"}, secret)
+		require.NoError(t, err)
+		assert.Equal(t, secretData, secret.Data)
+		assert.Empty(t, secret.OwnerReferences)
 	})
 
 	// Test when secret already exists with correct owner
@@ -197,6 +414,9 @@ func TestSync(t *testing.T) {
 						Controller: ptr.To(true),
 					},
 				},
+			},
+			Data: map[string][]byte{
+				corev1.ServiceAccountTokenKey: []byte("ready-token"),
 			},
 		}
 
@@ -219,6 +439,92 @@ func TestSync(t *testing.T) {
 		// Should not error when secret already exists
 		require.NoError(t, err)
 	})
+
+	for _, tc := range []struct {
+		name               string
+		tokenReady         bool
+		expectRequeue      bool
+		expectLegacySecret bool
+	}{
+		{
+			name:       "deletes owned legacy secret after new secret has token",
+			tokenReady: true,
+		},
+		{
+			name:               "keeps owned legacy secret while new secret waits for token",
+			expectRequeue:      true,
+			expectLegacySecret: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pcs := &grovecorev1alpha1.PodCliqueSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pcs",
+					Namespace: "default",
+					UID:       types.UID("pcs-uid-123"),
+				},
+			}
+			secret := newOwnedSecret(apicommon.GenerateInitContainerSATokenSecretName(pcs.Name), pcs)
+			if tc.tokenReady {
+				secret.Data = map[string][]byte{
+					corev1.ServiceAccountTokenKey: []byte("ready-token"),
+				}
+			}
+			legacySecret := newOwnedSecret(apicommon.GenerateLegacyInitContainerSATokenSecretName(pcs.Name), pcs)
+
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(secret, legacySecret).
+				Build()
+			operator := New(cl, scheme)
+
+			err := operator.Sync(context.Background(), logr.Discard(), pcs)
+
+			if tc.expectRequeue {
+				assertRequeueAfter(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			remainingSecret := &corev1.Secret{}
+			err = cl.Get(context.Background(), client.ObjectKeyFromObject(secret), remainingSecret)
+			require.NoError(t, err)
+
+			remainingLegacySecret := &corev1.Secret{}
+			err = cl.Get(context.Background(), client.ObjectKeyFromObject(legacySecret), remainingLegacySecret)
+			if tc.expectLegacySecret {
+				require.NoError(t, err)
+			} else {
+				assert.True(t, apierrors.IsNotFound(err))
+			}
+		})
+	}
+}
+
+func assertRequeueAfter(t *testing.T, err error) {
+	t.Helper()
+
+	var groveErr *groveerr.GroveError
+	require.True(t, errors.As(err, &groveErr))
+	assert.Equal(t, groveerr.ErrCodeRequeueAfter, groveErr.Code)
+}
+
+func newOwnedSecret(name string, pcs *grovecorev1alpha1.PodCliqueSet) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: pcs.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: grovecorev1alpha1.SchemeGroupVersion.String(),
+					Kind:       "PodCliqueSet",
+					Name:       pcs.Name,
+					UID:        pcs.UID,
+					Controller: ptr.To(true),
+				},
+			},
+		},
+	}
 }
 
 // TestDelete tests deleting secrets.
@@ -227,18 +533,24 @@ func TestDelete(t *testing.T) {
 	_ = grovecorev1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
 
-	// Test deleting existing secret
-	t.Run("deletes existing secret", func(t *testing.T) {
+	// Test deleting existing secrets
+	t.Run("deletes existing secrets", func(t *testing.T) {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      apicommon.GenerateInitContainerSATokenSecretName("test-pcs"),
 				Namespace: "default",
 			},
 		}
+		legacySecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      apicommon.GenerateLegacyInitContainerSATokenSecretName("test-pcs"),
+				Namespace: "default",
+			},
+		}
 
 		cl := fake.NewClientBuilder().
 			WithScheme(scheme).
-			WithObjects(secret).
+			WithObjects(secret, legacySecret).
 			Build()
 		operator := New(cl, scheme)
 
@@ -254,6 +566,11 @@ func TestDelete(t *testing.T) {
 		// Verify secret was deleted
 		secret = &corev1.Secret{}
 		err = cl.Get(context.Background(), client.ObjectKey{Name: apicommon.GenerateInitContainerSATokenSecretName("test-pcs"), Namespace: "default"}, secret)
+		assert.Error(t, err)
+		assert.True(t, client.IgnoreNotFound(err) == nil)
+
+		legacySecret = &corev1.Secret{}
+		err = cl.Get(context.Background(), client.ObjectKey{Name: apicommon.GenerateLegacyInitContainerSATokenSecretName("test-pcs"), Namespace: "default"}, legacySecret)
 		assert.Error(t, err)
 		assert.True(t, client.IgnoreNotFound(err) == nil)
 	})

--- a/operator/internal/controller/podcliqueset/components/satokensecret/satokensecret_test.go
+++ b/operator/internal/controller/podcliqueset/components/satokensecret/satokensecret_test.go
@@ -439,12 +439,12 @@ func TestSync(t *testing.T) {
 	})
 
 	for _, tc := range []struct {
-		name               string
-		tokenReady         bool
-		referenceLegacy    bool
-		expectRequeue      bool
-		expectContinue     bool
-		expectLegacySecret bool
+		name                       string
+		tokenReady                 bool
+		referenceLegacy            bool
+		expectRequeue              bool
+		expectLegacySecret         bool
+		retryAfterReferenceRemoval bool
 	}{
 		{
 			name:       "deletes owned legacy secret after new secret has token",
@@ -456,11 +456,11 @@ func TestSync(t *testing.T) {
 			expectLegacySecret: true,
 		},
 		{
-			name:               "keeps owned legacy secret while pods still reference it",
-			tokenReady:         true,
-			referenceLegacy:    true,
-			expectContinue:     true,
-			expectLegacySecret: true,
+			name:                       "keeps owned legacy secret without requeue while pods still reference it",
+			tokenReady:                 true,
+			referenceLegacy:            true,
+			expectLegacySecret:         true,
+			retryAfterReferenceRemoval: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -480,8 +480,10 @@ func TestSync(t *testing.T) {
 			legacySecret := newOwnedSecret(apicommon.GenerateLegacyInitContainerSATokenSecretName(pcs.Name), pcs)
 
 			objects := []client.Object{secret, legacySecret}
+			var referencingPod *corev1.Pod
 			if tc.referenceLegacy {
-				objects = append(objects, newPodReferencingSecret("test-pod", pcs, legacySecret.Name))
+				referencingPod = newPodReferencingSecret("test-pod", pcs, legacySecret.Name)
+				objects = append(objects, referencingPod)
 			}
 			cl := fake.NewClientBuilder().
 				WithScheme(scheme).
@@ -493,8 +495,6 @@ func TestSync(t *testing.T) {
 
 			if tc.expectRequeue {
 				assertRequeueAfter(t, err)
-			} else if tc.expectContinue {
-				assertContinueReconcileAndRequeue(t, err)
 			} else {
 				require.NoError(t, err)
 			}
@@ -510,16 +510,16 @@ func TestSync(t *testing.T) {
 			} else {
 				assert.True(t, apierrors.IsNotFound(err))
 			}
+
+			if tc.retryAfterReferenceRemoval {
+				require.NoError(t, cl.Delete(context.Background(), referencingPod))
+				require.NoError(t, operator.Sync(context.Background(), logr.Discard(), pcs))
+
+				err = cl.Get(context.Background(), client.ObjectKeyFromObject(legacySecret), &corev1.Secret{})
+				assert.True(t, apierrors.IsNotFound(err))
+			}
 		})
 	}
-}
-
-func assertContinueReconcileAndRequeue(t *testing.T, err error) {
-	t.Helper()
-
-	var groveErr *groveerr.GroveError
-	require.True(t, errors.As(err, &groveErr))
-	assert.Equal(t, groveerr.ErrCodeContinueReconcileAndRequeue, groveErr.Code)
 }
 
 func assertRequeueAfter(t *testing.T, err error) {

--- a/operator/internal/controller/podcliqueset/components/satokensecret/satokensecret_test.go
+++ b/operator/internal/controller/podcliqueset/components/satokensecret/satokensecret_test.go
@@ -383,6 +383,9 @@ func TestSync(t *testing.T) {
 		err := operator.Sync(context.Background(), logr.Discard(), pcs)
 
 		require.Error(t, err)
+		var groveErr *groveerr.GroveError
+		require.True(t, errors.As(err, &groveErr))
+		assert.Equal(t, errCodeSecretConflict, groveErr.Code)
 		assert.Contains(t, err.Error(), "already exists but is not controlled")
 		assert.Contains(t, err.Error(), secretName)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Shortens the init-container service account token Secret suffix from `-initc-sa-token-secret` to `-ic-sat`.

The old suffix could make generated Secret names too long when a long PodCliqueSet name was copied into labels such as `app.kubernetes.io/name`, causing Secret creation to fail. The shorter suffix keeps the generated name within Kubernetes label value limits for admitted PodCliqueSet names.

For compatibility, the controller still recognizes the legacy Secret name during cleanup:

- New Pods reference the shortened `<pcs>-ic-sat` Secret through the existing name generator.
- If the new Secret does not exist, the controller creates a new empty Secret with type `kubernetes.io/service-account-token`.
- No data is copied from the legacy Secret to the new Secret.
- Kubernetes issues a fresh token for the new Secret, avoiding reuse of a JWT bound to the legacy Secret name.
- Once the new Secret has a token, Sync deletes the owned legacy Secret when it is no longer referenced by Pods.
- If Pods still reference the legacy Secret, cleanup is deferred to future normal reconciles or PodCliqueSet deletion.
- PodCliqueSet deletion attempts to remove both the new and legacy Secret names.

#### Which issue(s) this PR fixes:

Fixes #658

#### Special notes for your reviewer:

- The legacy Secret is retained only as a compatibility cleanup target; its data is never copied.
- The replacement `<pcs>-ic-sat` Secret is created empty so the Kubernetes token controller issues a fresh token.
- Legacy Secret cleanup waits until the replacement Secret has `data.token`.
- Cleanup does not continuously requeue while Pods still reference the legacy Secret.
- Only a legacy Secret controlled by the same PodCliqueSet is eligible for cleanup.
- If a `<pcs>-ic-sat` Secret already exists but is not controlled by the PodCliqueSet, Sync fails instead of adopting it.
- I also verified the upgrade path locally with a real kind upgrade test from `v0.1.0-alpha.8`; that e2e is intentionally not included in this minimal PR.

#### Does this PR introduce an API change?

```release-note
action required: Grove now uses the shorter `-ic-sat` suffix for init-container service account token Secrets. The legacy `-initc-sa-token-secret` Secret name is still recognized during cleanup, but support for the legacy name will be removed three releases from now. Existing PodCliqueSets should be reconciled or recreated before then.
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```