### PR TITLE
feat: lpx scheduler backend

### DIFF
--- a/docs/api-reference/operator-api.md
+++ b/docs/api-reference/operator-api.md
@@ -1164,7 +1164,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `profiles` _[SchedulerProfile](#schedulerprofile) array_ | Profiles is the list of scheduler profiles. Each profile has a backend name and an optional config.<br />The default-scheduler backend is always enabled to ensure that the kubernetes default scheduler is always enabled and supported.<br />Use profile name "default-scheduler" to configure or set it as default.<br />Valid profile names: "default-scheduler", "kai-scheduler", "volcano". Use defaultProfileName to designate the default backend. |  |  |
+| `profiles` _[SchedulerProfile](#schedulerprofile) array_ | Profiles is the list of scheduler profiles. Each profile has a backend name and an optional config.<br />The default-scheduler backend is always enabled to ensure that the kubernetes default scheduler is always enabled and supported.<br />Use profile name "default-scheduler" to configure or set it as default.<br />Valid profile names: "default-scheduler", "kai-scheduler", "volcano", "lpx-scheduler".<br />Use defaultProfileName to designate the default backend. |  |  |
 | `defaultProfileName` _string_ | DefaultProfileName is the name of the default scheduler profile. If unset, defaulting sets it to "default-scheduler"<br />which is the kubernetes default scheduler. |  |  |
 
 
@@ -1184,6 +1184,7 @@ _Appears in:_
 | `kai-scheduler` | SchedulerNameKai is the KAI scheduler backend.<br /> |
 | `default-scheduler` | SchedulerNameKube is the profile name for the Kubernetes default scheduler in OperatorConfiguration.<br /> |
 | `volcano` | SchedulerNameVolcano is the Volcano scheduler backend. It supports gang scheduling via Volcano PodGroup.<br /> |
+| `lpx-scheduler` | SchedulerNameLPX is the LPX scheduler backend.<br /> |
 
 
 #### SchedulerProfile
@@ -1199,7 +1200,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `name` _[SchedulerName](#schedulername)_ | Name is the scheduler profile name.<br />For the Kubernetes default scheduler use the standard "default-scheduler".<br />Ensure that the name chosen is a valid scheduler name. The name will also be directly set in `Pod.Spec.SchedulerName`. |  | Enum: [kai-scheduler default-scheduler volcano] <br />Required: \{\} <br /> |
+| `name` _[SchedulerName](#schedulername)_ | Name is the scheduler profile name.<br />For the Kubernetes default scheduler use the standard "default-scheduler".<br />Ensure that the name chosen is a valid scheduler name. The name will also be directly set in `Pod.Spec.SchedulerName`. |  | Enum: [kai-scheduler default-scheduler volcano lpx-scheduler] <br />Required: \{\} <br /> |
 | `config` _[RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#rawextension-runtime-pkg)_ | Config holds backend-specific options. The operator unmarshals it into the config type for this backend (see backend config types). |  |  |
 
 

--- a/operator/api/config/v1alpha1/types.go
+++ b/operator/api/config/v1alpha1/types.go
@@ -60,11 +60,18 @@ const (
 	SchedulerNameKube SchedulerName = "default-scheduler"
 	// SchedulerNameVolcano is the Volcano scheduler backend. It supports gang scheduling via Volcano PodGroup.
 	SchedulerNameVolcano SchedulerName = "volcano"
+	// SchedulerNameLPX is the LPX scheduler backend.
+	SchedulerNameLPX SchedulerName = "lpx-scheduler"
 )
 
 var (
 	// SupportedSchedulerNames is the list of profile names allowed in scheduler.profiles[].name.
-	SupportedSchedulerNames = []SchedulerName{SchedulerNameKai, SchedulerNameKube, SchedulerNameVolcano}
+	SupportedSchedulerNames = []SchedulerName{
+		SchedulerNameKai,
+		SchedulerNameKube,
+		SchedulerNameVolcano,
+		SchedulerNameLPX,
+	}
 )
 
 // SchedulerConfiguration configures scheduler profiles and which is the default.
@@ -72,7 +79,8 @@ type SchedulerConfiguration struct {
 	// Profiles is the list of scheduler profiles. Each profile has a backend name and an optional config.
 	// The default-scheduler backend is always enabled to ensure that the kubernetes default scheduler is always enabled and supported.
 	// Use profile name "default-scheduler" to configure or set it as default.
-	// Valid profile names: "default-scheduler", "kai-scheduler", "volcano". Use defaultProfileName to designate the default backend.
+	// Valid profile names: "default-scheduler", "kai-scheduler", "volcano", "lpx-scheduler".
+	// Use defaultProfileName to designate the default backend.
 	// +optional
 	Profiles []SchedulerProfile `json:"profiles,omitempty"`
 	// DefaultProfileName is the name of the default scheduler profile. If unset, defaulting sets it to "default-scheduler"
@@ -87,7 +95,7 @@ type SchedulerProfile struct {
 	// For the Kubernetes default scheduler use the standard "default-scheduler".
 	// Ensure that the name chosen is a valid scheduler name. The name will also be directly set in `Pod.Spec.SchedulerName`.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=kai-scheduler;default-scheduler;volcano
+	// +kubebuilder:validation:Enum=kai-scheduler;default-scheduler;volcano;lpx-scheduler
 	Name SchedulerName `json:"name"`
 
 	// Config holds backend-specific options. The operator unmarshals it into the config type for this backend (see backend config types).

--- a/operator/api/config/validation/validation_test.go
+++ b/operator/api/config/validation/validation_test.go
@@ -239,6 +239,18 @@ func TestValidateSchedulerConfiguration(t *testing.T) {
 				Profiles: []configv1alpha1.SchedulerProfile{
 					{Name: configv1alpha1.SchedulerNameKube},
 					{Name: configv1alpha1.SchedulerNameKai},
+					{Name: configv1alpha1.SchedulerNameLPX},
+				},
+				DefaultProfileName: string(configv1alpha1.SchedulerNameKube),
+			},
+			expectErrors: 0,
+		},
+		{
+			name: "valid: lpx enabled with kube default",
+			scheduler: &configv1alpha1.SchedulerConfiguration{
+				Profiles: []configv1alpha1.SchedulerProfile{
+					{Name: configv1alpha1.SchedulerNameKube},
+					{Name: configv1alpha1.SchedulerNameLPX},
 				},
 				DefaultProfileName: string(configv1alpha1.SchedulerNameKube),
 			},

--- a/operator/charts/values.yaml
+++ b/operator/charts/values.yaml
@@ -98,6 +98,7 @@ config:
       - name: default-scheduler
       - name: kai-scheduler
       - name: volcano
+      - name: lpx-scheduler
   logLevel: info
   logFormat: json
   topologyAwareScheduling:

--- a/operator/internal/controller/podclique/components/pod/pod_test.go
+++ b/operator/internal/controller/podclique/components/pod/pod_test.go
@@ -22,12 +22,76 @@ import (
 
 	"github.com/ai-dynamo/grove/operator/api/common"
 	"github.com/ai-dynamo/grove/operator/api/common/constants"
+	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/ai-dynamo/grove/operator/internal/scheduler"
+	"github.com/ai-dynamo/grove/operator/internal/scheduler/lpx"
+	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 )
+
+func TestBuildResourceWithLPXBackend(t *testing.T) {
+	const (
+		namespace   = "default"
+		pcsName     = "model"
+		cliqueName  = "gpu-worker"
+		podGangName = "model-0"
+		claimName   = "model-gpu-000"
+	)
+
+	uid := types.UID("test-uid")
+	podSpec := corev1.PodSpec{
+		SchedulerName: string(configv1alpha1.SchedulerNameLPX),
+		Containers: []corev1.Container{{
+			Name:  "worker",
+			Image: "worker",
+		}},
+		ResourceClaims: []corev1.PodResourceClaim{{
+			Name:              "gpu",
+			ResourceClaimName: ptr.To(claimName),
+		}},
+	}
+	pcs := testutils.NewPodCliqueSetBuilder(pcsName, namespace, uid).
+		WithPodCliqueTemplateSpec(
+			testutils.NewPodCliqueTemplateSpecBuilder(cliqueName).
+				WithPodSpec(podSpec).
+				Build(),
+		).
+		Build()
+	pclq := testutils.NewPodCliqueBuilder(pcsName, uid, cliqueName, namespace, 0).Build()
+	pclq.Spec.PodSpec = *podSpec.DeepCopy()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
+	registry := &testutils.FakeSchedulerRegistry{
+		Backends: map[string]scheduler.Backend{
+			string(configv1alpha1.SchedulerNameLPX): lpx.New(
+				configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameLPX},
+			),
+		},
+		DefaultBackend: string(configv1alpha1.SchedulerNameLPX),
+	}
+	resource := &_resource{scheme: scheme, schedRegistry: registry}
+	pod := &corev1.Pod{}
+
+	require.NoError(t, resource.buildResource(pcs, pclq, podGangName, pod, 0))
+
+	assert.Equal(t, string(configv1alpha1.SchedulerNameLPX), pod.Spec.SchedulerName)
+	assert.Equal(t, pclq.Name+"-", pod.GenerateName)
+	assert.Equal(t, podGangName, pod.Labels[common.LabelPodGang])
+	require.Len(t, pod.Spec.SchedulingGates, 1)
+	assert.Equal(t, podGangSchedulingGate, pod.Spec.SchedulingGates[0].Name)
+	require.Len(t, pod.Spec.ResourceClaims, 1)
+	require.NotNil(t, pod.Spec.ResourceClaims[0].ResourceClaimName)
+	assert.Equal(t, claimName, *pod.Spec.ResourceClaims[0].ResourceClaimName)
+}
 
 // TestGetSelectorLabelsForPods_PCSGOwnedPodClique tests that getSelectorLabelsForPods
 // returns the correct selector labels for PCSG-owned PodCliques.

--- a/operator/internal/controller/podcliqueset/components/podgang/podgang_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/podgang_test.go
@@ -23,17 +23,79 @@ import (
 	apicommonconstants "github.com/ai-dynamo/grove/operator/api/common/constants"
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/ai-dynamo/grove/operator/internal/scheduler"
+	"github.com/ai-dynamo/grove/operator/internal/scheduler/lpx"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func TestBuildResourceWithLPXBackend(t *testing.T) {
+	const (
+		namespace   = "default"
+		pcsName     = "model"
+		cliqueName  = "gpu-worker"
+		podGangName = "model-0"
+		podName     = "model-0-gpu-worker-abcde"
+	)
+
+	pcs := testutils.NewPodCliqueSetBuilder(pcsName, namespace, "test-uid").
+		WithPodCliqueTemplateSpec(
+			testutils.NewPodCliqueTemplateSpecBuilder(cliqueName).
+				WithPodSpec(corev1.PodSpec{
+					SchedulerName: string(configv1alpha1.SchedulerNameLPX),
+					Containers: []corev1.Container{{
+						Name:  "worker",
+						Image: "worker",
+					}},
+				}).
+				Build(),
+		).
+		Build()
+	scheme := runtime.NewScheme()
+	require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
+	require.NoError(t, groveschedulerv1alpha1.AddToScheme(scheme))
+	registry := &testutils.FakeSchedulerRegistry{
+		Backends: map[string]scheduler.Backend{
+			string(configv1alpha1.SchedulerNameLPX): lpx.New(
+				configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameLPX},
+			),
+		},
+		DefaultBackend: string(configv1alpha1.SchedulerNameLPX),
+	}
+	resource := &_resource{
+		scheme:        scheme,
+		schedRegistry: registry,
+	}
+	podGang := &groveschedulerv1alpha1.PodGang{
+		ObjectMeta: metav1.ObjectMeta{Name: podGangName, Namespace: namespace},
+	}
+	info := &podGangInfo{
+		fqn: podGangName,
+		pclqs: []pclqInfo{{
+			fqn:                "model-0-gpu-worker",
+			replicas:           1,
+			minAvailable:       1,
+			associatedPodNames: []string{podName},
+		}},
+	}
+
+	require.NoError(t, resource.buildResource(pcs, info, podGang))
+
+	assert.Equal(t, string(configv1alpha1.SchedulerNameLPX), podGang.Labels[apicommon.LabelSchedulerName])
+	require.Len(t, podGang.Spec.PodGroups, 1)
+	require.Len(t, podGang.Spec.PodGroups[0].PodReferences, 1)
+	assert.Equal(t, namespace, podGang.Spec.PodGroups[0].PodReferences[0].Namespace)
+	assert.Equal(t, podName, podGang.Spec.PodGroups[0].PodReferences[0].Name)
+}
 
 func TestSetInitializedCondition(t *testing.T) {
 	pg := &groveschedulerv1alpha1.PodGang{

--- a/operator/internal/scheduler/lpx/backend.go
+++ b/operator/internal/scheduler/lpx/backend.go
@@ -1,0 +1,88 @@
+// /*
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package lpx
+
+import (
+	"context"
+	"errors"
+
+	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/ai-dynamo/grove/operator/internal/scheduler"
+
+	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	errTopologyConstraintsUnsupported = errors.New(
+		"lpx-scheduler does not support Grove topology constraints; " +
+			"placement topology must be expressed through the LPX workload contract",
+	)
+
+	_ scheduler.Backend = (*schedulerBackend)(nil)
+)
+
+type schedulerBackend struct {
+	name string
+}
+
+// New creates an LPX scheduler backend.
+func New(profile configv1alpha1.SchedulerProfile) scheduler.Backend {
+	return &schedulerBackend{name: string(profile.Name)}
+}
+
+func (b *schedulerBackend) Name() string {
+	return b.name
+}
+
+func (b *schedulerBackend) Init(_ client.Client) error {
+	return nil
+}
+
+func (b *schedulerBackend) SyncPodGang(
+	_ context.Context,
+	_ *groveschedulerv1alpha1.PodGang,
+) error {
+	return nil
+}
+
+func (b *schedulerBackend) PreparePod(pod *corev1.Pod) error {
+	pod.Spec.SchedulerName = b.name
+	return nil
+}
+
+func (b *schedulerBackend) ValidatePodCliqueSet(
+	_ context.Context,
+	pcs *grovecorev1alpha1.PodCliqueSet,
+) error {
+	if pcs.Spec.Template.TopologyConstraint != nil {
+		return errTopologyConstraintsUnsupported
+	}
+	for _, clique := range pcs.Spec.Template.Cliques {
+		if clique != nil && clique.TopologyConstraint != nil {
+			return errTopologyConstraintsUnsupported
+		}
+	}
+	for _, scalingGroup := range pcs.Spec.Template.PodCliqueScalingGroupConfigs {
+		if scalingGroup.TopologyConstraint != nil {
+			return errTopologyConstraintsUnsupported
+		}
+	}
+	return nil
+}

--- a/operator/internal/scheduler/lpx/backend_test.go
+++ b/operator/internal/scheduler/lpx/backend_test.go
@@ -1,0 +1,112 @@
+// /*
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package lpx
+
+import (
+	"context"
+	"testing"
+
+	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	testutils "github.com/ai-dynamo/grove/operator/test/utils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+)
+
+func TestBackendPreparePod(t *testing.T) {
+	backend := New(configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameLPX})
+	pod := testutils.NewPodBuilder("test-pod", "default").
+		WithSchedulerName("default-scheduler").
+		Build()
+	pod.Spec.SchedulingGates = []corev1.PodSchedulingGate{{Name: "grove.io/podgang-pending-creation"}}
+	pod.Spec.ResourceClaims = []corev1.PodResourceClaim{{
+		Name:              "partition",
+		ResourceClaimName: ptr.To("model-partition-000"),
+	}}
+
+	require.NoError(t, backend.PreparePod(pod))
+
+	assert.Equal(t, string(configv1alpha1.SchedulerNameLPX), pod.Spec.SchedulerName)
+	require.Len(t, pod.Spec.SchedulingGates, 1)
+	assert.Equal(t, "grove.io/podgang-pending-creation", pod.Spec.SchedulingGates[0].Name)
+	require.Len(t, pod.Spec.ResourceClaims, 1)
+	assert.Equal(t, "model-partition-000", *pod.Spec.ResourceClaims[0].ResourceClaimName)
+}
+
+func TestBackendValidatePodCliqueSet(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutatePCS func(*grovecorev1alpha1.PodCliqueSet)
+		wantError bool
+	}{
+		{
+			name:      "no Grove topology constraints",
+			mutatePCS: func(_ *grovecorev1alpha1.PodCliqueSet) {},
+		},
+		{
+			name: "PodCliqueSet topology constraint",
+			mutatePCS: func(pcs *grovecorev1alpha1.PodCliqueSet) {
+				pcs.Spec.Template.TopologyConstraint = &grovecorev1alpha1.TopologyConstraint{}
+			},
+			wantError: true,
+		},
+		{
+			name: "PodClique topology constraint",
+			mutatePCS: func(pcs *grovecorev1alpha1.PodCliqueSet) {
+				pcs.Spec.Template.Cliques[0].TopologyConstraint = &grovecorev1alpha1.TopologyConstraint{}
+			},
+			wantError: true,
+		},
+		{
+			name: "PodCliqueScalingGroup topology constraint",
+			mutatePCS: func(pcs *grovecorev1alpha1.PodCliqueSet) {
+				pcs.Spec.Template.PodCliqueScalingGroupConfigs = []grovecorev1alpha1.PodCliqueScalingGroupConfig{{
+					Name:               "workers",
+					TopologyConstraint: &grovecorev1alpha1.TopologyConstraint{},
+				}}
+			},
+			wantError: true,
+		},
+	}
+
+	backend := New(configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameLPX})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pcs := testutils.NewPodCliqueSetBuilder("test-pcs", "default", types.UID("test-uid")).
+				WithPodCliqueTemplateSpec(
+					testutils.NewPodCliqueTemplateSpecBuilder("worker").
+						WithRoleName("worker").
+						WithReplicas(1).
+						Build(),
+				).
+				Build()
+			tt.mutatePCS(pcs)
+
+			err := backend.ValidatePodCliqueSet(context.Background(), pcs)
+
+			if tt.wantError {
+				require.ErrorIs(t, err, errTopologyConstraintsUnsupported)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/operator/internal/scheduler/registry/registry.go
+++ b/operator/internal/scheduler/registry/registry.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ai-dynamo/grove/operator/internal/scheduler"
 	"github.com/ai-dynamo/grove/operator/internal/scheduler/kai"
 	"github.com/ai-dynamo/grove/operator/internal/scheduler/kube"
+	"github.com/ai-dynamo/grove/operator/internal/scheduler/lpx"
 	"github.com/ai-dynamo/grove/operator/internal/scheduler/volcano"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -104,6 +105,8 @@ func newSchedulerBackend(cl, directClient client.Client, scheme *runtime.Scheme,
 		b = kai.New(cl, scheme, rec, p)
 	case configv1alpha1.SchedulerNameVolcano:
 		b = volcano.New(cl, scheme, rec, p)
+	case configv1alpha1.SchedulerNameLPX:
+		b = lpx.New(p)
 	default:
 		return nil, fmt.Errorf("scheduler profile %q is not supported", p.Name)
 	}

--- a/operator/internal/scheduler/registry/registry_test.go
+++ b/operator/internal/scheduler/registry/registry_test.go
@@ -51,6 +51,12 @@ func TestNewRegistry(t *testing.T) {
 			expectedName:  "default-scheduler",
 		},
 		{
+			name:          "lpx scheduler initialization",
+			schedulerName: configv1alpha1.SchedulerNameLPX,
+			wantErr:       false,
+			expectedName:  "lpx-scheduler",
+		},
+		{
 			name:          "unsupported scheduler",
 			schedulerName: "unknown-scheduler",
 			wantErr:       true,
@@ -88,12 +94,14 @@ func TestNewRegistry(t *testing.T) {
 	}
 
 	t.Run("multiple profiles with default set to kai", func(t *testing.T) {
-		cl := testutils.CreateDefaultFakeClient(nil)
+		cl := testutils.CreateDefaultFakeClient([]client.Object{testutils.NewVolcanoPodGroupCRD(true)})
 		recorder := record.NewFakeRecorder(10)
 		cfg := configv1alpha1.SchedulerConfiguration{
 			Profiles: []configv1alpha1.SchedulerProfile{
 				{Name: configv1alpha1.SchedulerNameKube},
 				{Name: configv1alpha1.SchedulerNameKai},
+				{Name: configv1alpha1.SchedulerNameVolcano},
+				{Name: configv1alpha1.SchedulerNameLPX},
 			},
 			DefaultProfileName: string(configv1alpha1.SchedulerNameKai),
 		}
@@ -101,7 +109,10 @@ func TestNewRegistry(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, reg.Get(string(configv1alpha1.SchedulerNameKai)))
 		require.NotNil(t, reg.Get(string(configv1alpha1.SchedulerNameKube)))
+		require.NotNil(t, reg.Get(string(configv1alpha1.SchedulerNameVolcano)))
+		require.NotNil(t, reg.Get(string(configv1alpha1.SchedulerNameLPX)))
 		assert.Equal(t, reg.GetDefault(), reg.Get(string(configv1alpha1.SchedulerNameKai)))
+		assert.NotContains(t, reg.AllTopologyAware(), string(configv1alpha1.SchedulerNameLPX))
 	})
 
 	t.Run("volcano scheduler initialization", func(t *testing.T) {

--- a/operator/internal/webhook/admission/pcs/validation/handler_test.go
+++ b/operator/internal/webhook/admission/pcs/validation/handler_test.go
@@ -23,6 +23,8 @@ import (
 
 	groveconfigv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/ai-dynamo/grove/operator/internal/scheduler"
+	"github.com/ai-dynamo/grove/operator/internal/scheduler/lpx"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
 	"github.com/go-logr/logr"
@@ -207,6 +209,42 @@ func TestValidateCreate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidatePodCliqueSetWithLPXBackend(t *testing.T) {
+	profile := groveconfigv1alpha1.SchedulerProfile{Name: groveconfigv1alpha1.SchedulerNameLPX}
+	registry := &testutils.FakeSchedulerRegistry{
+		Backends: map[string]scheduler.Backend{
+			string(groveconfigv1alpha1.SchedulerNameKube): testutils.NewFakeSchedulerBackend(
+				string(groveconfigv1alpha1.SchedulerNameKube),
+			),
+			string(groveconfigv1alpha1.SchedulerNameLPX): lpx.New(profile),
+		},
+		DefaultBackend: string(groveconfigv1alpha1.SchedulerNameKube),
+	}
+	handler := &Handler{schedRegistry: registry}
+	pcs := testutils.NewPodCliqueSetBuilder("test-pcs", "default", uuid.NewUUID()).
+		WithPodCliqueTemplateSpec(
+			testutils.NewPodCliqueTemplateSpecBuilder("worker").
+				WithRoleName("worker").
+				WithReplicas(1).
+				WithPodSpec(corev1.PodSpec{
+					SchedulerName: string(groveconfigv1alpha1.SchedulerNameLPX),
+					Containers: []corev1.Container{{
+						Name:  "worker",
+						Image: "worker",
+					}},
+				}).
+				Build(),
+		).
+		Build()
+
+	require.NoError(t, handler.validatePodCliqueSetWithBackend(context.Background(), pcs))
+
+	pcs.Spec.Template.TopologyConstraint = &grovecorev1alpha1.TopologyConstraint{}
+	err := handler.validatePodCliqueSetWithBackend(context.Background(), pcs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support Grove topology constraints")
 }
 
 // TestValidateUpdate tests validation of PodCliqueSet update requests.

--- a/operator/internal/webhook/admission/pcs/validation/podcliqueset_test.go
+++ b/operator/internal/webhook/admission/pcs/validation/podcliqueset_test.go
@@ -247,6 +247,18 @@ func TestValidateSchedulerNames(t *testing.T) {
 			expectErrors:   0,
 		},
 		{
+			name: "single lpx-scheduler when enabled",
+			schedulerConfig: groveconfigv1alpha1.SchedulerConfiguration{
+				Profiles: []groveconfigv1alpha1.SchedulerProfile{
+					{Name: groveconfigv1alpha1.SchedulerNameKube},
+					{Name: groveconfigv1alpha1.SchedulerNameLPX},
+				},
+				DefaultProfileName: string(groveconfigv1alpha1.SchedulerNameKube),
+			},
+			schedulerNames: []string{"lpx-scheduler"},
+			expectErrors:   0,
+		},
+		{
 			name: "single default-scheduler when enabled (kube only)",
 			schedulerConfig: groveconfigv1alpha1.SchedulerConfiguration{
 				Profiles:           []groveconfigv1alpha1.SchedulerProfile{{Name: groveconfigv1alpha1.SchedulerNameKube}},


### PR DESCRIPTION
## summary

this adds `lpx-scheduler` as an explicit, opt-in Grove scheduler backend.
Grove still owns workload materialization and lifecycle; the external scheduler
owns topology solving, DRA device allocation, and final Pod binding.

the backend is intentionally narrow:

- `PreparePod` sets `spec.schedulerName: lpx-scheduler`;
- Grove preserves concrete Pod identity, PodGang membership, scheduling gates,
  and resource-claim references;
- `SyncPodGang` is a no-op because LPX consumes Grove's native PodGang directly;
- Grove topology constraints are rejected for LPX workloads so two schedulers
  cannot both claim topology authority; and
- existing Kubernetes, KAI, and Volcano backends remain unchanged.

```mermaid
flowchart LR
    A["workload opts in"] --> B["Grove PodCliqueSet"]
    B --> C["Grove Pods + PodGang + claims"]
    C --> D["lpx-scheduler"]
    D -->|"allocates claims + binds Pods"| C
```

## post-#516 integration

this branch is rebased onto `b3cf9caf`, after the scheduler backend interface
changes in #516. LPX now follows the same registry lifecycle as the other
backends:

- `Init(client.Client) error`;
- `PreparePod(*corev1.Pod) error`;
- the current base `Backend` interface, without the removed
  `OnPodGangDelete` hook; and
- coexistence with the new Volcano backend in the scheduler registry.

the LPX backend is not topology-aware from Grove's perspective. it therefore
does not register topology watches or create backend-specific scheduling
resources.

## why a named backend is needed

Grove validates scheduler names against enabled backends before creating Pods.
without this registration, an LPX workload cannot retain Grove's normal
PodCliqueSet, PodGang, claim-template, and Pod lifecycle while delegating
placement to `lpx-scheduler`.

the external scheduler is NVIDIA-internal today and is expected to be open
sourced. this change contains no dependency on that codebase or its APIs:
clusters that do not enable the profile are unaffected, and enabling the
profile without deploying the scheduler simply leaves opted-in Pods pending.

## scope

this PR does not:

- solve placement;
- inspect or mutate DRA allocations;
- bind Pods;
- prune candidate Pods;
- change `resourceSharing`; or
- add a Grove topology-affinity implementation for LPX.

## validation

the branch passes Grove generation, formatting, lint, full unit tests, build,
changed-package race tests, Helm lint, and chart rendering.

it also passes the campaign's isolated Kubernetes 1.35 Kind round trip against
this exact Grove commit. that proof deploys the real Grove and Dynamo
controllers, `lpx-scheduler`, and the real remote LPU DRA node plugin. it
covers legacy coexistence and upgrade, all four public LPX workload modes,
exact allocation and UID-safe binding, restart, replacement fencing, release,
driver restart recovery, and GPU inventory invalidation.

## issue

fixes #664

## release note

```release-note
adds lpx-scheduler as an opt-in scheduler backend while Grove retains workload materialization, PodGang, claim-reference, and lifecycle ownership.
```
