### PR TITLE
api/crds: add printer columns

### DIFF
--- a/operator/api/core/v1alpha1/clustertopologybinding.go
+++ b/operator/api/core/v1alpha1/clustertopologybinding.go
@@ -27,7 +27,6 @@ import (
 // +kubebuilder:resource:scope=Cluster,shortName=ct
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Domains",type=string,JSONPath=`.spec.levels[*].domain`
-// +kubebuilder:printcolumn:name="Schedulers",type=string,JSONPath=`.spec.schedulerTopologyBindings[*].schedulerName`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // ClusterTopologyBinding defines Grove's source-of-truth topology hierarchy and how it

--- a/operator/api/core/v1alpha1/clustertopologybinding.go
+++ b/operator/api/core/v1alpha1/clustertopologybinding.go
@@ -26,6 +26,11 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster,shortName=ct
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Domains",type=string,JSONPath=`.spec.levels[*].domain`
+// +kubebuilder:printcolumn:name="Drift",type=string,JSONPath=`.status.conditions[?(@.type=="SchedulerTopologyDrift")].status`
+// +kubebuilder:printcolumn:name="Schedulers",type=string,JSONPath=`.spec.schedulerTopologyBindings[*].schedulerName`,priority=1
+// +kubebuilder:printcolumn:name="Keys",type=string,JSONPath=`.spec.levels[*].key`,priority=1
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // ClusterTopologyBinding defines Grove's source-of-truth topology hierarchy and how it
 // binds to topology resources used by topology-aware scheduler backends.

--- a/operator/api/core/v1alpha1/clustertopologybinding.go
+++ b/operator/api/core/v1alpha1/clustertopologybinding.go
@@ -27,9 +27,7 @@ import (
 // +kubebuilder:resource:scope=Cluster,shortName=ct
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Domains",type=string,JSONPath=`.spec.levels[*].domain`
-// +kubebuilder:printcolumn:name="Drift",type=string,JSONPath=`.status.conditions[?(@.type=="SchedulerTopologyDrift")].status`
 // +kubebuilder:printcolumn:name="Schedulers",type=string,JSONPath=`.spec.schedulerTopologyBindings[*].schedulerName`,priority=1
-// +kubebuilder:printcolumn:name="Keys",type=string,JSONPath=`.spec.levels[*].key`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // ClusterTopologyBinding defines Grove's source-of-truth topology hierarchy and how it

--- a/operator/api/core/v1alpha1/crds/grove.io_clustertopologybindings.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_clustertopologybindings.yaml
@@ -16,7 +16,25 @@ spec:
     singular: clustertopologybinding
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.levels[*].domain
+      name: Domains
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="SchedulerTopologyDrift")].status
+      name: Drift
+      type: string
+    - jsonPath: .spec.schedulerTopologyBindings[*].schedulerName
+      name: Schedulers
+      priority: 1
+      type: string
+    - jsonPath: .spec.levels[*].key
+      name: Keys
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/operator/api/core/v1alpha1/crds/grove.io_clustertopologybindings.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_clustertopologybindings.yaml
@@ -20,10 +20,6 @@ spec:
     - jsonPath: .spec.levels[*].domain
       name: Domains
       type: string
-    - jsonPath: .spec.schedulerTopologyBindings[*].schedulerName
-      name: Schedulers
-      priority: 1
-      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/operator/api/core/v1alpha1/crds/grove.io_clustertopologybindings.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_clustertopologybindings.yaml
@@ -20,15 +20,8 @@ spec:
     - jsonPath: .spec.levels[*].domain
       name: Domains
       type: string
-    - jsonPath: .status.conditions[?(@.type=="SchedulerTopologyDrift")].status
-      name: Drift
-      type: string
     - jsonPath: .spec.schedulerTopologyBindings[*].schedulerName
       name: Schedulers
-      priority: 1
-      type: string
-    - jsonPath: .spec.levels[*].key
-      name: Keys
       priority: 1
       type: string
     - jsonPath: .metadata.creationTimestamp

