### PR TITLE
fix(podclique): prevent rolling update from deleting all serving replicas

### DIFF
--- a/operator/internal/controller/podclique/components/pod/rollingupdate.go
+++ b/operator/internal/controller/podclique/components/pod/rollingupdate.go
@@ -94,11 +94,15 @@ func (r _resource) processPendingUpdates(logger logr.Logger, sc *syncContext) er
 	// In either of these cases we should pick up next pod to update if there are any pending pods to update.
 	var nextPodToUpdate *corev1.Pod
 	if podNamesPendingUpdate := updateWork.getPodNamesPendingUpdate(r.expectationsStore.GetDeleteExpectations(sc.pclqExpectationsStoreKey)); len(podNamesPendingUpdate) > 0 {
-		if pclq.Status.ReadyReplicas < *pclq.Spec.MinAvailable {
+		// Selecting the next pod deletes one Ready pod. To keep at least MinAvailable Ready pods
+		// afterwards we need ReadyReplicas-1 >= MinAvailable, i.e. block while ReadyReplicas <= MinAvailable.
+		// Using '<' here is off-by-one: it permits deleting the last Ready pod when ReadyReplicas == MinAvailable,
+		// dropping Ready to below MinAvailable (contributed to the harbinger-24b 0-ready outage window).
+		if pclq.Status.ReadyReplicas <= *pclq.Spec.MinAvailable {
 			return groveerr.New(
 				groveerr.ErrCodeContinueReconcileAndRequeue,
 				component.OperationSync,
-				fmt.Sprintf("ready replicas %d lesser than minAvailable %d, requeuing", pclq.Status.ReadyReplicas, *pclq.Spec.MinAvailable),
+				fmt.Sprintf("ready replicas %d not greater than minAvailable %d, requeuing", pclq.Status.ReadyReplicas, *pclq.Spec.MinAvailable),
 			)
 		}
 		nextPodToUpdate = updateWork.getNextPodToUpdate()
@@ -149,13 +153,20 @@ func (r _resource) computeUpdateWork(logger logr.Logger, sc *syncContext) *updat
 			}
 			// Pending, unhealthy, starting, and uncategorized pods are deleted immediately;
 			// ready pods are queued for ordered one-at-a-time replacement.
+			//
+			// Readiness is checked BEFORE the unhealthy predicates so that a currently-Ready,
+			// serving pod is never classified as non-ready merely because it carries a stale
+			// non-zero LastTerminationState from an earlier restart. This mirrors the status-side
+			// categorization in k8sutils.CategorizePodsByConditionType (which counts such a pod in
+			// ReadyReplicas). Diverging here caused deleteOldNonReadyPods to hard-delete a serving
+			// pod out-of-band from the minAvailable-protected rolling path (harbinger-24b outage).
 			switch {
 			case k8sutils.IsPodPending(pod):
 				work.oldTemplateHashPendingPods = append(work.oldTemplateHashPendingPods, pod)
-			case k8sutils.HasAnyStartedButNotReadyContainer(pod) || k8sutils.HasAnyContainerExitedErroneously(logger, pod):
-				work.oldTemplateHashUnhealthyPods = append(work.oldTemplateHashUnhealthyPods, pod)
 			case k8sutils.IsPodReady(pod):
 				work.oldTemplateHashReadyPods = append(work.oldTemplateHashReadyPods, pod)
+			case k8sutils.HasAnyStartedButNotReadyContainer(pod) || k8sutils.HasAnyContainerExitedErroneously(logger, pod):
+				work.oldTemplateHashUnhealthyPods = append(work.oldTemplateHashUnhealthyPods, pod)
 			case k8sutils.HasAnyContainerNotStarted(pod):
 				work.oldTemplateHashStartingPods = append(work.oldTemplateHashStartingPods, pod)
 			default:

--- a/operator/internal/controller/podclique/components/pod/rollingupdate_test.go
+++ b/operator/internal/controller/podclique/components/pod/rollingupdate_test.go
@@ -17,17 +17,25 @@ limitations under the License.
 package pod
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/ai-dynamo/grove/operator/api/common"
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/ai-dynamo/grove/operator/internal/expect"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const (
@@ -46,6 +54,11 @@ func TestComputeUpdateWork(t *testing.T) {
 		{"old unhealthy (started, not ready)", newTestPod("old-unhealthy-started", testOldHash, withPhase(corev1.PodRunning), withContainerStatus(ptr.To(true), false)), bucketOldUnhealthy},
 		{"old unhealthy (erroneous exit)", newTestPod("old-unhealthy-exit", testOldHash, withPhase(corev1.PodRunning), withErroneousExit()), bucketOldUnhealthy},
 		{"old ready", newTestPod("old-ready", testOldHash, withPhase(corev1.PodRunning), withReadyCondition(), withContainerStatus(ptr.To(true), true)), bucketOldReady},
+		// A currently-Ready, serving pod that merely carries a stale non-zero LastTerminationState
+		// from an earlier restart must be treated as Ready (protected, one-at-a-time rolling path),
+		// NOT as unhealthy. Otherwise deleteOldNonReadyPods hard-deletes a serving pod. Regression
+		// for the harbinger-24b outage where both serving replicas were deleted in one reconcile.
+		{"old ready with stale erroneous exit (currently serving)", newTestPod("old-ready-stale-exit", testOldHash, withPhase(corev1.PodRunning), withReadyCondition(), withReadyContainerPreviouslyErrored()), bucketOldReady},
 		{"old starting (Started=false)", newTestPod("old-starting-false", testOldHash, withPhase(corev1.PodRunning), withContainerStatus(ptr.To(false), false)), bucketOldStarting},
 		{"old starting (Started=nil)", newTestPod("old-starting-nil", testOldHash, withPhase(corev1.PodRunning), withContainerStatus(nil, false)), bucketOldStarting},
 		{"old uncategorized (no containers)", newTestPod("old-uncategorized", testOldHash, withPhase(corev1.PodRunning)), bucketOldUncategorized},
@@ -114,6 +127,13 @@ func withPhase(phase corev1.PodPhase) func(*corev1.Pod) {
 	return func(pod *corev1.Pod) { pod.Status.Phase = phase }
 }
 
+// withUID assigns a distinct UID. Deletion expectations are keyed by UID; pods sharing an
+// empty UID collapse in getPodNamesPendingUpdate, so full-flow tests must give each pod a
+// unique UID to exercise multi-pod deletion behavior.
+func withUID(uid string) func(*corev1.Pod) {
+	return func(pod *corev1.Pod) { pod.UID = types.UID(uid) }
+}
+
 func withReadyCondition() func(*corev1.Pod) {
 	return func(pod *corev1.Pod) {
 		pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
@@ -141,12 +161,158 @@ func withErroneousExit() func(*corev1.Pod) {
 	}
 }
 
+// withReadyContainerPreviouslyErrored sets a single container status that is currently
+// started and ready but whose LastTerminationState records a prior non-zero exit — i.e.
+// a serving pod that restarted erroneously at some earlier point and recovered.
+func withReadyContainerPreviouslyErrored() func(*corev1.Pod) {
+	return func(pod *corev1.Pod) {
+		pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, corev1.ContainerStatus{
+			Name:    "main",
+			Started: ptr.To(true),
+			Ready:   true,
+			LastTerminationState: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{ExitCode: 137},
+			},
+		})
+	}
+}
+
 func withDeletionTimestamp() func(*corev1.Pod) {
 	return func(pod *corev1.Pod) {
 		now := metav1.Now()
 		pod.DeletionTimestamp = &now
 		pod.Finalizers = []string{"fake.finalizer/test"}
 	}
+}
+
+// TestProcessPendingUpdatesPreservesServingPodWithStaleErroneousExit reproduces the
+// harbinger-24b outage: replicas=2, minAvailable=1, where BOTH pods are currently Ready and
+// serving, but one carries a stale non-zero LastTerminationState from an earlier restart.
+// The rolling update must replace pods one-at-a-time (delete exactly one), never delete both
+// serving replicas in a single reconcile.
+func TestProcessPendingUpdatesPreservesServingPodWithStaleErroneousExit(t *testing.T) {
+	const namespace = testNS
+	const pclqName = "harbinger-24b-0-vllmdecodeworker"
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	pclq := &grovecorev1alpha1.PodClique{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pclqName,
+			Namespace: namespace,
+			Labels:    map[string]string{common.LabelPodTemplateHash: testOldHash},
+		},
+		Spec: grovecorev1alpha1.PodCliqueSpec{
+			Replicas:     2,
+			MinAvailable: ptr.To(int32(1)),
+		},
+		Status: grovecorev1alpha1.PodCliqueStatus{
+			Replicas:      2,
+			ReadyReplicas: 2, // both pods are Ready per the status categorization (IsPodReady first)
+			UpdateProgress: &grovecorev1alpha1.PodCliqueUpdateProgress{
+				UpdateStartedAt: metav1.Now(),
+				PodTemplateHash: testNewHash,
+			},
+		},
+	}
+
+	// kf92w: plain Ready serving pod. phckw: Ready + serving but with a stale erroneous exit.
+	kf92w := newTestPod("kf92w", testOldHash, withUID("uid-kf92w"), withPhase(corev1.PodRunning), withReadyCondition(), withContainerStatus(ptr.To(true), true))
+	phckw := newTestPod("phckw", testOldHash, withUID("uid-phckw"), withPhase(corev1.PodRunning), withReadyCondition(), withReadyContainerPreviouslyErrored())
+	pods := []*corev1.Pod{kf92w, phckw}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pclq, kf92w, phckw).
+		WithStatusSubresource(&grovecorev1alpha1.PodClique{}).
+		Build()
+
+	r := _resource{
+		client:            fakeClient,
+		scheme:            scheme,
+		eventRecorder:     record.NewFakeRecorder(32),
+		expectationsStore: expect.NewExpectationsStore(),
+	}
+	sc := &syncContext{
+		ctx:                      context.Background(),
+		pclq:                     pclq,
+		existingPCLQPods:         pods,
+		expectedPodTemplateHash:  testNewHash,
+		pclqExpectationsStoreKey: namespace + "/" + pclqName,
+	}
+
+	// processPendingUpdates requeues after selecting one pod; we only care how many it deleted.
+	_ = r.processPendingUpdates(logr.Discard(), sc)
+
+	remaining := &corev1.PodList{}
+	require.NoError(t, fakeClient.List(context.Background(), remaining, client.InNamespace(namespace)))
+	assert.Len(t, remaining.Items, 1,
+		"exactly one pod may be deleted per reconcile; deleting both serving replicas caused the harbinger-24b outage")
+}
+
+// TestProcessPendingUpdatesDoesNotDeleteLastReadyPod verifies the minAvailable guard: with
+// replicas=2, minAvailable=1, one Ready pod and one genuinely not-ready old pod, the rolling
+// update may delete the not-ready pod but must NOT delete the last Ready pod (which would breach
+// minAvailable). It must requeue and wait for a replacement to become Ready first.
+func TestProcessPendingUpdatesDoesNotDeleteLastReadyPod(t *testing.T) {
+	const namespace = testNS
+	const pclqName = "test-pclq-minavailable"
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	pclq := &grovecorev1alpha1.PodClique{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pclqName,
+			Namespace: namespace,
+			Labels:    map[string]string{common.LabelPodTemplateHash: testOldHash},
+		},
+		Spec: grovecorev1alpha1.PodCliqueSpec{
+			Replicas:     2,
+			MinAvailable: ptr.To(int32(1)),
+		},
+		Status: grovecorev1alpha1.PodCliqueStatus{
+			Replicas:      2,
+			ReadyReplicas: 1, // only the Ready pod counts
+			UpdateProgress: &grovecorev1alpha1.PodCliqueUpdateProgress{
+				UpdateStartedAt: metav1.Now(),
+				PodTemplateHash: testNewHash,
+			},
+		},
+	}
+
+	readyPod := newTestPod("ready-pod", testOldHash, withUID("uid-ready"), withPhase(corev1.PodRunning), withReadyCondition(), withContainerStatus(ptr.To(true), true))
+	notReadyPod := newTestPod("not-ready-pod", testOldHash, withUID("uid-notready"), withPhase(corev1.PodPending))
+	pods := []*corev1.Pod{readyPod, notReadyPod}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pclq, readyPod, notReadyPod).
+		WithStatusSubresource(&grovecorev1alpha1.PodClique{}).
+		Build()
+
+	r := _resource{
+		client:            fakeClient,
+		scheme:            scheme,
+		eventRecorder:     record.NewFakeRecorder(32),
+		expectationsStore: expect.NewExpectationsStore(),
+	}
+	sc := &syncContext{
+		ctx:                      context.Background(),
+		pclq:                     pclq,
+		existingPCLQPods:         pods,
+		expectedPodTemplateHash:  testNewHash,
+		pclqExpectationsStoreKey: namespace + "/" + pclqName,
+	}
+
+	_ = r.processPendingUpdates(logr.Discard(), sc)
+
+	// The last Ready pod must survive; only the not-ready pod may be deleted.
+	err := fakeClient.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: "ready-pod"}, &corev1.Pod{})
+	assert.NoError(t, err, "the last Ready pod must not be deleted — doing so breaches minAvailable and caused a 0-ready outage window")
 }
 
 // bucket identifies which updateWork bucket a pod should land in.


### PR DESCRIPTION
A PodCliqueSet spec change triggered a rolling update that deleted both replicas of a PodClique at once, causing a full outage despite minAvailable=1.

Two independent defects:

1. computeUpdateWork classified a currently-Ready, serving pod as "unhealthy" whenever it carried a stale non-zero LastTerminationState from an earlier restart, because the erroneous-exit predicate was checked before IsPodReady. Such a pod was then hard-deleted by deleteOldNonReadyPods, out-of-band from the minAvailable-protected rolling path. This diverged from the status-side categorization in CategorizePodsByConditionType (which counts it in ReadyReplicas). Fix: check IsPodReady before the unhealthy predicates.

2. The minAvailable guard used ReadyReplicas < MinAvailable, an off-by-one that permitted deleting the last Ready pod when ReadyReplicas == MinAvailable. Fix: use <=.

Adds one unit test (categorization) and two full-flow tests (incident reproduction + minAvailable guard).

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/ai-dynamo/grove/issues/697

#### Special notes for your reviewer:

#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs

```
