### PR TITLE
Move scheduler-specific schemes into backends

### DIFF
--- a/operator/internal/client/scheme.go
+++ b/operator/internal/client/scheme.go
@@ -30,6 +30,9 @@ import (
 // Scheme is the kubernetes runtime scheme
 var Scheme = runtime.NewScheme()
 
+// init adds Grove and Kubernetes API groups to Scheme via their AddToScheme functions.
+// Scheduler-specific API groups (KAI, Volcano, etc.) are added by each backend's
+// Init into the scheme passed to it and should not be added here.
 func init() {
 	localSchemeBuilder := runtime.NewSchemeBuilder(
 		configv1alpha1.AddToScheme,

--- a/operator/internal/client/scheme.go
+++ b/operator/internal/client/scheme.go
@@ -21,13 +21,10 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 
 	schedv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
-	kaitopologyv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
-	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 )
 
 // Scheme is the kubernetes runtime scheme
@@ -38,9 +35,6 @@ func init() {
 		configv1alpha1.AddToScheme,
 		grovecorev1alpha1.AddToScheme,
 		schedv1alpha1.AddToScheme,
-		kaitopologyv1alpha1.AddToScheme,
-		volcanov1beta1.AddToScheme,
-		apiextensionsv1.AddToScheme,
 		k8sscheme.AddToScheme,
 	)
 	utilruntime.Must(metav1.AddMetaToScheme(Scheme))

--- a/operator/internal/client/scheme_test.go
+++ b/operator/internal/client/scheme_test.go
@@ -19,24 +19,20 @@ package client
 import (
 	"testing"
 
-	kaitopologyv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	schedv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 )
 
-func TestSchemeExcludesSchedulerSpecificAPIs(t *testing.T) {
+func TestSchemeIncludesSharedAPIs(t *testing.T) {
 	_, err := apiutil.GVKForObject(&corev1.Pod{}, Scheme)
 	require.NoError(t, err)
 
-	_, err = apiutil.GVKForObject(&kaitopologyv1alpha1.Topology{}, Scheme)
-	require.Error(t, err)
+	_, err = apiutil.GVKForObject(&grovecorev1alpha1.PodCliqueSet{}, Scheme)
+	require.NoError(t, err)
 
-	_, err = apiutil.GVKForObject(&volcanov1beta1.PodGroup{}, Scheme)
-	require.Error(t, err)
-
-	_, err = apiutil.GVKForObject(&apiextensionsv1.CustomResourceDefinition{}, Scheme)
-	require.Error(t, err)
+	_, err = apiutil.GVKForObject(&schedv1alpha1.PodGang{}, Scheme)
+	require.NoError(t, err)
 }

--- a/operator/internal/client/scheme_test.go
+++ b/operator/internal/client/scheme_test.go
@@ -22,12 +22,9 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 
 	schedv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
-	kaitopologyv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 )
 
 func TestSchemeIncludesSharedAPIs(t *testing.T) {
@@ -39,19 +36,4 @@ func TestSchemeIncludesSharedAPIs(t *testing.T) {
 
 	_, err = apiutil.GVKForObject(&schedv1alpha1.PodGang{}, Scheme)
 	require.NoError(t, err)
-}
-
-func TestSchemeDoesNotIncludeSchedulerSpecificAPIs(t *testing.T) {
-	for _, obj := range []struct {
-		name   string
-		object runtime.Object
-	}{
-		{name: "KAI Topology", object: &kaitopologyv1alpha1.Topology{}},
-		{name: "Volcano PodGroup", object: &volcanov1beta1.PodGroup{}},
-	} {
-		t.Run(obj.name, func(t *testing.T) {
-			_, err := apiutil.GVKForObject(obj.object, Scheme)
-			require.Error(t, err)
-		})
-	}
 }

--- a/operator/internal/client/scheme_test.go
+++ b/operator/internal/client/scheme_test.go
@@ -1,0 +1,42 @@
+// /*
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package client
+
+import (
+	"testing"
+
+	kaitopologyv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+)
+
+func TestSchemeExcludesSchedulerSpecificAPIs(t *testing.T) {
+	_, err := apiutil.GVKForObject(&corev1.Pod{}, Scheme)
+	require.NoError(t, err)
+
+	_, err = apiutil.GVKForObject(&kaitopologyv1alpha1.Topology{}, Scheme)
+	require.Error(t, err)
+
+	_, err = apiutil.GVKForObject(&volcanov1beta1.PodGroup{}, Scheme)
+	require.Error(t, err)
+
+	_, err = apiutil.GVKForObject(&apiextensionsv1.CustomResourceDefinition{}, Scheme)
+	require.Error(t, err)
+}

--- a/operator/internal/client/scheme_test.go
+++ b/operator/internal/client/scheme_test.go
@@ -22,9 +22,12 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 
 	schedv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
+	kaitopologyv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 )
 
 func TestSchemeIncludesSharedAPIs(t *testing.T) {
@@ -36,4 +39,19 @@ func TestSchemeIncludesSharedAPIs(t *testing.T) {
 
 	_, err = apiutil.GVKForObject(&schedv1alpha1.PodGang{}, Scheme)
 	require.NoError(t, err)
+}
+
+func TestSchemeDoesNotIncludeSchedulerSpecificAPIs(t *testing.T) {
+	for _, obj := range []struct {
+		name   string
+		object runtime.Object
+	}{
+		{name: "KAI Topology", object: &kaitopologyv1alpha1.Topology{}},
+		{name: "Volcano PodGroup", object: &volcanov1beta1.PodGroup{}},
+	} {
+		t.Run(obj.name, func(t *testing.T) {
+			_, err := apiutil.GVKForObject(obj.object, Scheme)
+			require.Error(t, err)
+		})
+	}
 }

--- a/operator/internal/client/scheme_test.go
+++ b/operator/internal/client/scheme_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+
 	schedv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"

--- a/operator/internal/clustertopology/clustertopology_test.go
+++ b/operator/internal/clustertopology/clustertopology_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,9 +41,27 @@ import (
 
 const topologyName = "test-topology"
 
-func newKaiBackends(cl client.Client) map[string]scheduler.TopologyAwareBackend {
+func newKAIScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
+	require.NoError(t, kaitopologyv1alpha1.AddToScheme(scheme))
+	return scheme
+}
+
+func newKAIClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+	return testutils.NewTestClientBuilder().
+		WithScheme(newKAIScheme(t)).
+		WithObjects(objects...).
+		Build()
+}
+
+func newKaiBackends(t *testing.T, cl client.Client) map[string]scheduler.TopologyAwareBackend {
+	t.Helper()
 	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}
 	b := kai.New(cl, cl.Scheme(), nil, profile)
+	require.NoError(t, b.Init(cl))
 	return map[string]scheduler.TopologyAwareBackend{b.Name(): b.(scheduler.TopologyAwareBackend)}
 }
 
@@ -54,10 +73,10 @@ func TestSynchronizeTopologyListsAndSyncs(t *testing.T) {
 	}
 	ct := createTestClusterTopology(topologyName, topologyLevels)
 
-	cl := testutils.CreateDefaultFakeClient([]client.Object{ct})
+	cl := newKAIClient(t, ct)
 	logger := logr.Discard()
 
-	err := SynchronizeTopology(ctx, cl, logger, newKaiBackends(cl))
+	err := SynchronizeTopology(ctx, cl, logger, newKaiBackends(t, cl))
 	require.NoError(t, err)
 
 	// Verify KAI Topology was created
@@ -79,10 +98,10 @@ func TestSynchronizeTopologyMultipleCTs(t *testing.T) {
 		{Domain: grovecorev1alpha1.TopologyDomainHost, Key: "kubernetes.io/hostname"},
 	})
 
-	cl := testutils.CreateDefaultFakeClient([]client.Object{ct1, ct2})
+	cl := newKAIClient(t, ct1, ct2)
 	logger := logr.Discard()
 
-	err := SynchronizeTopology(ctx, cl, logger, newKaiBackends(cl))
+	err := SynchronizeTopology(ctx, cl, logger, newKaiBackends(t, cl))
 	require.NoError(t, err)
 
 	// Verify both KAI Topologies were created
@@ -99,10 +118,10 @@ func TestSynchronizeTopologyMultipleCTs(t *testing.T) {
 
 func TestSynchronizeTopologyNoCTs(t *testing.T) {
 	ctx := context.Background()
-	cl := testutils.CreateDefaultFakeClient(nil)
+	cl := newKAIClient(t)
 	logger := logr.Discard()
 
-	err := SynchronizeTopology(ctx, cl, logger, newKaiBackends(cl))
+	err := SynchronizeTopology(ctx, cl, logger, newKaiBackends(t, cl))
 	require.NoError(t, err)
 }
 
@@ -111,7 +130,7 @@ func TestSynchronizeTopologyNoTASBackends(t *testing.T) {
 	ct := createTestClusterTopology(topologyName, []grovecorev1alpha1.TopologyLevel{
 		{Domain: grovecorev1alpha1.TopologyDomainHost, Key: "kubernetes.io/hostname"},
 	})
-	cl := testutils.CreateDefaultFakeClient([]client.Object{ct})
+	cl := newKAIClient(t, ct)
 	logger := logr.Discard()
 
 	// Pass nil backends
@@ -130,13 +149,13 @@ func TestSynchronizeTopologySkipsExternallyManaged(t *testing.T) {
 		{SchedulerName: "kai-scheduler", TopologyReference: "external-kai-topology"},
 	}
 
-	cl := testutils.CreateDefaultFakeClient([]client.Object{ct})
+	cl := newKAIClient(t, ct)
 	logger := logr.Discard()
 
 	// KAI backend is listed in schedulerTopologyReferences — SyncTopology should NOT be called.
 	// If it were called, it would try to create a KAI Topology and succeed, so we verify
 	// that no KAI Topology was created.
-	err := SynchronizeTopology(ctx, cl, logger, newKaiBackends(cl))
+	err := SynchronizeTopology(ctx, cl, logger, newKaiBackends(t, cl))
 	require.NoError(t, err)
 
 	kaiTopology := &kaitopologyv1alpha1.Topology{}
@@ -149,11 +168,12 @@ func TestSynchronizeTopologyListError(t *testing.T) {
 	listErr := apierrors.NewInternalError(assert.AnError)
 	ctListGVK := grovecorev1alpha1.SchemeGroupVersion.WithKind("ClusterTopologyBindingList")
 	cl := testutils.NewTestClientBuilder().
+		WithScheme(newKAIScheme(t)).
 		RecordErrorForObjectsMatchingLabels(testutils.ClientMethodList, client.ObjectKey{}, ctListGVK, nil, listErr).
 		Build()
 	logger := logr.Discard()
 
-	err := SynchronizeTopology(ctx, cl, logger, newKaiBackends(cl))
+	err := SynchronizeTopology(ctx, cl, logger, newKaiBackends(t, cl))
 	assert.Error(t, err)
 }
 

--- a/operator/internal/clustertopology/clustertopology_test.go
+++ b/operator/internal/clustertopology/clustertopology_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ai-dynamo/grove/operator/internal/scheduler"
 	"github.com/ai-dynamo/grove/operator/internal/scheduler/kai"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
-	"github.com/ai-dynamo/grove/operator/test/utils/schedulertest"
+	schedulertest "github.com/ai-dynamo/grove/operator/test/utils/scheduler"
 
 	"github.com/go-logr/logr"
 	kaitopologyv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
@@ -41,14 +41,6 @@ import (
 
 const topologyName = "test-topology"
 
-func newKAIBackends(t *testing.T, cl client.Client) map[string]scheduler.TopologyAwareBackend {
-	t.Helper()
-	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}
-	b := kai.New(cl, cl.Scheme(), nil, profile)
-	require.NoError(t, b.Init(cl))
-	return map[string]scheduler.TopologyAwareBackend{b.Name(): b.(scheduler.TopologyAwareBackend)}
-}
-
 func TestSynchronizeTopologyListsAndSyncs(t *testing.T) {
 	ctx := context.Background()
 	topologyLevels := []grovecorev1alpha1.TopologyLevel{
@@ -60,7 +52,7 @@ func TestSynchronizeTopologyListsAndSyncs(t *testing.T) {
 	cl := schedulertest.NewKAIClient(t, ct)
 	logger := logr.Discard()
 
-	err := SynchronizeTopology(ctx, cl, logger, newKAIBackends(t, cl))
+	err := SynchronizeTopology(ctx, cl, logger, newKAIBackendMap(t, cl))
 	require.NoError(t, err)
 
 	// Verify KAI Topology was created
@@ -85,7 +77,7 @@ func TestSynchronizeTopologyMultipleCTs(t *testing.T) {
 	cl := schedulertest.NewKAIClient(t, ct1, ct2)
 	logger := logr.Discard()
 
-	err := SynchronizeTopology(ctx, cl, logger, newKAIBackends(t, cl))
+	err := SynchronizeTopology(ctx, cl, logger, newKAIBackendMap(t, cl))
 	require.NoError(t, err)
 
 	// Verify both KAI Topologies were created
@@ -105,7 +97,7 @@ func TestSynchronizeTopologyNoCTs(t *testing.T) {
 	cl := schedulertest.NewKAIClient(t)
 	logger := logr.Discard()
 
-	err := SynchronizeTopology(ctx, cl, logger, newKAIBackends(t, cl))
+	err := SynchronizeTopology(ctx, cl, logger, newKAIBackendMap(t, cl))
 	require.NoError(t, err)
 }
 
@@ -139,7 +131,7 @@ func TestSynchronizeTopologySkipsExternallyManaged(t *testing.T) {
 	// KAI backend is listed in schedulerTopologyReferences — SyncTopology should NOT be called.
 	// If it were called, it would try to create a KAI Topology and succeed, so we verify
 	// that no KAI Topology was created.
-	err := SynchronizeTopology(ctx, cl, logger, newKAIBackends(t, cl))
+	err := SynchronizeTopology(ctx, cl, logger, newKAIBackendMap(t, cl))
 	require.NoError(t, err)
 
 	kaiTopology := &kaitopologyv1alpha1.Topology{}
@@ -157,7 +149,7 @@ func TestSynchronizeTopologyListError(t *testing.T) {
 		Build()
 	logger := logr.Discard()
 
-	err := SynchronizeTopology(ctx, cl, logger, newKAIBackends(t, cl))
+	err := SynchronizeTopology(ctx, cl, logger, newKAIBackendMap(t, cl))
 	assert.Error(t, err)
 }
 
@@ -292,8 +284,26 @@ func TestGetClusterTopologyLevels(t *testing.T) {
 	}
 }
 
-// Helper functions for creating test resources
-// --------------------------------------------------
+func TestBuildSchedulerReferenceMap(t *testing.T) {
+	refs := []grovecorev1alpha1.SchedulerTopologyBinding{
+		{SchedulerName: "kai-scheduler", TopologyReference: "kai-topo"},
+		{SchedulerName: "other-scheduler", TopologyReference: "other-topo"},
+	}
+	m := BuildSchedulerReferenceMap(refs)
+	assert.NotNil(t, m["kai-scheduler"])
+	assert.Equal(t, "kai-topo", m["kai-scheduler"].TopologyReference)
+	assert.Nil(t, m["nonexistent"])
+	assert.Empty(t, BuildSchedulerReferenceMap(nil))
+}
+
+func newKAIBackendMap(t *testing.T, cl client.Client) map[string]scheduler.TopologyAwareBackend {
+	t.Helper()
+	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}
+	b := kai.New(cl, cl.Scheme(), nil, profile)
+	require.NoError(t, b.Init(cl))
+	return map[string]scheduler.TopologyAwareBackend{b.Name(): b.(scheduler.TopologyAwareBackend)}
+}
+
 // createTestClusterTopology creates a ClusterTopologyBinding with the given name and topology levels.
 func createTestClusterTopology(name string, levels []grovecorev1alpha1.TopologyLevel) *grovecorev1alpha1.ClusterTopologyBinding {
 	return &grovecorev1alpha1.ClusterTopologyBinding{
@@ -305,16 +315,4 @@ func createTestClusterTopology(name string, levels []grovecorev1alpha1.TopologyL
 			Levels: levels,
 		},
 	}
-}
-
-func TestBuildSchedulerReferenceMap(t *testing.T) {
-	refs := []grovecorev1alpha1.SchedulerTopologyBinding{
-		{SchedulerName: "kai-scheduler", TopologyReference: "kai-topo"},
-		{SchedulerName: "other-scheduler", TopologyReference: "other-topo"},
-	}
-	m := BuildSchedulerReferenceMap(refs)
-	assert.NotNil(t, m["kai-scheduler"])
-	assert.Equal(t, "kai-topo", m["kai-scheduler"].TopologyReference)
-	assert.Nil(t, m["nonexistent"])
-	assert.Empty(t, BuildSchedulerReferenceMap(nil))
 }

--- a/operator/internal/clustertopology/clustertopology_test.go
+++ b/operator/internal/clustertopology/clustertopology_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ai-dynamo/grove/operator/internal/scheduler"
 	"github.com/ai-dynamo/grove/operator/internal/scheduler/kai"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
+	"github.com/ai-dynamo/grove/operator/test/utils/schedulertest"
 
 	"github.com/go-logr/logr"
 	kaitopologyv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
@@ -33,7 +34,6 @@ import (
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,23 +41,7 @@ import (
 
 const topologyName = "test-topology"
 
-func newKAIScheme(t *testing.T) *runtime.Scheme {
-	t.Helper()
-	scheme := runtime.NewScheme()
-	require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
-	require.NoError(t, kaitopologyv1alpha1.AddToScheme(scheme))
-	return scheme
-}
-
-func newKAIClient(t *testing.T, objects ...client.Object) client.Client {
-	t.Helper()
-	return testutils.NewTestClientBuilder().
-		WithScheme(newKAIScheme(t)).
-		WithObjects(objects...).
-		Build()
-}
-
-func newKaiBackends(t *testing.T, cl client.Client) map[string]scheduler.TopologyAwareBackend {
+func newKAIBackends(t *testing.T, cl client.Client) map[string]scheduler.TopologyAwareBackend {
 	t.Helper()
 	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}
 	b := kai.New(cl, cl.Scheme(), nil, profile)
@@ -73,10 +57,10 @@ func TestSynchronizeTopologyListsAndSyncs(t *testing.T) {
 	}
 	ct := createTestClusterTopology(topologyName, topologyLevels)
 
-	cl := newKAIClient(t, ct)
+	cl := schedulertest.NewKAIClient(t, ct)
 	logger := logr.Discard()
 
-	err := SynchronizeTopology(ctx, cl, logger, newKaiBackends(t, cl))
+	err := SynchronizeTopology(ctx, cl, logger, newKAIBackends(t, cl))
 	require.NoError(t, err)
 
 	// Verify KAI Topology was created
@@ -98,10 +82,10 @@ func TestSynchronizeTopologyMultipleCTs(t *testing.T) {
 		{Domain: grovecorev1alpha1.TopologyDomainHost, Key: "kubernetes.io/hostname"},
 	})
 
-	cl := newKAIClient(t, ct1, ct2)
+	cl := schedulertest.NewKAIClient(t, ct1, ct2)
 	logger := logr.Discard()
 
-	err := SynchronizeTopology(ctx, cl, logger, newKaiBackends(t, cl))
+	err := SynchronizeTopology(ctx, cl, logger, newKAIBackends(t, cl))
 	require.NoError(t, err)
 
 	// Verify both KAI Topologies were created
@@ -118,10 +102,10 @@ func TestSynchronizeTopologyMultipleCTs(t *testing.T) {
 
 func TestSynchronizeTopologyNoCTs(t *testing.T) {
 	ctx := context.Background()
-	cl := newKAIClient(t)
+	cl := schedulertest.NewKAIClient(t)
 	logger := logr.Discard()
 
-	err := SynchronizeTopology(ctx, cl, logger, newKaiBackends(t, cl))
+	err := SynchronizeTopology(ctx, cl, logger, newKAIBackends(t, cl))
 	require.NoError(t, err)
 }
 
@@ -130,7 +114,7 @@ func TestSynchronizeTopologyNoTASBackends(t *testing.T) {
 	ct := createTestClusterTopology(topologyName, []grovecorev1alpha1.TopologyLevel{
 		{Domain: grovecorev1alpha1.TopologyDomainHost, Key: "kubernetes.io/hostname"},
 	})
-	cl := newKAIClient(t, ct)
+	cl := schedulertest.NewKAIClient(t, ct)
 	logger := logr.Discard()
 
 	// Pass nil backends
@@ -149,13 +133,13 @@ func TestSynchronizeTopologySkipsExternallyManaged(t *testing.T) {
 		{SchedulerName: "kai-scheduler", TopologyReference: "external-kai-topology"},
 	}
 
-	cl := newKAIClient(t, ct)
+	cl := schedulertest.NewKAIClient(t, ct)
 	logger := logr.Discard()
 
 	// KAI backend is listed in schedulerTopologyReferences — SyncTopology should NOT be called.
 	// If it were called, it would try to create a KAI Topology and succeed, so we verify
 	// that no KAI Topology was created.
-	err := SynchronizeTopology(ctx, cl, logger, newKaiBackends(t, cl))
+	err := SynchronizeTopology(ctx, cl, logger, newKAIBackends(t, cl))
 	require.NoError(t, err)
 
 	kaiTopology := &kaitopologyv1alpha1.Topology{}
@@ -168,12 +152,12 @@ func TestSynchronizeTopologyListError(t *testing.T) {
 	listErr := apierrors.NewInternalError(assert.AnError)
 	ctListGVK := grovecorev1alpha1.SchemeGroupVersion.WithKind("ClusterTopologyBindingList")
 	cl := testutils.NewTestClientBuilder().
-		WithScheme(newKAIScheme(t)).
+		WithScheme(schedulertest.NewKAIScheme(t)).
 		RecordErrorForObjectsMatchingLabels(testutils.ClientMethodList, client.ObjectKey{}, ctListGVK, nil, listErr).
 		Build()
 	logger := logr.Discard()
 
-	err := SynchronizeTopology(ctx, cl, logger, newKaiBackends(t, cl))
+	err := SynchronizeTopology(ctx, cl, logger, newKAIBackends(t, cl))
 	assert.Error(t, err)
 }
 

--- a/operator/internal/scheduler/kai/backend.go
+++ b/operator/internal/scheduler/kai/backend.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ai-dynamo/grove/operator/internal/scheduler"
 
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
+	kaitopologyv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -61,7 +62,7 @@ func (b *schedulerBackend) Name() string {
 
 // Init initializes the KAI backend
 func (b *schedulerBackend) Init(_ client.Client) error {
-	return nil
+	return kaitopologyv1alpha1.AddToScheme(b.scheme)
 }
 
 // SyncPodGang converts PodGang to KAI PodGroup and synchronizes it

--- a/operator/internal/scheduler/kai/backend.go
+++ b/operator/internal/scheduler/kai/backend.go
@@ -60,7 +60,8 @@ func (b *schedulerBackend) Name() string {
 	return b.name
 }
 
-// Init initializes the KAI backend
+// Init registers the KAI API types into b.scheme and must be called before
+// that scheme is used to serialize or deserialize KAI objects.
 func (b *schedulerBackend) Init(_ client.Client) error {
 	return kaitopologyv1alpha1.AddToScheme(b.scheme)
 }

--- a/operator/internal/scheduler/kai/topology_test.go
+++ b/operator/internal/scheduler/kai/topology_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/tools/record"
@@ -43,10 +44,28 @@ const topologyName = "test-topology"
 
 // -- Shared helpers --
 
-func newTASBackend(cl client.Client) scheduler.TopologyAwareBackend {
+func newKAIScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
+	require.NoError(t, kaitopologyv1alpha1.AddToScheme(scheme))
+	return scheme
+}
+
+func newKAIClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+	return testutils.NewTestClientBuilder().
+		WithScheme(newKAIScheme(t)).
+		WithObjects(objects...).
+		Build()
+}
+
+func newTASBackend(t *testing.T, cl client.Client) scheduler.TopologyAwareBackend {
+	t.Helper()
 	recorder := record.NewFakeRecorder(10)
 	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}
 	b := New(cl, cl.Scheme(), recorder, profile)
+	require.NoError(t, b.Init(cl))
 	return b.(scheduler.TopologyAwareBackend)
 }
 
@@ -106,8 +125,8 @@ func convertToKAITopologyLevels(levels []grovecorev1alpha1.TopologyLevel) []kait
 // -- GVR and no-op tests --
 
 func TestTopologyGVR(t *testing.T) {
-	cl := testutils.CreateDefaultFakeClient(nil)
-	b := newTASBackend(cl)
+	cl := newKAIClient(t)
+	b := newTASBackend(t, cl)
 
 	gvr := b.TopologyGVR()
 	assert.Equal(t, schema.GroupVersionResource{
@@ -118,8 +137,8 @@ func TestTopologyGVR(t *testing.T) {
 }
 
 func TestOnTopologyDeleteIsNoOp(t *testing.T) {
-	cl := testutils.CreateDefaultFakeClient(nil)
-	b := newTASBackend(cl)
+	cl := newKAIClient(t)
+	b := newTASBackend(t, cl)
 
 	ct := createTestClusterTopology(topologyName, defaultTopologyLevels())
 	err := b.OnTopologyDelete(context.Background(), cl, ct)
@@ -130,8 +149,8 @@ func TestOnTopologyDeleteIsNoOp(t *testing.T) {
 
 func TestSyncTopologyWhenNoneExists(t *testing.T) {
 	ctx := context.Background()
-	cl := testutils.CreateDefaultFakeClient(nil)
-	b := newTASBackend(cl)
+	cl := newKAIClient(t)
+	b := newTASBackend(t, cl)
 
 	topologyLevels := []grovecorev1alpha1.TopologyLevel{
 		{Domain: grovecorev1alpha1.TopologyDomainZone, Key: "topology.kubernetes.io/zone"},
@@ -164,8 +183,8 @@ func TestSyncTopologyWhenLevelsUpdated(t *testing.T) {
 		{NodeLabel: "kubernetes.io/hostname"},
 	}, ct)
 
-	cl := testutils.CreateDefaultFakeClient([]client.Object{ct, existingKAITopology})
-	b := newTASBackend(cl)
+	cl := newKAIClient(t, ct, existingKAITopology)
+	b := newTASBackend(t, cl)
 
 	err := b.SyncTopology(ctx, cl, ct)
 	require.NoError(t, err)
@@ -187,8 +206,8 @@ func TestSyncTopologyWhenNoChangeRequired(t *testing.T) {
 	existingKAITopology := createTestKAITopology(convertToKAITopologyLevels(topologyLevels), ct)
 	existingKAITopology.ResourceVersion = "1"
 
-	cl := testutils.CreateDefaultFakeClient([]client.Object{ct, existingKAITopology})
-	b := newTASBackend(cl)
+	cl := newKAIClient(t, ct, existingKAITopology)
+	b := newTASBackend(t, cl)
 
 	err := b.SyncTopology(ctx, cl, ct)
 	require.NoError(t, err)
@@ -210,8 +229,8 @@ func TestSyncTopologyWithUnknownOwner(t *testing.T) {
 		{NodeLabel: "topology.kubernetes.io/zone"},
 	}, differentOwner)
 
-	cl := testutils.CreateDefaultFakeClient([]client.Object{ct, existingKAITopology})
-	b := newTASBackend(cl)
+	cl := newKAIClient(t, ct, existingKAITopology)
+	b := newTASBackend(t, cl)
 
 	err := b.SyncTopology(ctx, cl, ct)
 	assert.Error(t, err)
@@ -272,10 +291,11 @@ func TestSyncTopologyErrors(t *testing.T) {
 			objects := tc.existingObjects(ct)
 
 			cl := testutils.NewTestClientBuilder().
+				WithScheme(newKAIScheme(t)).
 				WithObjects(objects...).
 				RecordErrorForObjects(tc.method, injectedErr, client.ObjectKey{Name: topologyName}).
 				Build()
-			b := newTASBackend(cl)
+			b := newTASBackend(t, cl)
 
 			err := b.SyncTopology(context.Background(), cl, ct)
 			assert.Error(t, err)
@@ -293,8 +313,8 @@ func TestCheckTopologyDrift_InSync(t *testing.T) {
 
 	existingKAITopology := createTestKAITopology(convertToKAITopologyLevels(topologyLevels), ct)
 
-	cl := testutils.CreateDefaultFakeClient([]client.Object{ct, existingKAITopology})
-	b := newTASBackend(cl)
+	cl := newKAIClient(t, ct, existingKAITopology)
+	b := newTASBackend(t, cl)
 
 	ref := grovecorev1alpha1.SchedulerTopologyBinding{
 		SchedulerName:     "kai-scheduler",
@@ -317,8 +337,8 @@ func TestCheckTopologyDrift_Drift(t *testing.T) {
 		{NodeLabel: "kubernetes.io/hostname"},
 	}, ct)
 
-	cl := testutils.CreateDefaultFakeClient([]client.Object{ct, existingKAITopology})
-	b := newTASBackend(cl)
+	cl := newKAIClient(t, ct, existingKAITopology)
+	b := newTASBackend(t, cl)
 
 	ref := grovecorev1alpha1.SchedulerTopologyBinding{
 		SchedulerName:     "kai-scheduler",
@@ -336,8 +356,8 @@ func TestCheckTopologyDrift_NotFound(t *testing.T) {
 	topologyLevels := defaultTopologyLevels()
 	ct := createTestClusterTopology(topologyName, topologyLevels)
 
-	cl := testutils.CreateDefaultFakeClient([]client.Object{ct})
-	b := newTASBackend(cl)
+	cl := newKAIClient(t, ct)
+	b := newTASBackend(t, cl)
 
 	ref := grovecorev1alpha1.SchedulerTopologyBinding{
 		SchedulerName:     "kai-scheduler",
@@ -373,10 +393,11 @@ func TestCheckTopologyDriftErrors(t *testing.T) {
 			objects := tc.existingObjects(ct)
 
 			cl := testutils.NewTestClientBuilder().
+				WithScheme(newKAIScheme(t)).
 				WithObjects(objects...).
 				RecordErrorForObjects(tc.method, injectedErr, client.ObjectKey{Name: topologyName}).
 				Build()
-			b := newTASBackend(cl)
+			b := newTASBackend(t, cl)
 
 			ref := grovecorev1alpha1.SchedulerTopologyBinding{
 				SchedulerName:     "kai-scheduler",
@@ -392,7 +413,7 @@ func TestCheckTopologyDriftErrors(t *testing.T) {
 // -- buildKAITopology and isKAITopologyChanged tests --
 
 func TestBuildKAITopology(t *testing.T) {
-	cl := testutils.CreateDefaultFakeClient(nil)
+	cl := newKAIClient(t)
 	topologyLevels := defaultTopologyLevels()
 	ct := &grovecorev1alpha1.ClusterTopologyBinding{
 		ObjectMeta: metav1.ObjectMeta{

--- a/operator/internal/scheduler/kai/topology_test.go
+++ b/operator/internal/scheduler/kai/topology_test.go
@@ -26,7 +26,7 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/ai-dynamo/grove/operator/internal/scheduler"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
-	"github.com/ai-dynamo/grove/operator/test/utils/schedulertest"
+	schedulertest "github.com/ai-dynamo/grove/operator/test/utils/scheduler"
 
 	kaitopologyv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
 	"github.com/stretchr/testify/assert"
@@ -41,72 +41,6 @@ import (
 )
 
 const topologyName = "test-topology"
-
-// -- Shared helpers --
-
-func newTASBackend(t *testing.T, cl client.Client) scheduler.TopologyAwareBackend {
-	t.Helper()
-	recorder := record.NewFakeRecorder(10)
-	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}
-	b := New(cl, cl.Scheme(), recorder, profile)
-	require.NoError(t, b.Init(cl))
-	return b.(scheduler.TopologyAwareBackend)
-}
-
-func defaultTopologyLevels() []grovecorev1alpha1.TopologyLevel {
-	return []grovecorev1alpha1.TopologyLevel{
-		{Domain: grovecorev1alpha1.TopologyDomainZone, Key: "topology.kubernetes.io/zone"},
-		{Domain: grovecorev1alpha1.TopologyDomainHost, Key: "kubernetes.io/hostname"},
-	}
-}
-
-func createTestClusterTopology(name string, levels []grovecorev1alpha1.TopologyLevel) *grovecorev1alpha1.ClusterTopologyBinding {
-	return &grovecorev1alpha1.ClusterTopologyBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			UID:  uuid.NewUUID(),
-		},
-		Spec: grovecorev1alpha1.ClusterTopologyBindingSpec{
-			Levels: levels,
-		},
-	}
-}
-
-func createTestKAITopology(levels []kaitopologyv1alpha1.TopologyLevel, owner *grovecorev1alpha1.ClusterTopologyBinding) *kaitopologyv1alpha1.Topology {
-	topology := &kaitopologyv1alpha1.Topology{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: topologyName,
-		},
-		Spec: kaitopologyv1alpha1.TopologySpec{
-			Levels: levels,
-		},
-	}
-	if owner != nil {
-		topology.OwnerReferences = []metav1.OwnerReference{
-			{
-				APIVersion:         grovecorev1alpha1.SchemeGroupVersion.String(),
-				Kind:               apicommonconstants.KindClusterTopology,
-				Name:               owner.Name,
-				UID:                owner.UID,
-				Controller:         ptr.To(true),
-				BlockOwnerDeletion: ptr.To(true),
-			},
-		}
-	}
-	return topology
-}
-
-func convertToKAITopologyLevels(levels []grovecorev1alpha1.TopologyLevel) []kaitopologyv1alpha1.TopologyLevel {
-	kaiLevels := make([]kaitopologyv1alpha1.TopologyLevel, len(levels))
-	for i, level := range levels {
-		kaiLevels[i] = kaitopologyv1alpha1.TopologyLevel{
-			NodeLabel: level.Key,
-		}
-	}
-	return kaiLevels
-}
-
-// -- GVR and no-op tests --
 
 func TestTopologyGVR(t *testing.T) {
 	cl := schedulertest.NewKAIClient(t)
@@ -288,8 +222,6 @@ func TestSyncTopologyErrors(t *testing.T) {
 	}
 }
 
-// -- CheckTopologyDrift tests --
-
 func TestCheckTopologyDrift_InSync(t *testing.T) {
 	ctx := context.Background()
 	topologyLevels := defaultTopologyLevels()
@@ -394,8 +326,6 @@ func TestCheckTopologyDriftErrors(t *testing.T) {
 	}
 }
 
-// -- buildKAITopology and isKAITopologyChanged tests --
-
 func TestBuildKAITopology(t *testing.T) {
 	cl := schedulertest.NewKAIClient(t)
 	topologyLevels := defaultTopologyLevels()
@@ -465,4 +395,66 @@ func TestIsKAITopologyChanged(t *testing.T) {
 			assert.Equal(t, test.expectedChanged, topologyChanged)
 		})
 	}
+}
+
+func newTASBackend(t *testing.T, cl client.Client) scheduler.TopologyAwareBackend {
+	t.Helper()
+	recorder := record.NewFakeRecorder(10)
+	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}
+	b := New(cl, cl.Scheme(), recorder, profile)
+	require.NoError(t, b.Init(cl))
+	return b.(scheduler.TopologyAwareBackend)
+}
+
+func defaultTopologyLevels() []grovecorev1alpha1.TopologyLevel {
+	return []grovecorev1alpha1.TopologyLevel{
+		{Domain: grovecorev1alpha1.TopologyDomainZone, Key: "topology.kubernetes.io/zone"},
+		{Domain: grovecorev1alpha1.TopologyDomainHost, Key: "kubernetes.io/hostname"},
+	}
+}
+
+func createTestClusterTopology(name string, levels []grovecorev1alpha1.TopologyLevel) *grovecorev1alpha1.ClusterTopologyBinding {
+	return &grovecorev1alpha1.ClusterTopologyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			UID:  uuid.NewUUID(),
+		},
+		Spec: grovecorev1alpha1.ClusterTopologyBindingSpec{
+			Levels: levels,
+		},
+	}
+}
+
+func createTestKAITopology(levels []kaitopologyv1alpha1.TopologyLevel, owner *grovecorev1alpha1.ClusterTopologyBinding) *kaitopologyv1alpha1.Topology {
+	topology := &kaitopologyv1alpha1.Topology{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: topologyName,
+		},
+		Spec: kaitopologyv1alpha1.TopologySpec{
+			Levels: levels,
+		},
+	}
+	if owner != nil {
+		topology.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion:         grovecorev1alpha1.SchemeGroupVersion.String(),
+				Kind:               apicommonconstants.KindClusterTopology,
+				Name:               owner.Name,
+				UID:                owner.UID,
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			},
+		}
+	}
+	return topology
+}
+
+func convertToKAITopologyLevels(levels []grovecorev1alpha1.TopologyLevel) []kaitopologyv1alpha1.TopologyLevel {
+	kaiLevels := make([]kaitopologyv1alpha1.TopologyLevel, len(levels))
+	for i, level := range levels {
+		kaiLevels[i] = kaitopologyv1alpha1.TopologyLevel{
+			NodeLabel: level.Key,
+		}
+	}
+	return kaiLevels
 }

--- a/operator/internal/scheduler/kai/topology_test.go
+++ b/operator/internal/scheduler/kai/topology_test.go
@@ -26,13 +26,13 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/ai-dynamo/grove/operator/internal/scheduler"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
+	"github.com/ai-dynamo/grove/operator/test/utils/schedulertest"
 
 	kaitopologyv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/tools/record"
@@ -43,22 +43,6 @@ import (
 const topologyName = "test-topology"
 
 // -- Shared helpers --
-
-func newKAIScheme(t *testing.T) *runtime.Scheme {
-	t.Helper()
-	scheme := runtime.NewScheme()
-	require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
-	require.NoError(t, kaitopologyv1alpha1.AddToScheme(scheme))
-	return scheme
-}
-
-func newKAIClient(t *testing.T, objects ...client.Object) client.Client {
-	t.Helper()
-	return testutils.NewTestClientBuilder().
-		WithScheme(newKAIScheme(t)).
-		WithObjects(objects...).
-		Build()
-}
 
 func newTASBackend(t *testing.T, cl client.Client) scheduler.TopologyAwareBackend {
 	t.Helper()
@@ -125,7 +109,7 @@ func convertToKAITopologyLevels(levels []grovecorev1alpha1.TopologyLevel) []kait
 // -- GVR and no-op tests --
 
 func TestTopologyGVR(t *testing.T) {
-	cl := newKAIClient(t)
+	cl := schedulertest.NewKAIClient(t)
 	b := newTASBackend(t, cl)
 
 	gvr := b.TopologyGVR()
@@ -137,7 +121,7 @@ func TestTopologyGVR(t *testing.T) {
 }
 
 func TestOnTopologyDeleteIsNoOp(t *testing.T) {
-	cl := newKAIClient(t)
+	cl := schedulertest.NewKAIClient(t)
 	b := newTASBackend(t, cl)
 
 	ct := createTestClusterTopology(topologyName, defaultTopologyLevels())
@@ -149,7 +133,7 @@ func TestOnTopologyDeleteIsNoOp(t *testing.T) {
 
 func TestSyncTopologyWhenNoneExists(t *testing.T) {
 	ctx := context.Background()
-	cl := newKAIClient(t)
+	cl := schedulertest.NewKAIClient(t)
 	b := newTASBackend(t, cl)
 
 	topologyLevels := []grovecorev1alpha1.TopologyLevel{
@@ -183,7 +167,7 @@ func TestSyncTopologyWhenLevelsUpdated(t *testing.T) {
 		{NodeLabel: "kubernetes.io/hostname"},
 	}, ct)
 
-	cl := newKAIClient(t, ct, existingKAITopology)
+	cl := schedulertest.NewKAIClient(t, ct, existingKAITopology)
 	b := newTASBackend(t, cl)
 
 	err := b.SyncTopology(ctx, cl, ct)
@@ -206,7 +190,7 @@ func TestSyncTopologyWhenNoChangeRequired(t *testing.T) {
 	existingKAITopology := createTestKAITopology(convertToKAITopologyLevels(topologyLevels), ct)
 	existingKAITopology.ResourceVersion = "1"
 
-	cl := newKAIClient(t, ct, existingKAITopology)
+	cl := schedulertest.NewKAIClient(t, ct, existingKAITopology)
 	b := newTASBackend(t, cl)
 
 	err := b.SyncTopology(ctx, cl, ct)
@@ -229,7 +213,7 @@ func TestSyncTopologyWithUnknownOwner(t *testing.T) {
 		{NodeLabel: "topology.kubernetes.io/zone"},
 	}, differentOwner)
 
-	cl := newKAIClient(t, ct, existingKAITopology)
+	cl := schedulertest.NewKAIClient(t, ct, existingKAITopology)
 	b := newTASBackend(t, cl)
 
 	err := b.SyncTopology(ctx, cl, ct)
@@ -291,7 +275,7 @@ func TestSyncTopologyErrors(t *testing.T) {
 			objects := tc.existingObjects(ct)
 
 			cl := testutils.NewTestClientBuilder().
-				WithScheme(newKAIScheme(t)).
+				WithScheme(schedulertest.NewKAIScheme(t)).
 				WithObjects(objects...).
 				RecordErrorForObjects(tc.method, injectedErr, client.ObjectKey{Name: topologyName}).
 				Build()
@@ -313,7 +297,7 @@ func TestCheckTopologyDrift_InSync(t *testing.T) {
 
 	existingKAITopology := createTestKAITopology(convertToKAITopologyLevels(topologyLevels), ct)
 
-	cl := newKAIClient(t, ct, existingKAITopology)
+	cl := schedulertest.NewKAIClient(t, ct, existingKAITopology)
 	b := newTASBackend(t, cl)
 
 	ref := grovecorev1alpha1.SchedulerTopologyBinding{
@@ -337,7 +321,7 @@ func TestCheckTopologyDrift_Drift(t *testing.T) {
 		{NodeLabel: "kubernetes.io/hostname"},
 	}, ct)
 
-	cl := newKAIClient(t, ct, existingKAITopology)
+	cl := schedulertest.NewKAIClient(t, ct, existingKAITopology)
 	b := newTASBackend(t, cl)
 
 	ref := grovecorev1alpha1.SchedulerTopologyBinding{
@@ -356,7 +340,7 @@ func TestCheckTopologyDrift_NotFound(t *testing.T) {
 	topologyLevels := defaultTopologyLevels()
 	ct := createTestClusterTopology(topologyName, topologyLevels)
 
-	cl := newKAIClient(t, ct)
+	cl := schedulertest.NewKAIClient(t, ct)
 	b := newTASBackend(t, cl)
 
 	ref := grovecorev1alpha1.SchedulerTopologyBinding{
@@ -393,7 +377,7 @@ func TestCheckTopologyDriftErrors(t *testing.T) {
 			objects := tc.existingObjects(ct)
 
 			cl := testutils.NewTestClientBuilder().
-				WithScheme(newKAIScheme(t)).
+				WithScheme(schedulertest.NewKAIScheme(t)).
 				WithObjects(objects...).
 				RecordErrorForObjects(tc.method, injectedErr, client.ObjectKey{Name: topologyName}).
 				Build()
@@ -413,7 +397,7 @@ func TestCheckTopologyDriftErrors(t *testing.T) {
 // -- buildKAITopology and isKAITopologyChanged tests --
 
 func TestBuildKAITopology(t *testing.T) {
-	cl := newKAIClient(t)
+	cl := schedulertest.NewKAIClient(t)
 	topologyLevels := defaultTopologyLevels()
 	ct := &grovecorev1alpha1.ClusterTopologyBinding{
 		ObjectMeta: metav1.ObjectMeta{

--- a/operator/internal/scheduler/registry/registry_test.go
+++ b/operator/internal/scheduler/registry/registry_test.go
@@ -128,7 +128,10 @@ func TestNewRegistry(t *testing.T) {
 	})
 
 	t.Run("volcano scheduler initialization", func(t *testing.T) {
-		cl := testutils.CreateDefaultFakeClient(nil)
+		scheme := runtime.NewScheme()
+		cl := testutils.NewTestClientBuilder().
+			WithScheme(scheme).
+			Build()
 		directClient := newVolcanoDirectClient(t, testutils.NewVolcanoPodGroupCRD(true))
 
 		recorder := record.NewFakeRecorder(10)
@@ -138,7 +141,7 @@ func TestNewRegistry(t *testing.T) {
 			},
 			DefaultProfileName: string(configv1alpha1.SchedulerNameVolcano),
 		}
-		reg, err := New(cl, directClient, cl.Scheme(), recorder, cfg)
+		reg, err := New(cl, directClient, scheme, recorder, cfg)
 		require.NoError(t, err)
 		require.NotNil(t, reg.GetDefault())
 		assert.Equal(t, string(configv1alpha1.SchedulerNameVolcano), reg.GetDefault().Name())

--- a/operator/internal/scheduler/registry/registry_test.go
+++ b/operator/internal/scheduler/registry/registry_test.go
@@ -22,24 +22,12 @@ import (
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	"github.com/ai-dynamo/grove/operator/internal/scheduler"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
+	schedulertest "github.com/ai-dynamo/grove/operator/test/utils/scheduler"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-func newVolcanoDirectClient(t *testing.T, objects ...client.Object) client.Client {
-	t.Helper()
-	scheme := runtime.NewScheme()
-	require.NoError(t, apiextensionsv1.AddToScheme(scheme))
-	return testutils.NewTestClientBuilder().
-		WithScheme(scheme).
-		WithObjects(objects...).
-		Build()
-}
 
 // TestNewRegistry tests New with different scheduler profiles.
 func TestNewRegistry(t *testing.T) {
@@ -106,7 +94,7 @@ func TestNewRegistry(t *testing.T) {
 	}
 
 	t.Run("multiple profiles with default set to kai", func(t *testing.T) {
-		cl := testutils.CreateDefaultFakeClient([]client.Object{testutils.NewVolcanoPodGroupCRD(true)})
+		cl := schedulertest.NewVolcanoClient(t, testutils.NewVolcanoPodGroupCRD(true))
 		recorder := record.NewFakeRecorder(10)
 		cfg := configv1alpha1.SchedulerConfiguration{
 			Profiles: []configv1alpha1.SchedulerProfile{
@@ -128,11 +116,7 @@ func TestNewRegistry(t *testing.T) {
 	})
 
 	t.Run("volcano scheduler initialization", func(t *testing.T) {
-		scheme := runtime.NewScheme()
-		cl := testutils.NewTestClientBuilder().
-			WithScheme(scheme).
-			Build()
-		directClient := newVolcanoDirectClient(t, testutils.NewVolcanoPodGroupCRD(true))
+		cl := schedulertest.NewVolcanoClient(t, testutils.NewVolcanoPodGroupCRD(true))
 
 		recorder := record.NewFakeRecorder(10)
 		cfg := configv1alpha1.SchedulerConfiguration{
@@ -141,7 +125,7 @@ func TestNewRegistry(t *testing.T) {
 			},
 			DefaultProfileName: string(configv1alpha1.SchedulerNameVolcano),
 		}
-		reg, err := New(cl, directClient, scheme, recorder, cfg)
+		reg, err := New(cl, cl, cl.Scheme(), recorder, cfg)
 		require.NoError(t, err)
 		require.NotNil(t, reg.GetDefault())
 		assert.Equal(t, string(configv1alpha1.SchedulerNameVolcano), reg.GetDefault().Name())

--- a/operator/internal/scheduler/registry/registry_test.go
+++ b/operator/internal/scheduler/registry/registry_test.go
@@ -25,9 +25,21 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func newVolcanoDirectClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, apiextensionsv1.AddToScheme(scheme))
+	return testutils.NewTestClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build()
+}
 
 // TestNewRegistry tests New with different scheduler profiles.
 func TestNewRegistry(t *testing.T) {
@@ -116,7 +128,8 @@ func TestNewRegistry(t *testing.T) {
 	})
 
 	t.Run("volcano scheduler initialization", func(t *testing.T) {
-		cl := testutils.CreateDefaultFakeClient([]client.Object{testutils.NewVolcanoPodGroupCRD(true)})
+		cl := testutils.CreateDefaultFakeClient(nil)
+		directClient := newVolcanoDirectClient(t, testutils.NewVolcanoPodGroupCRD(true))
 
 		recorder := record.NewFakeRecorder(10)
 		cfg := configv1alpha1.SchedulerConfiguration{
@@ -125,7 +138,7 @@ func TestNewRegistry(t *testing.T) {
 			},
 			DefaultProfileName: string(configv1alpha1.SchedulerNameVolcano),
 		}
-		reg, err := New(cl, cl, cl.Scheme(), recorder, cfg)
+		reg, err := New(cl, directClient, cl.Scheme(), recorder, cfg)
 		require.NoError(t, err)
 		require.NotNil(t, reg.GetDefault())
 		assert.Equal(t, string(configv1alpha1.SchedulerNameVolcano), reg.GetDefault().Name())

--- a/operator/internal/scheduler/volcano/backend.go
+++ b/operator/internal/scheduler/volcano/backend.go
@@ -64,6 +64,13 @@ func (b *schedulerBackend) Name() string {
 }
 
 func (b *schedulerBackend) Init(directClient client.Client) error {
+	if err := volcanov1beta1.AddToScheme(b.scheme); err != nil {
+		return err
+	}
+	if err := apiextensionsv1.AddToScheme(b.scheme); err != nil {
+		return err
+	}
+
 	crd := &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{Name: volcanoPodGroupCRDName},
 	}

--- a/operator/internal/scheduler/volcano/backend.go
+++ b/operator/internal/scheduler/volcano/backend.go
@@ -63,12 +63,14 @@ func (b *schedulerBackend) Name() string {
 	return b.name
 }
 
+// Init registers the Volcano API types into b.scheme and must be called before
+// that scheme is used to serialize or deserialize Volcano objects.
 func (b *schedulerBackend) Init(directClient client.Client) error {
 	if err := volcanov1beta1.AddToScheme(b.scheme); err != nil {
-		return err
+		return fmt.Errorf("failed to register volcano scheme: %w", err)
 	}
 	if err := apiextensionsv1.AddToScheme(b.scheme); err != nil {
-		return err
+		return fmt.Errorf("failed to register apiextensions scheme: %w", err)
 	}
 
 	crd := &apiextensionsv1.CustomResourceDefinition{

--- a/operator/internal/scheduler/volcano/backend_test.go
+++ b/operator/internal/scheduler/volcano/backend_test.go
@@ -24,38 +24,20 @@ import (
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
+	schedulertest "github.com/ai-dynamo/grove/operator/test/utils/scheduler"
 
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 )
 
-func newVolcanoScheme(t *testing.T) *runtime.Scheme {
-	t.Helper()
-	scheme := runtime.NewScheme()
-	require.NoError(t, groveschedulerv1alpha1.AddToScheme(scheme))
-	require.NoError(t, volcanov1beta1.AddToScheme(scheme))
-	require.NoError(t, apiextensionsv1.AddToScheme(scheme))
-	return scheme
-}
-
-func newVolcanoClient(t *testing.T, objects ...client.Object) client.Client {
-	t.Helper()
-	return testutils.NewTestClientBuilder().
-		WithScheme(newVolcanoScheme(t)).
-		WithObjects(objects...).
-		Build()
-}
-
 func TestBackend_PreparePod(t *testing.T) {
-	cl := newVolcanoClient(t)
+	cl := schedulertest.NewVolcanoClient(t)
 	recorder := record.NewFakeRecorder(10)
 	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameVolcano}
 	b := New(cl, cl.Scheme(), recorder, profile)
@@ -71,7 +53,7 @@ func TestBackend_PreparePod(t *testing.T) {
 }
 
 func TestBackend_PreparePodFailsWhenPodGangLabelMissing(t *testing.T) {
-	cl := newVolcanoClient(t)
+	cl := schedulertest.NewVolcanoClient(t)
 	recorder := record.NewFakeRecorder(10)
 	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameVolcano}
 	b := New(cl, cl.Scheme(), recorder, profile)
@@ -104,7 +86,7 @@ func TestBackend_Init(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cl := newVolcanoClient(t, tt.objects...)
+			cl := schedulertest.NewVolcanoClient(t, tt.objects...)
 			recorder := record.NewFakeRecorder(10)
 			profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameVolcano}
 			b := New(cl, cl.Scheme(), recorder, profile)
@@ -141,7 +123,7 @@ func TestBackend_SyncPodGang(t *testing.T) {
 			},
 		},
 	}
-	cl := newVolcanoClient(t, podGang)
+	cl := schedulertest.NewVolcanoClient(t, podGang)
 	recorder := record.NewFakeRecorder(10)
 	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameVolcano}
 	b := New(cl, cl.Scheme(), recorder, profile)
@@ -188,7 +170,7 @@ func TestBackend_SyncPodGangPreservesSchedulingConstraintsAfterRelease(t *testin
 			},
 		},
 	}
-	cl := newVolcanoClient(t, podGang)
+	cl := schedulertest.NewVolcanoClient(t, podGang)
 	recorder := record.NewFakeRecorder(10)
 	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameVolcano}
 	b := New(cl, cl.Scheme(), recorder, profile)
@@ -232,7 +214,7 @@ func TestBackend_SyncPodGangDefaultQueue(t *testing.T) {
 			},
 		},
 	}
-	cl := newVolcanoClient(t, podGang)
+	cl := schedulertest.NewVolcanoClient(t, podGang)
 	recorder := record.NewFakeRecorder(10)
 	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameVolcano}
 	b := New(cl, cl.Scheme(), recorder, profile)
@@ -247,7 +229,7 @@ func TestBackend_SyncPodGangDefaultQueue(t *testing.T) {
 }
 
 func TestBackend_ValidatePodCliqueSet(t *testing.T) {
-	cl := newVolcanoClient(t)
+	cl := schedulertest.NewVolcanoClient(t)
 	recorder := record.NewFakeRecorder(10)
 	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameVolcano}
 	b := New(cl, cl.Scheme(), recorder, profile)
@@ -393,7 +375,7 @@ func TestBackend_ValidatePodCliqueSetQueues(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			pcs := makePCS()
 			tc.mutate(pcs)
-			cl := newVolcanoClient(t, tc.existingObjs...)
+			cl := schedulertest.NewVolcanoClient(t, tc.existingObjs...)
 			recorder := record.NewFakeRecorder(10)
 			profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameVolcano}
 			b := New(cl, cl.Scheme(), recorder, profile)

--- a/operator/internal/scheduler/volcano/backend_test.go
+++ b/operator/internal/scheduler/volcano/backend_test.go
@@ -29,14 +29,33 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 )
 
+func newVolcanoScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, groveschedulerv1alpha1.AddToScheme(scheme))
+	require.NoError(t, volcanov1beta1.AddToScheme(scheme))
+	require.NoError(t, apiextensionsv1.AddToScheme(scheme))
+	return scheme
+}
+
+func newVolcanoClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+	return testutils.NewTestClientBuilder().
+		WithScheme(newVolcanoScheme(t)).
+		WithObjects(objects...).
+		Build()
+}
+
 func TestBackend_PreparePod(t *testing.T) {
-	cl := testutils.CreateDefaultFakeClient(nil)
+	cl := newVolcanoClient(t)
 	recorder := record.NewFakeRecorder(10)
 	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameVolcano}
 	b := New(cl, cl.Scheme(), recorder, profile)
@@ -52,7 +71,7 @@ func TestBackend_PreparePod(t *testing.T) {
 }
 
 func TestBackend_PreparePodFailsWhenPodGangLabelMissing(t *testing.T) {
-	cl := testutils.CreateDefaultFakeClient(nil)
+	cl := newVolcanoClient(t)
 	recorder := record.NewFakeRecorder(10)
 	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameVolcano}
 	b := New(cl, cl.Scheme(), recorder, profile)
@@ -85,7 +104,7 @@ func TestBackend_Init(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cl := testutils.CreateDefaultFakeClient(tt.objects)
+			cl := newVolcanoClient(t, tt.objects...)
 			recorder := record.NewFakeRecorder(10)
 			profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameVolcano}
 			b := New(cl, cl.Scheme(), recorder, profile)
@@ -122,7 +141,7 @@ func TestBackend_SyncPodGang(t *testing.T) {
 			},
 		},
 	}
-	cl := testutils.CreateDefaultFakeClient([]client.Object{podGang})
+	cl := newVolcanoClient(t, podGang)
 	recorder := record.NewFakeRecorder(10)
 	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameVolcano}
 	b := New(cl, cl.Scheme(), recorder, profile)
@@ -169,7 +188,7 @@ func TestBackend_SyncPodGangPreservesSchedulingConstraintsAfterRelease(t *testin
 			},
 		},
 	}
-	cl := testutils.CreateDefaultFakeClient([]client.Object{podGang})
+	cl := newVolcanoClient(t, podGang)
 	recorder := record.NewFakeRecorder(10)
 	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameVolcano}
 	b := New(cl, cl.Scheme(), recorder, profile)
@@ -213,7 +232,7 @@ func TestBackend_SyncPodGangDefaultQueue(t *testing.T) {
 			},
 		},
 	}
-	cl := testutils.CreateDefaultFakeClient([]client.Object{podGang})
+	cl := newVolcanoClient(t, podGang)
 	recorder := record.NewFakeRecorder(10)
 	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameVolcano}
 	b := New(cl, cl.Scheme(), recorder, profile)
@@ -228,7 +247,7 @@ func TestBackend_SyncPodGangDefaultQueue(t *testing.T) {
 }
 
 func TestBackend_ValidatePodCliqueSet(t *testing.T) {
-	cl := testutils.CreateDefaultFakeClient(nil)
+	cl := newVolcanoClient(t)
 	recorder := record.NewFakeRecorder(10)
 	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameVolcano}
 	b := New(cl, cl.Scheme(), recorder, profile)
@@ -374,7 +393,7 @@ func TestBackend_ValidatePodCliqueSetQueues(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			pcs := makePCS()
 			tc.mutate(pcs)
-			cl := testutils.CreateDefaultFakeClient(tc.existingObjs)
+			cl := newVolcanoClient(t, tc.existingObjs...)
 			recorder := record.NewFakeRecorder(10)
 			profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameVolcano}
 			b := New(cl, cl.Scheme(), recorder, profile)

--- a/operator/internal/scheduler/volcano/queue_test.go
+++ b/operator/internal/scheduler/volcano/queue_test.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"testing"
 
-	testutils "github.com/ai-dynamo/grove/operator/test/utils"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -95,19 +93,19 @@ func TestValidateQueueExistsAndIsOpen(t *testing.T) {
 	}
 
 	t.Run("existing open queue", func(t *testing.T) {
-		cl := testutils.CreateDefaultFakeClient([]client.Object{makeQueue("gpu-training", volcanov1beta1.QueueStateOpen)})
+		cl := newVolcanoClient(t, makeQueue("gpu-training", volcanov1beta1.QueueStateOpen))
 		require.NoError(t, validateQueueExistsAndIsOpen(context.Background(), cl, "gpu-training"))
 	})
 
 	t.Run("missing queue", func(t *testing.T) {
-		cl := testutils.CreateDefaultFakeClient(nil)
+		cl := newVolcanoClient(t)
 		err := validateQueueExistsAndIsOpen(context.Background(), cl, "gpu-training")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does not exist")
 	})
 
 	t.Run("queue not open", func(t *testing.T) {
-		cl := testutils.CreateDefaultFakeClient([]client.Object{makeQueue("gpu-training", "Closed")})
+		cl := newVolcanoClient(t, makeQueue("gpu-training", "Closed"))
 		err := validateQueueExistsAndIsOpen(context.Background(), cl, "gpu-training")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "is not Open")

--- a/operator/internal/scheduler/volcano/queue_test.go
+++ b/operator/internal/scheduler/volcano/queue_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	schedulertest "github.com/ai-dynamo/grove/operator/test/utils/scheduler"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -93,19 +95,19 @@ func TestValidateQueueExistsAndIsOpen(t *testing.T) {
 	}
 
 	t.Run("existing open queue", func(t *testing.T) {
-		cl := newVolcanoClient(t, makeQueue("gpu-training", volcanov1beta1.QueueStateOpen))
+		cl := schedulertest.NewVolcanoClient(t, makeQueue("gpu-training", volcanov1beta1.QueueStateOpen))
 		require.NoError(t, validateQueueExistsAndIsOpen(context.Background(), cl, "gpu-training"))
 	})
 
 	t.Run("missing queue", func(t *testing.T) {
-		cl := newVolcanoClient(t)
+		cl := schedulertest.NewVolcanoClient(t)
 		err := validateQueueExistsAndIsOpen(context.Background(), cl, "gpu-training")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does not exist")
 	})
 
 	t.Run("queue not open", func(t *testing.T) {
-		cl := newVolcanoClient(t, makeQueue("gpu-training", "Closed"))
+		cl := schedulertest.NewVolcanoClient(t, makeQueue("gpu-training", "Closed"))
 		err := validateQueueExistsAndIsOpen(context.Background(), cl, "gpu-training")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "is not Open")

--- a/operator/test/utils/client.go
+++ b/operator/test/utils/client.go
@@ -130,6 +130,12 @@ func (b *TestClientBuilder) WithClient(cl client.Client) *TestClientBuilder {
 	return b
 }
 
+// WithScheme sets the scheme used by the delegating fake client.
+func (b *TestClientBuilder) WithScheme(scheme *runtime.Scheme) *TestClientBuilder {
+	b.scheme = scheme
+	return b
+}
+
 // WithObjects initializes the delegating fake client builder with objects.
 func (b *TestClientBuilder) WithObjects(objects ...client.Object) *TestClientBuilder {
 	if len(objects) > 0 {

--- a/operator/test/utils/client.go
+++ b/operator/test/utils/client.go
@@ -117,6 +117,8 @@ func CreateFakeClientForObjectsMatchingLabels(deleteErr, listErr *apierrors.Stat
 // ------------------- Functions to explicitly create and configure a test client builder -------------------
 
 // NewTestClientBuilder creates a new TestClientBuilder with a default scheme.
+// Tests that use scheduler-specific types must provide a scheme containing
+// those types with WithScheme.
 func NewTestClientBuilder() *TestClientBuilder {
 	return &TestClientBuilder{
 		delegatingClientBuilder: fake.NewClientBuilder(),

--- a/operator/test/utils/scheduler/kai.go
+++ b/operator/test/utils/scheduler/kai.go
@@ -1,0 +1,47 @@
+// /*
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package scheduler
+
+import (
+	"testing"
+
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	testutils "github.com/ai-dynamo/grove/operator/test/utils"
+
+	kaitopologyv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewKAIScheme returns an isolated scheme with the Grove and KAI types used by KAI scheduler tests.
+func NewKAIScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
+	require.NoError(t, kaitopologyv1alpha1.AddToScheme(scheme))
+	return scheme
+}
+
+// NewKAIClient returns a fake client using NewKAIScheme.
+func NewKAIClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+	return testutils.NewTestClientBuilder().
+		WithScheme(NewKAIScheme(t)).
+		WithObjects(objects...).
+		Build()
+}

--- a/operator/test/utils/scheduler/volcano.go
+++ b/operator/test/utils/scheduler/volcano.go
@@ -14,34 +14,36 @@
 // limitations under the License.
 // */
 
-package schedulertest
+package scheduler
 
 import (
 	"testing"
 
-	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
-	kaitopologyv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
+	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 )
 
-// NewKAIScheme returns an isolated scheme with the Grove and KAI types used by KAI scheduler tests.
-func NewKAIScheme(t *testing.T) *runtime.Scheme {
+// NewVolcanoScheme returns an isolated scheme with the Grove, Volcano, and CRD types used by Volcano scheduler tests.
+func NewVolcanoScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	scheme := runtime.NewScheme()
-	require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
-	require.NoError(t, kaitopologyv1alpha1.AddToScheme(scheme))
+	require.NoError(t, groveschedulerv1alpha1.AddToScheme(scheme))
+	require.NoError(t, volcanov1beta1.AddToScheme(scheme))
+	require.NoError(t, apiextensionsv1.AddToScheme(scheme))
 	return scheme
 }
 
-// NewKAIClient returns a fake client using NewKAIScheme.
-func NewKAIClient(t *testing.T, objects ...client.Object) client.Client {
+// NewVolcanoClient returns a fake client using NewVolcanoScheme.
+func NewVolcanoClient(t *testing.T, objects ...client.Object) client.Client {
 	t.Helper()
 	return testutils.NewTestClientBuilder().
-		WithScheme(NewKAIScheme(t)).
+		WithScheme(NewVolcanoScheme(t)).
 		WithObjects(objects...).
 		Build()
 }

--- a/operator/test/utils/schedulertest/kai.go
+++ b/operator/test/utils/schedulertest/kai.go
@@ -1,0 +1,47 @@
+// /*
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package schedulertest
+
+import (
+	"testing"
+
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	testutils "github.com/ai-dynamo/grove/operator/test/utils"
+
+	kaitopologyv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewKAIScheme returns an isolated scheme with the Grove and KAI types used by KAI scheduler tests.
+func NewKAIScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
+	require.NoError(t, kaitopologyv1alpha1.AddToScheme(scheme))
+	return scheme
+}
+
+// NewKAIClient returns a fake client using NewKAIScheme.
+func NewKAIClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+	return testutils.NewTestClientBuilder().
+		WithScheme(NewKAIScheme(t)).
+		WithObjects(objects...).
+		Build()
+}


### PR DESCRIPTION
## Summary
- keep the shared operator client scheme scheduler-agnostic
- register KAI topology scheme from the KAI backend Init path
- register Volcano scheduling and CRD schemes from the Volcano backend Init path
- update tests to use backend-specific fake client schemes

Fixes #668

## Tests
- go test ./internal/client ./internal/scheduler/kai ./internal/scheduler/volcano ./internal/scheduler/registry ./internal/clustertopology