### PR TITLE
fix: wait for deployment availability in e2e setup

### DIFF
--- a/operator/hack/e2e-cluster/config-cluster.py
+++ b/operator/hack/e2e-cluster/config-cluster.py
@@ -161,12 +161,12 @@ def ensure_fake_gpu(desired: bool) -> None:
             f" --wait"
         )
 
-        log_info("Waiting for fake GPU operator pods to be ready...")
+        log_info("Waiting for fake GPU operator deployments to be available...")
         run_or_warn(
-            f"kubectl wait --for=condition=Ready pods"
+            f"kubectl wait --for=condition=Available deployment"
             f" -l app.kubernetes.io/name=fake-gpu-operator"
             f" -n {FAKE_GPU_NAMESPACE} --timeout=120s",
-            "Fake GPU operator pods did not become ready",
+            "Fake GPU operator deployments did not become available",
         )
 
         # Verify CRD exists
@@ -241,17 +241,17 @@ def _wait_for_cert_refresh_restart(
         log_info(f"No cert refresh restart detected within {timeout}s — continuing")
         return
 
-    log_info("Waiting for operator pod to be ready after cert refresh restart...")
+    log_info("Waiting for operator deployment to be available after cert refresh restart...")
     run_or_warn(
         f"kubectl rollout status deployment/{GROVE_RELEASE}"
         f" -n {GROVE_NAMESPACE} --timeout=120s",
         "Grove operator rollout did not complete after cert refresh restart",
     )
     run_or_warn(
-        f"kubectl wait --for=condition=Ready pods"
+        f"kubectl wait --for=condition=Available deployment"
         f" -l app.kubernetes.io/name=grove-operator"
         f" -n {GROVE_NAMESPACE} --timeout=120s",
-        "Grove operator pod did not become ready after cert refresh restart",
+        "Grove operator deployment did not become available after cert refresh restart",
     )
 
 
@@ -275,7 +275,7 @@ def ensure_auto_mnnvl(enabled: bool, *, skip_wait: bool = False) -> None:
     )
 
     if not skip_wait:
-        log_info("Waiting for Grove operator pod to be ready...")
+        log_info("Waiting for Grove operator deployment to be available...")
         # The upgrade may trigger a rolling restart; wait for the new pod.
         run_or_warn(
             f"kubectl rollout status deployment/{GROVE_RELEASE}"
@@ -283,10 +283,10 @@ def ensure_auto_mnnvl(enabled: bool, *, skip_wait: bool = False) -> None:
             "Grove operator rollout did not complete",
         )
         run_or_warn(
-            f"kubectl wait --for=condition=Ready pods"
+            f"kubectl wait --for=condition=Available deployment"
             f" -l app.kubernetes.io/name=grove-operator"
             f" -n {GROVE_NAMESPACE} --timeout=120s",
-            "Grove operator pod did not become ready",
+            "Grove operator deployment did not become available",
         )
         # Cert-rotation may exit the process to trigger a restart; poll for it
         # rather than using a fixed sleep.

--- a/operator/hack/e2e-cluster/create-e2e-cluster.py
+++ b/operator/hack/e2e-cluster/create-e2e-cluster.py
@@ -499,9 +499,9 @@ def deploy_grove_operator(config: ClusterConfig, operator_dir: Path):
 
     console.print("[green]✅ Grove operator deployed[/green]")
 
-    # Wait for Grove pods
-    console.print("[yellow]ℹ️  Waiting for Grove pods to be ready...[/yellow]")
-    sh.kubectl("wait", "--for=condition=Ready", "pods", "--all", "-n", "grove-system", "--timeout=5m")
+    # Wait for Grove deployments
+    console.print("[yellow]ℹ️  Waiting for Grove deployments to be available...[/yellow]")
+    sh.kubectl("wait", "--for=condition=Available", "deployment", "--all", "-n", "grove-system", "--timeout=5m")
 
     # Wait for webhook
     console.print("[yellow]ℹ️  Waiting for Grove webhook to be ready...[/yellow]")
@@ -692,8 +692,8 @@ def main(
 
     # Wait for Kai and apply queues
     if not skip_kai:
-        console.print("[yellow]ℹ️  Waiting for Kai Scheduler pods to be ready...[/yellow]")
-        sh.kubectl("wait", "--for=condition=Ready", "pods", "--all", "-n", "kai-scheduler", "--timeout=5m")
+        console.print("[yellow]ℹ️  Waiting for Kai Scheduler deployments to be available...[/yellow]")
+        sh.kubectl("wait", "--for=condition=Available", "deployment", "--all", "-n", "kai-scheduler", "--timeout=5m")
 
         # Wait for webhook to be available before applying queues (pods ready != webhook ready)
         console.print("[yellow]ℹ️  Creating default Kai queues (with retry for webhook readiness)...[/yellow]")

--- a/operator/hack/infra_manager/orchestrator.py
+++ b/operator/hack/infra_manager/orchestrator.py
@@ -143,7 +143,7 @@ def _run_prepull(registry_port: int) -> None:
 
 
 def _run_kai_post_install(operator_dir: Path) -> None:
-    """Wait for Kai pods and create queues.
+    """Wait for Kai deployments and create queues.
 
     Args:
         operator_dir: Root directory of the Grove operator source tree.
@@ -151,8 +151,8 @@ def _run_kai_post_install(operator_dir: Path) -> None:
     Raises:
         RuntimeError: If Kai queue creation fails after retries.
     """
-    console.print("[yellow]\u2139\ufe0f  Waiting for Kai Scheduler pods to be ready...[/yellow]")
-    sh.kubectl("wait", "--for=condition=Ready", "pods", "--all", "-n", NS_KAI_SCHEDULER, "--timeout=5m")
+    console.print("[yellow]\u2139\ufe0f  Waiting for Kai Scheduler deployments to be available...[/yellow]")
+    sh.kubectl("wait", "--for=condition=Available", "deployment", "--all", "-n", NS_KAI_SCHEDULER, "--timeout=5m")
     console.print("[yellow]\u2139\ufe0f  Creating default Kai queues (with retry for webhook readiness)...[/yellow]")
     try:
         apply_kai_queues(operator_dir / REL_QUEUES_YAML)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Makes e2e setup wait for Kubernetes Deployments to become `Available` instead of waiting on pod snapshots.

`kubectl wait --for=condition=Ready pods --all` can fail when a pod observed at the beginning of the wait is replaced during rollout, for example:

```text
Error from server (NotFound): pods "kai-scheduler-default-7b8f855998-rtmd5" not found
```

This updates the KAI Scheduler, Grove operator, and fake GPU operator setup waits to use Deployment availability instead.

#### Which issue(s) this PR fixes:

Fixes #684

#### Special notes for your reviewer:

This is intended to unblock the e2e setup flake seen in https://github.com/ai-dynamo/grove/pull/603.

This PR is stacked on the PR 603 branch, so it is opened as draft until the base change is ready.

Local:
- `python3 -m py_compile operator/hack/infra_manager/orchestrator.py operator/hack/e2e-cluster/create-e2e-cluster.py operator/hack/e2e-cluster/config-cluster.py`
- `git diff --check`

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