--- a/operator/api/core/v1alpha1/crds/grove.io_podcliques.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podcliques.yaml
@@ -17,6 +17,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .spec.minAvailable
+      name: MinAvail
+      type: integer
     - jsonPath: .spec.replicas
       name: Replicas
       type: integer
@@ -28,9 +31,6 @@ spec:
       type: integer
     - jsonPath: .status.updatedReplicas
       name: Updated
-      type: integer
-    - jsonPath: .spec.minAvailable
-      name: MinAvail
       type: integer
     - jsonPath: .status.scheduleGatedReplicas
       name: Gated

--- a/operator/api/core/v1alpha1/crds/grove.io_podcliques.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podcliques.yaml
@@ -16,7 +16,48 @@ spec:
     singular: podclique
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.replicas
+      name: Desired
+      type: integer
+    - jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - jsonPath: .status.scheduledReplicas
+      name: Scheduled
+      type: integer
+    - jsonPath: .status.scheduleGatedReplicas
+      name: Gated
+      type: integer
+    - jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - jsonPath: .spec.minAvailable
+      name: MinAvail
+      type: integer
+    - jsonPath: .status.conditions[?(@.type=="MinAvailableBreached")].status
+      name: MinBreached
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="PodCliqueScheduled")].status
+      name: SchedOK
+      priority: 1
+      type: string
+    - jsonPath: .status.currentPodCliqueSetGenerationHash
+      name: PCSHash
+      priority: 1
+      type: string
+    - jsonPath: .status.currentPodTemplateHash
+      name: TemplateHash
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: PodClique is a set of pods running the same image.

--- a/operator/api/core/v1alpha1/crds/grove.io_podcliques.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podcliques.yaml
@@ -18,9 +18,6 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.replicas
-      name: Desired
-      type: integer
-    - jsonPath: .status.replicas
       name: Replicas
       type: integer
     - jsonPath: .status.readyReplicas
@@ -29,29 +26,18 @@ spec:
     - jsonPath: .status.scheduledReplicas
       name: Scheduled
       type: integer
-    - jsonPath: .status.scheduleGatedReplicas
-      name: Gated
-      type: integer
     - jsonPath: .status.updatedReplicas
       name: Updated
       type: integer
     - jsonPath: .spec.minAvailable
       name: MinAvail
       type: integer
+    - jsonPath: .status.scheduleGatedReplicas
+      name: Gated
+      priority: 1
+      type: integer
     - jsonPath: .status.conditions[?(@.type=="MinAvailableBreached")].status
       name: MinBreached
-      priority: 1
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="PodCliqueScheduled")].status
-      name: SchedOK
-      priority: 1
-      type: string
-    - jsonPath: .status.currentPodCliqueSetGenerationHash
-      name: PCSHash
-      priority: 1
-      type: string
-    - jsonPath: .status.currentPodTemplateHash
-      name: TemplateHash
       priority: 1
       type: string
     - jsonPath: .metadata.creationTimestamp

--- a/operator/api/core/v1alpha1/crds/grove.io_podcliquescalinggroups.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podcliquescalinggroups.yaml
@@ -17,6 +17,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .spec.minAvailable
+      name: MinAvail
+      type: integer
     - jsonPath: .spec.replicas
       name: Replicas
       type: integer
@@ -34,9 +37,6 @@ spec:
       type: integer
     - jsonPath: .status.updateProgress.totalPodCliquesCount
       name: PCLQs-Total
-      type: integer
-    - jsonPath: .spec.minAvailable
-      name: MinAvail
       type: integer
     - jsonPath: .status.conditions[?(@.type=="MinAvailableBreached")].status
       name: MinBreached

--- a/operator/api/core/v1alpha1/crds/grove.io_podcliquescalinggroups.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podcliquescalinggroups.yaml
@@ -18,16 +18,13 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.replicas
-      name: Desired
-      type: integer
-    - jsonPath: .status.replicas
       name: Replicas
