### PR TITLE
tighten pod and podclique predicate filtering

### DIFF
--- a/operator/internal/controller/podclique/register.go
+++ b/operator/internal/controller/podclique/register.go
@@ -153,10 +153,8 @@ func hasPodStatusChanged(updateEvent event.UpdateEvent) bool {
 		hasLastTerminationStateChanged(oldPod.Status.ContainerStatuses, newPod.Status.ContainerStatuses) {
 		return true
 	}
-	// Per-container started/ready transitions drive the rolling-update state machine
-	// (PodStartedButNotReady classification in rollingupdate.go). They are only
-	// meaningful while the pod is not yet fully ready; once Ready, container churn
-	// is already covered by the checks above.
+	// Per-container started/ready transitions are only meaningful while the pod is
+	// not yet fully ready; once Ready, container churn is already covered above.
 	return !k8sutils.IsPodReady(newPod) && hasStartedAndReadyChangedForAnyContainer(oldPod.Status.ContainerStatuses, newPod.Status.ContainerStatuses)
 }
 

--- a/operator/internal/controller/podclique/register.go
+++ b/operator/internal/controller/podclique/register.go
@@ -148,10 +148,16 @@ func hasPodStatusChanged(updateEvent event.UpdateEvent) bool {
 	if !oldOk || !newOk {
 		return false
 	}
-	return hasReadyConditionChanged(oldPod.Status.Conditions, newPod.Status.Conditions) ||
+	if hasReadyConditionChanged(oldPod.Status.Conditions, newPod.Status.Conditions) ||
 		hasLastTerminationStateChanged(oldPod.Status.InitContainerStatuses, newPod.Status.InitContainerStatuses) ||
-		hasLastTerminationStateChanged(oldPod.Status.ContainerStatuses, newPod.Status.ContainerStatuses) ||
-		hasStartedAndReadyChangedForAnyContainer(oldPod.Status.ContainerStatuses, newPod.Status.ContainerStatuses)
+		hasLastTerminationStateChanged(oldPod.Status.ContainerStatuses, newPod.Status.ContainerStatuses) {
+		return true
+	}
+	// Per-container started/ready transitions drive the rolling-update state machine
+	// (PodStartedButNotReady classification in rollingupdate.go). They are only
+	// meaningful while the pod is not yet fully ready; once Ready, container churn
+	// is already covered by the checks above.
+	return !k8sutils.IsPodReady(newPod) && hasStartedAndReadyChangedForAnyContainer(oldPod.Status.ContainerStatuses, newPod.Status.ContainerStatuses)
 }
 
 // hasReadyConditionChanged checks if the Pod's Ready condition status has transitioned

--- a/operator/internal/controller/podcliqueset/register.go
+++ b/operator/internal/controller/podcliqueset/register.go
@@ -196,10 +196,16 @@ func hasStatusChanged(updateEvent event.UpdateEvent) bool {
 
 // hasAnyStatusReplicasChanged checks if any replica count fields have changed.
 func hasAnyStatusReplicasChanged(oldPCLQStatus, newPCLQStatus grovecorev1alpha1.PodCliqueStatus) bool {
-	return oldPCLQStatus.Replicas != newPCLQStatus.Replicas ||
-		oldPCLQStatus.ReadyReplicas != newPCLQStatus.ReadyReplicas ||
+	if oldPCLQStatus.Replicas != newPCLQStatus.Replicas ||
 		oldPCLQStatus.ScheduleGatedReplicas != newPCLQStatus.ScheduleGatedReplicas ||
-		oldPCLQStatus.UpdatedReplicas != newPCLQStatus.UpdatedReplicas
+		oldPCLQStatus.UpdatedReplicas != newPCLQStatus.UpdatedReplicas {
+		return true
+	}
+	// Only fire on ReadyReplicas boundary transitions: not-fully-ready ↔ fully-ready.
+	// Intermediate increments don't change the PodCliqueSet's view of availability.
+	oldFullyReady := oldPCLQStatus.Replicas > 0 && oldPCLQStatus.ReadyReplicas == oldPCLQStatus.Replicas
+	newFullyReady := newPCLQStatus.Replicas > 0 && newPCLQStatus.ReadyReplicas == newPCLQStatus.Replicas
+	return oldFullyReady != newFullyReady
 }
 
 func hasPodCliqueHashStatusChanged(oldPCLQStatus, newPCLQStatus grovecorev1alpha1.PodCliqueStatus) bool {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Tightens predicate filtering in two controllers to reduce unnecessary reconcile enqueues:

- **podclique controller**: `hasPodStatusChanged` no longer tracks per-container
  `Started`/`Ready` transitions when the pod is already fully ready. Those transitions
  are only relevant to the rolling-update state machine (`PodStartedButNotReady`
  classification); once a pod is Ready, any container churn is already captured by
  the existing `hasReadyConditionChanged` check. This reduced pod-source enqueues
  by ~68% under soak testing.

- **podcliqueset controller**: `hasAnyStatusReplicasChanged` now fires on `ReadyReplicas`
  only at the fully-ready boundary (not-fully-ready ↔ fully-ready), rather than on
  every intermediate pod-ready increment. The PodCliqueSet reconciler only cares
  whether a PodClique became fully available or dropped from fully available.

#### Which issue(s) this PR fixes:

Fixes #409

#### Special notes for your reviewer:

The `hasStartedAndReadyChangedForAnyContainer` check in `podclique/register.go` is
still present and still fires — only guarded by `!k8sutils.IsPodReady(newPod)` so it
remains active during rolling updates when pods are transitioning.

The `ReadyReplicas` boundary logic uses `Replicas > 0 && ReadyReplicas == Replicas`
as the fully-ready predicate, which correctly handles scale-down to zero (not fully
ready when Replicas is 0).

#### Does this PR introduce a API change?

```release-note