### PR TITLE
GREP-0677: Scale-to-Zero Component Hibernation

### DIFF
--- a/docs/proposals/0677-scale-to-zero-component-hibernation/README.md
+++ b/docs/proposals/0677-scale-to-zero-component-hibernation/README.md
@@ -25,7 +25,7 @@
 
 ## Summary
 
-Grove should treat standalone `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP leaves existing `minAvailable` semantics unchanged, makes gang logic tolerant of zero-replica members, and rejects any positive replica count below `minAvailable`.
+Grove should treat standalone `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP makes gang logic tolerant of zero-replica members, rejects any positive replica count below `minAvailable`, and treats a PCSG wake as ordinary scale-out with one scaled `PodGang` per replica.
 
 ## Motivation
 
@@ -43,11 +43,11 @@ External replica writers should target either `0` or a value at least `minAvaila
 
 ### Non-Goals
 
-- Change `minAvailable` semantics, including allowing `minAvailable: 0` or making it mutable.
+- Allow `minAvailable: 0` or make it mutable.
 
 ## Proposal
 
-When a standalone `PodClique` or `PodCliqueScalingGroup` has `replicas: 0`, Grove should not require it as a gang member. When replicas become positive again, its existing `minAvailable` should apply normally.
+When a standalone `PodClique` or `PodCliqueScalingGroup` has `replicas: 0`, Grove should not require it as a gang member. When replicas become positive again, `minAvailable` continues to define the component's availability and gang-termination threshold. For a waking `PodCliqueScalingGroup`, it does not require the first `minAvailable` replicas to be scheduled atomically with each other.
 
 An idle component should leave the `PodGang` rather than stay in it with a zero threshold: no `PodGroup` in `PodGang.spec.podGroups`, and no scaled `PodGang` for an idle `PodCliqueScalingGroup`. Shrinking a gang must not disturb the members still running.
 
@@ -71,7 +71,7 @@ Grove rejects positive replica counts below `minAvailable`:
 | --- | --- |
 | `0` | Intentional idle state. The component contributes no required gang members and does not breach `minAvailable`. |
 | `0 < replicas < minAvailable` | Rejected for create and update requests, including the `/scale` subresource. |
-| `replicas >= minAvailable` | Persisted as requested. Normal Grove gang behavior applies. |
+| `replicas >= minAvailable` | Persisted as requested. Waking components follow the [gang behavior](#gang-behavior) below. |
 
 For independent scale targets, the persisted invariant is:
 
@@ -99,7 +99,32 @@ For `PodClique`, omitted `replicas` defaults to `1`, while explicit `0` is prese
 
 While a component is idle, it contributes no `PodGroup` and zero observed scheduled, available, and updated replicas. It does not set `MinAvailableBreached` to `True`, counts as updated for rolling-update completion, and does not trigger gang termination.
 
-An idle component is omitted from `PodGangMap` entry membership. If all components are idle, Grove retains an empty current-generation anchor without materializing a `PodGang`. On wake, Grove populates that anchor if no `PodGang` is active; otherwise, it creates a new entry for the waking component without expanding an existing materialized `PodGang`.
+Idle components leave `PodGangMap` membership. Empty current-generation anchor and scale-out entries remain logical slots without materialized `PodGangs`.
+
+On `0 -> N`:
+
+1. **PCSG:** all replica indices enter the current-generation `ScaleOut` entry, creating one SPG per replica. Gang and PCSG topology constraints apply per replica, not across `minAvailable` replicas.
+2. **Standalone PodClique:** restore membership and the full `PodGroup` in the current-generation anchor (`A0`, or the highest `AnchorIndex` if several exist), materializing it if needed. No additional anchor is created.
+
+```text
+PCSG (minAvailable: 2):
+  Initial:  A0 [replica 0 + replica 1] + SPG [replica 2]
+  Wake:     A0, if active
+             +--> SPG [replica 0]
+             +--> SPG [replica 1]
+             +--> SPG [replica 2]
+
+Standalone Decode:
+  Before idle: A0 [Router + Decode]
+  Idle:        A0 [Router]
+  Wake:        A0 [Router + Decode]
+```
+
+An empty `ScaleOut` entry gets a fresh epoch, depending on a materialized anchor only if one exists. Non-empty entries retain their epoch and dependencies.
+
+Restoring a standalone PodClique's membership does not require it to be scheduled together with running anchor members or waking PCSGs. An already scheduled anchor keeps its epoch and `LastScheduled`, so dependent SPGs do not wait for this PodClique to wake. The restored `PodGroup` uses the PodClique's `minAvailable` as `MinReplicas`; backend tests must verify that this is enforced without disrupting running pods.
+
+With a running router and independent P/D PCSGs (`minAvailable: 1`), each `0 -> 1` wake creates one SPG, without another anchor or joint P/D scheduling.
 
 ### Autoscaler Integration
 
@@ -208,7 +233,8 @@ Prototype coverage should show:
 - rejected updates leave `spec.replicas` unchanged;
 - a KEDA-like integration transitions from `0` directly to `minAvailable` or above without writing a positive below-quorum value;
 - an HPA-like writer receives a validation error for a below-quorum recommendation and leaves `spec.replicas` unchanged, with repeated retry behavior documented;
-- scaling to `minAvailable` or above re-enters normal gang behavior.
+- repeated sleep/wake cycles, including all-idle and post-coherent-update cases, follow the gang behavior above without adding anchors on standalone wake;
+- scheduler-backed tests verify the restored standalone `MinReplicas` floor with `minAvailable > 1`, undisturbed running members, and SPG dependency behavior during concurrent wakes.
 
 ### Graduation Criteria
 

--- a/docs/proposals/0677-scale-to-zero-component-hibernation/README.md
+++ b/docs/proposals/0677-scale-to-zero-component-hibernation/README.md
@@ -1,4 +1,4 @@
-# GREP-0677: Zero-Replica Gang Membership
+# GREP-0677: Scale-to-Zero Component Hibernation
 
 <!-- toc -->
 - [Summary](#summary)

--- a/docs/proposals/0677-zero-replica-gang-membership/README.md
+++ b/docs/proposals/0677-zero-replica-gang-membership/README.md
@@ -18,7 +18,7 @@
 
 ## Summary
 
-Grove should treat `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP is only a direction-setting draft: it keeps `minAvailable` non-zero and immutable, makes future gang logic tolerant of zero-replica members, and intentionally leaves detailed implementation design to follow-up work.
+Grove should treat `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP is only a direction-setting draft: it keeps `minAvailable` non-zero and immutable, makes future gang logic tolerant of zero-replica members, and keeps positive replicas below `minAvailable` invalid.
 
 ## Motivation
 
@@ -29,6 +29,7 @@ Using `minAvailable: 0` would overload a field that already affects gang members
 ### Goals
 
 - Confirm `replicas: 0` as an intentional idle state for `PodClique` and `PodCliqueScalingGroup`.
+- Confirm that positive replicas below `minAvailable` remain invalid.
 - Keep `minAvailable` non-zero and immutable.
 - Give follow-up work one agreed direction.
 - Use a prototype PR only to show feasibility.
@@ -37,6 +38,7 @@ Using `minAvailable: 0` would overload a field that already affects gang members
 
 - Support `minAvailable: 0`.
 - Make `minAvailable` mutable.
+- Automatically inflate positive replicas below `minAvailable`.
 - Define the complete implementation in this draft.
 - Treat the prototype as production complete.
 - Define complete behavior differences between `PodClique` and `PodCliqueScalingGroup`.
@@ -45,13 +47,23 @@ Using `minAvailable: 0` would overload a field that already affects gang members
 
 When a `PodClique` or `PodCliqueScalingGroup` has `replicas: 0`, Grove should not require it as a gang member. When replicas become positive again, its existing `minAvailable` should apply normally.
 
-This GREP only special-cases `replicas: 0`; positive replicas below `minAvailable` remain invalid.
+This GREP only special-cases `replicas: 0`; positive replicas below `minAvailable` remain invalid. The intended contract is:
+
+| Desired replicas | Behavior |
+| --- | --- |
+| `replicas: 0` | Intentional idle state. The component contributes no required gang members and does not breach `minAvailable`. |
+| `0 < replicas < minAvailable` | Invalid desired state. Grove should reject it rather than gang-scheduling a partial component. |
+| `replicas >= minAvailable` | Normal Grove behavior. The component participates in gang scheduling and gang termination using its configured `minAvailable`. |
+
+Grove should not derive `max(minAvailable, replicas)` or overwrite the autoscaler's desired value.
 
 This draft does not define every controller or backend branch. Those details should be added only after reviewers agree on the direction.
 
 ### Limitations/Risks & Mitigations
 
 The main risk is confusing "idle" with "unavailable." The proposed direction ties idle state to desired replicas, not observed status.
+
+External autoscalers must follow the same contract: scale these components either to `0` or to `>= minAvailable`.
 
 The prototype must be described only as a feasibility artifact, not as the final design.
 
@@ -151,7 +163,8 @@ Prototype coverage should show:
 
 - zero-replica components do not block the base gang;
 - `minAvailable` remains non-zero;
-- scaling back above zero can re-enter normal gang behavior.
+- positive replicas below `minAvailable` are rejected;
+- scaling back to `minAvailable` or above can re-enter normal gang behavior.
 
 ### Graduation Criteria
 
@@ -163,6 +176,7 @@ Prototype coverage should show:
 
 - Allow `minAvailable: 0`: explicit, but overloads an existing availability contract.
 - Make `minAvailable` mutable: follows scale state, but changes the immutability contract.
+- Treat desired replicas as `max(minAvailable, replicas)`: avoids rejecting partial wake-ups, but hides the autoscaler's requested state.
 - Work around this outside Grove: avoids Grove changes, but leaves no consistent Grove semantics.
 
 ## Appendix

--- a/docs/proposals/0677-zero-replica-gang-membership/README.md
+++ b/docs/proposals/0677-zero-replica-gang-membership/README.md
@@ -1,0 +1,176 @@
+# GREP-0677: Zero-Replica Gang Membership
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [Limitations/Risks &amp; Mitigations](#limitationsrisks--mitigations)
+- [Design Details](#design-details)
+  - [Example](#example)
+  - [Monitoring](#monitoring)
+  - [Test Plan](#test-plan)
+  - [Graduation Criteria](#graduation-criteria)
+- [Alternatives](#alternatives)
+- [Appendix](#appendix)
+<!-- /toc -->
+
+## Summary
+
+Grove should treat `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP is only a direction-setting draft: it keeps `minAvailable` non-zero and immutable, makes future gang logic tolerant of zero-replica members, and intentionally leaves detailed implementation design to follow-up work.
+
+## Motivation
+
+Scale-to-zero serving commonly keeps a router running while workers scale to zero. In that state, worker pods are intentionally absent, not unhealthy.
+
+Using `minAvailable: 0` would overload a field that already affects gang membership, termination, rolling updates, and startup ordering. `replicas` is the mutable scale target, so `replicas: 0` is the cleaner signal.
+
+### Goals
+
+- Confirm `replicas: 0` as an intentional idle state for `PodClique` and `PodCliqueScalingGroup`.
+- Keep `minAvailable` non-zero and immutable.
+- Give follow-up work one agreed direction.
+- Use a prototype PR only to show feasibility.
+
+### Non-Goals
+
+- Support `minAvailable: 0`.
+- Make `minAvailable` mutable.
+- Define the complete implementation in this draft.
+- Treat the prototype as production complete.
+- Define complete behavior differences between `PodClique` and `PodCliqueScalingGroup`.
+
+## Proposal
+
+When a `PodClique` or `PodCliqueScalingGroup` has `replicas: 0`, Grove should not require it as a gang member. When replicas become positive again, its existing `minAvailable` should apply normally.
+
+This GREP only special-cases `replicas: 0`; positive replicas below `minAvailable` remain invalid.
+
+This draft does not define every controller or backend branch. Those details should be added only after reviewers agree on the direction.
+
+### Limitations/Risks & Mitigations
+
+The main risk is confusing "idle" with "unavailable." The proposed direction ties idle state to desired replicas, not observed status.
+
+The prototype must be described only as a feasibility artifact, not as the final design.
+
+## Design Details
+
+No new API fields are proposed.
+
+Implementation should derive effective gang membership from desired replicas. A zero-replica component contributes zero required members while idle.
+
+### Example
+
+Only the fields relevant to gang membership are shown.
+
+Initial serving shape: the router, standalone decode worker, and prefill worker group are running.
+
+```yaml
+apiVersion: grove.io/v1alpha1
+kind: PodCliqueSet
+metadata:
+  name: scale-to-zero-deepseek
+spec:
+  replicas: 1
+  template:
+    cliques:
+    - name: router
+      spec:
+        roleName: router
+        replicas: 1
+        minAvailable: 1
+        podSpec:
+          containers: [{name: router, image: nginx:latest}]
+    - name: pleader
+      spec:
+        roleName: pleader
+        replicas: 1
+        minAvailable: 1
+        podSpec:
+          containers: [{name: pleader, image: nginx:latest}]
+    - name: pworker
+      spec:
+        roleName: pworker
+        replicas: 1
+        minAvailable: 1
+        podSpec:
+          containers: [{name: pworker, image: nginx:latest}]
+    - name: decode
+      spec:
+        roleName: decode
+        replicas: 1
+        minAvailable: 1
+        podSpec:
+          containers: [{name: decode, image: nginx:latest}]
+    podCliqueScalingGroups:
+    - name: prefill
+      cliqueNames: [pleader, pworker]
+      replicas: 1
+      minAvailable: 1
+```
+
+After scale-to-zero: the components remain defined, and the autoscaler only changes the worker `replicas`.
+
+```yaml
+apiVersion: grove.io/v1alpha1
+kind: PodCliqueSet
+metadata:
+  name: scale-to-zero-deepseek
+spec:
+  template:
+    cliques:
+    - name: decode
+      spec:
+        replicas: 0
+        minAvailable: 1
+    podCliqueScalingGroups:
+    - name: prefill
+      cliqueNames: [pleader, pworker]
+      replicas: 0
+      minAvailable: 1
+```
+
+Under this GREP, the second shape means the standalone decode `PodClique` and prefill `PodCliqueScalingGroup` are idle and do not block the router. If they scale above zero, their existing `minAvailable` applies again.
+
+With current Grove validation, the full scale-to-zero shape is rejected because `PodCliqueScalingGroup.replicas: 0` is not yet allowed:
+
+```text
+spec.template.podCliqueScalingGroups[0].replicas: Invalid value: 0: must be greater than 0
+spec.template.podCliqueScalingGroups[0].minAvailable: Invalid value: 1: minAvailable must not be greater than replicas
+```
+
+### Monitoring
+
+No new metrics or status fields are required by this initial draft.
+
+### Test Plan
+
+Prototype coverage should show:
+
+- zero-replica components do not block the base gang;
+- `minAvailable` remains non-zero;
+- scaling back above zero can re-enter normal gang behavior.
+
+### Graduation Criteria
+
+- Alpha: direction accepted and initial implementation exists.
+- Beta: behavior documented and tested.
+- GA: semantics are stable and validated with real scale-to-zero workloads.
+
+## Alternatives
+
+- Allow `minAvailable: 0`: explicit, but overloads an existing availability contract.
+- Make `minAvailable` mutable: follows scale state, but changes the immutability contract.
+- Work around this outside Grove: avoids Grove changes, but leaves no consistent Grove semantics.
+
+## Appendix
+
+- Tracking issue: [ai-dynamo/grove#677](https://github.com/ai-dynamo/grove/issues/677)
+- Related bug: [ai-dynamo/grove#676](https://github.com/ai-dynamo/grove/issues/676)
+- Feasibility prototype: [yankay/grove#2](https://github.com/yankay/grove/pull/2)
+- Local YAML shape: [multinode-disaggregated-with-frontend.yaml](../../../operator/samples/user-guide/02_pod-and-resource-naming-conventions/multinode-disaggregated-with-frontend.yaml)
+- Related Dynamo issue: [ai-dynamo/dynamo#10753](https://github.com/ai-dynamo/dynamo/issues/10753)
+- Related Dynamo PR: [ai-dynamo/dynamo#10532](https://github.com/ai-dynamo/dynamo/pull/10532)
+- Dynamo autoscaling guide: [Dynamo autoscaling](https://docs.nvidia.com/dynamo/v1.1.1/kubernetes-deployment/deployment-guide/autoscaling)

--- a/docs/proposals/0677-zero-replica-gang-membership/README.md
+++ b/docs/proposals/0677-zero-replica-gang-membership/README.md
@@ -18,7 +18,7 @@
 
 ## Summary
 
-Grove should treat `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP is only a direction-setting draft: it keeps `minAvailable` non-zero and immutable, makes future gang logic tolerant of zero-replica members, and keeps positive replicas below `minAvailable` invalid.
+Grove should treat `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP is only a direction-setting draft: it keeps `minAvailable` non-zero and immutable, makes future gang logic tolerant of zero-replica members, keeps the default behavior for positive replicas below `minAvailable`, and defines an opt-in clamp policy for generic autoscalers.
 
 ## Motivation
 
@@ -26,36 +26,36 @@ Scale-to-zero serving commonly keeps a router running while workers scale to zer
 
 Using `minAvailable: 0` would overload a field that already affects gang membership, termination, rolling updates, and startup ordering. `replicas` is the mutable scale target, so `replicas: 0` is the cleaner signal.
 
+External autoscalers should be treated as producers of desired replicas, not as components that understand Grove's per-component `minAvailable`. If Grove needs gang-safe membership above the autoscaler-written value, Grove should derive an internal effective value without writing back to `spec.replicas`.
+
 ### Goals
 
-- Confirm `replicas: 0` as an intentional idle state for `PodClique` and `PodCliqueScalingGroup`.
-- Confirm that positive replicas below `minAvailable` remain invalid.
-- Keep `minAvailable` non-zero and immutable.
-- Give follow-up work one agreed direction.
-- Use a prototype PR only to show feasibility.
+- Treat `replicas: 0` as an intentional idle state without changing `minAvailable`.
+- Keep the default validation behavior for positive replicas below `minAvailable`.
+- Define an opt-in `Clamp` policy for generic autoscalers that wake below `minAvailable`.
+- Preserve autoscaler-written `spec.replicas` as desired scale.
 
 ### Non-Goals
 
-- Support `minAvailable: 0`.
-- Make `minAvailable` mutable.
-- Automatically inflate positive replicas below `minAvailable`.
-- Define the complete implementation in this draft.
-- Treat the prototype as production complete.
-- Define complete behavior differences between `PodClique` and `PodCliqueScalingGroup`.
+- Change `minAvailable` semantics, including allowing `minAvailable: 0` or making it mutable.
+- Require generic autoscalers to discover Grove component quorum.
+- Define the complete production implementation in this draft.
 
 ## Proposal
 
 When a `PodClique` or `PodCliqueScalingGroup` has `replicas: 0`, Grove should not require it as a gang member. When replicas become positive again, its existing `minAvailable` should apply normally.
 
-This GREP only special-cases `replicas: 0`; positive replicas below `minAvailable` remain invalid. The intended contract is:
+For `0 < replicas < minAvailable`, Grove should define an explicit below-quorum policy:
 
-| Desired replicas | Behavior |
-| --- | --- |
-| `replicas: 0` | Intentional idle state. The component contributes no required gang members and does not breach `minAvailable`. |
-| `0 < replicas < minAvailable` | Invalid desired state. Grove should reject it rather than gang-scheduling a partial component. |
-| `replicas >= minAvailable` | Normal Grove behavior. The component participates in gang scheduling and gang termination using its configured `minAvailable`. |
+| Desired replicas | Default policy `Block` | Opt-in policy `Clamp` |
+| --- | --- | --- |
+| `replicas: 0` | Intentional idle state. The component contributes no required gang members and does not breach `minAvailable`. | Same as `Block`. |
+| `0 < replicas < minAvailable` | Invalid, preserving the existing positive-replica validation behavior. Grove does not create partial gang members. | Grove preserves `spec.replicas` as desired scale, computes `effectiveReplicas = minAvailable`, and exposes the desired/effective split in status or events. |
+| `replicas >= minAvailable` | Normal Grove behavior. The component participates in gang scheduling and gang termination using its configured `minAvailable`. | Same as `Block`; desired and effective replicas are equal. |
 
-Grove should not derive `max(minAvailable, replicas)` or overwrite the autoscaler's desired value.
+Under the default `Block` policy, this GREP only changes the zero-replica case; positive replicas below `minAvailable` keep the existing validation behavior.
+
+Grove should not implement `Clamp` by writing the clamped value back to `spec.replicas`. HPA or KEDA may repeatedly recompute a desired value such as `1`; writing `minAvailable` back into the scale target can create a control-plane write fight. If `Clamp` is used, the autoscaler-written value remains desired scale and Grove uses a separate effective value internally.
 
 This draft does not define every controller or backend branch. Those details should be added only after reviewers agree on the direction.
 
@@ -63,15 +63,34 @@ This draft does not define every controller or backend branch. Those details sho
 
 The main risk is confusing "idle" with "unavailable." The proposed direction ties idle state to desired replicas, not observed status.
 
-External autoscalers must follow the same contract: scale these components either to `0` or to `>= minAvailable`.
+The default `Block` policy keeps the existing positive-replica validation behavior. Generic HPA/KEDA users can still fail to wake from zero to one if they do not configure an autoscaler floor. Users who prefer automatic wake-up can opt into `Clamp`.
+
+The `Clamp` policy makes generic HPA/KEDA scale-from-zero friendlier, but `spec.replicas: 1` may intentionally run `minAvailable` members. This desired/effective split must be visible in status or events.
 
 The prototype must be described only as a feasibility artifact, not as the final design.
 
 ## Design Details
 
-No new API fields are proposed.
+Implementation should derive gang membership from desired replicas and the below-quorum policy. A zero-replica component contributes zero required members while idle.
 
-Implementation should derive effective gang membership from desired replicas. A zero-replica component contributes zero required members while idle.
+This draft proposes `belowMinAvailablePolicy` as an optional enum field next to `replicas` and `minAvailable` on `PodClique`, `PodCliqueScalingGroup`, and their `PodCliqueSet` template configs:
+
+```go
+// +kubebuilder:validation:Enum=Block;Clamp
+// +kubebuilder:default=Block
+BelowMinAvailablePolicy *BelowMinAvailablePolicy `json:"belowMinAvailablePolicy,omitempty"`
+```
+
+The default value is `Block`. `Clamp` is opt-in for users who want Grove to translate a positive desired replica count below `minAvailable` into gang-safe effective replicas.
+
+For `Clamp`, the effective count is:
+
+```text
+effectiveReplicas = 0 if desiredReplicas == 0
+effectiveReplicas = max(desiredReplicas, minAvailable) otherwise
+```
+
+For `Block`, positive desired replicas below `minAvailable` remain invalid, preserving the existing behavior for positive replicas.
 
 ### Example
 
@@ -137,14 +156,26 @@ spec:
       spec:
         replicas: 0
         minAvailable: 1
+        belowMinAvailablePolicy: Clamp
     podCliqueScalingGroups:
     - name: prefill
       cliqueNames: [pleader, pworker]
       replicas: 0
       minAvailable: 1
+      belowMinAvailablePolicy: Clamp
 ```
 
 Under this GREP, the second shape means the standalone decode `PodClique` and prefill `PodCliqueScalingGroup` are idle and do not block the router. If they scale above zero, their existing `minAvailable` applies again.
+
+A canonical below-quorum wake-up looks like:
+
+```text
+minAvailable = 2
+replicas = 0
+external autoscaler writes replicas = 1
+```
+
+With `Block`, this remains invalid because positive replicas are below `minAvailable`. With `Clamp`, Grove preserves `replicas: 1`, internally uses `effectiveReplicas: 2`, and exposes that split.
 
 With current Grove validation, the full scale-to-zero shape is rejected because `PodCliqueScalingGroup.replicas: 0` is not yet allowed:
 
@@ -155,7 +186,7 @@ spec.template.podCliqueScalingGroups[0].minAvailable: Invalid value: 1: minAvail
 
 ### Monitoring
 
-No new metrics or status fields are required by this initial draft.
+For `Clamp`, status or events should show desired replicas and effective replicas so users can understand why the running member count is greater than `spec.replicas`.
 
 ### Test Plan
 
@@ -163,7 +194,9 @@ Prototype coverage should show:
 
 - zero-replica components do not block the base gang;
 - `minAvailable` remains non-zero;
-- positive replicas below `minAvailable` are rejected;
+- default `Block` rejects `0 < replicas < minAvailable`;
+- opt-in `Clamp` computes an effective count of at least `minAvailable`;
+- `Clamp` does not write the effective value back to `spec.replicas`;
 - scaling back to `minAvailable` or above can re-enter normal gang behavior.
 
 ### Graduation Criteria
@@ -176,7 +209,9 @@ Prototype coverage should show:
 
 - Allow `minAvailable: 0`: explicit, but overloads an existing availability contract.
 - Make `minAvailable` mutable: follows scale state, but changes the immutability contract.
-- Treat desired replicas as `max(minAvailable, replicas)`: avoids rejecting partial wake-ups, but hides the autoscaler's requested state.
+- Only support `Block` and never add `Clamp`: keeps `spec.replicas` truthful, but generic HPA/KEDA scale-from-zero can get stuck without an autoscaler floor.
+- Always clamp positive replicas below `minAvailable`: makes generic HPA/KEDA wake-up work, but imposes a default desired/effective split on every below-quorum state.
+- Add `activeMinReplicas` now: useful if active warm capacity can differ from gang quorum, but premature if the active floor is simply `minAvailable`.
 - Work around this outside Grove: avoids Grove changes, but leaves no consistent Grove semantics.
 
 ## Appendix
@@ -188,3 +223,4 @@ Prototype coverage should show:
 - Related Dynamo issue: [ai-dynamo/dynamo#10753](https://github.com/ai-dynamo/dynamo/issues/10753)
 - Related Dynamo PR: [ai-dynamo/dynamo#10532](https://github.com/ai-dynamo/dynamo/pull/10532)
 - Dynamo autoscaling guide: [Dynamo autoscaling](https://docs.nvidia.com/dynamo/v1.1.1/kubernetes-deployment/deployment-guide/autoscaling)
+- Research notes: [research-notes.md](research-notes.md)

--- a/docs/proposals/0677-zero-replica-gang-membership/README.md
+++ b/docs/proposals/0677-zero-replica-gang-membership/README.md
@@ -18,13 +18,14 @@
 - [Open Questions](#open-questions)
 - [Remaining Work](#remaining-work)
 - [Alternatives](#alternatives)
+- [Historical Discussion](#historical-discussion)
 - [Appendix](#appendix)
   - [Upstream Follow-ups](#upstream-follow-ups)
 <!-- /toc -->
 
 ## Summary
 
-Grove should treat `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP keeps `minAvailable` non-zero and immutable, makes gang logic tolerant of zero-replica members, and describes two below-quorum policies for `0 < replicas < minAvailable`: `Block`, which keeps today's rejection, and `Clamp`, which wakes the component at `minAvailable`. Both are carried here because the choice between them is an [open question](#open-questions).
+Grove should treat `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP keeps `minAvailable` non-zero and immutable, makes gang logic tolerant of zero-replica members, and uses a fixed `Clamp` rule to wake a component at `minAvailable` when an autoscaler writes a positive value below quorum.
 
 ## Motivation
 
@@ -38,7 +39,7 @@ External autoscalers should be treated as producers of desired replicas, not as 
 
 - Treat `replicas: 0` as an intentional idle state without changing `minAvailable`.
 - Make `0` the only value below `minAvailable` that Grove runs as written.
-- Describe both below-quorum policies for `0 < replicas < minAvailable`, `Block` and `Clamp`, and leave the choice between them to [Open Questions](#open-questions).
+- Clamp a wake-up request in `0 < replicas < minAvailable` to an effective count of `minAvailable`.
 - Preserve autoscaler-written `spec.replicas` as desired scale, never writing an effective value back.
 
 ### Non-Goals
@@ -65,17 +66,15 @@ An idle component should leave the `PodGang` rather than stay in it with a zero 
 
 ### Below-Quorum Policy
 
-For `0 < replicas < minAvailable`, Grove should define an explicit below-quorum policy:
+For `0 < replicas < minAvailable`, Grove uses a fixed `Clamp` rule:
 
-| Desired replicas | Default policy `Block` | Opt-in policy `Clamp` |
-| --- | --- | --- |
-| `replicas: 0` | Intentional idle state. The component contributes no required gang members and does not breach `minAvailable`. | Same as `Block`. |
-| `0 < replicas < minAvailable` | Invalid, as in the `PodCliqueSet` template today, with the same rule extended to the object and its `scale` subresource. Grove does not create partial gang members. | Accepted only when waking from `0`. Grove preserves `spec.replicas` as desired scale and computes `effectiveReplicas = minAvailable`. |
-| `replicas >= minAvailable` | Normal Grove behavior. The component participates in gang scheduling and gang termination using its configured `minAvailable`. | Same as `Block`; desired and effective replicas are equal. |
+| Desired replicas | Behavior |
+| --- | --- |
+| `replicas: 0` | Intentional idle state. The component contributes no required gang members and does not breach `minAvailable`. |
+| `0 < replicas < minAvailable` | Accepted only when waking from `0`. Grove preserves `spec.replicas` as desired scale and computes `effectiveReplicas = minAvailable`. |
+| `replicas >= minAvailable` | Normal Grove behavior. The component participates in gang scheduling and gang termination using its configured `minAvailable`; desired and effective replicas are equal. |
 
-Which column survives is an [open question](#open-questions): reviewers have asked for `Clamp` to be the only behavior. The columns are independent, so dropping one leaves the other unchanged.
-
-Existing manifests keep their meaning, except a `PodClique` with `replicas: 0` and `minAvailable: 1`: one replica today, idle here.
+Existing behavior changes in two cases: a `PodClique` with `replicas: 0` becomes idle instead of defaulting to one, and an object already in `(0, minAvailable)` is reconciled at `effectiveReplicas = minAvailable`.
 
 `Clamp` applies only on the wake-up edge: a write from `0` into the range is accepted, one from `minAvailable` or above is rejected, so `0` is the only legal scale-in target below `minAvailable`. An explicit scale-in deserves an error, not a silent promotion. Comparing against the previous value puts that check in a validating webhook on the resource and its `scale` subresource, not in defaulting.
 
@@ -85,7 +84,7 @@ Grove should not implement `Clamp` by writing the clamped value back to `spec.re
 
 The main risk is confusing "idle" with "unavailable." The proposed direction ties idle state to desired replicas, not observed status.
 
-Generic HPA/KEDA users can still fail to wake from zero to one without an autoscaler floor, and `Clamp` is the opt-in escape. Its cost is a desired/effective split: `spec.replicas: 1` may intentionally run `minAvailable` members. Validity also depends on the object's current value, so the same manifest can be accepted or rejected.
+Generic HPA/KEDA users can still fail to wake from zero to one without an autoscaler floor, so Grove applies `Clamp` on that wake-up edge. Its cost is a desired/effective split: `spec.replicas: 1` may intentionally run `minAvailable` members. Validity also depends on the object's current value, so the same manifest can be accepted or rejected.
 
 That split is transitional: most replica writers cannot express an active floor above `1` while still allowing `0`. KEDA can, pairing `minReplicaCount` with `idleReplicaCount: 0`, and if the rest gain it nothing lands in `(0, minAvailable)`. Grove must still define the case, since users and custom controllers also write `spec.replicas`.
 
@@ -93,15 +92,7 @@ Rolling updates already stall on a zero-replica standalone `PodClique`: completi
 
 ## Design Details
 
-This GREP proposes `belowMinAvailablePolicy` as an optional enum field next to `replicas` and `minAvailable` on `PodClique`, `PodCliqueScalingGroup`, and their `PodCliqueSet` template configs:
-
-```go
-// +kubebuilder:validation:Enum=Block;Clamp
-// +kubebuilder:default=Block
-BelowMinAvailablePolicy *BelowMinAvailablePolicy `json:"belowMinAvailablePolicy,omitempty"`
-```
-
-`Clamp` is opt-in for users who want Grove to translate a positive desired replica count below `minAvailable` into gang-safe effective replicas. It must never clamp `replicas: 0`, which would defeat scale-to-zero.
+`Clamp` is fixed behavior for translating a positive desired replica count below `minAvailable` into gang-safe effective replicas when waking from zero. It must never clamp `replicas: 0`, which would defeat scale-to-zero.
 
 For `Clamp`, the effective count is:
 
@@ -112,6 +103,8 @@ effectiveReplicas = max(desiredReplicas, minAvailable) otherwise
 
 `effectiveReplicas` is derived per reconciliation, not stored; only admission consults the previous value. A `Clamp` component therefore cannot oscillate: it is idle or at least `minAvailable`. Grove treats `spec.replicas` as read-only, leaving the replica writer as its only writer, and the defaulting of `PodClique` `replicas: 0` to `1` is removed.
 
+For the `/scale` subresource, `spec.replicas` remains the desired replica count and `status.replicas` reports actual observed replicas. `PodClique`, `PodCliqueScalingGroup`, and `PodCliqueSet` should use that same semantic contract.
+
 Gang logic reads `minAvailable` directly today, so idle needs a derived floor: `effectiveMinAvailable` is `0` while idle and `minAvailable` otherwise. The contributed `PodGroup`, the breach condition, and the rolling-update completion check should all read it, so an idle component contributes no `PodGroup`, never breaches, and counts as updated.
 
 ### Autoscaler Integration
@@ -120,11 +113,11 @@ Grove only observes `spec.replicas`, so what matters per writer is when it sleep
 
 | Replica writer | Sleep trigger | Wake-up value | Grove needs |
 | --- | --- | --- | --- |
-| Native HPA | Manual `0` is Kubernetes' maintenance mode and stops the HPA. It sleeps by itself only with the `HPAScaleToZero` gate. | Manual, or `1` if the HPA slept it. | `Block`, and no defaulting back to `1`. |
-| KEDA | Triggers idle for `cooldownPeriod`, 5 minutes by default. Sleeping is the default shape. | `minReplicaCount`, `1` by default. It is also the scale-down floor, so skipping the below-quorum range needs `minReplicaCount: minAvailable` with `idleReplicaCount: 0`. | `Block` with that pairing. `Clamp` if `minAvailable` is above `1` and the `ScaledObject` is not editable. |
+| Native HPA | Manual `0` is Kubernetes' maintenance mode and stops the HPA. It sleeps by itself only with the `HPAScaleToZero` gate. | Manual, or `1` if the HPA slept it. | Fixed `Clamp` on wake-up, and no defaulting back to `1`. |
+| KEDA | Triggers idle for `cooldownPeriod`, 5 minutes by default. Sleeping is the default shape. | `minReplicaCount`, `1` by default. It is also the scale-down floor, so skipping the below-quorum range needs `minReplicaCount: minAvailable` with `idleReplicaCount: 0`. | Fixed `Clamp` if `minAvailable` is above `1`; the pairing avoids the desired/effective split when the `ScaledObject` is editable. |
 | Knative KPA | An idle window with no requests, on by default. | `1`, when the activator takes a request. | Same as KEDA, but out of reach: its activator and metrics assume Knative Revisions. |
-| Dynamo Planner, writing the DGD or a `DynamoGraphDeploymentScalingAdapter` | Its own policy; zero is a computed target. | Whatever it computes. | `Clamp` when `minAvailable` is above `1`. Its only floor, `min_endpoint`, permits zero only at `0`, so a decaying load enters the below-quorum range. |
-| A custom controller | Its own policy. | Whatever it computes. | Only zero support, provided it skips `1 .. minAvailable - 1`. |
+| Dynamo Planner, writing the DGD or a `DynamoGraphDeploymentScalingAdapter` | Its own policy; zero is a computed target. | Whatever it computes. | `Clamp` only on a wake from `0`; active scale-in must stay at or above `minAvailable` or jump to `0`. |
+| A custom controller | Its own policy. | Whatever it computes. | Fixed `Clamp` when it wakes into `1 .. minAvailable - 1`; active scale-in into that range is rejected. |
 | Grove's `scaleConfig` | Never; admission requires `minReplicas >= minAvailable`. | n/a | `minReplicas: 0` valid while `1 .. minAvailable - 1` stays invalid, no defaulting it from `replicas`, and the `HPAScaleToZero` gate on the generated HPA. |
 
 Waking from zero also needs a signal independent of a running replica, since serving metrics deadlock: in Dynamo, a model with no workers leaves `/v1/models` and returns `404`.
@@ -170,7 +163,6 @@ spec:
         roleName: decode
         replicas: 2
         minAvailable: 2
-        belowMinAvailablePolicy: Clamp
         podSpec:
           containers: [{name: decode, image: nginx:latest}]
     podCliqueScalingGroups:
@@ -178,7 +170,6 @@ spec:
       cliqueNames: [pleader, pworker]
       replicas: 2
       minAvailable: 2
-      belowMinAvailablePolicy: Clamp
 ```
 
 Scale-to-zero happens on the derived objects, not this template: Grove sets `replicas` only at creation, so the replica writer owns it afterwards.
@@ -200,14 +191,14 @@ kubectl scale podcliquescalinggroup scale-to-zero-deepseek-0-prefill --replicas=
 
 Each row is one write on that component:
 
-| Write | `Block` | `Clamp` |
-| --- | --- | --- |
-| `0` to `1` | Rejected | Accepted, `effectiveReplicas: 2` |
-| `1` to `2` | Unreachable | Accepted, still two members |
-| `2` to `3` | Accepted | Accepted |
-| `3` to `2` | Accepted | Accepted |
-| `2` to `1` | Rejected | Rejected |
-| `2` to `0` | Accepted | Accepted |
+| Write | Fixed `Clamp` behavior |
+| --- | --- |
+| `0` to `1` | Accepted, `effectiveReplicas: 2` |
+| `1` to `2` | Accepted, still two members |
+| `2` to `3` | Accepted |
+| `3` to `2` | Accepted |
+| `2` to `1` | Rejected |
+| `2` to `0` | Accepted |
 
 `(0, minAvailable)` is therefore one-way: reachable only from `0`, left by scaling up or by writing `0`.
 
@@ -222,7 +213,7 @@ A `PodClique` produces no error there only because defaulting rewrites `replicas
 
 ### Monitoring
 
-For `Clamp`, a `ReplicasBelowMinAvailable` condition should carry the desired and effective replica counts, so users can see why the running member count exceeds `spec.replicas`. It is also the only feedback channel for a below-quorum write, since an autoscaler cannot act on a rejection. Whether it is also the only channel for the desired/effective split depends on what `/scale` reports, which [Open Questions](#open-questions) leaves undecided.
+For `Clamp`, a `ReplicasBelowMinAvailable` condition should carry the desired and effective replica counts, so users can see why the running member count exceeds `spec.replicas`; `/scale.status.replicas` exposes the observed count but not why it differs.
 
 ### Test Plan
 
@@ -230,10 +221,10 @@ Prototype coverage should show:
 
 - zero-replica components do not block the base gang;
 - an idle component does not stall a rolling update;
-- default `Block` rejects `0 < replicas < minAvailable`;
-- opt-in `Clamp` computes an effective count of at least `minAvailable` when waking from `0`;
+- fixed `Clamp` computes an effective count of at least `minAvailable` when waking from `0`;
 - `Clamp` rejects a scale-in into the below-quorum range on both the resource and its `scale` subresource;
 - `Clamp` does not write the effective value back to `spec.replicas`;
+- all three `/scale.status.replicas` implementations report actual observed replicas;
 - scaling back to `minAvailable` or above can re-enter normal gang behavior.
 
 ### Graduation Criteria
@@ -244,17 +235,16 @@ Prototype coverage should show:
 
 ## Open Questions
 
-- Is the below-quorum behavior a fixed rule or an opt-in policy? Reviewer feedback describes the override as unconditional, keeping only `Clamp` and dropping `belowMinAvailablePolicy`. This GREP still carries both, because unconditional clamping is not purely additive: no admission webhook covers `PodClique` or `PodCliqueScalingGroup` today, so a component already at `replicas: 1` with `minAvailable: 2` runs one pod now and would silently run two. Settling on one behavior drops the other column, the field, and the policy names that qualify the rest of this GREP.
-- What does `/scale` `status.replicas` report, and should the three levels agree? It can mirror `spec.replicas` as `desired`, report the clamped target as `effective`, or report `actual` observed pods, which is what the subresource contract asks for. The question exists only under `Clamp`. The levels disagree today: `PodClique` counts non-terminating pods while `PodCliqueScalingGroup` and `PodCliqueSet` mirror `spec.replicas`, so behavior depends on where an autoscaler attaches. HPA reads `spec.replicas` to rescale, but its per-pod branch, used by KEDA's `AverageValue` metrics, divides by `status.replicas`. Reporting `desired` leaves [Monitoring](#monitoring) as the only channel for the split. Answering this needs the contract read and HPA and KEDA behavior measured; a later revision will cover both.
+- Should active scale-in into `(0, minAvailable)` be rejected, or accepted and internally clamped? The current direction limits `Clamp` to scale-out from `0`, returning a validation error for invalid scale-in so callers receive explicit feedback; rejection, however, makes HPA retry failed writes. Acceptance avoids retries by preserving the autoscaler-written desired value in `spec.replicas` while `status.replicas` remains observed, but HPA may report a successful scale-down without reducing pods.
 
 ## Remaining Work
 
 Accepting the direction above does not finish the GREP. Still to come, in this order:
 
-- Measured autoscaler behavior, not reasoning about it: HPA and KEDA against a `Clamp` component across the wake-up edge, repeated below-quorum writes, `cooldownPeriod` and stabilization windows, and each `status.replicas` choice. It confirms or replaces the no-write-fight and no-oscillation claims above, and lands here with its setup and versions.
+- Measured autoscaler behavior, not reasoning about it: HPA and KEDA against a `Clamp` component across the wake-up edge, repeated below-quorum writes, `cooldownPeriod` and stabilization windows, and observed `status.replicas`. It confirms or replaces the no-write-fight and no-oscillation claims above, and lands here with its setup and versions.
 - The admission rule over previous and new value pairs, including create and re-apply, where there is no previous value.
 - Gang behavior in detail: how the `PodGang` reshapes on idle and wake, whether an idle component is absent from the [coherent update](../393-coherent-rolling-updates/README.md) `PodGangMap` or present and empty, whether it joins an MVU, what a scale to zero does to an update in flight, and what that means for gang termination and partial scale.
-- The implementation surface in one place. Neither `PodClique` nor `PodCliqueScalingGroup` has a webhook today, so this GREP implies new ones on both and their `scale` subresource, plus dropping the `PodClique` `replicas: 0` defaulting, the `effectiveMinAvailable` readers, and looser `scaleConfig` rules. Listing them is in scope; designing them is not.
+- The implementation surface in one place. Neither `PodClique` nor `PodCliqueScalingGroup` has a webhook today, so this GREP implies new ones on both and their `scale` subresource, plus dropping the `PodClique` `replicas: 0` defaulting, the `effectiveMinAvailable` readers, looser `scaleConfig` rules, observed `status.replicas` at all three levels, and upgrade handling for pre-existing below-quorum objects. Listing them is in scope; designing them is not.
 
 ## Alternatives
 
@@ -264,6 +254,31 @@ Accepting the direction above does not finish the GREP. Still to come, in this o
 - Only support `Block` and never add `Clamp`: keeps `spec.replicas` truthful, but generic HPA/KEDA scale-from-zero can get stuck without an autoscaler floor.
 - Make `Clamp` direction-agnostic: re-applying a stored object never fails, but an explicit scale-in is silently promoted with no signal to the caller.
 - Add `activeMinReplicas` now: useful if active warm capacity can differ from gang quorum, but premature if the active floor is simply `minAvailable`.
+
+## Historical Discussion
+
+This section records an earlier design stage and is not normative. The proposal originally carried two below-quorum policies while reviewers considered whether `Clamp` should be fixed behavior:
+
+| Desired replicas | Default policy `Block` | Opt-in policy `Clamp` |
+| --- | --- | --- |
+| `replicas: 0` | Intentional idle state. The component contributes no required gang members and does not breach `minAvailable`. | Same as `Block`. |
+| `0 < replicas < minAvailable` | Invalid, as in the `PodCliqueSet` template today, with the same rule extended to the object and its `scale` subresource. Grove does not create partial gang members. | Accepted only when waking from `0`. Grove preserves `spec.replicas` as desired scale and computes `effectiveReplicas = minAvailable`. |
+| `replicas >= minAvailable` | Normal Grove behavior. The component participates in gang scheduling and gang termination using its configured `minAvailable`. | Same as `Block`; desired and effective replicas are equal. |
+
+The opt-in design proposed `belowMinAvailablePolicy` next to `replicas` and `minAvailable` on `PodClique`, `PodCliqueScalingGroup`, and their `PodCliqueSet` template configs:
+
+```go
+// +kubebuilder:validation:Enum=Block;Clamp
+// +kubebuilder:default=Block
+BelowMinAvailablePolicy *BelowMinAvailablePolicy `json:"belowMinAvailablePolicy,omitempty"`
+```
+
+This preserved existing behavior by default because unconditional clamping is not purely additive: no admission webhook covers `PodClique` or `PodCliqueScalingGroup` today, so a component already at `replicas: 1` with `minAvailable: 2` runs one pod now and would run two under `Clamp`. Opt-in `Clamp` was the escape for generic autoscalers that wake below `minAvailable`, at the cost of an additional API field and behavior that varied by policy.
+
+Review resolved two questions: `Clamp` is fixed behavior without a policy field, and `/scale.status.replicas` reports observed replicas while `spec.replicas` holds desired state. The normative proposal therefore drops `Block`, `belowMinAvailablePolicy`, and policy-qualified behavior; they remain here only to preserve the design history.
+
+An intermediate draft considered persisting the clamped value to `spec.replicas`. The current proposal keeps `Clamp` internal to preserve replica-writer ownership and avoid write contention.
+
 ## Appendix
 
 - Tracking issue: [ai-dynamo/grove#677](https://github.com/ai-dynamo/grove/issues/677)

--- a/docs/proposals/0677-zero-replica-gang-membership/README.md
+++ b/docs/proposals/0677-zero-replica-gang-membership/README.md
@@ -6,19 +6,24 @@
   - [Goals](#goals)
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
+  - [Zero Replicas Per Level](#zero-replicas-per-level)
+  - [Below-Quorum Policy](#below-quorum-policy)
   - [Limitations/Risks &amp; Mitigations](#limitationsrisks--mitigations)
 - [Design Details](#design-details)
+  - [Autoscaler Integration](#autoscaler-integration)
   - [Example](#example)
   - [Monitoring](#monitoring)
   - [Test Plan](#test-plan)
   - [Graduation Criteria](#graduation-criteria)
+- [Open Questions](#open-questions)
 - [Alternatives](#alternatives)
 - [Appendix](#appendix)
+  - [Upstream Follow-ups](#upstream-follow-ups)
 <!-- /toc -->
 
 ## Summary
 
-Grove should treat `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP is only a direction-setting draft: it keeps `minAvailable` non-zero and immutable, makes future gang logic tolerant of zero-replica members, keeps the default behavior for positive replicas below `minAvailable`, and defines an opt-in clamp policy for generic autoscalers.
+Grove should treat `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP keeps `minAvailable` non-zero and immutable, makes gang logic tolerant of zero-replica members, keeps the default behavior for positive replicas below `minAvailable`, and defines an opt-in clamp policy for generic autoscalers.
 
 ## Motivation
 
@@ -31,7 +36,7 @@ External autoscalers should be treated as producers of desired replicas, not as 
 ### Goals
 
 - Treat `replicas: 0` as an intentional idle state without changing `minAvailable`.
-- Keep the default validation behavior for positive replicas below `minAvailable`.
+- Keep positive replicas below `minAvailable` invalid by default.
 - Define an opt-in `Clamp` policy for generic autoscalers that wake below `minAvailable`.
 - Preserve autoscaler-written `spec.replicas` as desired scale.
 
@@ -39,41 +44,53 @@ External autoscalers should be treated as producers of desired replicas, not as 
 
 - Change `minAvailable` semantics, including allowing `minAvailable: 0` or making it mutable.
 - Require generic autoscalers to discover Grove component quorum.
-- Define the complete production implementation in this draft.
+- Define the complete production implementation.
 
 ## Proposal
 
 When a `PodClique` or `PodCliqueScalingGroup` has `replicas: 0`, Grove should not require it as a gang member. When replicas become positive again, its existing `minAvailable` should apply normally.
+
+An idle component should leave the `PodGang` rather than stay in it with a zero threshold: no `PodGroup` in `PodGang.spec.podGroups`, and no scaled `PodGang` for a fully idle `PodCliqueScalingGroup` replica. Shrinking a gang must not disturb the members still running.
+
+### Zero Replicas Per Level
+
+`replicas: 0` means something different at each level:
+
+| Level | `replicas: 0` today | Proposed |
+| --- | --- | --- |
+| `PodCliqueSet` | Already allowed. Nothing is created; no `minAvailable` at this level. | Unchanged. |
+| `PodCliqueScalingGroup` | Rejected in the `PodCliqueSet` template; accepted on the object, which has no webhook. | Idle. No `PodGroup` in the base `PodGang` and no scaled `PodGang`. |
+| `PodClique` | Silently defaulted to `1`. | Idle when standalone, contributing no `PodGroup`. Inside a scaling group, idle is expressed at the group level. |
+
+### Below-Quorum Policy
 
 For `0 < replicas < minAvailable`, Grove should define an explicit below-quorum policy:
 
 | Desired replicas | Default policy `Block` | Opt-in policy `Clamp` |
 | --- | --- | --- |
 | `replicas: 0` | Intentional idle state. The component contributes no required gang members and does not breach `minAvailable`. | Same as `Block`. |
-| `0 < replicas < minAvailable` | Invalid, preserving the existing positive-replica validation behavior. Grove does not create partial gang members. | Grove preserves `spec.replicas` as desired scale, computes `effectiveReplicas = minAvailable`, and exposes the desired/effective split in status or events. |
+| `0 < replicas < minAvailable` | Invalid, as in the `PodCliqueSet` template today, with the same rule extended to the object and its `scale` subresource. Grove does not create partial gang members. | Accepted only when waking from `0`. Grove preserves `spec.replicas` as desired scale and computes `effectiveReplicas = minAvailable`. |
 | `replicas >= minAvailable` | Normal Grove behavior. The component participates in gang scheduling and gang termination using its configured `minAvailable`. | Same as `Block`; desired and effective replicas are equal. |
 
-Under the default `Block` policy, this GREP only changes the zero-replica case; positive replicas below `minAvailable` keep the existing validation behavior.
+Existing manifests keep their meaning, except a `PodClique` with `replicas: 0` and `minAvailable: 1`: one replica today, idle here.
 
-Grove should not implement `Clamp` by writing the clamped value back to `spec.replicas`. HPA or KEDA may repeatedly recompute a desired value such as `1`; writing `minAvailable` back into the scale target can create a control-plane write fight. If `Clamp` is used, the autoscaler-written value remains desired scale and Grove uses a separate effective value internally.
+`Clamp` applies only on the wake-up edge: a write from `0` into the range is accepted, one from `minAvailable` or above is rejected, so `0` is the only legal scale-in target below `minAvailable`. An explicit scale-in deserves an error, not a silent promotion. Comparing against the previous value puts that check in a validating webhook on the resource and its `scale` subresource, not in defaulting.
 
-This draft does not define every controller or backend branch. Those details should be added only after reviewers agree on the direction.
+Grove should not implement `Clamp` by writing the clamped value back to `spec.replicas`. HPA or KEDA may repeatedly recompute a desired value such as `1`; writing `minAvailable` back into the scale target can create a control-plane write fight. The override is therefore internal only: the autoscaler-written value stays in `spec.replicas` as desired scale, Grove derives the effective value separately, and a writer that keeps recomputing `1` keeps rewriting the value it already wrote, which is a no-op rather than a fight.
 
 ### Limitations/Risks & Mitigations
 
 The main risk is confusing "idle" with "unavailable." The proposed direction ties idle state to desired replicas, not observed status.
 
-The default `Block` policy keeps the existing positive-replica validation behavior. Generic HPA/KEDA users can still fail to wake from zero to one if they do not configure an autoscaler floor. Users who prefer automatic wake-up can opt into `Clamp`.
+Generic HPA/KEDA users can still fail to wake from zero to one without an autoscaler floor, and `Clamp` is the opt-in escape. Its cost is a desired/effective split: `spec.replicas: 1` may intentionally run `minAvailable` members. Validity also depends on the object's current value, so the same manifest can be accepted or rejected.
 
-The `Clamp` policy makes generic HPA/KEDA scale-from-zero friendlier, but `spec.replicas: 1` may intentionally run `minAvailable` members. This desired/effective split must be visible in status or events.
+That split is transitional: most replica writers cannot express an active floor above `1` while still allowing `0`. KEDA can, pairing `minReplicaCount` with `idleReplicaCount: 0`, and if the rest gain it nothing lands in `(0, minAvailable)`. Grove must still define the case, since users and custom controllers also write `spec.replicas`.
 
-The prototype must be described only as a feasibility artifact, not as the final design.
+Rolling updates already stall on a zero-replica standalone `PodClique`: completion requires `minAvailable` updated and ready pods, which zero pods never reach. A `PodCliqueScalingGroup` at `replicas: 0` does not stall, because its completion check compares only generation hashes. That asymmetry is why idle needs an explicit definition rather than a per-level accident.
 
 ## Design Details
 
-Implementation should derive gang membership from desired replicas and the below-quorum policy. A zero-replica component contributes zero required members while idle.
-
-This draft proposes `belowMinAvailablePolicy` as an optional enum field next to `replicas` and `minAvailable` on `PodClique`, `PodCliqueScalingGroup`, and their `PodCliqueSet` template configs:
+This GREP proposes `belowMinAvailablePolicy` as an optional enum field next to `replicas` and `minAvailable` on `PodClique`, `PodCliqueScalingGroup`, and their `PodCliqueSet` template configs:
 
 ```go
 // +kubebuilder:validation:Enum=Block;Clamp
@@ -81,7 +98,7 @@ This draft proposes `belowMinAvailablePolicy` as an optional enum field next to 
 BelowMinAvailablePolicy *BelowMinAvailablePolicy `json:"belowMinAvailablePolicy,omitempty"`
 ```
 
-The default value is `Block`. `Clamp` is opt-in for users who want Grove to translate a positive desired replica count below `minAvailable` into gang-safe effective replicas.
+`Clamp` is opt-in for users who want Grove to translate a positive desired replica count below `minAvailable` into gang-safe effective replicas. It must never clamp `replicas: 0`, which would defeat scale-to-zero.
 
 For `Clamp`, the effective count is:
 
@@ -90,13 +107,30 @@ effectiveReplicas = 0 if desiredReplicas == 0
 effectiveReplicas = max(desiredReplicas, minAvailable) otherwise
 ```
 
-For `Block`, positive desired replicas below `minAvailable` remain invalid, preserving the existing behavior for positive replicas.
+`effectiveReplicas` is derived per reconciliation, not stored; only admission consults the previous value. A `Clamp` component therefore cannot oscillate: it is idle or at least `minAvailable`. Grove treats `spec.replicas` as read-only, leaving the replica writer as its only writer, and the defaulting of `PodClique` `replicas: 0` to `1` is removed.
+
+Gang logic reads `minAvailable` directly today, so idle needs a derived floor: `effectiveMinAvailable` is `0` while idle and `minAvailable` otherwise. The contributed `PodGroup`, the breach condition, and the rolling-update completion check should all read it, so an idle component contributes no `PodGroup`, never breaches, and counts as updated.
+
+### Autoscaler Integration
+
+Grove only observes `spec.replicas`, so what matters per writer is when it sleeps and what it writes on wake-up.
+
+| Replica writer | Sleep trigger | Wake-up value | Grove needs |
+| --- | --- | --- | --- |
+| Native HPA | Manual `0` is Kubernetes' maintenance mode and stops the HPA. It sleeps by itself only with the `HPAScaleToZero` gate. | Manual, or `1` if the HPA slept it. | `Block`, and no defaulting back to `1`. |
+| KEDA | Triggers idle for `cooldownPeriod`, 5 minutes by default. Sleeping is the default shape. | `minReplicaCount`, `1` by default. It is also the scale-down floor, so skipping the below-quorum range needs `minReplicaCount: minAvailable` with `idleReplicaCount: 0`. | `Block` with that pairing. `Clamp` if `minAvailable` is above `1` and the `ScaledObject` is not editable. |
+| Knative KPA | An idle window with no requests, on by default. | `1`, when the activator takes a request. | Same as KEDA, but out of reach: its activator and metrics assume Knative Revisions. |
+| Dynamo Planner, writing the DGD or a `DynamoGraphDeploymentScalingAdapter` | Its own policy; zero is a computed target. | Whatever it computes. | `Clamp` when `minAvailable` is above `1`. Its only floor, `min_endpoint`, permits zero only at `0`, so a decaying load enters the below-quorum range. |
+| A custom controller | Its own policy. | Whatever it computes. | Only zero support, provided it skips `1 .. minAvailable - 1`. |
+| Grove's `scaleConfig` | Never; admission requires `minReplicas >= minAvailable`. | n/a | `minReplicas: 0` valid while `1 .. minAvailable - 1` stays invalid, no defaulting it from `replicas`, and the `HPAScaleToZero` gate on the generated HPA. |
+
+Waking from zero also needs a signal independent of a running replica, since serving metrics deadlock: in Dynamo, a model with no workers leaves `/v1/models` and returns `404`.
 
 ### Example
 
 Only the fields relevant to gang membership are shown.
 
-Initial serving shape: the router, standalone decode worker, and prefill worker group are running.
+Initial shape: a standalone router, a standalone decode clique, and a prefill scaling group of one leader plus three workers. Decode and prefill need two members for quorum, so `(0, 2)` is a real below-quorum range.
 
 ```yaml
 apiVersion: grove.io/v1alpha1
@@ -124,78 +158,78 @@ spec:
     - name: pworker
       spec:
         roleName: pworker
-        replicas: 1
-        minAvailable: 1
+        replicas: 3
+        minAvailable: 3
         podSpec:
           containers: [{name: pworker, image: nginx:latest}]
     - name: decode
       spec:
         roleName: decode
-        replicas: 1
-        minAvailable: 1
+        replicas: 2
+        minAvailable: 2
+        belowMinAvailablePolicy: Clamp
         podSpec:
           containers: [{name: decode, image: nginx:latest}]
     podCliqueScalingGroups:
     - name: prefill
       cliqueNames: [pleader, pworker]
-      replicas: 1
-      minAvailable: 1
-```
-
-After scale-to-zero: the components remain defined, and the autoscaler only changes the worker `replicas`.
-
-```yaml
-apiVersion: grove.io/v1alpha1
-kind: PodCliqueSet
-metadata:
-  name: scale-to-zero-deepseek
-spec:
-  template:
-    cliques:
-    - name: decode
-      spec:
-        replicas: 0
-        minAvailable: 1
-        belowMinAvailablePolicy: Clamp
-    podCliqueScalingGroups:
-    - name: prefill
-      cliqueNames: [pleader, pworker]
-      replicas: 0
-      minAvailable: 1
+      replicas: 2
+      minAvailable: 2
       belowMinAvailablePolicy: Clamp
 ```
 
-Under this GREP, the second shape means the standalone decode `PodClique` and prefill `PodCliqueScalingGroup` are idle and do not block the router. If they scale above zero, their existing `minAvailable` applies again.
+Scale-to-zero happens on the derived objects, not this template: Grove sets `replicas` only at creation, so the replica writer owns it afterwards.
 
-A canonical below-quorum wake-up looks like:
-
-```text
-minAvailable = 2
-replicas = 0
-external autoscaler writes replicas = 1
+```bash
+kubectl scale podclique scale-to-zero-deepseek-0-decode --replicas=0
+kubectl scale podcliquescalinggroup scale-to-zero-deepseek-0-prefill --replicas=0
 ```
 
-With `Block`, this remains invalid because positive replicas are below `minAvailable`. With `Clamp`, Grove preserves `replicas: 1`, internally uses `effectiveReplicas: 2`, and exposes that split.
+The router keeps serving. Both idle components contribute no `PodGroup`, so they neither hold the base `PodGang` nor breach `minAvailable`.
 
-With current Grove validation, the full scale-to-zero shape is rejected because `PodCliqueScalingGroup.replicas: 0` is not yet allowed:
+KEDA wakes them by writing its `minReplicaCount`, `1` by default:
+
+```bash
+kubectl scale podcliquescalinggroup scale-to-zero-deepseek-0-prefill --replicas=1
+```
+
+`Clamp` accepts that write, keeps `spec.replicas: 1` as desired scale, and runs `effectiveReplicas: 2`.
+
+Each row is one write on that component:
+
+| Write | `Block` | `Clamp` |
+| --- | --- | --- |
+| `0` to `1` | Rejected | Accepted, `effectiveReplicas: 2` |
+| `1` to `2` | Unreachable | Accepted, still two members |
+| `2` to `3` | Accepted | Accepted |
+| `3` to `2` | Accepted | Accepted |
+| `2` to `1` | Rejected | Rejected |
+| `2` to `0` | Accepted | Accepted |
+
+`(0, minAvailable)` is therefore one-way: reachable only from `0`, left by scaling up or by writing `0`.
+
+Today neither write is rejected: no admission webhook covers `PodClique` or `PodCliqueScalingGroup`. Both are accepted, and the idle member then holds the whole `PodGang` below its member count, leaving the router `SchedulingGated` (#676). Only the `PodCliqueSet` template validates the same shape:
 
 ```text
 spec.template.podCliqueScalingGroups[0].replicas: Invalid value: 0: must be greater than 0
-spec.template.podCliqueScalingGroups[0].minAvailable: Invalid value: 1: minAvailable must not be greater than replicas
+spec.template.podCliqueScalingGroups[0].minAvailable: Invalid value: 2: minAvailable must not be greater than replicas
 ```
+
+A `PodClique` produces no error there only because defaulting rewrites `replicas: 0` to `1` first.
 
 ### Monitoring
 
-For `Clamp`, status or events should show desired replicas and effective replicas so users can understand why the running member count is greater than `spec.replicas`.
+For `Clamp`, a `ReplicasBelowMinAvailable` condition should carry the desired and effective replica counts, so users can see why the running member count exceeds `spec.replicas`. It is also the only feedback channel for a below-quorum write, since an autoscaler cannot act on a rejection.
 
 ### Test Plan
 
 Prototype coverage should show:
 
 - zero-replica components do not block the base gang;
-- `minAvailable` remains non-zero;
+- an idle component does not stall a rolling update;
 - default `Block` rejects `0 < replicas < minAvailable`;
-- opt-in `Clamp` computes an effective count of at least `minAvailable`;
+- opt-in `Clamp` computes an effective count of at least `minAvailable` when waking from `0`;
+- `Clamp` rejects a scale-in into the below-quorum range on both the resource and its `scale` subresource;
 - `Clamp` does not write the effective value back to `spec.replicas`;
 - scaling back to `minAvailable` or above can re-enter normal gang behavior.
 
@@ -205,15 +239,19 @@ Prototype coverage should show:
 - Beta: behavior documented and tested.
 - GA: semantics are stable and validated with real scale-to-zero workloads.
 
+## Open Questions
+
+- Is the below-quorum behavior a fixed rule or an opt-in policy? Reviewer feedback describes the override as unconditional, which would drop `belowMinAvailablePolicy`. This GREP keeps the field, defaulting to `Block`.
+- Does `/scale` `status.replicas` report desired or effective replicas, and should the three levels agree? Today `PodClique` counts non-terminating pods while `PodCliqueScalingGroup` and `PodCliqueSet` mirror `spec.replicas`. The HPA rescale decision reads `spec.replicas`, but KEDA's per-pod external metric divides by `status.replicas`.
+
 ## Alternatives
 
 - Allow `minAvailable: 0`: explicit, but overloads an existing availability contract.
+- Keep idle members in the `PodGang` with `minReplicas: 0`: keeps the gang spec stable across idle transitions, but that value already signals released constraints during a coherent update, and backends map it back to a positive threshold.
 - Make `minAvailable` mutable: follows scale state, but changes the immutability contract.
 - Only support `Block` and never add `Clamp`: keeps `spec.replicas` truthful, but generic HPA/KEDA scale-from-zero can get stuck without an autoscaler floor.
-- Always clamp positive replicas below `minAvailable`: makes generic HPA/KEDA wake-up work, but imposes a default desired/effective split on every below-quorum state.
+- Make `Clamp` direction-agnostic: re-applying a stored object never fails, but an explicit scale-in is silently promoted with no signal to the caller.
 - Add `activeMinReplicas` now: useful if active warm capacity can differ from gang quorum, but premature if the active floor is simply `minAvailable`.
-- Work around this outside Grove: avoids Grove changes, but leaves no consistent Grove semantics.
-
 ## Appendix
 
 - Tracking issue: [ai-dynamo/grove#677](https://github.com/ai-dynamo/grove/issues/677)
@@ -223,4 +261,11 @@ Prototype coverage should show:
 - Related Dynamo issue: [ai-dynamo/dynamo#10753](https://github.com/ai-dynamo/dynamo/issues/10753)
 - Related Dynamo PR: [ai-dynamo/dynamo#10532](https://github.com/ai-dynamo/dynamo/pull/10532)
 - Dynamo autoscaling guide: [Dynamo autoscaling](https://docs.nvidia.com/dynamo/v1.1.1/kubernetes-deployment/deployment-guide/autoscaling)
-- Research notes: [research-notes.md](research-notes.md)
+
+### Upstream Follow-ups
+
+Outside Grove, none blocking this GREP.
+
+- Kubernetes HPA: allow an active floor above `1` alongside `minReplicas: 0`, and resume from `spec.replicas: 0`, which disables the HPA today.
+- KEDA: nothing needed; `minReplicaCount` with `idleReplicaCount: 0` already expresses that floor.
+- Dynamo: give the SLA Planner an idle floor separate from `min_endpoint`, so it reaches `0` without passing through `1 .. minAvailable - 1`.

--- a/docs/proposals/0677-zero-replica-gang-membership/README.md
+++ b/docs/proposals/0677-zero-replica-gang-membership/README.md
@@ -10,12 +10,12 @@
   - [Below-Quorum Behavior](#below-quorum-behavior)
   - [Limitations/Risks &amp; Mitigations](#limitationsrisks--mitigations)
 - [Design Details](#design-details)
+  - [Gang Behavior](#gang-behavior)
   - [Autoscaler Integration](#autoscaler-integration)
   - [Example](#example)
   - [Monitoring](#monitoring)
   - [Test Plan](#test-plan)
   - [Graduation Criteria](#graduation-criteria)
-- [Remaining Work](#remaining-work)
 - [Alternatives](#alternatives)
 - [Historical Discussion](#historical-discussion)
 - [Appendix](#appendix)
@@ -93,9 +93,13 @@ Rolling updates already stall on a zero-replica standalone `PodClique`: completi
 
 ## Design Details
 
-Admission rejects any positive requested replica count below `minAvailable` without rewriting `spec.replicas`. The defaulting of `PodClique` `replicas: 0` to `1` is removed.
+For `PodClique`, omitted `replicas` defaults to `1`, while explicit `0` is preserved. Omitted `minAvailable` defaults to `max(1, replicas)`.
 
-While a component is idle, it contributes no `PodGroup`, does not set `MinAvailableBreached` to `True`, and counts as updated for rolling-update completion.
+### Gang Behavior
+
+While a component is idle, it contributes no `PodGroup` and zero observed scheduled, available, and updated replicas. It does not set `MinAvailableBreached` to `True`, counts as updated for rolling-update completion, and does not trigger gang termination.
+
+An idle component is omitted from `PodGangMap` entry membership. If all components are idle, Grove retains an empty current-generation anchor without materializing a `PodGang`. On wake, Grove populates that anchor if no `PodGang` is active; otherwise, it creates a new entry for the waking component without expanding an existing materialized `PodGang`.
 
 ### Autoscaler Integration
 
@@ -198,8 +202,6 @@ spec.template.podCliqueScalingGroups[0].replicas: Invalid value: 0: must be grea
 spec.template.podCliqueScalingGroups[0].minAvailable: Invalid value: 2: minAvailable must not be greater than replicas
 ```
 
-A `PodClique` produces no error there only because defaulting rewrites `replicas: 0` to `1` first.
-
 ### Monitoring
 
 No new metrics, conditions, or status fields are introduced. Idle is indicated by `spec.replicas: 0`.
@@ -209,6 +211,8 @@ No new metrics, conditions, or status fields are introduced. Idle is indicated b
 Prototype coverage should show:
 
 - zero-replica components do not block the base gang;
+- omitted `PodClique` `replicas` defaults to `1`, while explicit `0` is preserved;
+- omitted `minAvailable` defaults to `max(1, replicas)`;
 - an idle component does not stall a rolling update;
 - create requests and updates through the main resource or `/scale` reject `0 < replicas < minAvailable`;
 - rejected updates leave `spec.replicas` unchanged;
@@ -221,12 +225,6 @@ Prototype coverage should show:
 - Alpha: direction accepted and initial implementation exists.
 - Beta: behavior documented and tested.
 - GA: semantics are stable and validated with real scale-to-zero workloads.
-
-## Remaining Work
-
-- The admission rules for rejecting invalid creates and replica updates through the main resource or `/scale`.
-- Gang behavior in detail: how the `PodGang` reshapes on idle and wake, how idle state propagates through scheduled, available, and updated status at each resource level, how `startsAfter` handles an idle dependency, whether an idle component is absent from the [coherent update](../393-coherent-rolling-updates/README.md) `PodGangMap` or present and empty, whether it joins an MVU, what a scale to zero does to an update in flight, and what that means for gang termination and partial scale.
-- Implementation requires webhooks for `PodClique` and `PodCliqueScalingGroup` resource and `/scale` updates; template validation that allows `replicas: 0` for standalone `PodClique` and `PodCliqueScalingGroup` components but rejects it for scaling-group member `PodClique`s; removal of the standalone `PodClique` zero-to-one default; updates to gang membership, breach, and rolling-update paths for idle components; and a migration rule for pre-existing below-quorum objects.
 
 ## Alternatives
 

--- a/docs/proposals/0677-zero-replica-gang-membership/README.md
+++ b/docs/proposals/0677-zero-replica-gang-membership/README.md
@@ -101,6 +101,8 @@ canonicalReplicas = max(requestedReplicas, minAvailable) otherwise
 
 `spec.replicas` stores `canonicalReplicas`; the defaulting of `PodClique` `replicas: 0` to `1` is removed.
 
+When Grove clamps an update, the admission response includes a warning with the requested value, `minAvailable`, and the persisted value. The warning gives interactive clients immediate feedback without adding persistent annotations or conditions.
+
 For the `/scale` subresource, `spec.replicas` remains the desired replica count and `status.replicas` reports actual observed replicas. `PodClique`, `PodCliqueScalingGroup`, and `PodCliqueSet` should use that same semantic contract.
 
 Gang logic reads `minAvailable` directly today, so idle needs a derived floor: `effectiveMinAvailable` is `0` while idle and `minAvailable` otherwise. The contributed `PodGroup`, the breach condition, and the rolling-update completion check should all read it, so an idle component contributes no `PodGroup`, never breaches, and counts as updated.
@@ -209,6 +211,7 @@ Prototype coverage should show:
 - an idle component does not stall a rolling update;
 - create rejects `0 < replicas < minAvailable`;
 - resource and `/scale` updates clamp any positive below-quorum request to `minAvailable`, regardless of direction;
+- clamped updates return an admission warning, while valid updates do not;
 - replica writers that repeatedly request a positive below-quorum value converge without a write loop;
 - all three `/scale.status.replicas` implementations report actual observed replicas;
 - KEDA with `idleReplicaCount: 0` and `minReplicaCount: minAvailable` writes only valid values;

--- a/docs/proposals/0677-zero-replica-gang-membership/README.md
+++ b/docs/proposals/0677-zero-replica-gang-membership/README.md
@@ -7,7 +7,7 @@
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
   - [Zero Replicas Per Level](#zero-replicas-per-level)
-  - [Below-Quorum Policy](#below-quorum-policy)
+  - [Below-Quorum Behavior](#below-quorum-behavior)
   - [Limitations/Risks &amp; Mitigations](#limitationsrisks--mitigations)
 - [Design Details](#design-details)
   - [Autoscaler Integration](#autoscaler-integration)
@@ -15,6 +15,7 @@
   - [Monitoring](#monitoring)
   - [Test Plan](#test-plan)
   - [Graduation Criteria](#graduation-criteria)
+- [Open Questions](#open-questions)
 - [Remaining Work](#remaining-work)
 - [Alternatives](#alternatives)
 - [Historical Discussion](#historical-discussion)
@@ -44,7 +45,6 @@ External replica writers should target either `0` or a value at least `minAvaila
 ### Non-Goals
 
 - Change `minAvailable` semantics, including allowing `minAvailable: 0` or making it mutable.
-- Define the complete production implementation.
 
 ## Proposal
 
@@ -62,7 +62,7 @@ An idle component should leave the `PodGang` rather than stay in it with a zero 
 | `PodCliqueScalingGroup` | Rejected in the `PodCliqueSet` template; accepted on the object, which has no webhook. | Idle. No `PodGroup` in the base `PodGang` and no scaled `PodGang`. |
 | `PodClique` | `replicas: 0` is accepted on the object, which has no webhook, but is silently defaulted to `1` in the `PodCliqueSet` template. | Idle when standalone, contributing no `PodGroup`. Inside a scaling group, idle is expressed at the group level. |
 
-### Below-Quorum Policy
+### Below-Quorum Behavior
 
 For positive scaling updates below `minAvailable`, Grove uses a fixed, direction-agnostic `Clamp` rule:
 
@@ -86,7 +86,7 @@ A newly submitted `PodClique`, `PodCliqueScalingGroup`, or corresponding `PodCli
 
 The main risk is confusing "idle" with "unavailable." The proposed direction ties idle state to desired replicas, not observed status.
 
-An autoscaler may request `1` and observe `spec.replicas: 3` when `minAvailable` is `3`. Supported autoscalers should avoid this path by expressing separate idle and active floors. KEDA does so with `idleReplicaCount: 0` and `minReplicaCount: minAvailable`; Grove still defines `Clamp` for other writers.
+An autoscaler may request `1` and observe `spec.replicas: 3` when `minAvailable` is `3`; the risk of repeated below-quorum writes is tracked in [Open Questions](#open-questions).
 
 Rolling updates already stall on a zero-replica standalone `PodClique`: completion requires `minAvailable` updated and ready pods, which zero pods never reach. A `PodCliqueScalingGroup` at `replicas: 0` does not stall, because its completion check compares only generation hashes. That asymmetry is why idle needs an explicit definition rather than a per-level accident.
 
@@ -105,11 +105,11 @@ When Grove clamps an update, the admission response includes a warning with the 
 
 For the `/scale` subresource, `spec.replicas` remains the desired replica count and `status.replicas` reports actual observed replicas. `PodClique`, `PodCliqueScalingGroup`, and `PodCliqueSet` should use that same semantic contract.
 
-Gang logic reads `minAvailable` directly today, so idle needs a derived floor: `effectiveMinAvailable` is `0` while idle and `minAvailable` otherwise. The contributed `PodGroup`, the breach condition, and the rolling-update completion check should all read it, so an idle component contributes no `PodGroup`, never breaches, and counts as updated.
+While a component is idle, it contributes no `PodGroup`, does not set `MinAvailableBreached` to `True`, and counts as updated for rolling-update completion.
 
 ### Autoscaler Integration
 
-Grove expects replica writers to emit either `0` or at least `minAvailable`. Future compatibility work should cover Native HPA, KEDA, Knative KPA, Dynamo Planner, custom controllers, and Grove's `scaleConfig`. KEDA can express the contract directly with `idleReplicaCount: 0` and `minReplicaCount: minAvailable`; other writers must either emit valid values or converge under `Clamp` without a write loop.
+Grove expects replica writers to emit either `0` or at least `minAvailable`. KEDA can express this contract with `idleReplicaCount: 0` and `minReplicaCount: minAvailable`. The HPA POC in [Open Questions](#open-questions) tests whether repeated positive below-quorum requests create a write loop. Compatibility work remains for Knative KPA, Dynamo Planner, custom controllers, and Grove's `scaleConfig`; each must either emit valid values or tolerate persisted `Clamp` without a write loop.
 
 ### Example
 
@@ -201,7 +201,7 @@ A `PodClique` produces no error there only because defaulting rewrites `replicas
 
 ### Monitoring
 
-No new metrics or conditions are introduced. Idle is indicated by `spec.replicas: 0`, while `/scale.status.replicas` reports observed replicas.
+No new metrics, conditions, or status fields are introduced. Idle is indicated by `spec.replicas: 0`.
 
 ### Test Plan
 
@@ -212,7 +212,7 @@ Prototype coverage should show:
 - create rejects `0 < replicas < minAvailable`;
 - resource and `/scale` updates clamp any positive below-quorum request to `minAvailable`, regardless of direction;
 - clamped updates return an admission warning, while valid updates do not;
-- replica writers that repeatedly request a positive below-quorum value converge without a write loop;
+- replica writers that repeatedly request a positive below-quorum value converge without a write loop, pending confirmation by the HPA POC in [Open Questions](#open-questions);
 - all three `/scale.status.replicas` implementations report actual observed replicas;
 - KEDA with `idleReplicaCount: 0` and `minReplicaCount: minAvailable` writes only valid values;
 - scaling to `minAvailable` or above re-enters normal gang behavior.
@@ -223,13 +223,15 @@ Prototype coverage should show:
 - Beta: behavior documented and tested.
 - GA: semantics are stable and validated with real scale-to-zero workloads.
 
+## Open Questions
+
+- Does an autoscaler that repeatedly requests `0 < replicas < minAvailable` create a write loop after Grove persists `minAvailable`? A POC should test HPA with `minReplicas < minAvailable`; scale-to-zero is not required.
+
 ## Remaining Work
 
-Accepting the direction above does not finish the GREP. Still to come, in this order:
-
 - The admission rules for rejecting invalid creates and clamping resource and `/scale` updates.
-- Gang behavior in detail: how the `PodGang` reshapes on idle and wake, whether an idle component is absent from the [coherent update](../393-coherent-rolling-updates/README.md) `PodGangMap` or present and empty, whether it joins an MVU, what a scale to zero does to an update in flight, and what that means for gang termination and partial scale.
-- The implementation surface in one place. Neither `PodClique` nor `PodCliqueScalingGroup` has a webhook today, so this GREP implies new ones on both and their `scale` subresources, updating the `PodClique` and `PodCliqueScalingGroup` template validation to allow `replicas: 0` while rejecting positive below-quorum values, dropping the `PodClique` `replicas: 0` defaulting, the `effectiveMinAvailable` readers, observed `status.replicas` at all three levels, and upgrade handling for pre-existing below-quorum objects. Listing them is in scope; designing them is not.
+- Gang behavior in detail: how the `PodGang` reshapes on idle and wake, how idle state propagates through scheduled, available, and updated status at each resource level, how `startsAfter` handles an idle dependency, whether an idle component is absent from the [coherent update](../393-coherent-rolling-updates/README.md) `PodGangMap` or present and empty, whether it joins an MVU, what a scale to zero does to an update in flight, and what that means for gang termination and partial scale.
+- Implementation requires webhooks for `PodClique` and `PodCliqueScalingGroup` resource and `/scale` updates; template validation that allows `replicas: 0` but rejects positive below-quorum creates; removal of the `PodClique` zero-to-one default; updates to gang membership, breach, and rolling-update paths for idle components; observed `status.replicas` at all three levels; and a migration rule that specifies whether pre-existing below-quorum objects are clamped during upgrade or retained until a later replica update brings them into the invariant.
 
 ## Alternatives
 

--- a/docs/proposals/0677-zero-replica-gang-membership/README.md
+++ b/docs/proposals/0677-zero-replica-gang-membership/README.md
@@ -78,7 +78,7 @@ Existing behavior changes in two cases: a `PodClique` with `replicas: 0` becomes
 
 `Clamp` applies only on the wake-up edge: a write from `0` into the range is accepted, one from `minAvailable` or above is rejected, so `0` is the only legal scale-in target below `minAvailable`. An explicit scale-in deserves an error, not a silent promotion. Comparing against the previous value puts that check in a validating webhook on the resource and its `scale` subresource, not in defaulting.
 
-Grove should not implement `Clamp` by writing the clamped value back to `spec.replicas`. HPA or KEDA may repeatedly recompute a desired value such as `1`; writing `minAvailable` back into the scale target can create a control-plane write fight. The override is therefore internal only: the autoscaler-written value stays in `spec.replicas` as desired scale, Grove derives the effective value separately, and a writer that keeps recomputing `1` keeps rewriting the value it already wrote, which is a no-op rather than a fight.
+Grove should not implement `Clamp` by writing the clamped value back to `spec.replicas`. HPA or KEDA may repeatedly recompute a desired value such as `1`; writing `minAvailable` back into the scale target can create a control-plane write fight. The override is therefore internal only: the autoscaler-written value stays in `spec.replicas` as desired scale and Grove derives the effective value separately. After a successful wake, repeated writes of the stored below-quorum value are no-ops. A later active scale-in into the same range is rejected under the current wake-only rule and may be retried periodically; this is control-plane retry churn, not replica oscillation.
 
 ### Limitations/Risks & Mitigations
 
@@ -104,6 +104,8 @@ effectiveReplicas = max(desiredReplicas, minAvailable) otherwise
 `effectiveReplicas` is derived per reconciliation, not stored; only admission consults the previous value. A `Clamp` component therefore cannot oscillate: it is idle or at least `minAvailable`. Grove treats `spec.replicas` as read-only, leaving the replica writer as its only writer, and the defaulting of `PodClique` `replicas: 0` to `1` is removed.
 
 For the `/scale` subresource, `spec.replicas` remains the desired replica count and `status.replicas` reports actual observed replicas. `PodClique`, `PodCliqueScalingGroup`, and `PodCliqueSet` should use that same semantic contract.
+
+With `AverageValue` metrics, reporting observed replicas can cause one corrective HPA write from `1` to `2`; the experiment observed convergence without repeated writes or replica reversal.
 
 Gang logic reads `minAvailable` directly today, so idle needs a derived floor: `effectiveMinAvailable` is `0` while idle and `minAvailable` otherwise. The contributed `PodGroup`, the breach condition, and the rolling-update completion check should all read it, so an idle component contributes no `PodGroup`, never breaches, and counts as updated.
 
@@ -193,14 +195,17 @@ Each row is one write on that component:
 
 | Write | Fixed `Clamp` behavior |
 | --- | --- |
-| `0` to `1` | Accepted, `effectiveReplicas: 2` |
+| `0` to `1` | Accepted, `spec.replicas: 1`, `effectiveReplicas: 2` |
+| `1` to `1` | Accepted as an idempotent re-apply; no stored-value change |
 | `1` to `2` | Accepted, still two members |
 | `2` to `3` | Accepted |
 | `3` to `2` | Accepted |
-| `2` to `1` | Rejected |
+| `2` to `1` | Rejected; direction-agnostic behavior remains an open question |
 | `2` to `0` | Accepted |
 
 `(0, minAvailable)` is therefore one-way: reachable only from `0`, left by scaling up or by writing `0`.
+
+The same update semantics apply to the main resource and its `/scale` subresource. `CREATE` has no previous value and remains part of the admission rule follow-up.
 
 Today neither write is rejected: no admission webhook covers `PodClique` or `PodCliqueScalingGroup`. Both are accepted, and the idle member then holds the whole `PodGang` below its member count, leaving the router `SchedulingGated` (#676). Only the `PodCliqueSet` template validates the same shape:
 
@@ -227,6 +232,8 @@ Prototype coverage should show:
 - all three `/scale.status.replicas` implementations report actual observed replicas;
 - scaling back to `minAvailable` or above can re-enter normal gang behavior.
 
+An experiment-only prototype recorded 142 logical cases. Wake-only `Clamp` produced periodic denied HPA writes during active below-quorum scale-in, while direction-agnostic internal clamping completed the KEDA and Grove writer gates without persistent rejection, mutation, quorum breach, or replica reversal.
+
 ### Graduation Criteria
 
 - Alpha: direction accepted and initial implementation exists.
@@ -235,13 +242,14 @@ Prototype coverage should show:
 
 ## Open Questions
 
-- Should active scale-in into `(0, minAvailable)` be rejected, or accepted and internally clamped? The current direction limits `Clamp` to scale-out from `0`, returning a validation error for invalid scale-in so callers receive explicit feedback; rejection, however, makes HPA retry failed writes. Acceptance avoids retries by preserving the autoscaler-written desired value in `spec.replicas` while `status.replicas` remains observed, but HPA may report a successful scale-down without reducing pods.
+- Should active scale-in into `(0, minAvailable)` be rejected, or accepted and internally clamped? Wake-only `Clamp` gives callers an explicit validation error and avoids reporting a successful scale-down that does not reduce effective replicas. In KEDA 2.20.2 tests, however, it caused 8-9 denied HPA writes in 30 seconds and 65 during a 300-second cooldown. This was control-plane retry churn, not replica oscillation or quorum loss.
+
+  Direction-agnostic `Clamp` preserved the requested `spec.replicas` and completed 11/11 KEDA contract cases and 15/15 Grove writer cases without denied writes, repeated writes, or replica reversal. Its trade-off is that a below-quorum scale-in appears successful while effective replicas remain at `minAvailable`.
 
 ## Remaining Work
 
 Accepting the direction above does not finish the GREP. Still to come, in this order:
 
-- Measured autoscaler behavior, not reasoning about it: HPA and KEDA against a `Clamp` component across the wake-up edge, repeated below-quorum writes, `cooldownPeriod` and stabilization windows, and observed `status.replicas`. It confirms or replaces the no-write-fight and no-oscillation claims above, and lands here with its setup and versions.
 - The admission rule over previous and new value pairs, including create and re-apply, where there is no previous value.
 - Gang behavior in detail: how the `PodGang` reshapes on idle and wake, whether an idle component is absent from the [coherent update](../393-coherent-rolling-updates/README.md) `PodGangMap` or present and empty, whether it joins an MVU, what a scale to zero does to an update in flight, and what that means for gang termination and partial scale.
 - The implementation surface in one place. Neither `PodClique` nor `PodCliqueScalingGroup` has a webhook today, so this GREP implies new ones on both and their `scale` subresource, plus dropping the `PodClique` `replicas: 0` defaulting, the `effectiveMinAvailable` readers, looser `scaleConfig` rules, observed `status.replicas` at all three levels, and upgrade handling for pre-existing below-quorum objects. Listing them is in scope; designing them is not.

--- a/docs/proposals/0677-zero-replica-gang-membership/README.md
+++ b/docs/proposals/0677-zero-replica-gang-membership/README.md
@@ -227,6 +227,19 @@ Prototype coverage should show:
 
 - Does an autoscaler that repeatedly requests `0 < replicas < minAvailable` create a write loop after Grove persists `minAvailable`? A POC should test HPA with `minReplicas < minAvailable`; scale-to-zero is not required.
 
+  A POC against [PR #788](https://github.com/ai-dynamo/grove/pull/788) at commit `1b0ced6c9abda9b6fec1dd38a2d9bcbe83eba515` tested `minAvailable: 2`, initial `replicas: 3`, and a 35-second observation window after the target reached `spec.replicas: 2` and `status.replicas: 2`. A `WRITE_LOOP` means that the writer issued at least two additional requests for `replicas: 1` during that window; the stored replica count does not need to oscillate.
+
+  | Replica writer | Floor-respecting control (`NO_LOOP`) | Below-quorum treatment (`WRITE_LOOP`) | Scope |
+  | --- | --- | --- | --- |
+  | Native HPA | `minReplicas: 2` | `minReplicas: 1`, recommending `1` | `Value` and `AverageValue`; PCLQ and PCSG |
+  | Grove `scaleConfig` | `minReplicas: 2` | `minReplicas: 0`, recommending `1` | `Value` and `AverageValue`; PCLQ and PCSG; control cannot scale to zero |
+  | KEDA | `idleReplicaCount: 0`, `minReplicaCount: 2` | `idleReplicaCount: 0`, `minReplicaCount: 1` | `Value` and `AverageValue`; PCLQ and PCSG |
+  | Custom controller | Repeatedly requests `2` | Repeatedly requests `1` | PCLQ and PCSG |
+  | Knative KPA | One adapter request produced no repeat | Not tested | Continuous-writer behavior not established |
+  | Dynamo Planner | Not established | Not established | `INCONCLUSIVE`; full Planner metric loop was not driven |
+
+  These columns describe experimental controls and treatments, not recommended scale-to-zero configurations. All 14 floor-respecting controls completed with `NO_LOOP`. All 14 treatments that repeatedly requested `1` completed with `WRITE_LOOP`, each issuing seven post-stabilization requests. The remaining design question is whether Grove should require supported replica writers to enforce the active `minAvailable` floor, provide an adapter for writers that cannot express it, or revise persisted `Clamp`.
+
 ## Remaining Work
 
 - The admission rules for rejecting invalid creates and clamping resource and `/scale` updates.

--- a/docs/proposals/0677-zero-replica-gang-membership/README.md
+++ b/docs/proposals/0677-zero-replica-gang-membership/README.md
@@ -16,6 +16,7 @@
   - [Test Plan](#test-plan)
   - [Graduation Criteria](#graduation-criteria)
 - [Open Questions](#open-questions)
+- [Remaining Work](#remaining-work)
 - [Alternatives](#alternatives)
 - [Appendix](#appendix)
   - [Upstream Follow-ups](#upstream-follow-ups)
@@ -23,7 +24,7 @@
 
 ## Summary
 
-Grove should treat `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP keeps `minAvailable` non-zero and immutable, makes gang logic tolerant of zero-replica members, keeps the default behavior for positive replicas below `minAvailable`, and defines an opt-in clamp policy for generic autoscalers.
+Grove should treat `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP keeps `minAvailable` non-zero and immutable, makes gang logic tolerant of zero-replica members, and describes two below-quorum policies for `0 < replicas < minAvailable`: `Block`, which keeps today's rejection, and `Clamp`, which wakes the component at `minAvailable`. Both are carried here because the choice between them is an [open question](#open-questions).
 
 ## Motivation
 
@@ -36,9 +37,9 @@ External autoscalers should be treated as producers of desired replicas, not as 
 ### Goals
 
 - Treat `replicas: 0` as an intentional idle state without changing `minAvailable`.
-- Keep positive replicas below `minAvailable` invalid by default.
-- Define an opt-in `Clamp` policy for generic autoscalers that wake below `minAvailable`.
-- Preserve autoscaler-written `spec.replicas` as desired scale.
+- Make `0` the only value below `minAvailable` that Grove runs as written.
+- Describe both below-quorum policies for `0 < replicas < minAvailable`, `Block` and `Clamp`, and leave the choice between them to [Open Questions](#open-questions).
+- Preserve autoscaler-written `spec.replicas` as desired scale, never writing an effective value back.
 
 ### Non-Goals
 
@@ -71,6 +72,8 @@ For `0 < replicas < minAvailable`, Grove should define an explicit below-quorum 
 | `replicas: 0` | Intentional idle state. The component contributes no required gang members and does not breach `minAvailable`. | Same as `Block`. |
 | `0 < replicas < minAvailable` | Invalid, as in the `PodCliqueSet` template today, with the same rule extended to the object and its `scale` subresource. Grove does not create partial gang members. | Accepted only when waking from `0`. Grove preserves `spec.replicas` as desired scale and computes `effectiveReplicas = minAvailable`. |
 | `replicas >= minAvailable` | Normal Grove behavior. The component participates in gang scheduling and gang termination using its configured `minAvailable`. | Same as `Block`; desired and effective replicas are equal. |
+
+Which column survives is an [open question](#open-questions): reviewers have asked for `Clamp` to be the only behavior. The columns are independent, so dropping one leaves the other unchanged.
 
 Existing manifests keep their meaning, except a `PodClique` with `replicas: 0` and `minAvailable: 1`: one replica today, idle here.
 
@@ -219,7 +222,7 @@ A `PodClique` produces no error there only because defaulting rewrites `replicas
 
 ### Monitoring
 
-For `Clamp`, a `ReplicasBelowMinAvailable` condition should carry the desired and effective replica counts, so users can see why the running member count exceeds `spec.replicas`. It is also the only feedback channel for a below-quorum write, since an autoscaler cannot act on a rejection.
+For `Clamp`, a `ReplicasBelowMinAvailable` condition should carry the desired and effective replica counts, so users can see why the running member count exceeds `spec.replicas`. It is also the only feedback channel for a below-quorum write, since an autoscaler cannot act on a rejection. Whether it is also the only channel for the desired/effective split depends on what `/scale` reports, which [Open Questions](#open-questions) leaves undecided.
 
 ### Test Plan
 
@@ -241,8 +244,17 @@ Prototype coverage should show:
 
 ## Open Questions
 
-- Is the below-quorum behavior a fixed rule or an opt-in policy? Reviewer feedback describes the override as unconditional, which would drop `belowMinAvailablePolicy`. This GREP keeps the field, defaulting to `Block`.
-- Does `/scale` `status.replicas` report desired or effective replicas, and should the three levels agree? Today `PodClique` counts non-terminating pods while `PodCliqueScalingGroup` and `PodCliqueSet` mirror `spec.replicas`. The HPA rescale decision reads `spec.replicas`, but KEDA's per-pod external metric divides by `status.replicas`.
+- Is the below-quorum behavior a fixed rule or an opt-in policy? Reviewer feedback describes the override as unconditional, keeping only `Clamp` and dropping `belowMinAvailablePolicy`. This GREP still carries both, because unconditional clamping is not purely additive: no admission webhook covers `PodClique` or `PodCliqueScalingGroup` today, so a component already at `replicas: 1` with `minAvailable: 2` runs one pod now and would silently run two. Settling on one behavior drops the other column, the field, and the policy names that qualify the rest of this GREP.
+- What does `/scale` `status.replicas` report, and should the three levels agree? It can mirror `spec.replicas` as `desired`, report the clamped target as `effective`, or report `actual` observed pods, which is what the subresource contract asks for. The question exists only under `Clamp`. The levels disagree today: `PodClique` counts non-terminating pods while `PodCliqueScalingGroup` and `PodCliqueSet` mirror `spec.replicas`, so behavior depends on where an autoscaler attaches. HPA reads `spec.replicas` to rescale, but its per-pod branch, used by KEDA's `AverageValue` metrics, divides by `status.replicas`. Reporting `desired` leaves [Monitoring](#monitoring) as the only channel for the split. Answering this needs the contract read and HPA and KEDA behavior measured; a later revision will cover both.
+
+## Remaining Work
+
+Accepting the direction above does not finish the GREP. Still to come, in this order:
+
+- Measured autoscaler behavior, not reasoning about it: HPA and KEDA against a `Clamp` component across the wake-up edge, repeated below-quorum writes, `cooldownPeriod` and stabilization windows, and each `status.replicas` choice. It confirms or replaces the no-write-fight and no-oscillation claims above, and lands here with its setup and versions.
+- The admission rule over previous and new value pairs, including create and re-apply, where there is no previous value.
+- Gang behavior in detail: how the `PodGang` reshapes on idle and wake, whether an idle component is absent from the [coherent update](../393-coherent-rolling-updates/README.md) `PodGangMap` or present and empty, whether it joins an MVU, what a scale to zero does to an update in flight, and what that means for gang termination and partial scale.
+- The implementation surface in one place. Neither `PodClique` nor `PodCliqueScalingGroup` has a webhook today, so this GREP implies new ones on both and their `scale` subresource, plus dropping the `PodClique` `replicas: 0` defaulting, the `effectiveMinAvailable` readers, and looser `scaleConfig` rules. Listing them is in scope; designing them is not.
 
 ## Alternatives
 

--- a/docs/proposals/0677-zero-replica-gang-membership/README.md
+++ b/docs/proposals/0677-zero-replica-gang-membership/README.md
@@ -15,7 +15,6 @@
   - [Monitoring](#monitoring)
   - [Test Plan](#test-plan)
   - [Graduation Criteria](#graduation-criteria)
-- [Open Questions](#open-questions)
 - [Remaining Work](#remaining-work)
 - [Alternatives](#alternatives)
 - [Historical Discussion](#historical-discussion)
@@ -25,7 +24,7 @@
 
 ## Summary
 
-Grove should treat `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP keeps `minAvailable` non-zero and immutable, makes gang logic tolerant of zero-replica members, and uses a fixed `Clamp` rule to wake a component at `minAvailable` when an autoscaler writes a positive value below quorum.
+Grove should treat `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP keeps `minAvailable` non-zero and immutable, makes gang logic tolerant of zero-replica members, and uses a fixed, direction-agnostic `Clamp` rule that persists any positive scaling update below quorum as `minAvailable`.
 
 ## Motivation
 
@@ -33,26 +32,25 @@ Scale-to-zero serving commonly keeps a router running while workers scale to zer
 
 Using `minAvailable: 0` would overload a field that already affects gang membership, termination, rolling updates, and startup ordering. `replicas` is the mutable scale target, so `replicas: 0` is the cleaner signal.
 
-External autoscalers should be treated as producers of desired replicas, not as components that understand Grove's per-component `minAvailable`. If Grove needs gang-safe membership above the autoscaler-written value, Grove should derive an internal effective value without writing back to `spec.replicas`.
+External replica writers should target either `0` or a value at least `minAvailable`; Grove clamps other positive below-quorum updates to `minAvailable` before persisting them.
 
 ### Goals
 
 - Treat `replicas: 0` as an intentional idle state without changing `minAvailable`.
-- Make `0` the only value below `minAvailable` that Grove runs as written.
-- Clamp a wake-up request in `0 < replicas < minAvailable` to an effective count of `minAvailable`.
-- Preserve autoscaler-written `spec.replicas` as desired scale, never writing an effective value back.
+- Keep `spec.replicas` valid: it is either `0` or greater than or equal to `minAvailable`.
+- Clamp any positive scaling update below `minAvailable` to `minAvailable`, for both wake-up and active scale-in.
+- Persist the clamped value in `spec.replicas` as the desired replica count.
 
 ### Non-Goals
 
 - Change `minAvailable` semantics, including allowing `minAvailable: 0` or making it mutable.
-- Require generic autoscalers to discover Grove component quorum.
 - Define the complete production implementation.
 
 ## Proposal
 
 When a `PodClique` or `PodCliqueScalingGroup` has `replicas: 0`, Grove should not require it as a gang member. When replicas become positive again, its existing `minAvailable` should apply normally.
 
-An idle component should leave the `PodGang` rather than stay in it with a zero threshold: no `PodGroup` in `PodGang.spec.podGroups`, and no scaled `PodGang` for a fully idle `PodCliqueScalingGroup` replica. Shrinking a gang must not disturb the members still running.
+An idle component should leave the `PodGang` rather than stay in it with a zero threshold: no `PodGroup` in `PodGang.spec.podGroups`, and no scaled `PodGang` for an idle `PodCliqueScalingGroup`. Shrinking a gang must not disturb the members still running.
 
 ### Zero Replicas Per Level
 
@@ -62,67 +60,54 @@ An idle component should leave the `PodGang` rather than stay in it with a zero 
 | --- | --- | --- |
 | `PodCliqueSet` | Already allowed. Nothing is created; no `minAvailable` at this level. | Unchanged. |
 | `PodCliqueScalingGroup` | Rejected in the `PodCliqueSet` template; accepted on the object, which has no webhook. | Idle. No `PodGroup` in the base `PodGang` and no scaled `PodGang`. |
-| `PodClique` | Silently defaulted to `1`. | Idle when standalone, contributing no `PodGroup`. Inside a scaling group, idle is expressed at the group level. |
+| `PodClique` | `replicas: 0` is accepted on the object, which has no webhook, but is silently defaulted to `1` in the `PodCliqueSet` template. | Idle when standalone, contributing no `PodGroup`. Inside a scaling group, idle is expressed at the group level. |
 
 ### Below-Quorum Policy
 
-For `0 < replicas < minAvailable`, Grove uses a fixed `Clamp` rule:
+For positive scaling updates below `minAvailable`, Grove uses a fixed, direction-agnostic `Clamp` rule:
 
-| Desired replicas | Behavior |
+| Requested replicas | Behavior |
 | --- | --- |
-| `replicas: 0` | Intentional idle state. The component contributes no required gang members and does not breach `minAvailable`. |
-| `0 < replicas < minAvailable` | Accepted only when waking from `0`. Grove preserves `spec.replicas` as desired scale and computes `effectiveReplicas = minAvailable`. |
-| `replicas >= minAvailable` | Normal Grove behavior. The component participates in gang scheduling and gang termination using its configured `minAvailable`; desired and effective replicas are equal. |
+| `0` | Intentional idle state. The component contributes no required gang members and does not breach `minAvailable`. |
+| `0 < replicas < minAvailable` | Accepted and persisted as `spec.replicas: minAvailable`, for both wake-up and active scale-in. |
+| `replicas >= minAvailable` | Persisted as requested. Normal Grove gang behavior applies. |
 
-Existing behavior changes in two cases: a `PodClique` with `replicas: 0` becomes idle instead of defaulting to one, and an object already in `(0, minAvailable)` is reconciled at `effectiveReplicas = minAvailable`.
+The persisted invariant is:
 
-`Clamp` applies only on the wake-up edge: a write from `0` into the range is accepted, one from `minAvailable` or above is rejected, so `0` is the only legal scale-in target below `minAvailable`. An explicit scale-in deserves an error, not a silent promotion. Comparing against the previous value puts that check in a validating webhook on the resource and its `scale` subresource, not in defaulting.
+```text
+spec.replicas == 0 || spec.replicas >= minAvailable
+```
 
-Grove should not implement `Clamp` by writing the clamped value back to `spec.replicas`. HPA or KEDA may repeatedly recompute a desired value such as `1`; writing `minAvailable` back into the scale target can create a control-plane write fight. The override is therefore internal only: the autoscaler-written value stays in `spec.replicas` as desired scale and Grove derives the effective value separately. After a successful wake, repeated writes of the stored below-quorum value are no-ops. A later active scale-in into the same range is rejected under the current wake-only rule and may be retried periodically; this is control-plane retry churn, not replica oscillation.
+`Clamp` is independent of the previous replica count. With `minAvailable: 3`, requests from `0` to `1` and from `4` to `2` both persist `spec.replicas: 3`, allowing the closest viable scale-in while keeping the service alive.
+
+A newly submitted `PodClique`, `PodCliqueScalingGroup`, or corresponding `PodCliqueSet` template entry must already satisfy the invariant: create requests with `0 < replicas < minAvailable` are rejected. Updates through the resource or its `/scale` subresource are clamped.
 
 ### Limitations/Risks & Mitigations
 
 The main risk is confusing "idle" with "unavailable." The proposed direction ties idle state to desired replicas, not observed status.
 
-Generic HPA/KEDA users can still fail to wake from zero to one without an autoscaler floor, so Grove applies `Clamp` on that wake-up edge. Its cost is a desired/effective split: `spec.replicas: 1` may intentionally run `minAvailable` members. Validity also depends on the object's current value, so the same manifest can be accepted or rejected.
-
-That split is transitional: most replica writers cannot express an active floor above `1` while still allowing `0`. KEDA can, pairing `minReplicaCount` with `idleReplicaCount: 0`, and if the rest gain it nothing lands in `(0, minAvailable)`. Grove must still define the case, since users and custom controllers also write `spec.replicas`.
+An autoscaler may request `1` and observe `spec.replicas: 3` when `minAvailable` is `3`. Supported autoscalers should avoid this path by expressing separate idle and active floors. KEDA does so with `idleReplicaCount: 0` and `minReplicaCount: minAvailable`; Grove still defines `Clamp` for other writers.
 
 Rolling updates already stall on a zero-replica standalone `PodClique`: completion requires `minAvailable` updated and ready pods, which zero pods never reach. A `PodCliqueScalingGroup` at `replicas: 0` does not stall, because its completion check compares only generation hashes. That asymmetry is why idle needs an explicit definition rather than a per-level accident.
 
 ## Design Details
 
-`Clamp` is fixed behavior for translating a positive desired replica count below `minAvailable` into gang-safe effective replicas when waking from zero. It must never clamp `replicas: 0`, which would defeat scale-to-zero.
-
-For `Clamp`, the effective count is:
+`Clamp` converts a scaling request into a valid desired replica count. It must never clamp `replicas: 0`, which would defeat scale-to-zero.
 
 ```text
-effectiveReplicas = 0 if desiredReplicas == 0
-effectiveReplicas = max(desiredReplicas, minAvailable) otherwise
+canonicalReplicas = 0 if requestedReplicas == 0
+canonicalReplicas = max(requestedReplicas, minAvailable) otherwise
 ```
 
-`effectiveReplicas` is derived per reconciliation, not stored; only admission consults the previous value. A `Clamp` component therefore cannot oscillate: it is idle or at least `minAvailable`. Grove treats `spec.replicas` as read-only, leaving the replica writer as its only writer, and the defaulting of `PodClique` `replicas: 0` to `1` is removed.
+`spec.replicas` stores `canonicalReplicas`; the defaulting of `PodClique` `replicas: 0` to `1` is removed.
 
 For the `/scale` subresource, `spec.replicas` remains the desired replica count and `status.replicas` reports actual observed replicas. `PodClique`, `PodCliqueScalingGroup`, and `PodCliqueSet` should use that same semantic contract.
-
-With `AverageValue` metrics, reporting observed replicas can cause one corrective HPA write from `1` to `2`; the experiment observed convergence without repeated writes or replica reversal.
 
 Gang logic reads `minAvailable` directly today, so idle needs a derived floor: `effectiveMinAvailable` is `0` while idle and `minAvailable` otherwise. The contributed `PodGroup`, the breach condition, and the rolling-update completion check should all read it, so an idle component contributes no `PodGroup`, never breaches, and counts as updated.
 
 ### Autoscaler Integration
 
-Grove only observes `spec.replicas`, so what matters per writer is when it sleeps and what it writes on wake-up.
-
-| Replica writer | Sleep trigger | Wake-up value | Grove needs |
-| --- | --- | --- | --- |
-| Native HPA | Manual `0` is Kubernetes' maintenance mode and stops the HPA. It sleeps by itself only with the `HPAScaleToZero` gate. | Manual, or `1` if the HPA slept it. | Fixed `Clamp` on wake-up, and no defaulting back to `1`. |
-| KEDA | Triggers idle for `cooldownPeriod`, 5 minutes by default. Sleeping is the default shape. | `minReplicaCount`, `1` by default. It is also the scale-down floor, so skipping the below-quorum range needs `minReplicaCount: minAvailable` with `idleReplicaCount: 0`. | Fixed `Clamp` if `minAvailable` is above `1`; the pairing avoids the desired/effective split when the `ScaledObject` is editable. |
-| Knative KPA | An idle window with no requests, on by default. | `1`, when the activator takes a request. | Same as KEDA, but out of reach: its activator and metrics assume Knative Revisions. |
-| Dynamo Planner, writing the DGD or a `DynamoGraphDeploymentScalingAdapter` | Its own policy; zero is a computed target. | Whatever it computes. | `Clamp` only on a wake from `0`; active scale-in must stay at or above `minAvailable` or jump to `0`. |
-| A custom controller | Its own policy. | Whatever it computes. | Fixed `Clamp` when it wakes into `1 .. minAvailable - 1`; active scale-in into that range is rejected. |
-| Grove's `scaleConfig` | Never; admission requires `minReplicas >= minAvailable`. | n/a | `minReplicas: 0` valid while `1 .. minAvailable - 1` stays invalid, no defaulting it from `replicas`, and the `HPAScaleToZero` gate on the generated HPA. |
-
-Waking from zero also needs a signal independent of a running replica, since serving metrics deadlock: in Dynamo, a model with no workers leaves `/v1/models` and returns `404`.
+Grove expects replica writers to emit either `0` or at least `minAvailable`. Future compatibility work should cover Native HPA, KEDA, Knative KPA, Dynamo Planner, custom controllers, and Grove's `scaleConfig`. KEDA can express the contract directly with `idleReplicaCount: 0` and `minReplicaCount: minAvailable`; other writers must either emit valid values or converge under `Clamp` without a write loop.
 
 ### Example
 
@@ -174,7 +159,7 @@ spec:
       minAvailable: 2
 ```
 
-Scale-to-zero happens on the derived objects, not this template: Grove sets `replicas` only at creation, so the replica writer owns it afterwards.
+Subsequent scale-to-zero happens on the derived objects, not this template: Grove sets `replicas` only at creation, so the replica writer owns it afterwards.
 
 ```bash
 kubectl scale podclique scale-to-zero-deepseek-0-decode --replicas=0
@@ -183,31 +168,27 @@ kubectl scale podcliquescalinggroup scale-to-zero-deepseek-0-prefill --replicas=
 
 The router keeps serving. Both idle components contribute no `PodGroup`, so they neither hold the base `PodGang` nor breach `minAvailable`.
 
-KEDA wakes them by writing its `minReplicaCount`, `1` by default:
+A writer wakes prefill by requesting one replica:
 
 ```bash
 kubectl scale podcliquescalinggroup scale-to-zero-deepseek-0-prefill --replicas=1
 ```
 
-`Clamp` accepts that write, keeps `spec.replicas: 1` as desired scale, and runs `effectiveReplicas: 2`.
+`Clamp` accepts the request and persists `spec.replicas: 2`. The controller then reconciles two replicas.
 
-Each row is one write on that component:
+Each row is one request on that component:
 
-| Write | Fixed `Clamp` behavior |
+| Request | Persisted `spec.replicas` |
 | --- | --- |
-| `0` to `1` | Accepted, `spec.replicas: 1`, `effectiveReplicas: 2` |
-| `1` to `1` | Accepted as an idempotent re-apply; no stored-value change |
-| `1` to `2` | Accepted, still two members |
-| `2` to `3` | Accepted |
-| `3` to `2` | Accepted |
-| `2` to `1` | Rejected; direction-agnostic behavior remains an open question |
-| `2` to `0` | Accepted |
+| `0` to `1` | `2` |
+| `2` to `1` | `2` |
+| `2` to `3` | `3` |
+| `3` to `2` | `2` |
+| `2` to `0` | `0` |
 
-`(0, minAvailable)` is therefore one-way: reachable only from `0`, left by scaling up or by writing `0`.
+No positive below-quorum value is stored. The same update semantics apply to the main resource and its `/scale` subresource. A create request with `replicas: 1` and `minAvailable: 2` is rejected rather than clamped.
 
-The same update semantics apply to the main resource and its `/scale` subresource. `CREATE` has no previous value and remains part of the admission rule follow-up.
-
-Today neither write is rejected: no admission webhook covers `PodClique` or `PodCliqueScalingGroup`. Both are accepted, and the idle member then holds the whole `PodGang` below its member count, leaving the router `SchedulingGated` (#676). Only the `PodCliqueSet` template validates the same shape:
+Today neither scale-to-zero write above is rejected: no admission webhook covers `PodClique` or `PodCliqueScalingGroup`. Both are accepted, and the idle member then holds the whole `PodGang` below its member count, leaving the router `SchedulingGated` (#676). Only the `PodCliqueSet` template validates the same shape:
 
 ```text
 spec.template.podCliqueScalingGroups[0].replicas: Invalid value: 0: must be greater than 0
@@ -218,7 +199,7 @@ A `PodClique` produces no error there only because defaulting rewrites `replicas
 
 ### Monitoring
 
-For `Clamp`, a `ReplicasBelowMinAvailable` condition should carry the desired and effective replica counts, so users can see why the running member count exceeds `spec.replicas`; `/scale.status.replicas` exposes the observed count but not why it differs.
+No new metrics or conditions are introduced. Idle is indicated by `spec.replicas: 0`, while `/scale.status.replicas` reports observed replicas.
 
 ### Test Plan
 
@@ -226,13 +207,12 @@ Prototype coverage should show:
 
 - zero-replica components do not block the base gang;
 - an idle component does not stall a rolling update;
-- fixed `Clamp` computes an effective count of at least `minAvailable` when waking from `0`;
-- `Clamp` rejects a scale-in into the below-quorum range on both the resource and its `scale` subresource;
-- `Clamp` does not write the effective value back to `spec.replicas`;
+- create rejects `0 < replicas < minAvailable`;
+- resource and `/scale` updates clamp any positive below-quorum request to `minAvailable`, regardless of direction;
+- replica writers that repeatedly request a positive below-quorum value converge without a write loop;
 - all three `/scale.status.replicas` implementations report actual observed replicas;
-- scaling back to `minAvailable` or above can re-enter normal gang behavior.
-
-An experiment-only prototype recorded 142 logical cases. Wake-only `Clamp` produced periodic denied HPA writes during active below-quorum scale-in, while direction-agnostic internal clamping completed the KEDA and Grove writer gates without persistent rejection, mutation, quorum breach, or replica reversal.
+- KEDA with `idleReplicaCount: 0` and `minReplicaCount: minAvailable` writes only valid values;
+- scaling to `minAvailable` or above re-enters normal gang behavior.
 
 ### Graduation Criteria
 
@@ -240,27 +220,21 @@ An experiment-only prototype recorded 142 logical cases. Wake-only `Clamp` produ
 - Beta: behavior documented and tested.
 - GA: semantics are stable and validated with real scale-to-zero workloads.
 
-## Open Questions
-
-- Should active scale-in into `(0, minAvailable)` be rejected, or accepted and internally clamped? Wake-only `Clamp` gives callers an explicit validation error and avoids reporting a successful scale-down that does not reduce effective replicas. In KEDA 2.20.2 tests, however, it caused 8-9 denied HPA writes in 30 seconds and 65 during a 300-second cooldown. This was control-plane retry churn, not replica oscillation or quorum loss.
-
-  Direction-agnostic `Clamp` preserved the requested `spec.replicas` and completed 11/11 KEDA contract cases and 15/15 Grove writer cases without denied writes, repeated writes, or replica reversal. Its trade-off is that a below-quorum scale-in appears successful while effective replicas remain at `minAvailable`.
-
 ## Remaining Work
 
 Accepting the direction above does not finish the GREP. Still to come, in this order:
 
-- The admission rule over previous and new value pairs, including create and re-apply, where there is no previous value.
+- The admission rules for rejecting invalid creates and clamping resource and `/scale` updates.
 - Gang behavior in detail: how the `PodGang` reshapes on idle and wake, whether an idle component is absent from the [coherent update](../393-coherent-rolling-updates/README.md) `PodGangMap` or present and empty, whether it joins an MVU, what a scale to zero does to an update in flight, and what that means for gang termination and partial scale.
-- The implementation surface in one place. Neither `PodClique` nor `PodCliqueScalingGroup` has a webhook today, so this GREP implies new ones on both and their `scale` subresource, plus dropping the `PodClique` `replicas: 0` defaulting, the `effectiveMinAvailable` readers, looser `scaleConfig` rules, observed `status.replicas` at all three levels, and upgrade handling for pre-existing below-quorum objects. Listing them is in scope; designing them is not.
+- The implementation surface in one place. Neither `PodClique` nor `PodCliqueScalingGroup` has a webhook today, so this GREP implies new ones on both and their `scale` subresources, updating the `PodClique` and `PodCliqueScalingGroup` template validation to allow `replicas: 0` while rejecting positive below-quorum values, dropping the `PodClique` `replicas: 0` defaulting, the `effectiveMinAvailable` readers, observed `status.replicas` at all three levels, and upgrade handling for pre-existing below-quorum objects. Listing them is in scope; designing them is not.
 
 ## Alternatives
 
 - Allow `minAvailable: 0`: explicit, but overloads an existing availability contract.
 - Keep idle members in the `PodGang` with `minReplicas: 0`: keeps the gang spec stable across idle transitions, but that value already signals released constraints during a coherent update, and backends map it back to a positive threshold.
 - Make `minAvailable` mutable: follows scale state, but changes the immutability contract.
-- Only support `Block` and never add `Clamp`: keeps `spec.replicas` truthful, but generic HPA/KEDA scale-from-zero can get stuck without an autoscaler floor.
-- Make `Clamp` direction-agnostic: re-applying a stored object never fails, but an explicit scale-in is silently promoted with no signal to the caller.
+- Only support `Block` and never add `Clamp`: keeps `spec.replicas` valid, but writers without an active floor cannot wake from zero or repeatedly receive rejections.
+- Preserve the below-quorum request in `spec.replicas` and derive an internal effective replica count: avoids mutating the writer's request, but permanently separates stored desired state from the count the controller actually reconciles.
 - Add `activeMinReplicas` now: useful if active warm capacity can differ from gang quorum, but premature if the active floor is simply `minAvailable`.
 
 ## Historical Discussion
@@ -283,9 +257,7 @@ BelowMinAvailablePolicy *BelowMinAvailablePolicy `json:"belowMinAvailablePolicy,
 
 This preserved existing behavior by default because unconditional clamping is not purely additive: no admission webhook covers `PodClique` or `PodCliqueScalingGroup` today, so a component already at `replicas: 1` with `minAvailable: 2` runs one pod now and would run two under `Clamp`. Opt-in `Clamp` was the escape for generic autoscalers that wake below `minAvailable`, at the cost of an additional API field and behavior that varied by policy.
 
-Review resolved two questions: `Clamp` is fixed behavior without a policy field, and `/scale.status.replicas` reports observed replicas while `spec.replicas` holds desired state. The normative proposal therefore drops `Block`, `belowMinAvailablePolicy`, and policy-qualified behavior; they remain here only to preserve the design history.
-
-An intermediate draft considered persisting the clamped value to `spec.replicas`. The current proposal keeps `Clamp` internal to preserve replica-writer ownership and avoid write contention.
+An intermediate draft left active scale-in into `(0, minAvailable)` open: should it be rejected or clamped? Latest review feedback favored direction-agnostic `Clamp`; with `minAvailable: 3`, a scale-in request from `4` to `2` persists `spec.replicas: 3`, allowing the closest viable scale-in while keeping the service alive. That feedback also favored storing the valid clamped desired count in `spec.replicas` and reporting observed replicas in `/scale.status.replicas`. The normative proposal therefore drops `Block`, `belowMinAvailablePolicy`, the wake-only rule, and the in-memory `effectiveReplicas` split.
 
 ## Appendix
 
@@ -301,6 +273,6 @@ An intermediate draft considered persisting the clamped value to `spec.replicas`
 
 Outside Grove, none blocking this GREP.
 
-- Kubernetes HPA: allow an active floor above `1` alongside `minReplicas: 0`, and resume from `spec.replicas: 0`, which disables the HPA today.
+- Kubernetes HPA: allow an active floor above `1` alongside `minReplicas: 0`; without `HPAScaleToZero`, `spec.replicas: 0` disables the HPA today.
 - KEDA: nothing needed; `minReplicaCount` with `idleReplicaCount: 0` already expresses that floor.
 - Dynamo: give the SLA Planner an idle floor separate from `min_endpoint`, so it reaches `0` without passing through `1 .. minAvailable - 1`.

--- a/docs/proposals/0677-zero-replica-gang-membership/README.md
+++ b/docs/proposals/0677-zero-replica-gang-membership/README.md
@@ -25,7 +25,7 @@
 
 ## Summary
 
-Grove should treat standalone `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP leaves existing `minAvailable` semantics unchanged, makes gang logic tolerant of zero-replica members, and rejects any positive replica count below `minAvailable` instead of clamping it.
+Grove should treat standalone `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP leaves existing `minAvailable` semantics unchanged, makes gang logic tolerant of zero-replica members, and rejects any positive replica count below `minAvailable`.
 
 ## Motivation
 
@@ -183,16 +183,6 @@ Grove rejects the request because it is below `minAvailable: 2`. The writer must
 kubectl scale podcliquescalinggroup scale-to-zero-deepseek-0-prefill --replicas=2
 ```
 
-Each row is one request on that component:
-
-| Request | Behavior |
-| --- | --- |
-| `0` to `1` | Rejected |
-| `2` to `1` | Rejected |
-| `2` to `3` | Persist `3` |
-| `3` to `2` | Persist `2` |
-| `2` to `0` | Persist `0` |
-
 No positive below-quorum value is stored. The same validation applies to the main resource, its `/scale` subresource, and create requests.
 
 Today neither scale-to-zero write above is rejected: no admission webhook covers `PodClique` or `PodCliqueScalingGroup`. Both are accepted, and the idle member then holds the whole `PodGang` below its member count, leaving the router `SchedulingGated` (#676). Only the `PodCliqueSet` template validates the same shape:
@@ -231,7 +221,7 @@ Prototype coverage should show:
 - Allow `minAvailable: 0`: explicit, but overloads an existing availability contract.
 - Keep idle members in the `PodGang` with `minReplicas: 0`: keeps the gang spec stable across idle transitions, but that value already signals released constraints during a coherent update, and backends map it back to a positive threshold.
 - Make `minAvailable` mutable: follows scale state, but changes the immutability contract.
-- Clamp positive below-quorum requests to `minAvailable`: lets writers without an active floor wake from zero, but silently rewrites caller intent and does not make HPA-like writers converge.
+- [Clamp positive below-quorum requests to `minAvailable`](#historical-discussion): lets writers without an active floor wake from zero, but silently rewrites caller intent and does not make HPA-like writers converge.
 - Preserve the below-quorum request in `spec.replicas` and derive an internal effective replica count: avoids mutating the writer's request, but permanently separates stored desired state from the count the controller actually reconciles.
 - Add `activeMinReplicas` now: useful if active warm capacity can differ from gang quorum, but premature if the active floor is simply `minAvailable`.
 

--- a/docs/proposals/0677-zero-replica-gang-membership/README.md
+++ b/docs/proposals/0677-zero-replica-gang-membership/README.md
@@ -15,7 +15,6 @@
   - [Monitoring](#monitoring)
   - [Test Plan](#test-plan)
   - [Graduation Criteria](#graduation-criteria)
-- [Open Questions](#open-questions)
 - [Remaining Work](#remaining-work)
 - [Alternatives](#alternatives)
 - [Historical Discussion](#historical-discussion)
@@ -26,7 +25,7 @@
 
 ## Summary
 
-Grove should treat `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP leaves existing `minAvailable` semantics unchanged, makes gang logic tolerant of zero-replica members, and rejects any positive replica count below `minAvailable` instead of clamping it.
+Grove should treat standalone `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP leaves existing `minAvailable` semantics unchanged, makes gang logic tolerant of zero-replica members, and rejects any positive replica count below `minAvailable` instead of clamping it.
 
 ## Motivation
 
@@ -38,7 +37,7 @@ External replica writers should target either `0` or a value at least `minAvaila
 
 ### Goals
 
-- Treat `replicas: 0` as an intentional idle state without changing `minAvailable`.
+- Treat `replicas: 0` as an intentional idle state for standalone `PodClique` and `PodCliqueScalingGroup` components without changing `minAvailable`.
 - Keep `spec.replicas` valid: it is either `0` or greater than or equal to `minAvailable`.
 - Reject any positive replica count below `minAvailable`.
 
@@ -48,7 +47,7 @@ External replica writers should target either `0` or a value at least `minAvaila
 
 ## Proposal
 
-When a `PodClique` or `PodCliqueScalingGroup` has `replicas: 0`, Grove should not require it as a gang member. When replicas become positive again, its existing `minAvailable` should apply normally.
+When a standalone `PodClique` or `PodCliqueScalingGroup` has `replicas: 0`, Grove should not require it as a gang member. When replicas become positive again, its existing `minAvailable` should apply normally.
 
 An idle component should leave the `PodGang` rather than stay in it with a zero threshold: no `PodGroup` in `PodGang.spec.podGroups`, and no scaled `PodGang` for an idle `PodCliqueScalingGroup`. Shrinking a gang must not disturb the members still running.
 
@@ -60,7 +59,9 @@ An idle component should leave the `PodGang` rather than stay in it with a zero 
 | --- | --- | --- |
 | `PodCliqueSet` | Already allowed. Nothing is created; no `minAvailable` at this level. | Unchanged. |
 | `PodCliqueScalingGroup` | Rejected in the `PodCliqueSet` template; accepted on the object, which has no webhook. | Idle. No `PodGroup` in the base `PodGang` and no scaled `PodGang`. |
-| `PodClique` | `replicas: 0` is accepted on the object, which has no webhook, but is silently defaulted to `1` in the `PodCliqueSet` template. | Idle when standalone, contributing no `PodGroup`. Inside a scaling group, idle is expressed at the group level. |
+| `PodClique` | `replicas: 0` is accepted on the object, which has no webhook, but is silently defaulted to `1` in the `PodCliqueSet` template. | Idle when standalone, contributing no `PodGroup`. A scaling-group member is not an independent scale target and cannot set `replicas: 0`; idle is expressed at the group level. |
+
+A `PodClique` owned by a `PodCliqueScalingGroup` must not be scaled independently, including to zero. To idle its members, set the owning `PodCliqueScalingGroup` to `replicas: 0`.
 
 ### Below-Quorum Behavior
 
@@ -72,7 +73,7 @@ Grove rejects positive replica counts below `minAvailable`:
 | `0 < replicas < minAvailable` | Rejected for create and update requests, including the `/scale` subresource. |
 | `replicas >= minAvailable` | Persisted as requested. Normal Grove gang behavior applies. |
 
-The persisted invariant is:
+For independent scale targets, the persisted invariant is:
 
 ```text
 spec.replicas == 0 || spec.replicas >= minAvailable
@@ -80,7 +81,7 @@ spec.replicas == 0 || spec.replicas >= minAvailable
 
 Reject is independent of the previous replica count. With `minAvailable: 3`, requests from `0` to `1` and from `4` to `2` are both rejected.
 
-A newly submitted `PodClique`, `PodCliqueScalingGroup`, or corresponding `PodCliqueSet` template entry must already satisfy the invariant. Updates through the main resource or its `/scale` subresource that request `0 < replicas < minAvailable` are rejected.
+A newly submitted standalone `PodClique`, `PodCliqueScalingGroup`, or corresponding `PodCliqueSet` template entry must already satisfy the invariant. Updates through the main resource or its `/scale` subresource that request `0 < replicas < minAvailable` are rejected.
 
 ### Limitations/Risks & Mitigations
 
@@ -221,15 +222,11 @@ Prototype coverage should show:
 - Beta: behavior documented and tested.
 - GA: semantics are stable and validated with real scale-to-zero workloads.
 
-## Open Questions
-
-Should a `PodClique` owned by a `PodCliqueScalingGroup` be allowed to set `replicas: 0` independently? The general replica invariant permits it, while [Zero Replicas Per Level](#zero-replicas-per-level) says that idle for a scaling-group member is expressed at the group level. The template, derived object, and admission semantics must align once this is resolved.
-
 ## Remaining Work
 
 - The admission rules for rejecting invalid creates and replica updates through the main resource or `/scale`.
 - Gang behavior in detail: how the `PodGang` reshapes on idle and wake, how idle state propagates through scheduled, available, and updated status at each resource level, how `startsAfter` handles an idle dependency, whether an idle component is absent from the [coherent update](../393-coherent-rolling-updates/README.md) `PodGangMap` or present and empty, whether it joins an MVU, what a scale to zero does to an update in flight, and what that means for gang termination and partial scale.
-- Implementation requires webhooks for `PodClique` and `PodCliqueScalingGroup` resource and `/scale` updates; template validation that allows `replicas: 0` but rejects positive below-quorum creates; removal of the `PodClique` zero-to-one default; updates to gang membership, breach, and rolling-update paths for idle components; and a migration rule for pre-existing below-quorum objects.
+- Implementation requires webhooks for `PodClique` and `PodCliqueScalingGroup` resource and `/scale` updates; template validation that allows `replicas: 0` for standalone `PodClique` and `PodCliqueScalingGroup` components but rejects it for scaling-group member `PodClique`s; removal of the standalone `PodClique` zero-to-one default; updates to gang membership, breach, and rolling-update paths for idle components; and a migration rule for pre-existing below-quorum objects.
 
 ## Alternatives
 

--- a/docs/proposals/0677-zero-replica-gang-membership/README.md
+++ b/docs/proposals/0677-zero-replica-gang-membership/README.md
@@ -86,7 +86,7 @@ A newly submitted `PodClique`, `PodCliqueScalingGroup`, or corresponding `PodCli
 
 The main risk is confusing "idle" with "unavailable." The proposed direction ties idle state to desired replicas, not observed status.
 
-An autoscaler may request `1` and observe `spec.replicas: 3` when `minAvailable` is `3`; the risk of repeated below-quorum writes is tracked in [Open Questions](#open-questions).
+An HPA may request `1` and observe `spec.replicas: 3` when `minAvailable` is `3`; repeated below-quorum HPA writes are demonstrated in [Open Questions](#open-questions).
 
 Rolling updates already stall on a zero-replica standalone `PodClique`: completion requires `minAvailable` updated and ready pods, which zero pods never reach. A `PodCliqueScalingGroup` at `replicas: 0` does not stall, because its completion check compares only generation hashes. That asymmetry is why idle needs an explicit definition rather than a per-level accident.
 
@@ -103,13 +103,18 @@ canonicalReplicas = max(requestedReplicas, minAvailable) otherwise
 
 When Grove clamps an update, the admission response includes a warning with the requested value, `minAvailable`, and the persisted value. The warning gives interactive clients immediate feedback without adding persistent annotations or conditions.
 
-For the `/scale` subresource, `spec.replicas` remains the desired replica count and `status.replicas` reports actual observed replicas. `PodClique`, `PodCliqueScalingGroup`, and `PodCliqueSet` should use that same semantic contract.
-
 While a component is idle, it contributes no `PodGroup`, does not set `MinAvailableBreached` to `True`, and counts as updated for rolling-update completion.
 
 ### Autoscaler Integration
 
-Grove expects replica writers to emit either `0` or at least `minAvailable`. KEDA can express this contract with `idleReplicaCount: 0` and `minReplicaCount: minAvailable`. The HPA POC in [Open Questions](#open-questions) tests whether repeated positive below-quorum requests create a write loop. Compatibility work remains for Knative KPA, Dynamo Planner, custom controllers, and Grove's `scaleConfig`; each must either emit valid values or tolerate persisted `Clamp` without a write loop.
+Grove-compatible replica writers must converge to `0` while idle and at least `minAvailable` while active without repeatedly writing a positive below-quorum value.
+
+| Model | Behavior | Compatibility |
+| --- | --- | --- |
+| KEDA-like | Separate idle and active floors, such as KEDA `idleReplicaCount: 0` with `minReplicaCount: minAvailable`. | Compatible. |
+| HPA-like | May repeatedly write a positive below-quorum value or prevent scale-to-zero. | Incompatible. |
+
+[KEDA](https://keda.sh/docs/2.20/reference/scaledobject-spec/) emits only `0` or at least `minAvailable`. Native [HPA](https://kubernetes.io/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/#scaling-to-and-from-zero) is HPA-like. Knative Serving v1.23.0 KPA is also HPA-like because [`autoscaling.knative.dev/activation-scale`](https://knative.dev/docs/serving/autoscaling/scale-bounds/#scale-up-minimum) is not a persistent active floor. Dynamo Planner has not established Grove-compatible scale-to-zero behavior. Grove `scaleConfig` is HPA-like because it generates an HPA. New custom controllers should use KEDA-like semantics to support scale-to-zero.
 
 ### Example
 
@@ -212,9 +217,7 @@ Prototype coverage should show:
 - create rejects `0 < replicas < minAvailable`;
 - resource and `/scale` updates clamp any positive below-quorum request to `minAvailable`, regardless of direction;
 - clamped updates return an admission warning, while valid updates do not;
-- replica writers that repeatedly request a positive below-quorum value converge without a write loop, pending confirmation by the HPA POC in [Open Questions](#open-questions);
-- all three `/scale.status.replicas` implementations report actual observed replicas;
-- KEDA with `idleReplicaCount: 0` and `minReplicaCount: minAvailable` writes only valid values;
+- a KEDA-like integration transitions from `0` directly to `minAvailable` or above without writing a positive below-quorum value;
 - scaling to `minAvailable` or above re-enters normal gang behavior.
 
 ### Graduation Criteria
@@ -225,26 +228,24 @@ Prototype coverage should show:
 
 ## Open Questions
 
-- Does an autoscaler that repeatedly requests `0 < replicas < minAvailable` create a write loop after Grove persists `minAvailable`? A POC should test HPA with `minReplicas < minAvailable`; scale-to-zero is not required.
+**Status: Resolved.**
 
-  A POC against [PR #788](https://github.com/ai-dynamo/grove/pull/788) at commit `1b0ced6c9abda9b6fec1dd38a2d9bcbe83eba515` tested `minAvailable: 2`, initial `replicas: 3`, and a 35-second observation window after the target reached `spec.replicas: 2` and `status.replicas: 2`. A `WRITE_LOOP` means that the writer issued at least two additional requests for `replicas: 1` during that window; the stored replica count does not need to oscillate.
+Does persisted `Clamp` make an HPA-like writer converge after a below-quorum recommendation?
 
-  | Replica writer | Floor-respecting control (`NO_LOOP`) | Below-quorum treatment (`WRITE_LOOP`) | Scope |
-  | --- | --- | --- | --- |
-  | Native HPA | `minReplicas: 2` | `minReplicas: 1`, recommending `1` | `Value` and `AverageValue`; PCLQ and PCSG |
-  | Grove `scaleConfig` | `minReplicas: 2` | `minReplicas: 0`, recommending `1` | `Value` and `AverageValue`; PCLQ and PCSG; control cannot scale to zero |
-  | KEDA | `idleReplicaCount: 0`, `minReplicaCount: 2` | `idleReplicaCount: 0`, `minReplicaCount: 1` | `Value` and `AverageValue`; PCLQ and PCSG |
-  | Custom controller | Repeatedly requests `2` | Repeatedly requests `1` | PCLQ and PCSG |
-  | Knative KPA | One adapter request produced no repeat | Not tested | Continuous-writer behavior not established |
-  | Dynamo Planner | Not established | Not established | `INCONCLUSIVE`; full Planner metric loop was not driven |
+**Experiment.** An HPA POC against [PR #788](https://github.com/ai-dynamo/grove/pull/788) used `minAvailable: 2` and observed each case for 35 seconds after stabilization. Both configurations were tested with `Value` and `AverageValue` metrics against `PodClique` and `PodCliqueScalingGroup`.
 
-  These columns describe experimental controls and treatments, not recommended scale-to-zero configurations. All 14 floor-respecting controls completed with `NO_LOOP`. All 14 treatments that repeatedly requested `1` completed with `WRITE_LOOP`, each issuing seven post-stabilization requests. The remaining design question is whether Grove should require supported replica writers to enforce the active `minAvailable` floor, provide an adapter for writers that cannot express it, or revise persisted `Clamp`.
+| HPA configuration | Result for both metrics and scale targets |
+| --- | --- |
+| `minReplicas: 2` | `0` repeated writes; `NO_LOOP` |
+| `minReplicas: 1`, recommending `1` | `7` repeated writes per case; `WRITE_LOOP` |
+
+Persisted `Clamp` does not make an HPA-like writer converge: HPA keeps requesting `1` while Grove stores `2`. KEDA-like writers avoid this loop by emitting only `0` or at least `minAvailable`.
 
 ## Remaining Work
 
 - The admission rules for rejecting invalid creates and clamping resource and `/scale` updates.
 - Gang behavior in detail: how the `PodGang` reshapes on idle and wake, how idle state propagates through scheduled, available, and updated status at each resource level, how `startsAfter` handles an idle dependency, whether an idle component is absent from the [coherent update](../393-coherent-rolling-updates/README.md) `PodGangMap` or present and empty, whether it joins an MVU, what a scale to zero does to an update in flight, and what that means for gang termination and partial scale.
-- Implementation requires webhooks for `PodClique` and `PodCliqueScalingGroup` resource and `/scale` updates; template validation that allows `replicas: 0` but rejects positive below-quorum creates; removal of the `PodClique` zero-to-one default; updates to gang membership, breach, and rolling-update paths for idle components; observed `status.replicas` at all three levels; and a migration rule that specifies whether pre-existing below-quorum objects are clamped during upgrade or retained until a later replica update brings them into the invariant.
+- Implementation requires webhooks for `PodClique` and `PodCliqueScalingGroup` resource and `/scale` updates; template validation that allows `replicas: 0` but rejects positive below-quorum creates; removal of the `PodClique` zero-to-one default; updates to gang membership, breach, and rolling-update paths for idle components; and a migration rule that specifies whether pre-existing below-quorum objects are clamped during upgrade or retained until a later replica update brings them into the invariant.
 
 ## Alternatives
 
@@ -275,7 +276,7 @@ BelowMinAvailablePolicy *BelowMinAvailablePolicy `json:"belowMinAvailablePolicy,
 
 This preserved existing behavior by default because unconditional clamping is not purely additive: no admission webhook covers `PodClique` or `PodCliqueScalingGroup` today, so a component already at `replicas: 1` with `minAvailable: 2` runs one pod now and would run two under `Clamp`. Opt-in `Clamp` was the escape for generic autoscalers that wake below `minAvailable`, at the cost of an additional API field and behavior that varied by policy.
 
-An intermediate draft left active scale-in into `(0, minAvailable)` open: should it be rejected or clamped? Latest review feedback favored direction-agnostic `Clamp`; with `minAvailable: 3`, a scale-in request from `4` to `2` persists `spec.replicas: 3`, allowing the closest viable scale-in while keeping the service alive. That feedback also favored storing the valid clamped desired count in `spec.replicas` and reporting observed replicas in `/scale.status.replicas`. The normative proposal therefore drops `Block`, `belowMinAvailablePolicy`, the wake-only rule, and the in-memory `effectiveReplicas` split.
+An intermediate draft left active scale-in into `(0, minAvailable)` open: should it be rejected or clamped? Latest review feedback favored direction-agnostic `Clamp`; with `minAvailable: 3`, a scale-in request from `4` to `2` persists `spec.replicas: 3`, allowing the closest viable scale-in while keeping the service alive. The normative proposal therefore stores the valid clamped value in `spec.replicas` and drops `Block`, `belowMinAvailablePolicy`, the wake-only rule, and the in-memory `effectiveReplicas` split.
 
 ## Appendix
 
@@ -291,6 +292,6 @@ An intermediate draft left active scale-in into `(0, minAvailable)` open: should
 
 Outside Grove, none blocking this GREP.
 
-- Kubernetes HPA: allow an active floor above `1` alongside `minReplicas: 0`; without `HPAScaleToZero`, `spec.replicas: 0` disables the HPA today.
-- KEDA: nothing needed; `minReplicaCount` with `idleReplicaCount: 0` already expresses that floor.
-- Dynamo: give the SLA Planner an idle floor separate from `min_endpoint`, so it reaches `0` without passing through `1 .. minAvailable - 1`.
+- [Kubernetes HPA](https://kubernetes.io/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/#scaling-to-and-from-zero): provide separate idle and active floors. In Kubernetes v1.37, `HPAScaleToZero` is beta and enabled by default for Object and External metrics, but HPA still exposes only one `minReplicas` floor.
+- [KEDA](https://keda.sh/docs/2.20/reference/scaledobject-spec/): nothing needed; `minReplicaCount` with `idleReplicaCount: 0` already expresses that floor.
+- Dynamo Planner: provide separate idle and active floors.

--- a/docs/proposals/0677-zero-replica-gang-membership/README.md
+++ b/docs/proposals/0677-zero-replica-gang-membership/README.md
@@ -20,12 +20,13 @@
 - [Alternatives](#alternatives)
 - [Historical Discussion](#historical-discussion)
 - [Appendix](#appendix)
+  - [Historical HPA Clamp Experiment](#historical-hpa-clamp-experiment)
   - [Upstream Follow-ups](#upstream-follow-ups)
 <!-- /toc -->
 
 ## Summary
 
-Grove should treat `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP keeps `minAvailable` non-zero and immutable, makes gang logic tolerant of zero-replica members, and uses a fixed, direction-agnostic `Clamp` rule that persists any positive scaling update below quorum as `minAvailable`.
+Grove should treat `PodClique` or `PodCliqueScalingGroup` components with `replicas: 0` as an intentional idle state. This GREP leaves existing `minAvailable` semantics unchanged, makes gang logic tolerant of zero-replica members, and rejects any positive replica count below `minAvailable` instead of clamping it.
 
 ## Motivation
 
@@ -33,14 +34,13 @@ Scale-to-zero serving commonly keeps a router running while workers scale to zer
 
 Using `minAvailable: 0` would overload a field that already affects gang membership, termination, rolling updates, and startup ordering. `replicas` is the mutable scale target, so `replicas: 0` is the cleaner signal.
 
-External replica writers should target either `0` or a value at least `minAvailable`; Grove clamps other positive below-quorum updates to `minAvailable` before persisting them.
+External replica writers should target either `0` or a value at least `minAvailable`; Grove rejects any other positive below-quorum request.
 
 ### Goals
 
 - Treat `replicas: 0` as an intentional idle state without changing `minAvailable`.
 - Keep `spec.replicas` valid: it is either `0` or greater than or equal to `minAvailable`.
-- Clamp any positive scaling update below `minAvailable` to `minAvailable`, for both wake-up and active scale-in.
-- Persist the clamped value in `spec.replicas` as the desired replica count.
+- Reject any positive replica count below `minAvailable`.
 
 ### Non-Goals
 
@@ -64,12 +64,12 @@ An idle component should leave the `PodGang` rather than stay in it with a zero 
 
 ### Below-Quorum Behavior
 
-For positive scaling updates below `minAvailable`, Grove uses a fixed, direction-agnostic `Clamp` rule:
+Grove rejects positive replica counts below `minAvailable`:
 
 | Requested replicas | Behavior |
 | --- | --- |
 | `0` | Intentional idle state. The component contributes no required gang members and does not breach `minAvailable`. |
-| `0 < replicas < minAvailable` | Accepted and persisted as `spec.replicas: minAvailable`, for both wake-up and active scale-in. |
+| `0 < replicas < minAvailable` | Rejected for create and update requests, including the `/scale` subresource. |
 | `replicas >= minAvailable` | Persisted as requested. Normal Grove gang behavior applies. |
 
 The persisted invariant is:
@@ -78,30 +78,21 @@ The persisted invariant is:
 spec.replicas == 0 || spec.replicas >= minAvailable
 ```
 
-`Clamp` is independent of the previous replica count. With `minAvailable: 3`, requests from `0` to `1` and from `4` to `2` both persist `spec.replicas: 3`, allowing the closest viable scale-in while keeping the service alive.
+Reject is independent of the previous replica count. With `minAvailable: 3`, requests from `0` to `1` and from `4` to `2` are both rejected.
 
-A newly submitted `PodClique`, `PodCliqueScalingGroup`, or corresponding `PodCliqueSet` template entry must already satisfy the invariant: create requests with `0 < replicas < minAvailable` are rejected. Updates through the resource or its `/scale` subresource are clamped.
+A newly submitted `PodClique`, `PodCliqueScalingGroup`, or corresponding `PodCliqueSet` template entry must already satisfy the invariant. Updates through the main resource or its `/scale` subresource that request `0 < replicas < minAvailable` are rejected.
 
 ### Limitations/Risks & Mitigations
 
 The main risk is confusing "idle" with "unavailable." The proposed direction ties idle state to desired replicas, not observed status.
 
-An HPA may request `1` and observe `spec.replicas: 3` when `minAvailable` is `3`; repeated below-quorum HPA writes are demonstrated in [Open Questions](#open-questions).
+An HPA may repeatedly request an invalid below-quorum value. The [historical HPA Clamp experiment](#historical-hpa-clamp-experiment) shows that accepting and clamping such requests does not make the writer converge; the reject path requires verification once implemented.
 
 Rolling updates already stall on a zero-replica standalone `PodClique`: completion requires `minAvailable` updated and ready pods, which zero pods never reach. A `PodCliqueScalingGroup` at `replicas: 0` does not stall, because its completion check compares only generation hashes. That asymmetry is why idle needs an explicit definition rather than a per-level accident.
 
 ## Design Details
 
-`Clamp` converts a scaling request into a valid desired replica count. It must never clamp `replicas: 0`, which would defeat scale-to-zero.
-
-```text
-canonicalReplicas = 0 if requestedReplicas == 0
-canonicalReplicas = max(requestedReplicas, minAvailable) otherwise
-```
-
-`spec.replicas` stores `canonicalReplicas`; the defaulting of `PodClique` `replicas: 0` to `1` is removed.
-
-When Grove clamps an update, the admission response includes a warning with the requested value, `minAvailable`, and the persisted value. The warning gives interactive clients immediate feedback without adding persistent annotations or conditions.
+Admission rejects any positive requested replica count below `minAvailable` without rewriting `spec.replicas`. The defaulting of `PodClique` `replicas: 0` to `1` is removed.
 
 While a component is idle, it contributes no `PodGroup`, does not set `MinAvailableBreached` to `True`, and counts as updated for rolling-update completion.
 
@@ -181,19 +172,23 @@ A writer wakes prefill by requesting one replica:
 kubectl scale podcliquescalinggroup scale-to-zero-deepseek-0-prefill --replicas=1
 ```
 
-`Clamp` accepts the request and persists `spec.replicas: 2`. The controller then reconciles two replicas.
+Grove rejects the request because it is below `minAvailable: 2`. The writer must request at least two replicas:
+
+```bash
+kubectl scale podcliquescalinggroup scale-to-zero-deepseek-0-prefill --replicas=2
+```
 
 Each row is one request on that component:
 
-| Request | Persisted `spec.replicas` |
+| Request | Behavior |
 | --- | --- |
-| `0` to `1` | `2` |
-| `2` to `1` | `2` |
-| `2` to `3` | `3` |
-| `3` to `2` | `2` |
-| `2` to `0` | `0` |
+| `0` to `1` | Rejected |
+| `2` to `1` | Rejected |
+| `2` to `3` | Persist `3` |
+| `3` to `2` | Persist `2` |
+| `2` to `0` | Persist `0` |
 
-No positive below-quorum value is stored. The same update semantics apply to the main resource and its `/scale` subresource. A create request with `replicas: 1` and `minAvailable: 2` is rejected rather than clamped.
+No positive below-quorum value is stored. The same validation applies to the main resource, its `/scale` subresource, and create requests.
 
 Today neither scale-to-zero write above is rejected: no admission webhook covers `PodClique` or `PodCliqueScalingGroup`. Both are accepted, and the idle member then holds the whole `PodGang` below its member count, leaving the router `SchedulingGated` (#676). Only the `PodCliqueSet` template validates the same shape:
 
@@ -214,10 +209,10 @@ Prototype coverage should show:
 
 - zero-replica components do not block the base gang;
 - an idle component does not stall a rolling update;
-- create rejects `0 < replicas < minAvailable`;
-- resource and `/scale` updates clamp any positive below-quorum request to `minAvailable`, regardless of direction;
-- clamped updates return an admission warning, while valid updates do not;
+- create requests and updates through the main resource or `/scale` reject `0 < replicas < minAvailable`;
+- rejected updates leave `spec.replicas` unchanged;
 - a KEDA-like integration transitions from `0` directly to `minAvailable` or above without writing a positive below-quorum value;
+- an HPA-like writer receives a validation error for a below-quorum recommendation and leaves `spec.replicas` unchanged, with repeated retry behavior documented;
 - scaling to `minAvailable` or above re-enters normal gang behavior.
 
 ### Graduation Criteria
@@ -228,31 +223,20 @@ Prototype coverage should show:
 
 ## Open Questions
 
-**Status: Resolved.**
-
-Does persisted `Clamp` make an HPA-like writer converge after a below-quorum recommendation?
-
-**Experiment.** An HPA POC against [PR #788](https://github.com/ai-dynamo/grove/pull/788) used `minAvailable: 2` and observed each case for 35 seconds after stabilization. Both configurations were tested with `Value` and `AverageValue` metrics against `PodClique` and `PodCliqueScalingGroup`.
-
-| HPA configuration | Result for both metrics and scale targets |
-| --- | --- |
-| `minReplicas: 2` | `0` repeated writes; `NO_LOOP` |
-| `minReplicas: 1`, recommending `1` | `7` repeated writes per case; `WRITE_LOOP` |
-
-Persisted `Clamp` does not make an HPA-like writer converge: HPA keeps requesting `1` while Grove stores `2`. KEDA-like writers avoid this loop by emitting only `0` or at least `minAvailable`.
+Should a `PodClique` owned by a `PodCliqueScalingGroup` be allowed to set `replicas: 0` independently? The general replica invariant permits it, while [Zero Replicas Per Level](#zero-replicas-per-level) says that idle for a scaling-group member is expressed at the group level. The template, derived object, and admission semantics must align once this is resolved.
 
 ## Remaining Work
 
-- The admission rules for rejecting invalid creates and clamping resource and `/scale` updates.
+- The admission rules for rejecting invalid creates and replica updates through the main resource or `/scale`.
 - Gang behavior in detail: how the `PodGang` reshapes on idle and wake, how idle state propagates through scheduled, available, and updated status at each resource level, how `startsAfter` handles an idle dependency, whether an idle component is absent from the [coherent update](../393-coherent-rolling-updates/README.md) `PodGangMap` or present and empty, whether it joins an MVU, what a scale to zero does to an update in flight, and what that means for gang termination and partial scale.
-- Implementation requires webhooks for `PodClique` and `PodCliqueScalingGroup` resource and `/scale` updates; template validation that allows `replicas: 0` but rejects positive below-quorum creates; removal of the `PodClique` zero-to-one default; updates to gang membership, breach, and rolling-update paths for idle components; and a migration rule that specifies whether pre-existing below-quorum objects are clamped during upgrade or retained until a later replica update brings them into the invariant.
+- Implementation requires webhooks for `PodClique` and `PodCliqueScalingGroup` resource and `/scale` updates; template validation that allows `replicas: 0` but rejects positive below-quorum creates; removal of the `PodClique` zero-to-one default; updates to gang membership, breach, and rolling-update paths for idle components; and a migration rule for pre-existing below-quorum objects.
 
 ## Alternatives
 
 - Allow `minAvailable: 0`: explicit, but overloads an existing availability contract.
 - Keep idle members in the `PodGang` with `minReplicas: 0`: keeps the gang spec stable across idle transitions, but that value already signals released constraints during a coherent update, and backends map it back to a positive threshold.
 - Make `minAvailable` mutable: follows scale state, but changes the immutability contract.
-- Only support `Block` and never add `Clamp`: keeps `spec.replicas` valid, but writers without an active floor cannot wake from zero or repeatedly receive rejections.
+- Clamp positive below-quorum requests to `minAvailable`: lets writers without an active floor wake from zero, but silently rewrites caller intent and does not make HPA-like writers converge.
 - Preserve the below-quorum request in `spec.replicas` and derive an internal effective replica count: avoids mutating the writer's request, but permanently separates stored desired state from the count the controller actually reconciles.
 - Add `activeMinReplicas` now: useful if active warm capacity can differ from gang quorum, but premature if the active floor is simply `minAvailable`.
 
@@ -276,7 +260,7 @@ BelowMinAvailablePolicy *BelowMinAvailablePolicy `json:"belowMinAvailablePolicy,
 
 This preserved existing behavior by default because unconditional clamping is not purely additive: no admission webhook covers `PodClique` or `PodCliqueScalingGroup` today, so a component already at `replicas: 1` with `minAvailable: 2` runs one pod now and would run two under `Clamp`. Opt-in `Clamp` was the escape for generic autoscalers that wake below `minAvailable`, at the cost of an additional API field and behavior that varied by policy.
 
-An intermediate draft left active scale-in into `(0, minAvailable)` open: should it be rejected or clamped? Latest review feedback favored direction-agnostic `Clamp`; with `minAvailable: 3`, a scale-in request from `4` to `2` persists `spec.replicas: 3`, allowing the closest viable scale-in while keeping the service alive. The normative proposal therefore stores the valid clamped value in `spec.replicas` and drops `Block`, `belowMinAvailablePolicy`, the wake-only rule, and the in-memory `effectiveReplicas` split.
+An intermediate draft favored direction-agnostic `Clamp`; with `minAvailable: 3`, a scale-in request from `4` to `2` would persist `spec.replicas: 3`. Later review favored cleaner API semantics that reject the invalid range. The normative proposal therefore uses reject-only behavior for every positive value below `minAvailable` and does not add `belowMinAvailablePolicy`, wake-only clamping, or the in-memory `effectiveReplicas` split.
 
 ## Appendix
 
@@ -287,6 +271,21 @@ An intermediate draft left active scale-in into `(0, minAvailable)` open: should
 - Related Dynamo issue: [ai-dynamo/dynamo#10753](https://github.com/ai-dynamo/dynamo/issues/10753)
 - Related Dynamo PR: [ai-dynamo/dynamo#10532](https://github.com/ai-dynamo/dynamo/pull/10532)
 - Dynamo autoscaling guide: [Dynamo autoscaling](https://docs.nvidia.com/dynamo/v1.1.1/kubernetes-deployment/deployment-guide/autoscaling)
+
+### Historical HPA Clamp Experiment
+
+This historical, non-normative experiment evaluated persisted `Clamp`, not the current Reject proposal. It shows that Clamp did not eliminate repeated writes, but provides no evidence about retry behavior after rejection.
+
+Can persisted `Clamp` make an HPA-like writer converge when its recommendation falls below `minAvailable`?
+
+An HPA POC against [PR #788](https://github.com/ai-dynamo/grove/pull/788) used `minAvailable: 2` and observed each case for 35 seconds after stabilization. Both configurations were tested with `Value` and `AverageValue` metrics against `PodClique` and `PodCliqueScalingGroup`.
+
+| HPA configuration | Result for both metrics and scale targets |
+| --- | --- |
+| `minReplicas: 2` | `0` repeated writes; `NO_LOOP` |
+| `minReplicas: 1`, recommending `1` | `7` repeated writes per case; `WRITE_LOOP` |
+
+The experiment demonstrates that persisted `Clamp` does not make an HPA-like writer converge: HPA keeps requesting `1` while Grove stores `2`. Reject preserves the stored replica count and surfaces the invalid recommendation instead of silently rewriting it, but the experiment did not test whether HPA retries after a rejected update. The reject implementation must verify and document that behavior. KEDA-like writers avoid the invalid range by emitting only `0` or at least `minAvailable`.
 
 ### Upstream Follow-ups
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Adds GREP-0677 to define hibernation for standalone `PodClique` and `PodCliqueScalingGroup` components at `replicas: 0`, without disrupting components that remain active. Idle components should not block gang scheduling, trigger gang termination, or stall rolling updates. Wake-up preserves gang-scheduling guarantees; `minAvailable` stays positive and immutable.

New positive replica targets below `minAvailable` are rejected. Existing below-quorum objects may update unrelated fields without changing `replicas` or `minAvailable`.

#### Which issue(s) this PR fixes:

Fixes #677
Related to #676

#### Special notes for your reviewer:

Design proposal only; no implementation changes.

Runtime hibernation targets the derived PodClique or PodCliqueScalingGroup, not PodCliqueSet replicas. PCSG members idle through their group; non-zero scaling remains allowed when `replicas >= minAvailable`.

Detailed wake, backend, and autoscaler contracts are in the GREP.

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
docs/proposals/0677-scale-to-zero-component-hibernation/README.md
```