-      type: integer
-    - jsonPath: .status.scheduledReplicas
-      name: Scheduled
       type: integer
     - jsonPath: .status.availableReplicas
       name: Available
+      type: integer
+    - jsonPath: .status.scheduledReplicas
+      name: Scheduled
       type: integer
     - jsonPath: .status.updatedReplicas
       name: Updated
@@ -43,10 +40,6 @@ spec:
       type: integer
     - jsonPath: .status.conditions[?(@.type=="MinAvailableBreached")].status
       name: MinBreached
-      priority: 1
-      type: string
-    - jsonPath: .status.currentPodCliqueSetGenerationHash
-      name: PCSHash
       priority: 1
       type: string
     - jsonPath: .metadata.creationTimestamp

--- a/operator/api/core/v1alpha1/crds/grove.io_podcliquescalinggroups.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podcliquescalinggroups.yaml
@@ -17,8 +17,14 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .spec.replicas
+      name: Desired
+      type: integer
     - jsonPath: .status.replicas
       name: Replicas
+      type: integer
+    - jsonPath: .status.scheduledReplicas
+      name: Scheduled
       type: integer
     - jsonPath: .status.availableReplicas
       name: Available
@@ -32,6 +38,20 @@ spec:
     - jsonPath: .status.updateProgress.totalPodCliquesCount
       name: PCLQs-Total
       type: integer
+    - jsonPath: .spec.minAvailable
+      name: MinAvail
+      type: integer
+    - jsonPath: .status.conditions[?(@.type=="MinAvailableBreached")].status
+      name: MinBreached
+      priority: 1
+      type: string
+    - jsonPath: .status.currentPodCliqueSetGenerationHash
+      name: PCSHash
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/operator/api/core/v1alpha1/crds/grove.io_podcliquesets.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podcliquesets.yaml
@@ -18,9 +18,6 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.replicas
-      name: Desired
-      type: integer
-    - jsonPath: .status.replicas
       name: Replicas
       type: integer
     - jsonPath: .status.availableReplicas
@@ -41,18 +38,6 @@ spec:
     - jsonPath: .status.updateProgress.totalPodCliqueScalingGroupsCount
       name: PCSGs-Total
       type: integer
-    - jsonPath: .spec.updateStrategy.type
-      name: Strategy
-      priority: 1
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="TopologyLevelsUnavailable")].status
-      name: TopoMissing
-      priority: 1
-      type: string
-    - jsonPath: .status.currentGenerationHash
-      name: Hash
-      priority: 1
-      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/operator/api/core/v1alpha1/crds/grove.io_podcliquesets.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podcliquesets.yaml
@@ -17,6 +17,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .spec.replicas
+      name: Desired
+      type: integer
     - jsonPath: .status.replicas
       name: Replicas
       type: integer
@@ -38,6 +41,21 @@ spec:
     - jsonPath: .status.updateProgress.totalPodCliqueScalingGroupsCount
       name: PCSGs-Total
       type: integer
+    - jsonPath: .spec.updateStrategy.type
+      name: Strategy
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="TopologyLevelsUnavailable")].status
+      name: TopoMissing
+      priority: 1
+      type: string
+    - jsonPath: .status.currentGenerationHash
+      name: Hash
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/operator/api/core/v1alpha1/podclique.go
+++ b/operator/api/core/v1alpha1/podclique.go
@@ -28,6 +28,18 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.hpaPodSelector
 // +kubebuilder:resource:shortName={pclq}
