### PR TITLE
podclique/status: converge updated replicas

### DIFF
--- a/operator/internal/controller/podclique/reconcilespec.go
+++ b/operator/internal/controller/podclique/reconcilespec.go
@@ -86,7 +86,7 @@ func (r *Reconciler) processUpdate(ctx context.Context, logger logr.Logger, pclq
 		return ctrlcommon.ContinueReconcile()
 	}
 
-	if pcsHasNoActiveRollingUpdate(pcs) {
+	if pcs.Status.CurrentGenerationHash == nil {
 		return ctrlcommon.ContinueReconcile()
 	}
 	shouldEvaluatePCLQForUpdates, err := shouldCheckPendingUpdatesForPCLQ(logger, pcs, pclq)
@@ -107,17 +107,23 @@ func (r *Reconciler) processUpdate(ctx context.Context, logger logr.Logger, pclq
 	return ctrlcommon.ContinueReconcile()
 }
 
-// pcsHasNoActiveRollingUpdate checks if the PodCliqueSet has no active rolling update in progress
-func pcsHasNoActiveRollingUpdate(pcs *grovecorev1alpha1.PodCliqueSet) bool {
-	return pcs.Status.CurrentGenerationHash == nil || pcs.Status.UpdateProgress == nil || len(pcs.Status.UpdateProgress.CurrentlyUpdating) == 0
-}
-
 // shouldCheckPendingUpdatesForPCLQ determines if this PodClique should be evaluated for updates based on its owner, and the currently updating PodCliqueSet replica index
 func shouldCheckPendingUpdatesForPCLQ(logger logr.Logger, pcs *grovecorev1alpha1.PodCliqueSet, pclq *grovecorev1alpha1.PodClique) (bool, error) {
 	// Only if PCLQ does not belong to any PCSG should an update be triggered for the PCLQ. For PCLQs that belong to
 	// a PCSG, the PCSG controller will handle the updates by deleting the PCLQ resources instead of updating PCLQ pods
 	// individually.
 	if !slices.Contains(componentutils.GetPodCliqueFQNsForPCSNotInPCSG(pcs), pclq.Name) {
+		return false, nil
+	}
+
+	// If the PCS is not actively rolling, evaluate standalone PCLQs against
+	// their own persisted generation state. This lets status recover when PCLQ
+	// UpdateProgress was missed or cleared.
+	if pcs.Status.UpdateProgress == nil || pcs.Status.UpdateProgress.UpdateEndedAt != nil {
+		return true, nil
+	}
+	if len(pcs.Status.UpdateProgress.CurrentlyUpdating) == 0 {
+		logger.Info("PodCliqueSet update is active but no replica is currently selected for update. Skipping processing update for this PodClique")
 		return false, nil
 	}
 

--- a/operator/internal/controller/podclique/reconcilespec_test.go
+++ b/operator/internal/controller/podclique/reconcilespec_test.go
@@ -34,72 +34,82 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// TestPcsHasNoActiveRollingUpdate tests the pcsHasNoActiveRollingUpdate function
-func TestPcsHasNoActiveRollingUpdate(t *testing.T) {
+// TestShouldCheckPendingUpdatesForPCLQ verifies that standalone PCLQs can
+// evaluate their own update state when the owning PCS has a current generation,
+// even before a PCS replica is actively selected for rolling update.
+func TestShouldCheckPendingUpdatesForPCLQ(t *testing.T) {
+	replicas := int32(1)
+	minAvailable := int32(1)
 	tests := []struct {
 		// Test case description
-		name string
-		// pcs is the PodCliqueSet to check
-		pcs *grovecorev1alpha1.PodCliqueSet
+		name                string
+		pcsUpdateProgress   *grovecorev1alpha1.PodCliqueSetUpdateProgress
+		pclqPCSReplicaIndex int32
+		pcsgOwned           bool
 		// expected is the expected result
 		expected bool
 	}{
 		{
-			// Tests when CurrentGenerationHash is nil
-			name: "current_generation_hash_nil",
-			pcs: &grovecorev1alpha1.PodCliqueSet{
-				Status: grovecorev1alpha1.PodCliqueSetStatus{
-					CurrentGenerationHash: nil,
-				},
-			},
-			expected: true,
+			name:                "standalone_without_pcs_update_progress",
+			pclqPCSReplicaIndex: 0,
+			expected:            true,
 		},
 		{
-			// Tests when UpdateProgress is nil
-			name: "update_progress_nil",
-			pcs: &grovecorev1alpha1.PodCliqueSet{
-				Status: grovecorev1alpha1.PodCliqueSetStatus{
-					CurrentGenerationHash: ptr.To("hash123"),
-					UpdateProgress:        nil,
-				},
+			name: "standalone_matching_active_pcs_replica",
+			pcsUpdateProgress: &grovecorev1alpha1.PodCliqueSetUpdateProgress{
+				CurrentlyUpdating: []grovecorev1alpha1.PodCliqueSetReplicaUpdateProgress{{ReplicaIndex: 0}},
 			},
-			expected: true,
+			pclqPCSReplicaIndex: 0,
+			expected:            true,
 		},
 		{
-			// Tests when CurrentlyUpdating is empty
-			name: "currently_updating_nil",
-			pcs: &grovecorev1alpha1.PodCliqueSet{
-				Status: grovecorev1alpha1.PodCliqueSetStatus{
-					CurrentGenerationHash: ptr.To("hash123"),
-					UpdateProgress: &grovecorev1alpha1.PodCliqueSetUpdateProgress{
-						CurrentlyUpdating: nil,
-					},
-				},
-			},
-			expected: true,
+			name:                "standalone_active_pcs_update_without_selected_replica",
+			pcsUpdateProgress:   &grovecorev1alpha1.PodCliqueSetUpdateProgress{},
+			pclqPCSReplicaIndex: 0,
+			expected:            false,
 		},
 		{
-			// Tests when all required fields are present (active rolling update)
-			name: "active_rolling_update",
-			pcs: &grovecorev1alpha1.PodCliqueSet{
-				Status: grovecorev1alpha1.PodCliqueSetStatus{
-					CurrentGenerationHash: ptr.To("hash123"),
-					UpdateProgress: &grovecorev1alpha1.PodCliqueSetUpdateProgress{
-						CurrentlyUpdating: []grovecorev1alpha1.PodCliqueSetReplicaUpdateProgress{
-							{
-								ReplicaIndex: 0,
-							},
-						},
-					},
-				},
+			name: "standalone_nonmatching_active_pcs_replica",
+			pcsUpdateProgress: &grovecorev1alpha1.PodCliqueSetUpdateProgress{
+				CurrentlyUpdating: []grovecorev1alpha1.PodCliqueSetReplicaUpdateProgress{{ReplicaIndex: 1}},
 			},
-			expected: false,
+			pclqPCSReplicaIndex: 0,
+			expected:            false,
+		},
+		{
+			name:                "pcsg_owned_pclq",
+			pclqPCSReplicaIndex: 0,
+			pcsgOwned:           true,
+			expected:            false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := pcsHasNoActiveRollingUpdate(tc.pcs)
+			pcsUID := uuid.NewUUID()
+			pcsBuilder := testutils.NewPodCliqueSetBuilder(testPCSName, testNamespace, pcsUID).
+				WithReplicas(2).
+				WithPodCliqueParameters("worker", 1, nil).
+				WithPodCliqueSetGenerationHash(ptr.To("current-hash"))
+			if tc.pcsUpdateProgress != nil {
+				pcsBuilder.WithUpdateProgress(tc.pcsUpdateProgress)
+			}
+			if tc.pcsgOwned {
+				pcsBuilder.WithPodCliqueScalingGroupConfig(grovecorev1alpha1.PodCliqueScalingGroupConfig{
+					Name:         "group",
+					CliqueNames:  []string{"worker"},
+					Replicas:     &replicas,
+					MinAvailable: &minAvailable,
+				})
+			}
+			pcs := pcsBuilder.Build()
+			pclq := testutils.NewPodCliqueBuilder(testPCSName, pcsUID, "worker", testNamespace, tc.pclqPCSReplicaIndex).Build()
+			if tc.pcsgOwned {
+				pclq = testutils.NewPCSGPodCliqueBuilder(testPCSName+"-0-worker-0", testNamespace, testPCSName, "group", 0, 0).Build()
+			}
+
+			result, err := shouldCheckPendingUpdatesForPCLQ(logr.Discard(), pcs, pclq)
+			require.NoError(t, err)
 			assert.Equal(t, tc.expected, result)
 		})
 	}
@@ -237,6 +247,39 @@ const (
 	testNamespace = "test-namespace"
 	testPCSName   = "test-pcs"
 )
+
+func TestProcessUpdateInitializesProgressWithoutActivePCSUpdate(t *testing.T) {
+	pcsUID := uuid.NewUUID()
+	pcs := testutils.NewPodCliqueSetBuilder(testPCSName, testNamespace, pcsUID).
+		WithReplicas(1).
+		WithPodCliqueParameters("worker", 1, nil).
+		WithUpdateStrategy(&grovecorev1alpha1.PodCliqueSetUpdateStrategy{
+			Type: grovecorev1alpha1.RollingRecreateStrategy,
+		}).
+		WithPodCliqueSetGenerationHash(ptr.To("new-generation-hash")).
+		Build()
+	pclq := testutils.NewPodCliqueBuilder(testPCSName, pcsUID, "worker", testNamespace, 0).Build()
+	pclq.Status = grovecorev1alpha1.PodCliqueStatus{
+		CurrentPodCliqueSetGenerationHash: ptr.To("old-generation-hash"),
+		CurrentPodTemplateHash:            ptr.To("old-template-hash"),
+		UpdatedReplicas:                   1,
+	}
+
+	fakeClient := testutils.SetupFakeClient(pcs, pclq)
+	reconciler := &Reconciler{client: fakeClient}
+
+	result := reconciler.processUpdate(context.Background(), logr.Discard(), pclq)
+
+	_, err := result.Result()
+	require.NoError(t, err)
+	updatedPCLQ := &grovecorev1alpha1.PodClique{}
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(pclq), updatedPCLQ))
+	require.NotNil(t, updatedPCLQ.Status.UpdateProgress)
+	assert.Nil(t, updatedPCLQ.Status.UpdateProgress.UpdateEndedAt)
+	assert.Equal(t, "new-generation-hash", updatedPCLQ.Status.UpdateProgress.PodCliqueSetGenerationHash)
+	assert.NotEmpty(t, updatedPCLQ.Status.UpdateProgress.PodTemplateHash)
+	assert.Equal(t, int32(0), updatedPCLQ.Status.UpdatedReplicas)
+}
 
 // TestInitOrResetUpdate tests the initOrResetUpdate function for both OnDelete and RollingRecreate strategies
 func TestInitOrResetUpdate(t *testing.T) {

--- a/operator/internal/controller/podclique/reconcilestatus.go
+++ b/operator/internal/controller/podclique/reconcilestatus.go
@@ -62,14 +62,14 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 
 	podCategories := k8sutils.CategorizePodsByConditionType(logger, existingPods)
 
+	// mutate PodClique Status Replicas, ReadyReplicas, ScheduleGatedReplicas and UpdatedReplicas.
+	mutateReplicas(pclq, podCategories, len(existingPods))
+	mutateUpdatedReplica(pclq, existingPods)
 	// mutate PodClique.Status.CurrentPodTemplateHash and PodClique.Status.CurrentPodCliqueSetGenerationHash
 	if err = mutateCurrentHashes(logger, pcs, pclq); err != nil {
 		logger.Error(err, "failed to compute PodClique current hashes")
 		return ctrlcommon.ReconcileWithErrors("failed to compute PodClique current hashes", err)
 	}
-	// mutate PodClique Status Replicas, ReadyReplicas, ScheduleGatedReplicas and UpdatedReplicas.
-	mutateReplicas(pclq, podCategories, len(existingPods))
-	mutateUpdatedReplica(pclq, existingPods)
 
 	// mutate the conditions only if the PodClique has been successfully reconciled at least once.
 	// This prevents prematurely setting incorrect conditions.
@@ -117,7 +117,7 @@ func mutateCurrentHashes(logger logr.Logger, pcs *grovecorev1alpha1.PodCliqueSet
 		if err != nil {
 			return err
 		}
-		if pclq.Status.CurrentPodTemplateHash == nil || *pclq.Status.CurrentPodTemplateHash == expectedPodTemplateHash {
+		if isPodCliqueTemplateHashCurrent(pclq, expectedPodTemplateHash) {
 			pclq.Status.CurrentPodTemplateHash = ptr.To(expectedPodTemplateHash)
 			pclq.Status.CurrentPodCliqueSetGenerationHash = pcs.Status.CurrentGenerationHash
 		}
@@ -127,6 +127,11 @@ func mutateCurrentHashes(logger logr.Logger, pcs *grovecorev1alpha1.PodCliqueSet
 		pclq.Status.CurrentPodCliqueSetGenerationHash = ptr.To(pclq.Status.UpdateProgress.PodCliqueSetGenerationHash)
 	}
 	return nil
+}
+
+func isPodCliqueTemplateHashCurrent(pclq *grovecorev1alpha1.PodClique, expectedPodTemplateHash string) bool {
+	labelPodTemplateHash, ok := pclq.Labels[apicommon.LabelPodTemplateHash]
+	return ok && labelPodTemplateHash == expectedPodTemplateHash
 }
 
 // mutateReplicas updates the PodClique status with current replica counts based on pod categorization
@@ -146,6 +151,11 @@ func mutateUpdatedReplica(pclq *grovecorev1alpha1.PodClique, existingPods []*cor
 	// This covers both the active update phase and the window after completion before CurrentPodTemplateHash is synced.
 	if pclq.Status.UpdateProgress != nil {
 		expectedPodTemplateHash = pclq.Status.UpdateProgress.PodTemplateHash
+	} else if labelPodTemplateHash := pclq.Labels[apicommon.LabelPodTemplateHash]; labelPodTemplateHash != "" {
+		// The PodClique label is the desired pod template hash propagated by the
+		// owner sync. Prefer it over stale current-status bookkeeping so status can
+		// recover after a replacement pod already converged to the desired hash.
+		expectedPodTemplateHash = labelPodTemplateHash
 	} else if pclq.Status.CurrentPodTemplateHash != nil {
 		// Steady state: no rolling update tracking exists.
 		// Use the stable current hash for pods that have been reconciled.

--- a/operator/internal/controller/podclique/reconcilestatus_test.go
+++ b/operator/internal/controller/podclique/reconcilestatus_test.go
@@ -17,6 +17,7 @@
 package podclique
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -24,10 +25,15 @@ import (
 	"github.com/ai-dynamo/grove/operator/api/common/constants"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	internalconstants "github.com/ai-dynamo/grove/operator/internal/constants"
+	componentutils "github.com/ai-dynamo/grove/operator/internal/controller/common/component/utils"
+	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 )
@@ -145,6 +151,25 @@ func TestMutateUpdatedReplica(t *testing.T) {
 			expectedUpdatedReplicas: 2, // Only pods with current hash
 		},
 		{
+			name: "desired metadata label overrides stale current status",
+			pclq: &grovecorev1alpha1.PodClique{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						apicommon.LabelPodTemplateHash: "desired-hash",
+					},
+				},
+				Status: grovecorev1alpha1.PodCliqueStatus{
+					UpdateProgress:         nil,
+					CurrentPodTemplateHash: ptr.To("stale-hash"),
+				},
+			},
+			existingPods: []*corev1.Pod{
+				createPodWithHash("pod-1", "desired-hash"),
+				createPodWithHash("pod-2", "stale-hash"),
+			},
+			expectedUpdatedReplicas: 1,
+		},
+		{
 			name: "no pods exist",
 			pclq: &grovecorev1alpha1.PodClique{
 				Status: grovecorev1alpha1.PodCliqueStatus{
@@ -185,6 +210,105 @@ func TestMutateUpdatedReplica(t *testing.T) {
 	}
 }
 
+// TestReconcileStatusConvergesWhenReadyPodMatchesDesiredHash covers the live
+// latch where PCLQ metadata and the Ready pod already carry the desired
+// pod-template hash, but Status.CurrentPodTemplateHash is stale and
+// UpdateProgress is absent. UpdatedReplicas must be derived from the desired
+// hash first so CurrentPodTemplateHash can advance in the same status pass.
+func TestReconcileStatusConvergesWhenReadyPodMatchesDesiredHash(t *testing.T) {
+	pcs, pclq, templateHash := newPodCliqueHashConvergenceFixture(t)
+	pclq.UID = types.UID("pclq-uid")
+	pclq.Generation = 2
+	pclq.Spec = grovecorev1alpha1.PodCliqueSpec{
+		Replicas:     1,
+		MinAvailable: ptr.To[int32](1),
+	}
+	pclq.Status = grovecorev1alpha1.PodCliqueStatus{
+		Replicas:                          1,
+		ReadyReplicas:                     1,
+		ScheduledReplicas:                 1,
+		UpdatedReplicas:                   0,
+		ObservedGeneration:                ptr.To[int64](2),
+		CurrentPodTemplateHash:            ptr.To("stale-template-hash"),
+		CurrentPodCliqueSetGenerationHash: ptr.To("old-generation-hash"),
+	}
+	pod := createReadyOwnedPodWithHash("ready-current-pod", pclq, templateHash)
+
+	cl := testutils.SetupFakeClient(pcs, pclq, pod)
+	r := &Reconciler{
+		client:        cl,
+		eventRecorder: record.NewFakeRecorder(1),
+	}
+
+	result := r.reconcileStatus(context.Background(), logr.Discard(), pclq)
+
+	_, err := result.Result()
+	require.NoError(t, err)
+	updatedPCLQ := &grovecorev1alpha1.PodClique{}
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: pclq.Name, Namespace: pclq.Namespace}, updatedPCLQ))
+	assert.Equal(t, int32(1), updatedPCLQ.Status.UpdatedReplicas)
+	assert.Equal(t, templateHash, *updatedPCLQ.Status.CurrentPodTemplateHash)
+	assert.Equal(t, *pcs.Status.CurrentGenerationHash, *updatedPCLQ.Status.CurrentPodCliqueSetGenerationHash)
+}
+
+// TestMutateCurrentHashesDoesNotAdvanceWhenTemplateHashIsStale verifies that
+// mutateCurrentHashes refuses to advance CurrentPodTemplateHash or
+// CurrentPodCliqueSetGenerationHash when the PodClique metadata label has not
+// actually converged on the current PodCliqueSet template, even though the
+// replica counts (Replicas == UpdatedReplicas) would superficially suggest it has.
+func TestMutateCurrentHashesDoesNotAdvanceWhenTemplateHashIsStale(t *testing.T) {
+	pcs, pclq, _ := newPodCliqueHashConvergenceFixture(t)
+	pclq.Labels[apicommon.LabelPodTemplateHash] = "stale-template-hash"
+	pclq.Status.CurrentPodTemplateHash = ptr.To("")
+	pclq.Status.CurrentPodCliqueSetGenerationHash = ptr.To("old-generation-hash")
+	pclq.Status.Replicas = 2
+	pclq.Status.UpdatedReplicas = 2
+
+	err := mutateCurrentHashes(logr.Discard(), pcs, pclq)
+
+	require.NoError(t, err)
+	assert.Equal(t, "", *pclq.Status.CurrentPodTemplateHash)
+	assert.Equal(t, "old-generation-hash", *pclq.Status.CurrentPodCliqueSetGenerationHash)
+}
+
+func newPodCliqueHashConvergenceFixture(t *testing.T) (*grovecorev1alpha1.PodCliqueSet, *grovecorev1alpha1.PodClique, string) {
+	t.Helper()
+	template := &grovecorev1alpha1.PodCliqueTemplateSpec{
+		Name: "worker",
+		Spec: grovecorev1alpha1.PodCliqueSpec{
+			PodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "main", Image: "main:v1"}},
+			},
+		},
+	}
+	generationHash := "current-generation-hash"
+	pcs := &grovecorev1alpha1.PodCliqueSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "pcs", Namespace: "default"},
+		Spec: grovecorev1alpha1.PodCliqueSetSpec{
+			Template: grovecorev1alpha1.PodCliqueSetTemplateSpec{
+				Cliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{template},
+			},
+		},
+		Status: grovecorev1alpha1.PodCliqueSetStatus{
+			CurrentGenerationHash: ptr.To(generationHash),
+		},
+	}
+	pclq := &grovecorev1alpha1.PodClique{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pcs-0-worker",
+			Namespace: "default",
+			Labels: map[string]string{
+				apicommon.LabelPartOfKey:                "pcs",
+				apicommon.LabelPodCliqueSetReplicaIndex: "0",
+			},
+		},
+	}
+	templateHash, err := componentutils.GetExpectedPCLQPodTemplateHash(pcs, pclq.ObjectMeta)
+	require.NoError(t, err)
+	pclq.Labels[apicommon.LabelPodTemplateHash] = templateHash
+	return pcs, pclq, templateHash
+}
+
 // createPodWithHash creates a test pod with the specified template hash label
 func createPodWithHash(name string, templateHash string) *corev1.Pod {
 	return &corev1.Pod{
@@ -197,9 +321,29 @@ func createPodWithHash(name string, templateHash string) *corev1.Pod {
 	}
 }
 
+func createReadyOwnedPodWithHash(name string, owner *grovecorev1alpha1.PodClique, templateHash string) *corev1.Pod {
+	pod := createPodWithHash(name, templateHash)
+	pod.Namespace = owner.Namespace
+	pod.Labels[apicommon.LabelPodClique] = owner.Name
+	pod.OwnerReferences = []metav1.OwnerReference{
+		*metav1.NewControllerRef(owner, grovecorev1alpha1.SchemeGroupVersion.WithKind("PodClique")),
+	}
+	pod.Status.Conditions = []corev1.PodCondition{
+		{
+			Type:   corev1.PodScheduled,
+			Status: corev1.ConditionTrue,
+		},
+		{
+			Type:   corev1.PodReady,
+			Status: corev1.ConditionTrue,
+		},
+	}
+	return pod
+}
+
 // TestEmitAllScheduledReplicasLostIfNeeded covers the only explicit signal users have when a
 // previously-running PodClique loses every scheduled pod. Gang termination is suppressed in
-// that state, so this event must fire on the non-zero → zero transition (and only on that
+// that state, so this event must fire on the non-zero to zero transition (and only on that
 // transition) for the regression to remain observable.
 func TestEmitAllScheduledReplicasLostIfNeeded(t *testing.T) {
 	tests := []struct {
@@ -294,7 +438,7 @@ func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testin
 			// previously healthy. Gang termination has no useful action here
 			// (would re-create the same Pending pods) and the suppression has
 			// to win to avoid a churn loop.
-			name: "previously-healthy PCLQ loses all scheduled pods — must NOT breach",
+			name: "previously-healthy PCLQ loses all scheduled pods - must NOT breach",
 			pclq: &grovecorev1alpha1.PodClique{
 				Spec: grovecorev1alpha1.PodCliqueSpec{
 					Replicas:     2,
@@ -321,7 +465,7 @@ func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testin
 		{
 			// Sanity case that the fix must preserve: a freshly-created PCLQ
 			// that has not yet scheduled any pods MUST NOT be considered breached.
-			name: "fresh PCLQ never scheduled — must not breach",
+			name: "fresh PCLQ never scheduled - must not breach",
 			pclq: &grovecorev1alpha1.PodClique{
 				Spec: grovecorev1alpha1.PodCliqueSpec{
 					Replicas:     3,

--- a/operator/test/utils/setup.go
+++ b/operator/test/utils/setup.go
@@ -20,6 +20,7 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,6 +43,13 @@ func SetupFakeClient(objects ...client.Object) client.WithWatch {
 		WithStatusSubresource(&grovecorev1alpha1.PodCliqueScalingGroup{}).
 		WithStatusSubresource(&grovecorev1alpha1.PodClique{}).
 		WithStatusSubresource(&v1.Pod{}).
+		WithIndex(&v1.Pod{}, ".metadata.controller.uid", func(obj client.Object) []string {
+			controllerRef := metav1.GetControllerOfNoCopy(obj)
+			if controllerRef == nil {
+				return nil
+			}
+			return []string{string(controllerRef.UID)}
+		}).
 		WithObjects(objects...).
 		Build()
 }


### PR DESCRIPTION
Fixes #672

## Summary
- Count PodClique updated replicas against the current desired pod-template hash when the PodClique metadata label has already converged
- Reorder PodClique status reconciliation so fresh replica/update counts are available before promoting current hash fields
- Add a regression for the live latch: Ready pod and PCLQ label on the desired hash, stale status.currentPodTemplateHash, no UpdateProgress

## Why
We saw a status deadlock in a live DynamoGraphDeployment consumer flow after a template change and manual pod replacement. The PodClique object and the new Ready pod both had the desired `grove.io/pod-template-hash`, but `status.currentPodTemplateHash` still held the old hash and `status.updateProgress` was absent.

The old status flow first tried to promote `currentPodTemplateHash`, but refused because `updatedReplicas != replicas`. It then computed `updatedReplicas` using the stale status hash instead of the desired hash from the converged PodClique label, so the Ready replacement pod was counted as outdated. That left `updatedReplicas=0`, which kept blocking hash promotion on every reconcile.

As a result, the PodCliqueSet reported `availableReplicas=1` but `updatedReplicas=0`, and the owning DynamoGraphDeployment stayed `Ready=False` with the user-visible reason that its frontend PodClique had `desired=1, updated=0`, even though the live pod was Ready and on the desired template.

## Tests
- go test ./internal/controller/podclique -run TestReconcileStatusConvergesWhenReadyPodMatchesDesiredHash -count=1
- go test ./internal/controller/podclique -run TestMutateUpdatedReplica -count=1
- go test ./internal/controller/podclique -run TestMutateCurrentHashes -count=1
- go test ./internal/controller/podclique -count=1
- go test ./internal/controller/podcliqueset -count=1
- go test ./internal/controller/podcliquescalinggroup -count=1
- git diff --check