### PR TITLE
fix: silence reconcile warning with non-nil error and requeue

### DIFF
--- a/operator/internal/controller/common/flow.go
+++ b/operator/internal/controller/common/flow.go
@@ -92,7 +92,6 @@ func ContinueReconcile() ReconcileStepResult {
 // ReconcileWithErrors returns a ReconcileStepResult that re-queues the reconciliation with the given errors.
 func ReconcileWithErrors(description string, errs ...error) ReconcileStepResult {
 	return ReconcileStepResult{
-		result:            ctrl.Result{Requeue: true},
 		errs:              errs,
 		continueReconcile: false,
 		description:       description,

--- a/operator/internal/controller/common/flow_test.go
+++ b/operator/internal/controller/common/flow_test.go
@@ -151,7 +151,7 @@ func TestReconcileWithErrors(t *testing.T) {
 	result := ReconcileWithErrors("test description", err1, err2)
 
 	assert.False(t, result.continueReconcile)
-	assert.True(t, result.result.Requeue)
+	assert.True(t, result.result.IsZero())
 	assert.True(t, result.HasErrors())
 	assert.Len(t, result.GetErrors(), 2)
 	assert.Equal(t, "test description", result.GetDescription())


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Silences this warning:
https://github.com/kubernetes-sigs/controller-runtime/blob/v0.24.1/pkg/internal/controller/controller.go#L492

#### Which issue(s) this PR fixes:

Fixes #721

#### Special notes for your reviewer:

_N/A_

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs

```