+// +kubebuilder:printcolumn:name="Desired",type=integer,JSONPath=`.spec.replicas`
+// +kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=`.status.replicas`
+// +kubebuilder:printcolumn:name="Ready",type=integer,JSONPath=`.status.readyReplicas`
+// +kubebuilder:printcolumn:name="Scheduled",type=integer,JSONPath=`.status.scheduledReplicas`
+// +kubebuilder:printcolumn:name="Gated",type=integer,JSONPath=`.status.scheduleGatedReplicas`
+// +kubebuilder:printcolumn:name="Updated",type=integer,JSONPath=`.status.updatedReplicas`
+// +kubebuilder:printcolumn:name="MinAvail",type=integer,JSONPath=`.spec.minAvailable`
+// +kubebuilder:printcolumn:name="MinBreached",type=string,JSONPath=`.status.conditions[?(@.type=="MinAvailableBreached")].status`,priority=1
+// +kubebuilder:printcolumn:name="SchedOK",type=string,JSONPath=`.status.conditions[?(@.type=="PodCliqueScheduled")].status`,priority=1
+// +kubebuilder:printcolumn:name="PCSHash",type=string,JSONPath=`.status.currentPodCliqueSetGenerationHash`,priority=1
+// +kubebuilder:printcolumn:name="TemplateHash",type=string,JSONPath=`.status.currentPodTemplateHash`,priority=1
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // PodClique is a set of pods running the same image.
 type PodClique struct {

--- a/operator/api/core/v1alpha1/podclique.go
+++ b/operator/api/core/v1alpha1/podclique.go
@@ -28,17 +28,13 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.hpaPodSelector
 // +kubebuilder:resource:shortName={pclq}
-// +kubebuilder:printcolumn:name="Desired",type=integer,JSONPath=`.spec.replicas`
-// +kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=`.status.replicas`
+// +kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=`.spec.replicas`
 // +kubebuilder:printcolumn:name="Ready",type=integer,JSONPath=`.status.readyReplicas`
 // +kubebuilder:printcolumn:name="Scheduled",type=integer,JSONPath=`.status.scheduledReplicas`
-// +kubebuilder:printcolumn:name="Gated",type=integer,JSONPath=`.status.scheduleGatedReplicas`
 // +kubebuilder:printcolumn:name="Updated",type=integer,JSONPath=`.status.updatedReplicas`
 // +kubebuilder:printcolumn:name="MinAvail",type=integer,JSONPath=`.spec.minAvailable`
+// +kubebuilder:printcolumn:name="Gated",type=integer,JSONPath=`.status.scheduleGatedReplicas`,priority=1
 // +kubebuilder:printcolumn:name="MinBreached",type=string,JSONPath=`.status.conditions[?(@.type=="MinAvailableBreached")].status`,priority=1
-// +kubebuilder:printcolumn:name="SchedOK",type=string,JSONPath=`.status.conditions[?(@.type=="PodCliqueScheduled")].status`,priority=1
-// +kubebuilder:printcolumn:name="PCSHash",type=string,JSONPath=`.status.currentPodCliqueSetGenerationHash`,priority=1
-// +kubebuilder:printcolumn:name="TemplateHash",type=string,JSONPath=`.status.currentPodTemplateHash`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // PodClique is a set of pods running the same image.

--- a/operator/api/core/v1alpha1/podclique.go
+++ b/operator/api/core/v1alpha1/podclique.go
@@ -28,11 +28,11 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.hpaPodSelector
 // +kubebuilder:resource:shortName={pclq}
+// +kubebuilder:printcolumn:name="MinAvail",type=integer,JSONPath=`.spec.minAvailable`
 // +kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=`.spec.replicas`
 // +kubebuilder:printcolumn:name="Ready",type=integer,JSONPath=`.status.readyReplicas`
 // +kubebuilder:printcolumn:name="Scheduled",type=integer,JSONPath=`.status.scheduledReplicas`
 // +kubebuilder:printcolumn:name="Updated",type=integer,JSONPath=`.status.updatedReplicas`
-// +kubebuilder:printcolumn:name="MinAvail",type=integer,JSONPath=`.spec.minAvailable`
 // +kubebuilder:printcolumn:name="Gated",type=integer,JSONPath=`.status.scheduleGatedReplicas`,priority=1
 // +kubebuilder:printcolumn:name="MinBreached",type=string,JSONPath=`.status.conditions[?(@.type=="MinAvailableBreached")].status`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`

--- a/operator/api/core/v1alpha1/podcliqueset.go
+++ b/operator/api/core/v1alpha1/podcliqueset.go
@@ -27,6 +27,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.hpaPodSelector
 // +kubebuilder:resource:shortName={pcs}
+// +kubebuilder:printcolumn:name="Desired",type=integer,JSONPath=`.spec.replicas`
 // +kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=`.status.replicas`
 // +kubebuilder:printcolumn:name="Available",type=integer,JSONPath=`.status.availableReplicas`
 // +kubebuilder:printcolumn:name="Updated",type=integer,JSONPath=`.status.updatedReplicas`
@@ -34,6 +35,10 @@ import (
 // +kubebuilder:printcolumn:name="PCLQs-Total",type=integer,JSONPath=`.status.updateProgress.totalPodCliquesCount`
 // +kubebuilder:printcolumn:name="PCSGs-Updated",type=integer,JSONPath=`.status.updateProgress.updatedPodCliqueScalingGroupsCount`
 // +kubebuilder:printcolumn:name="PCSGs-Total",type=integer,JSONPath=`.status.updateProgress.totalPodCliqueScalingGroupsCount`
+// +kubebuilder:printcolumn:name="Strategy",type=string,JSONPath=`.spec.updateStrategy.type`,priority=1
+// +kubebuilder:printcolumn:name="TopoMissing",type=string,JSONPath=`.status.conditions[?(@.type=="TopologyLevelsUnavailable")].status`,priority=1
+// +kubebuilder:printcolumn:name="Hash",type=string,JSONPath=`.status.currentGenerationHash`,priority=1
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:validation:XValidation:rule="oldSelf.hasValue() || !has(self.spec.template.topologyConstraint) || !has(self.spec.template.topologyConstraint.packDomain)",message="packDomain is deprecated and cannot be used on new workloads; use pack.required",fieldPath=".spec.template.topologyConstraint.packDomain",optionalOldSelf=true,reason=FieldValueForbidden
 // +kubebuilder:validation:XValidation:rule="oldSelf.hasValue() || !has(self.spec.template.cliques) || self.spec.template.cliques.all(c, !has(c.topologyConstraint) || !has(c.topologyConstraint.packDomain))",message="packDomain is deprecated and cannot be used on new workloads; use pack.required",fieldPath=".spec.template.cliques",optionalOldSelf=true,reason=FieldValueForbidden
 // +kubebuilder:validation:XValidation:rule="oldSelf.hasValue() || !has(self.spec.template.podCliqueScalingGroups) || self.spec.template.podCliqueScalingGroups.all(g, !has(g.topologyConstraint) || !has(g.topologyConstraint.packDomain))",message="packDomain is deprecated and cannot be used on new workloads; use pack.required",fieldPath=".spec.template.podCliqueScalingGroups",optionalOldSelf=true,reason=FieldValueForbidden

--- a/operator/api/core/v1alpha1/podcliqueset.go
+++ b/operator/api/core/v1alpha1/podcliqueset.go
@@ -27,17 +27,13 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.hpaPodSelector
 // +kubebuilder:resource:shortName={pcs}
-// +kubebuilder:printcolumn:name="Desired",type=integer,JSONPath=`.spec.replicas`
-// +kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=`.status.replicas`
+// +kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=`.spec.replicas`
 // +kubebuilder:printcolumn:name="Available",type=integer,JSONPath=`.status.availableReplicas`
 // +kubebuilder:printcolumn:name="Updated",type=integer,JSONPath=`.status.updatedReplicas`
 // +kubebuilder:printcolumn:name="PCLQs-Updated",type=integer,JSONPath=`.status.updateProgress.updatedPodCliquesCount`
 // +kubebuilder:printcolumn:name="PCLQs-Total",type=integer,JSONPath=`.status.updateProgress.totalPodCliquesCount`
 // +kubebuilder:printcolumn:name="PCSGs-Updated",type=integer,JSONPath=`.status.updateProgress.updatedPodCliqueScalingGroupsCount`
 // +kubebuilder:printcolumn:name="PCSGs-Total",type=integer,JSONPath=`.status.updateProgress.totalPodCliqueScalingGroupsCount`
-// +kubebuilder:printcolumn:name="Strategy",type=string,JSONPath=`.spec.updateStrategy.type`,priority=1
-// +kubebuilder:printcolumn:name="TopoMissing",type=string,JSONPath=`.status.conditions[?(@.type=="TopologyLevelsUnavailable")].status`,priority=1
-// +kubebuilder:printcolumn:name="Hash",type=string,JSONPath=`.status.currentGenerationHash`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:validation:XValidation:rule="oldSelf.hasValue() || !has(self.spec.template.topologyConstraint) || !has(self.spec.template.topologyConstraint.packDomain)",message="packDomain is deprecated and cannot be used on new workloads; use pack.required",fieldPath=".spec.template.topologyConstraint.packDomain",optionalOldSelf=true,reason=FieldValueForbidden
 // +kubebuilder:validation:XValidation:rule="oldSelf.hasValue() || !has(self.spec.template.cliques) || self.spec.template.cliques.all(c, !has(c.topologyConstraint) || !has(c.topologyConstraint.packDomain))",message="packDomain is deprecated and cannot be used on new workloads; use pack.required",fieldPath=".spec.template.cliques",optionalOldSelf=true,reason=FieldValueForbidden

--- a/operator/api/core/v1alpha1/scalinggroup.go
+++ b/operator/api/core/v1alpha1/scalinggroup.go
@@ -24,13 +24,13 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:resource:shortName={pcsg}
+// +kubebuilder:printcolumn:name="MinAvail",type=integer,JSONPath=`.spec.minAvailable`
 // +kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=`.spec.replicas`
 // +kubebuilder:printcolumn:name="Available",type=integer,JSONPath=`.status.availableReplicas`
 // +kubebuilder:printcolumn:name="Scheduled",type=integer,JSONPath=`.status.scheduledReplicas`
 // +kubebuilder:printcolumn:name="Updated",type=integer,JSONPath=`.status.updatedReplicas`
 // +kubebuilder:printcolumn:name="PCLQs-Updated",type=integer,JSONPath=`.status.updateProgress.updatedPodCliquesCount`
 // +kubebuilder:printcolumn:name="PCLQs-Total",type=integer,JSONPath=`.status.updateProgress.totalPodCliquesCount`
-// +kubebuilder:printcolumn:name="MinAvail",type=integer,JSONPath=`.spec.minAvailable`
 // +kubebuilder:printcolumn:name="MinBreached",type=string,JSONPath=`.status.conditions[?(@.type=="MinAvailableBreached")].status`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/operator/api/core/v1alpha1/scalinggroup.go
+++ b/operator/api/core/v1alpha1/scalinggroup.go
@@ -24,11 +24,17 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:resource:shortName={pcsg}
+// +kubebuilder:printcolumn:name="Desired",type=integer,JSONPath=`.spec.replicas`
 // +kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=`.status.replicas`
+// +kubebuilder:printcolumn:name="Scheduled",type=integer,JSONPath=`.status.scheduledReplicas`
 // +kubebuilder:printcolumn:name="Available",type=integer,JSONPath=`.status.availableReplicas`
 // +kubebuilder:printcolumn:name="Updated",type=integer,JSONPath=`.status.updatedReplicas`
 // +kubebuilder:printcolumn:name="PCLQs-Updated",type=integer,JSONPath=`.status.updateProgress.updatedPodCliquesCount`
 // +kubebuilder:printcolumn:name="PCLQs-Total",type=integer,JSONPath=`.status.updateProgress.totalPodCliquesCount`
+// +kubebuilder:printcolumn:name="MinAvail",type=integer,JSONPath=`.spec.minAvailable`
+// +kubebuilder:printcolumn:name="MinBreached",type=string,JSONPath=`.status.conditions[?(@.type=="MinAvailableBreached")].status`,priority=1
+// +kubebuilder:printcolumn:name="PCSHash",type=string,JSONPath=`.status.currentPodCliqueSetGenerationHash`,priority=1
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // PodCliqueScalingGroup is the schema to define scaling groups that is used to scale a group of PodClique's.
 // An instance of this custom resource will be created for every pod clique scaling group defined as part of PodCliqueSet.

--- a/operator/api/core/v1alpha1/scalinggroup.go
+++ b/operator/api/core/v1alpha1/scalinggroup.go
@@ -24,16 +24,14 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:resource:shortName={pcsg}
-// +kubebuilder:printcolumn:name="Desired",type=integer,JSONPath=`.spec.replicas`
-// +kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=`.status.replicas`
-// +kubebuilder:printcolumn:name="Scheduled",type=integer,JSONPath=`.status.scheduledReplicas`
+// +kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=`.spec.replicas`
 // +kubebuilder:printcolumn:name="Available",type=integer,JSONPath=`.status.availableReplicas`
+// +kubebuilder:printcolumn:name="Scheduled",type=integer,JSONPath=`.status.scheduledReplicas`
 // +kubebuilder:printcolumn:name="Updated",type=integer,JSONPath=`.status.updatedReplicas`
 // +kubebuilder:printcolumn:name="PCLQs-Updated",type=integer,JSONPath=`.status.updateProgress.updatedPodCliquesCount`
 // +kubebuilder:printcolumn:name="PCLQs-Total",type=integer,JSONPath=`.status.updateProgress.totalPodCliquesCount`
 // +kubebuilder:printcolumn:name="MinAvail",type=integer,JSONPath=`.spec.minAvailable`
 // +kubebuilder:printcolumn:name="MinBreached",type=string,JSONPath=`.status.conditions[?(@.type=="MinAvailableBreached")].status`,priority=1
-// +kubebuilder:printcolumn:name="PCSHash",type=string,JSONPath=`.status.currentPodCliqueSetGenerationHash`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // PodCliqueScalingGroup is the schema to define scaling groups that is used to scale a group of PodClique's.

--- a/scheduler/api/core/v1alpha1/crds/scheduler.grove.io_podgangs.yaml
+++ b/scheduler/api/core/v1alpha1/crds/scheduler.grove.io_podgangs.yaml
@@ -20,23 +20,6 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
-    - jsonPath: .status.conditions[?(@.type=="Initialized")].status
-      name: Initialized
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Scheduled")].status
-      name: Scheduled
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Unhealthy")].status
-      name: Unhealthy
-      priority: 1
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="DisruptionTarget")].status
-      name: Disrupting
-      priority: 1
-      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/scheduler/api/core/v1alpha1/crds/scheduler.grove.io_podgangs.yaml
+++ b/scheduler/api/core/v1alpha1/crds/scheduler.grove.io_podgangs.yaml
@@ -16,7 +16,35 @@ spec:
     singular: podgang
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Initialized")].status
+      name: Initialized
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Scheduled")].status
+      name: Scheduled
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Unhealthy")].status
+      name: Unhealthy
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="DisruptionTarget")].status
+      name: Disrupting
+      priority: 1
+      type: string
+    - jsonPath: .status.placementScore
+      name: Score
+      priority: 1
+      type: number
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: PodGang defines a specification of a group of pods that should

