### PR TITLE
fix: avoid duplicate empty PodClique name errors

### DIFF
--- a/operator/internal/webhook/admission/pcs/validation/podcliqueset.go
+++ b/operator/internal/webhook/admission/pcs/validation/podcliqueset.go
@@ -436,7 +436,8 @@ func (v *pcsValidator) validatePodCliqueTemplateSpec(cliqueTemplateSpec *groveco
 	fldPath *field.Path, scalingGroupCliqueNames sets.Set[string]) ([]string, field.ErrorList) {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, validateNonEmptyStringField(cliqueTemplateSpec.Name, fldPath.Child("name"))...)
+	nameErrs := validateNonEmptyStringField(cliqueTemplateSpec.Name, fldPath.Child("name"))
+	allErrs = append(allErrs, nameErrs...)
 	allErrs = append(allErrs, metav1validation.ValidateLabels(cliqueTemplateSpec.Labels, fldPath.Child("labels"))...)
 	allErrs = append(allErrs, apivalidation.ValidateAnnotations(cliqueTemplateSpec.Annotations, fldPath.Child("annotations"))...)
 
@@ -445,7 +446,9 @@ func (v *pcsValidator) validatePodCliqueTemplateSpec(cliqueTemplateSpec *groveco
 	if len(errs) != 0 {
 		allErrs = append(allErrs, errs...)
 	}
-	allErrs = append(allErrs, v.validatePodCliqueNameConstraints(fldPath, cliqueTemplateSpec, scalingGroupCliqueNames)...)
+	if len(nameErrs) == 0 {
+		allErrs = append(allErrs, v.validatePodCliqueNameConstraints(fldPath, cliqueTemplateSpec, scalingGroupCliqueNames)...)
+	}
 
 	return warnings, allErrs
 }

--- a/operator/internal/webhook/admission/pcs/validation/podcliqueset.go
+++ b/operator/internal/webhook/admission/pcs/validation/podcliqueset.go
@@ -431,13 +431,25 @@ func (v *pcsValidator) validateTopologyConstraintsOnCreate(ctx context.Context) 
 	return topologyValidator.warnings(), topologyValidator.validate()
 }
 
+// validatePodCliqueTemplateName skips constraint checks when the name is empty.
+func (v *pcsValidator) validatePodCliqueTemplateName(
+	cliqueTemplateSpec *grovecorev1alpha1.PodCliqueTemplateSpec,
+	fldPath *field.Path,
+	scalingGroupCliqueNames sets.Set[string],
+) field.ErrorList {
+	allErrs := validateNonEmptyStringField(cliqueTemplateSpec.Name, fldPath.Child("name"))
+	if len(allErrs) > 0 {
+		return allErrs
+	}
+	return append(allErrs, v.validatePodCliqueNameConstraints(fldPath, cliqueTemplateSpec, scalingGroupCliqueNames)...)
+}
+
 // validatePodCliqueTemplateSpec validates a single PodClique template specification including metadata and spec.
 func (v *pcsValidator) validatePodCliqueTemplateSpec(cliqueTemplateSpec *grovecorev1alpha1.PodCliqueTemplateSpec,
 	fldPath *field.Path, scalingGroupCliqueNames sets.Set[string]) ([]string, field.ErrorList) {
 	allErrs := field.ErrorList{}
 
-	nameErrs := validateNonEmptyStringField(cliqueTemplateSpec.Name, fldPath.Child("name"))
-	allErrs = append(allErrs, nameErrs...)
+	allErrs = append(allErrs, v.validatePodCliqueTemplateName(cliqueTemplateSpec, fldPath, scalingGroupCliqueNames)...)
 	allErrs = append(allErrs, metav1validation.ValidateLabels(cliqueTemplateSpec.Labels, fldPath.Child("labels"))...)
 	allErrs = append(allErrs, apivalidation.ValidateAnnotations(cliqueTemplateSpec.Annotations, fldPath.Child("annotations"))...)
 
@@ -445,9 +457,6 @@ func (v *pcsValidator) validatePodCliqueTemplateSpec(cliqueTemplateSpec *groveco
 	warnings, errs := v.validatePodCliqueSpec(cliqueTemplateSpec.Name, cliqueTemplateSpec.Spec, fldPath.Child("spec"))
 	if len(errs) != 0 {
 		allErrs = append(allErrs, errs...)
-	}
-	if len(nameErrs) == 0 {
-		allErrs = append(allErrs, v.validatePodCliqueNameConstraints(fldPath, cliqueTemplateSpec, scalingGroupCliqueNames)...)
 	}
 
 	return warnings, allErrs

--- a/operator/internal/webhook/admission/pcs/validation/podcliqueset_test.go
+++ b/operator/internal/webhook/admission/pcs/validation/podcliqueset_test.go
@@ -78,9 +78,7 @@ func TestResourceNamingValidation(t *testing.T) {
 			pcsName:     "inference",
 			cliqueNames: []string{""},
 			errorMatchers: []testutils.ErrorMatcher{
-				// TODO: @unmarshall @renormalize only one should be required here, fix later
 				{ErrorType: field.ErrorTypeRequired, Field: "spec.template.cliques[0].name"},
-				{ErrorType: field.ErrorTypeInvalid, Field: "spec.template.cliques[0].name"},
 			},
 		},
 		{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Resolve the TODO in PodCliqueSet validation for empty PodClique template names.

Empty names now report only the required-field validation error instead of also running the dependent name-constraint checks.

#### Which issue(s) this PR fixes:

Fixes #679

#### Special notes for your reviewer:

None

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```