### PR TITLE
fix(helm): disable optional scheduler profiles by default

### DIFF
--- a/operator/charts/values.yaml
+++ b/operator/charts/values.yaml
@@ -93,12 +93,15 @@ config:
       concurrentSyncs: 3
   # Scheduler configures which scheduler backends are active. default-scheduler is always available.
   # List profiles to enable backends; set defaultProfileName to the profile that is the default backend.
+  # Optional scheduler backends, such as volcano and lpx-scheduler, must be added explicitly when
+  # their scheduler dependencies are installed in the cluster.
   scheduler:
     profiles:
       - name: default-scheduler
       - name: kai-scheduler
-      - name: volcano
-      - name: lpx-scheduler
+      # Uncomment optional scheduler profiles only when their dependencies are installed.
+      # - name: volcano
+      # - name: lpx-scheduler
   logLevel: info
   logFormat: json
   topologyAwareScheduling:


### PR DESCRIPTION
Fixes #700

Summary
- Remove optional scheduler backends (`volcano` and `lpx-scheduler`) from the Grove Helm chart default profiles.
- Document that optional scheduler profiles should be added explicitly when their scheduler dependencies are installed.
- This prevents default Grove installs from requiring optional scheduler CRDs such as Volcano PodGroup.

Validation
- `helm template grove /Users/admin/work/go/src/github.com/ai-dynamo/grove/operator/charts | rg -n "profiles:|name: default-scheduler|name: kai-scheduler|name: volcano|name: lpx-scheduler|scheduling.volcano.sh|podgroups"`
- `go test ./internal/scheduler/...`