### PR TITLE
chore: align Go toolchain pins to 1.26.3

### DIFF
--- a/.github/actions/e2e-setup/action.yaml
+++ b/.github/actions/e2e-setup/action.yaml
@@ -21,7 +21,7 @@ inputs:
   go-version:
     description: "Go version to install"
     required: false
-    default: "1.25.7"  # Keep in sync with .github/workflows/build-check-test.yaml
+    default: "1.26.3"  # Keep in sync with .github/workflows/build-check-test.yaml
 
 runs:
   using: "composite"
@@ -63,6 +63,10 @@ runs:
         go-version: ${{ inputs.go-version }}
         cache: true
         cache-dependency-path: operator/go.sum
+
+    - name: Pin GOROOT to active Go
+      shell: bash
+      run: echo "GOROOT=$(env -u GOROOT go env GOROOT)" >> "$GITHUB_ENV"
 
     - name: Install k3d
       shell: bash

--- a/.github/workflows/build-check-test.yaml
+++ b/.github/workflows/build-check-test.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.3"
           cache: true
           cache-dependency-path: |
             operator/go.sum
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.3"
           cache: true
           cache-dependency-path: operator/go.sum
       - name: build-operator
@@ -87,7 +87,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.3"
           cache: true
           cache-dependency-path: operator/go.sum
       - name: check

--- a/.github/workflows/push-artifacts.yaml
+++ b/.github/workflows/push-artifacts.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.3'
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/scale-test-ci.yaml
+++ b/.github/workflows/scale-test-ci.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: E2E setup
         uses: ./.github/actions/e2e-setup
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.3"
 
       # Compile before cluster setup so KWOK nodes are fresh when the test starts.
       # KWOK nodes can become NotReady if the Go build runs after creation.

--- a/cli-plugin/go.mod
+++ b/cli-plugin/go.mod
@@ -1,3 +1,3 @@
 module github.com/ai-dynamo/grove/cli-plugin
 
-go 1.25.0
+go 1.26.3

--- a/operator/api/go.mod
+++ b/operator/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/ai-dynamo/grove/operator/api
 
-go 1.25.0
+go 1.26.3
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/operator/client/go.mod
+++ b/operator/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/ai-dynamo/grove/operator/client
 
-go 1.25.0
+go 1.26.3
 
 require (
 	github.com/ai-dynamo/grove/operator/api v0.0.0

--- a/operator/e2e/README.md
+++ b/operator/e2e/README.md
@@ -10,7 +10,7 @@ The following tools must be installed:
 - **Docker** - For running containers and k3d
 - **skaffold** (v2.x) - For deploying Grove operator
 - **helm** - For deploying Helm charts
-- **Go** (1.24.5+) - For running the tests
+- **Go** (1.26.3+) - For running the tests
 
 The following tools are nice to have
 - **k3d** (v5.x) - For creating local Kubernetes clusters

--- a/operator/hack/e2e-autoMNNVL/README.md
+++ b/operator/hack/e2e-autoMNNVL/README.md
@@ -86,7 +86,7 @@ make e2e-cluster-down
 - `kubectl` installed
 - `helm` installed
 - `skaffold` installed
-- Go 1.25+
+- Go 1.26.3+
 
 ## Cluster Details
 

--- a/scheduler/api/go.mod
+++ b/scheduler/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/ai-dynamo/grove/scheduler/api
 
-go 1.25.0
+go 1.26.3
 
 require k8s.io/apimachinery v0.35.5
 

--- a/scheduler/client/go.mod
+++ b/scheduler/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/ai-dynamo/grove/scheduler/client
 
-go 1.25.0
+go 1.26.3
 
 require (
 	github.com/ai-dynamo/grove/scheduler/api v0.0.0


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Aligns Grove's Go baseline to `1.26.3` across the remaining modules, CI workflows, e2e setup, and related documentation.

This completes the follow-up work after:
- #603 updated the operator module Go directive while upgrading Kubernetes dependencies.
- #681 updated the operator Dockerfile builder image.

The e2e setup also pins `GOROOT` to the active Go toolchain after `setup-go`, so self-hosted runners do not leak a stale `GOROOT` from their preinstalled Go version into `skaffold`/`ko` builds.

#### Which issue(s) this PR fixes:

Fixes: #683

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a API change?

```release-note
Upgrade Go baseline to 1.26.3
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
