### PR TITLE
fix: preserve scheduling gates owned by other controllers

### DIFF
--- a/operator/internal/controller/podclique/components/pod/syncflow.go
+++ b/operator/internal/controller/podclique/components/pod/syncflow.go
@@ -289,9 +289,9 @@ func (r _resource) checkAndRemovePodSchedulingGates(sc *syncContext, logger logr
 				Name: fmt.Sprintf("RemoveSchedulingGate-%s-%d", p.Name, i),
 				Fn: func(ctx context.Context) error {
 					podClone := p.DeepCopy()
-					// Remove only the Grove PodGang gate. Other controllers (for example Kueue) may
-					// add their own scheduling gates on the same Pod; clearing the whole list would
-					// wipe those and let the Pod schedule before those owners have released it.
+					// Remove only the Grove PodGang gate. Other controllers may add their own
+					// scheduling gates on the same Pod; clearing the whole list would wipe those
+					// and let the Pod schedule before those owners have released it.
 					if !removePodGangSchedulingGate(p) {
 						return nil
 					}

--- a/operator/internal/controller/podclique/components/pod/syncflow.go
+++ b/operator/internal/controller/podclique/components/pod/syncflow.go
@@ -289,11 +289,16 @@ func (r _resource) checkAndRemovePodSchedulingGates(sc *syncContext, logger logr
 				Name: fmt.Sprintf("RemoveSchedulingGate-%s-%d", p.Name, i),
 				Fn: func(ctx context.Context) error {
 					podClone := p.DeepCopy()
-					p.Spec.SchedulingGates = nil
+					// Remove only the Grove PodGang gate. Other controllers (for example Kueue) may
+					// add their own scheduling gates on the same Pod; clearing the whole list would
+					// wipe those and let the Pod schedule before those owners have released it.
+					if !removePodGangSchedulingGate(p) {
+						return nil
+					}
 					if err := client.IgnoreNotFound(r.client.Patch(ctx, p, client.MergeFrom(podClone))); err != nil {
 						return err
 					}
-					logger.Info("Removed scheduling gate from pod", "podObjectKey", podObjectKey)
+					logger.Info("Removed Grove PodGang scheduling gate from pod", "podObjectKey", podObjectKey)
 					return nil
 				},
 			}
@@ -408,6 +413,19 @@ func hasPodGangSchedulingGate(pod *corev1.Pod) bool {
 	return slices.ContainsFunc(pod.Spec.SchedulingGates, func(schedulingGate corev1.PodSchedulingGate) bool {
 		return podGangSchedulingGate == schedulingGate.Name
 	})
+}
+
+// removePodGangSchedulingGate removes only the Grove PodGang scheduling gate from the Pod,
+// leaving any other scheduling gates untouched. Returns true if the gate was present and removed.
+func removePodGangSchedulingGate(pod *corev1.Pod) bool {
+	idx := slices.IndexFunc(pod.Spec.SchedulingGates, func(schedulingGate corev1.PodSchedulingGate) bool {
+		return podGangSchedulingGate == schedulingGate.Name
+	})
+	if idx < 0 {
+		return false
+	}
+	pod.Spec.SchedulingGates = slices.Delete(pod.Spec.SchedulingGates, idx, idx+1)
+	return true
 }
 
 // createPods creates the specified number of new pods for the PodClique with proper indexing and concurrency control

--- a/operator/internal/controller/podclique/components/pod/syncflow_test.go
+++ b/operator/internal/controller/podclique/components/pod/syncflow_test.go
@@ -320,6 +320,81 @@ func TestCheckAndRemovePodSchedulingGates_ConcurrentExecution(t *testing.T) {
 	}
 }
 
+func TestCheckAndRemovePodSchedulingGates_PreservesForeignGates(t *testing.T) {
+	const kueueAdmissionGate = "kueue.x-k8s.io/admission"
+
+	pod := createTestPod("simple1-0", true, true)
+	pod.Spec.SchedulingGates = append(pod.Spec.SchedulingGates, corev1.PodSchedulingGate{Name: kueueAdmissionGate})
+
+	basePodGang := &groveschedulerv1alpha1.PodGang{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple1-0",
+			Namespace: "default",
+		},
+		Spec: groveschedulerv1alpha1.PodGangSpec{
+			PodGroups: []groveschedulerv1alpha1.PodGroup{
+				{Name: "simple1-0-pcb", MinReplicas: 1},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
+	require.NoError(t, groveschedulerv1alpha1.AddToScheme(scheme))
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod, basePodGang).Build()
+
+	r := &_resource{client: fakeClient}
+	sc := &syncContext{
+		ctx:                           context.Background(),
+		pclq:                          &grovecorev1alpha1.PodClique{ObjectMeta: metav1.ObjectMeta{Name: "test-pclq", Namespace: "default"}},
+		existingPCLQPods:              []*corev1.Pod{pod},
+		podNamesUpdatedInPCLQPodGangs: []string{pod.Name},
+	}
+
+	skippedPods, err := r.checkAndRemovePodSchedulingGates(sc, logr.Discard())
+	require.NoError(t, err)
+	assert.Empty(t, skippedPods)
+
+	updatedPod := &corev1.Pod{}
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(pod), updatedPod))
+	assert.False(t, hasPodGangSchedulingGate(updatedPod), "Grove PodGang gate should be removed")
+	require.Len(t, updatedPod.Spec.SchedulingGates, 1)
+	assert.Equal(t, kueueAdmissionGate, updatedPod.Spec.SchedulingGates[0].Name, "foreign Kueue admission gate must be preserved")
+}
+
+func TestRemovePodGangSchedulingGate(t *testing.T) {
+	t.Run("removes only the Grove gate", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				SchedulingGates: []corev1.PodSchedulingGate{
+					{Name: "kueue.x-k8s.io/admission"},
+					{Name: podGangSchedulingGate},
+					{Name: "kueue.x-k8s.io/topology"},
+				},
+			},
+		}
+		assert.True(t, removePodGangSchedulingGate(pod))
+		assert.Equal(t, []corev1.PodSchedulingGate{
+			{Name: "kueue.x-k8s.io/admission"},
+			{Name: "kueue.x-k8s.io/topology"},
+		}, pod.Spec.SchedulingGates)
+	})
+	t.Run("returns false when Grove gate is absent", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				SchedulingGates: []corev1.PodSchedulingGate{
+					{Name: "kueue.x-k8s.io/admission"},
+				},
+			},
+		}
+		assert.False(t, removePodGangSchedulingGate(pod))
+		assert.Equal(t, []corev1.PodSchedulingGate{
+			{Name: "kueue.x-k8s.io/admission"},
+		}, pod.Spec.SchedulingGates)
+	})
+}
+
 func TestIsBasePodGangScheduled(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/operator/internal/controller/podclique/components/pod/syncflow_test.go
+++ b/operator/internal/controller/podclique/components/pod/syncflow_test.go
@@ -321,10 +321,10 @@ func TestCheckAndRemovePodSchedulingGates_ConcurrentExecution(t *testing.T) {
 }
 
 func TestCheckAndRemovePodSchedulingGates_PreservesForeignGates(t *testing.T) {
-	const kueueAdmissionGate = "kueue.x-k8s.io/admission"
+	const foreignAdmissionGate = "foo.io/admission"
 
 	pod := createTestPod("simple1-0", true, true)
-	pod.Spec.SchedulingGates = append(pod.Spec.SchedulingGates, corev1.PodSchedulingGate{Name: kueueAdmissionGate})
+	pod.Spec.SchedulingGates = append(pod.Spec.SchedulingGates, corev1.PodSchedulingGate{Name: foreignAdmissionGate})
 
 	basePodGang := &groveschedulerv1alpha1.PodGang{
 		ObjectMeta: metav1.ObjectMeta{
@@ -360,7 +360,7 @@ func TestCheckAndRemovePodSchedulingGates_PreservesForeignGates(t *testing.T) {
 	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(pod), updatedPod))
 	assert.False(t, hasPodGangSchedulingGate(updatedPod), "Grove PodGang gate should be removed")
 	require.Len(t, updatedPod.Spec.SchedulingGates, 1)
-	assert.Equal(t, kueueAdmissionGate, updatedPod.Spec.SchedulingGates[0].Name, "foreign Kueue admission gate must be preserved")
+	assert.Equal(t, foreignAdmissionGate, updatedPod.Spec.SchedulingGates[0].Name, "foreign admission gate must be preserved")
 }
 
 func TestRemovePodGangSchedulingGate(t *testing.T) {
@@ -368,29 +368,29 @@ func TestRemovePodGangSchedulingGate(t *testing.T) {
 		pod := &corev1.Pod{
 			Spec: corev1.PodSpec{
 				SchedulingGates: []corev1.PodSchedulingGate{
-					{Name: "kueue.x-k8s.io/admission"},
+					{Name: "foo.io/admission"},
 					{Name: podGangSchedulingGate},
-					{Name: "kueue.x-k8s.io/topology"},
+					{Name: "foo.io/topology"},
 				},
 			},
 		}
 		assert.True(t, removePodGangSchedulingGate(pod))
 		assert.Equal(t, []corev1.PodSchedulingGate{
-			{Name: "kueue.x-k8s.io/admission"},
-			{Name: "kueue.x-k8s.io/topology"},
+			{Name: "foo.io/admission"},
+			{Name: "foo.io/topology"},
 		}, pod.Spec.SchedulingGates)
 	})
 	t.Run("returns false when Grove gate is absent", func(t *testing.T) {
 		pod := &corev1.Pod{
 			Spec: corev1.PodSpec{
 				SchedulingGates: []corev1.PodSchedulingGate{
-					{Name: "kueue.x-k8s.io/admission"},
+					{Name: "foo.io/admission"},
 				},
 			},
 		}
 		assert.False(t, removePodGangSchedulingGate(pod))
 		assert.Equal(t, []corev1.PodSchedulingGate{
-			{Name: "kueue.x-k8s.io/admission"},
+			{Name: "foo.io/admission"},
 		}, pod.Spec.SchedulingGates)
 	})
 }


### PR DESCRIPTION
## Summary

- remove only Grove's `grove.io/podgang-pending-creation` scheduling gate when PodGang dependencies are ready
- preserve admission and topology gates owned by other controllers
- add unit coverage for selective gate removal and foreign-gate preservation

Fixes #723

## Test plan

- [x] `cd operator && go test ./internal/controller/podclique/components/pod/`