### PR TITLE
Make `default-scheduler` the only enabled profile by default.

### DIFF
--- a/operator/charts/values.yaml
+++ b/operator/charts/values.yaml
@@ -93,12 +93,13 @@ config:
       concurrentSyncs: 3
   # Scheduler configures which scheduler backends are active. default-scheduler is always available.
   # List profiles to enable backends; set defaultProfileName to the profile that is the default backend.
+  # Enable the corresponding profiles when required.
   scheduler:
     profiles:
       - name: default-scheduler
-      - name: kai-scheduler
-      - name: volcano
-      - name: lpx-scheduler
+      # - name: kai-scheduler
+      # - name: volcano
+      # - name: lpx-scheduler
   logLevel: info
   logFormat: json
   topologyAwareScheduling:


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api
-->

/kind bug

#### What this PR does / why we need it:

* The operator `CrashLoopBackOff`s when brought up using the development make targets `make kind-up deploy`. This is because the CRDs required by Volcano (and other backends) are not installed in this cluster by default.

* Commented out all profiles other than the `default-scheduler` profile in `charts/values.yaml`, users can configure this as needed.

Specifying all the supported backends by Grove as an uncommented list in the profiles will make consumption harder; all these profiles are *expected* to be in the cluster when the users are using the default, unmodified charts.

Commenting these additional profiles in the default charts will force consumers to make a conscious decision to enable a specific profile that they want to use, setting the expectation that they are responsible to installing the relevant CRDs into the cluster.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #695

#### Special notes for your reviewer:

#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
