### PR TITLE
Limit scale dashboard milestone details

### DIFF
--- a/operator/hack/scale-dashboard/app.js
+++ b/operator/hack/scale-dashboard/app.js
@@ -146,7 +146,7 @@ function setOptions(select, values) {
 function render() {
   const runs = selectedRuns();
   const detail = selectedRunDetail(runs);
-  const detailNote = detail.isLimited ? "; milestone details hidden" : "";
+  const detailNote = detail.hideMilestoneCharts || detail.hideLatestMilestoneRows ? "; milestone details hidden" : "";
   setStatus(`${runs.length} ${state.testName} runs loaded${detailNote}`);
 
   drawTotalChart(runs);
@@ -268,10 +268,11 @@ function selectedRunDetail(runs) {
   const latest = runs[runs.length - 1];
   const milestoneChartCount = milestonePhaseNames(runs).length;
   const latestTableRowCount = latest ? latestValueRows(latest, true).length : 0;
+  const latestTableRowCountWithoutMilestones = latest ? latestValueRows(latest, false).length : 0;
+  const hasLatestMilestoneRows = latestTableRowCount > latestTableRowCountWithoutMilestones;
   return {
     hideMilestoneCharts: milestoneChartCount > MAX_MILESTONE_CHARTS,
-    hideLatestMilestoneRows: latestTableRowCount > MAX_LATEST_TABLE_ROWS,
-    isLimited: milestoneChartCount > MAX_MILESTONE_CHARTS || latestTableRowCount > MAX_LATEST_TABLE_ROWS,
+    hideLatestMilestoneRows: hasLatestMilestoneRows && latestTableRowCount > MAX_LATEST_TABLE_ROWS,
     latestTableRowCount,
     milestoneChartCount,
   };

--- a/operator/hack/scale-dashboard/app.js
+++ b/operator/hack/scale-dashboard/app.js
@@ -15,6 +15,8 @@
  */
 
 const RUNS_URL = "index/runs.ndjson";
+const MAX_MILESTONE_CHARTS = 8;
+const MAX_LATEST_TABLE_ROWS = 40;
 
 const STACK_COLORS = [
   "#16736f",
@@ -143,12 +145,14 @@ function setOptions(select, values) {
 
 function render() {
   const runs = selectedRuns();
-  setStatus(`${runs.length} runs loaded`);
+  const detail = selectedRunDetail(runs);
+  const detailNote = detail.isLimited ? "; milestone details hidden" : "";
+  setStatus(`${runs.length} ${state.testName} runs loaded${detailNote}`);
 
   drawTotalChart(runs);
   drawPhaseChart(runs);
-  renderMilestoneCharts(runs);
-  renderLatestTable(runs);
+  renderMilestoneCharts(runs, detail);
+  renderLatestTable(runs, detail);
 }
 
 function selectedRuns() {
@@ -260,10 +264,29 @@ function drawPhaseChart(runs) {
   drawStackedBars(els.phaseChart, stacks);
 }
 
-function renderMilestoneCharts(runs) {
+function selectedRunDetail(runs) {
+  const latest = runs[runs.length - 1];
+  const milestoneChartCount = milestonePhaseNames(runs).length;
+  const latestTableRowCount = latest ? latestValueRows(latest, true).length : 0;
+  return {
+    hideMilestoneCharts: milestoneChartCount > MAX_MILESTONE_CHARTS,
+    hideLatestMilestoneRows: latestTableRowCount > MAX_LATEST_TABLE_ROWS,
+    isLimited: milestoneChartCount > MAX_MILESTONE_CHARTS || latestTableRowCount > MAX_LATEST_TABLE_ROWS,
+    latestTableRowCount,
+    milestoneChartCount,
+  };
+}
+
+function renderMilestoneCharts(runs, detail) {
   els.milestoneCharts.replaceChildren();
-  const phaseNames = orderedPhaseNames(runs)
-    .filter((phaseName) => runs.some((run) => (phaseByName(run, phaseName)?.milestones || []).length > 0));
+  const phaseNames = milestonePhaseNames(runs);
+
+  if (detail.hideMilestoneCharts) {
+    els.milestoneCharts.append(detailMessage(
+      `Milestone charts hidden because this test has ${detail.milestoneChartCount} milestone-bearing phases. Download runs as JSON for raw milestone data.`,
+    ));
+    return;
+  }
 
   for (const phaseName of phaseNames) {
     const article = document.createElement("article");
@@ -293,6 +316,11 @@ function renderMilestoneCharts(runs) {
 
     drawMilestoneChart(runs, phaseName, svg, legend);
   }
+}
+
+function milestonePhaseNames(runs) {
+  return orderedPhaseNames(runs)
+    .filter((phaseName) => runs.some((run) => (phaseByName(run, phaseName)?.milestones || []).length > 0));
 }
 
 function drawMilestoneChart(runs, phaseName, svg, legend) {
@@ -490,13 +518,37 @@ function drawEmpty(svg, message) {
   addText(svg, dims.width / 2, dims.height / 2, message, "empty-label", "middle");
 }
 
-function renderLatestTable(runs) {
+function renderLatestTable(runs, detail) {
   const latest = runs[runs.length - 1];
   if (!latest) {
     els.latestBody.replaceChildren();
     return;
   }
 
+  const rows = latestValueRows(latest, !detail.hideLatestMilestoneRows);
+  const tableRows = rows.map((row) => {
+    const tr = document.createElement("tr");
+    tr.append(
+      cell(row.metric),
+      cell(`${formatSeconds(row.valueSeconds)}s`),
+      cell(row.runID),
+    );
+    return tr;
+  });
+
+  if (detail.hideLatestMilestoneRows) {
+    const tr = document.createElement("tr");
+    tr.className = "detail-note-row";
+    const td = cell(`Milestone rows hidden because the latest run has ${detail.latestTableRowCount} values. Download runs as JSON for raw milestone data.`);
+    td.colSpan = 3;
+    tr.append(td);
+    tableRows.push(tr);
+  }
+
+  els.latestBody.replaceChildren(...tableRows);
+}
+
+function latestValueRows(latest, includeMilestones) {
   const rows = [{ metric: "total", valueSeconds: latest.totalSeconds, runID: latest.runID }];
   for (const phase of latest.phases) {
     rows.push({
@@ -504,26 +556,25 @@ function renderLatestTable(runs) {
       valueSeconds: phase.valueSeconds,
       runID: latest.runID,
     });
-    for (const milestone of phase.milestones) {
-      rows.push({
-        metric: `milestone.${phase.name}.${milestone.name}`,
-        valueSeconds: milestone.valueSeconds,
-        runID: latest.runID,
-      });
+    if (includeMilestones) {
+      for (const milestone of phase.milestones) {
+        rows.push({
+          metric: `milestone.${phase.name}.${milestone.name}`,
+          valueSeconds: milestone.valueSeconds,
+          runID: latest.runID,
+        });
+      }
     }
   }
 
-  els.latestBody.replaceChildren(
-    ...rows.map((row) => {
-      const tr = document.createElement("tr");
-      tr.append(
-        cell(row.metric),
-        cell(`${formatSeconds(row.valueSeconds)}s`),
-        cell(row.runID),
-      );
-      return tr;
-    }),
-  );
+  return rows;
+}
+
+function detailMessage(text) {
+  const article = document.createElement("article");
+  article.className = "detail-message";
+  article.textContent = text;
+  return article;
 }
 
 function renderSummary(target, items) {

--- a/operator/hack/scale-dashboard/index.html
+++ b/operator/hack/scale-dashboard/index.html
@@ -22,7 +22,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Grove Scale Test</title>
-    <link rel="stylesheet" href="style.css?v=charts-v3">
+    <link rel="stylesheet" href="style.css?v=charts-v4">
   </head>
   <body>
     <main class="page">
@@ -80,6 +80,6 @@
       </section>
     </main>
     <div id="tooltip" class="tooltip" hidden></div>
-    <script src="app.js?v=charts-v3"></script>
+    <script src="app.js?v=charts-v4"></script>
   </body>
 </html>

--- a/operator/hack/scale-dashboard/style.css
+++ b/operator/hack/scale-dashboard/style.css
@@ -137,6 +137,18 @@ select {
   padding: 14px 14px 10px;
 }
 
+.detail-message {
+  align-items: center;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  display: flex;
+  margin-bottom: 16px;
+  min-height: 56px;
+  padding: 14px;
+}
+
 .chart-panel-header {
   align-items: flex-start;
   display: flex;
@@ -300,6 +312,10 @@ th {
   color: var(--muted);
   font-size: 12px;
   text-transform: uppercase;
+}
+
+.detail-note-row td {
+  color: var(--muted);
 }
 
 td:nth-child(2),


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This makes the scale-test dashboard adapt when a selected test has too many milestone details to render cleanly.

The dashboard always shows the total runtime and phase charts. For milestone-heavy tests, such as `SoakChurn`, it hides the per-milestone charts and milestone rows in the latest-values table, while keeping the raw milestone data available in `runs.ndjson`.

#### Which issue(s) this PR fixes:

Related to #550

#### Special notes for your reviewer:

Current thresholds:

- hide milestone charts above 8 milestone-bearing phases
- hide latest-table milestone rows above 40 latest-value rows

Validated locally against the current `scale-test-history` data:

- `ScaleTest_1000` keeps milestone charts and full latest table
- `SoakChurn` shows total and phase charts, with milestone details hidden
- `node --check operator/hack/scale-dashboard/app.js` passes

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
