### PR TITLE
fix: prevent concurrent Pod annotation map writes

### DIFF
--- a/operator/internal/controller/podclique/components/pod/pod.go
+++ b/operator/internal/controller/podclique/components/pod/pod.go
@@ -19,6 +19,7 @@ package pod
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strconv"
 
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
@@ -153,7 +154,7 @@ func (r _resource) buildResource(pcs *grovecorev1alpha1.PodCliqueSet, pclq *grov
 		GenerateName: fmt.Sprintf("%s-", pclq.Name),
 		Namespace:    pclq.Namespace,
 		Labels:       labels,
-		Annotations:  pclq.Annotations,
+		Annotations:  maps.Clone(pclq.Annotations),
 	}
 	if err = controllerutil.SetControllerReference(pclq, pod, r.scheme); err != nil {
 		return groveerr.WrapError(err,

--- a/operator/internal/controller/podclique/components/pod/pod_test.go
+++ b/operator/internal/controller/podclique/components/pod/pod_test.go
@@ -67,6 +67,7 @@ func TestBuildResourceWithLPXBackend(t *testing.T) {
 		Build()
 	pclq := testutils.NewPodCliqueBuilder(pcsName, uid, cliqueName, namespace, 0).Build()
 	pclq.Spec.PodSpec = *podSpec.DeepCopy()
+	pclq.Annotations = map[string]string{"example.com/source": "podclique"}
 
 	scheme := runtime.NewScheme()
 	require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
@@ -91,6 +92,10 @@ func TestBuildResourceWithLPXBackend(t *testing.T) {
 	require.Len(t, pod.Spec.ResourceClaims, 1)
 	require.NotNil(t, pod.Spec.ResourceClaims[0].ResourceClaimName)
 	assert.Equal(t, claimName, *pod.Spec.ResourceClaims[0].ResourceClaimName)
+	assert.Equal(t, "podclique", pod.Annotations["example.com/source"])
+
+	pod.Annotations["example.com/source"] = "pod"
+	assert.Equal(t, "podclique", pclq.Annotations["example.com/source"])
 }
 
 // TestGetSelectorLabelsForPods_PCSGOwnedPodClique tests that getSelectorLabelsForPods


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Pod creation tasks for a PodClique run concurrently. Each generated Pod previously reused the source `PodClique.Annotations` map. The Volcano backend mutates that map in `PreparePod` to add PodGroup annotations, allowing concurrent tasks to write to the same map and terminate the operator with `fatal error: concurrent map writes`.

Clone annotations while building each Pod so scheduler backends receive a per-Pod map. Add regression coverage ensuring Pod annotation mutations do not change the source PodClique annotations.

#### Which issue(s) this PR fixes:

Fixes #719

#### Special notes for your reviewer:

Validation:
- `make test-unit`
- `go test -race ./internal/controller/podclique/components/pod ./internal/scheduler/volcano -count=1`
- `make validate`

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