--- a/scheduler/api/core/v1alpha1/crds/scheduler.grove.io_podgangs.yaml
+++ b/scheduler/api/core/v1alpha1/crds/scheduler.grove.io_podgangs.yaml
@@ -37,10 +37,6 @@ spec:
       name: Disrupting
       priority: 1
       type: string
-    - jsonPath: .status.placementScore
-      name: Score
-      priority: 1
-      type: number
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/scheduler/api/core/v1alpha1/podgang.go
+++ b/scheduler/api/core/v1alpha1/podgang.go
@@ -31,7 +31,6 @@ import (
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Unhealthy",type=string,JSONPath=`.status.conditions[?(@.type=="Unhealthy")].status`,priority=1
 // +kubebuilder:printcolumn:name="Disrupting",type=string,JSONPath=`.status.conditions[?(@.type=="DisruptionTarget")].status`,priority=1
-// +kubebuilder:printcolumn:name="Score",type=number,JSONPath=`.status.placementScore`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // PodGang defines a specification of a group of pods that should be scheduled together.

--- a/scheduler/api/core/v1alpha1/podgang.go
+++ b/scheduler/api/core/v1alpha1/podgang.go
@@ -25,6 +25,14 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName={pg}
+// +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+// +kubebuilder:printcolumn:name="Initialized",type=string,JSONPath=`.status.conditions[?(@.type=="Initialized")].status`
+// +kubebuilder:printcolumn:name="Scheduled",type=string,JSONPath=`.status.conditions[?(@.type=="Scheduled")].status`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Unhealthy",type=string,JSONPath=`.status.conditions[?(@.type=="Unhealthy")].status`,priority=1
+// +kubebuilder:printcolumn:name="Disrupting",type=string,JSONPath=`.status.conditions[?(@.type=="DisruptionTarget")].status`,priority=1
+// +kubebuilder:printcolumn:name="Score",type=number,JSONPath=`.status.placementScore`,priority=1
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // PodGang defines a specification of a group of pods that should be scheduled together.
 type PodGang struct {

--- a/scheduler/api/core/v1alpha1/podgang.go
+++ b/scheduler/api/core/v1alpha1/podgang.go
@@ -26,11 +26,6 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName={pg}
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
-// +kubebuilder:printcolumn:name="Initialized",type=string,JSONPath=`.status.conditions[?(@.type=="Initialized")].status`
-// +kubebuilder:printcolumn:name="Scheduled",type=string,JSONPath=`.status.conditions[?(@.type=="Scheduled")].status`
-// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
-// +kubebuilder:printcolumn:name="Unhealthy",type=string,JSONPath=`.status.conditions[?(@.type=="Unhealthy")].status`,priority=1
-// +kubebuilder:printcolumn:name="Disrupting",type=string,JSONPath=`.status.conditions[?(@.type=="DisruptionTarget")].status`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // PodGang defines a specification of a group of pods that should be scheduled together.


### PR DESCRIPTION
Fixes #673

## Summary
Add kubectl printer columns for PodClique, PodCliqueSet, PodCliqueScalingGroup, ClusterTopologyBinding, and PodGang so common rollout, scheduling, and availability state is visible from `kubectl get` without overloading the default table.

Default column previews, with wide-only columns shown in parentheses:

PodClique:

```text
NAMESPACE         NAME                  MINAVAIL   REPLICAS   READY   SCHEDULED   UPDATED   (GATED   MINBREACHED)   AGE
dynamo-workload   vllm-agg-0-frontend   1          1          1       1           1         (0       False)         33m
```

PodCliqueSet:

```text
NAMESPACE         NAME       REPLICAS   AVAILABLE   UPDATED   PCLQS-UPDATED   PCLQS-TOTAL   PCSGS-UPDATED   PCSGS-TOTAL   AGE
dynamo-workload   vllm-agg   1          1           1         2               2             1               1             33m
```

PodCliqueScalingGroup:

```text
NAMESPACE         NAME                          MINAVAIL   REPLICAS   AVAILABLE   SCHEDULED   UPDATED   PCLQS-UPDATED   PCLQS-TOTAL   (MINBREACHED)   AGE
dynamo-workload   vllm-agg-0-vllmdecodeworker   1          1          1           1           1         1               1             (False)        33m
```

ClusterTopologyBinding:

```text
NAME             DOMAINS                 AGE
grove-topology   region,zone,rack,host   10m
```

PodGang:

```text
NAMESPACE         NAME         PHASE     AGE
dynamo-workload   vllm-agg-0   Running   33m
```

## Testing
- make generate
- make lint
- go test ./... in operator/api
- go test ./... in scheduler/api
