### PR TITLE
feat: add KAI scheduler backend with one PodGroup per PodGang

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -288,3 +288,6 @@ Currently the following schedulers support gang scheduling of `PodGang`s created
 
 - [kai-scheduler/kai-scheduler](https://github.com/kai-scheduler/kai-scheduler)
   - Topology Aware Scheduling (TAS) requires [v0.15.2](https://github.com/kai-scheduler/kai-scheduler/releases/tag/v0.15.2)+
+  - Disable KAI stale-gang eviction with
+    `--set-string scheduler.args.default-staleness-grace-period=-1`. KAI's default eviction can terminate a
+    partially scheduled gang before Grove's controller-owned termination delay.

--- a/docs/proposals/525-KAI-Scheduler-Backend/README.md
+++ b/docs/proposals/525-KAI-Scheduler-Backend/README.md
@@ -185,9 +185,9 @@ This mapping focuses on PodGroup ownership and gang membership. KAI Topology res
 
 KAI accepts one queue per PodGroup. The backend resolves that queue from the PodGang's owning PodCliqueSet:
 
-1. A `kai.scheduler/queue` label on the PodCliqueSet takes precedence. Its annotation is a compatibility fallback when the label is absent.
-2. Without a PodCliqueSet-level queue, the backend resolves labels first and annotations second on every PodClique template. All non-empty template values must name the same queue.
-3. If no queue is configured, or template queues conflict without a PodCliqueSet-level override, the backend reports a mapping error and does not create or update the KAI PodGroup.
+1. A `kai.scheduler/queue` label on the PodCliqueSet selects the queue for the complete scheduling unit. Its annotation is a compatibility fallback when the label is absent.
+2. Any explicitly configured PodClique-template queue must resolve to that same queue. Without a PodCliqueSet-level queue, labels are resolved first and annotations second on every PodClique template; all non-empty template values must name the same queue.
+3. For a PodCliqueSet targeting the KAI backend, admission rejects missing queue configuration and conflicting effective queue values. Reconciliation retains the same checks for pre-existing objects and does not create or update the KAI PodGroup when mapping fails.
 
 This preserves existing workloads that set the queue on PodClique templates while allowing the PodCliqueSet to select one queue explicitly for its complete scheduling unit.
 

--- a/docs/proposals/525-KAI-Scheduler-Backend/README.md
+++ b/docs/proposals/525-KAI-Scheduler-Backend/README.md
@@ -17,6 +17,7 @@
   - [Precondition: KAI Backend Enabled](#precondition-kai-backend-enabled)
   - [KAI Backend Responsibilities](#kai-backend-responsibilities)
   - [PodCliqueSet to PodGroup Mapping](#podcliqueset-to-podgroup-mapping)
+    - [KAI Queue Resolution](#kai-queue-resolution)
     - [SubGroup Mapping Rules](#subgroup-mapping-rules)
   - [Pod Preparation](#pod-preparation)
   - [PodGroup Update Semantics](#podgroup-update-semantics)
@@ -171,7 +172,7 @@ In the KAI representation, BPG and SPG are not separate KAI PodGroups. They are 
 | PodCliqueSet and PodGang labels/annotations | PodGroup labels and annotations, preserving existing target-only keys |
 | Sum of all mapped subgroup minimum replicas | PodGroup `minMember` |
 | PodGang priority class | PodGroup priority class |
-| Queue label or annotation | PodGroup queue on initial creation |
+| PodCliqueSet `kai.scheduler/queue` metadata, or a shared PodClique-template queue | PodGroup queue on initial creation |
 | Base PodGang | Top-level KAI subgroup, usually named from the BPG name |
 | Scaled PodGang collection for a PCSG | Top-level KAI subgroup that groups scaled PodGang replicas |
 | Individual Scaled PodGang replica | Child KAI subgroup under the SPG collection subgroup |
@@ -179,6 +180,16 @@ In the KAI representation, BPG and SPG are not separate KAI PodGroups. They are 
 | PodGang owner reference | Preserved through PodGroup ownership metadata so cleanup follows Grove lifecycle |
 
 This mapping focuses on PodGroup ownership and gang membership. KAI Topology resources and topology-aware scheduling semantics are outside the scope of this proposal.
+
+#### KAI Queue Resolution
+
+KAI accepts one queue per PodGroup. The backend resolves that queue from the PodGang's owning PodCliqueSet:
+
+1. A `kai.scheduler/queue` label on the PodCliqueSet takes precedence. Its annotation is a compatibility fallback when the label is absent.
+2. Without a PodCliqueSet-level queue, the backend resolves labels first and annotations second on every PodClique template. All non-empty template values must name the same queue.
+3. If no queue is configured, or template queues conflict without a PodCliqueSet-level override, the backend reports a mapping error and does not create or update the KAI PodGroup.
+
+This preserves existing workloads that set the queue on PodClique templates while allowing the PodCliqueSet to select one queue explicitly for its complete scheduling unit.
 
 #### SubGroup Mapping Rules
 
@@ -308,7 +319,8 @@ Operational implications:
 
 - Validate `PreparePod` sets Pod `schedulerName` to `kai-scheduler` and adds Pod annotation `kai.scheduler/skip-podgrouper` when missing without dropping existing annotations.
 - Validate `Init()` compatibility guardrails: KAI versions below `v0.15.0` fail closed.
-- Validate `SyncPodGang` creates and updates KAI PodGroup state, including required field mapping and runtime-managed field preservation.
+- Validate `SyncPodGang` creates and updates KAI PodGroup state, including required field mapping, queue resolution, and runtime-managed field preservation.
+- Validate PodCliqueSet queue precedence, consistent PodClique-template queue fallback, and mapping failures for missing or conflicting queue configuration.
 - Validate `SyncPodGang` adds PodGang annotation `kai.scheduler/skip-podgrouper` when missing without dropping existing annotations.
 - Validate subgroup translation: Base PodGang and Scaled PodGang structure maps to KAI subgroups with correct `name`, `minSubGroup` / `minMember`, and parent relationships.
 - Validate subgroup-name constraints (lowercase/unique/valid label) and explicit error surfacing on invalid subgroup references.

--- a/operator/charts/templates/clusterrole.yaml
+++ b/operator/charts/templates/clusterrole.yaml
@@ -167,9 +167,10 @@ rules:
   - get
   - list
   - watch
-{{- if include "grove.scheduler.hasProfile" (list . "volcano") }}
+# KAI Scheduler integration for resource sharing
+{{- if include "grove.scheduler.hasProfile" (list . "kai-scheduler") }}
 - apiGroups:
-  - scheduling.volcano.sh
+  - scheduling.run.ai
   resources:
   - podgroups
   verbs:
@@ -180,6 +181,8 @@ rules:
   - patch
   - update
   - delete
+{{- end }}
+{{- if include "grove.scheduler.hasProfile" (list . "volcano") }}
 - apiGroups:
   - scheduling.volcano.sh
   resources:

--- a/operator/charts/templates/clusterrole.yaml
+++ b/operator/charts/templates/clusterrole.yaml
@@ -167,7 +167,6 @@ rules:
   - get
   - list
   - watch
-# KAI Scheduler integration for resource sharing
 {{- if include "grove.scheduler.hasProfile" (list . "kai-scheduler") }}
 - apiGroups:
   - scheduling.run.ai
@@ -183,6 +182,18 @@ rules:
   - delete
 {{- end }}
 {{- if include "grove.scheduler.hasProfile" (list . "volcano") }}
+- apiGroups:
+  - scheduling.volcano.sh
+  resources:
+  - podgroups
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - patch
+  - update
+  - delete
 - apiGroups:
   - scheduling.volcano.sh
   resources:

--- a/operator/e2e/tests/topology_test.go
+++ b/operator/e2e/tests/topology_test.go
@@ -1751,6 +1751,7 @@ func Test_TAS21_TopologyValidationWebhooks(t *testing.T) {
 				Build(),
 		).
 		Build()
+	pcs.Labels = map[string]string{"kai.scheduler/queue": "test"}
 
 	if err := tc.Client.Create(ctx, pcs); err != nil {
 		t.Fatalf("Expected PodCliqueSet create to succeed with inherited optional topologyName, got: %v", err)
@@ -1774,7 +1775,7 @@ func Test_TAS22_PodCliqueSetTopologyCELValidation(t *testing.T) {
 	ensureGroveTopology(ctx, t, topologyVerifier)
 
 	newPCS := func(name string, topologyConstraint *corev1alpha1.TopologyConstraint) *corev1alpha1.PodCliqueSet {
-		return testutils.NewPodCliqueSetBuilder(name, "default", uuid.NewUUID()).
+		pcs := testutils.NewPodCliqueSetBuilder(name, "default", uuid.NewUUID()).
 			WithReplicas(0).
 			WithTopologyConstraint(topologyConstraint).
 			WithPodCliqueTemplateSpec(
@@ -1784,6 +1785,8 @@ func Test_TAS22_PodCliqueSetTopologyCELValidation(t *testing.T) {
 					Build(),
 			).
 			Build()
+		pcs.Labels = map[string]string{"kai.scheduler/queue": "test"}
+		return pcs
 	}
 
 	tests := []struct {

--- a/operator/e2e/yaml/auto-mnnvl/mnnvl-comprehensive-bare.yaml
+++ b/operator/e2e/yaml/auto-mnnvl/mnnvl-comprehensive-bare.yaml
@@ -7,6 +7,8 @@ apiVersion: grove.io/v1alpha1
 kind: PodCliqueSet
 metadata:
   name: mnnvl-comprehensive-bare
+  labels:
+    kai.scheduler/queue: test
 spec:
   replicas: 1
   template:

--- a/operator/e2e/yaml/auto-mnnvl/mnnvl-comprehensive-mix.yaml
+++ b/operator/e2e/yaml/auto-mnnvl/mnnvl-comprehensive-mix.yaml
@@ -10,6 +10,8 @@ apiVersion: grove.io/v1alpha1
 kind: PodCliqueSet
 metadata:
   name: mnnvl-mix
+  labels:
+    kai.scheduler/queue: test
   annotations:
     grove.io/mnnvl-group: "default"
 spec:

--- a/operator/e2e/yaml/auto-mnnvl/mnnvl-cpu-with-annotation.yaml
+++ b/operator/e2e/yaml/auto-mnnvl/mnnvl-cpu-with-annotation.yaml
@@ -6,6 +6,8 @@ apiVersion: grove.io/v1alpha1
 kind: PodCliqueSet
 metadata:
   name: mnnvl-cpu-with-annotation
+  labels:
+    kai.scheduler/queue: test
   annotations:
     grove.io/mnnvl-group: "default"
 spec:

--- a/operator/e2e/yaml/auto-mnnvl/mnnvl-gpu-bare.yaml
+++ b/operator/e2e/yaml/auto-mnnvl/mnnvl-gpu-bare.yaml
@@ -5,6 +5,8 @@ apiVersion: grove.io/v1alpha1
 kind: PodCliqueSet
 metadata:
   name: mnnvl-gpu-bare
+  labels:
+    kai.scheduler/queue: test
 spec:
   replicas: 1
   template:

--- a/operator/e2e/yaml/auto-mnnvl/mnnvl-gpu-default.yaml
+++ b/operator/e2e/yaml/auto-mnnvl/mnnvl-gpu-default.yaml
@@ -6,6 +6,8 @@ apiVersion: grove.io/v1alpha1
 kind: PodCliqueSet
 metadata:
   name: mnnvl-gpu-default
+  labels:
+    kai.scheduler/queue: test
   annotations:
     grove.io/mnnvl-group: "default"
 spec:

--- a/operator/e2e/yaml/auto-mnnvl/mnnvl-gpu-invalid.yaml
+++ b/operator/e2e/yaml/auto-mnnvl/mnnvl-gpu-invalid.yaml
@@ -5,6 +5,8 @@ apiVersion: grove.io/v1alpha1
 kind: PodCliqueSet
 metadata:
   name: mnnvl-gpu-invalid
+  labels:
+    kai.scheduler/queue: test
   annotations:
     grove.io/mnnvl-group: "invalid value with spaces"
 spec:

--- a/operator/e2e/yaml/auto-mnnvl/mnnvl-gpu-optout.yaml
+++ b/operator/e2e/yaml/auto-mnnvl/mnnvl-gpu-optout.yaml
@@ -5,6 +5,8 @@ apiVersion: grove.io/v1alpha1
 kind: PodCliqueSet
 metadata:
   name: mnnvl-gpu-optout
+  labels:
+    kai.scheduler/queue: test
   annotations:
     grove.io/mnnvl-group: "none"
 spec:

--- a/operator/internal/scheduler/kai/backend.go
+++ b/operator/internal/scheduler/kai/backend.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	apicommonconstants "github.com/ai-dynamo/grove/operator/api/common/constants"
@@ -93,7 +94,7 @@ func (b *schedulerBackend) SyncPodGang(ctx context.Context, podGang *groveschedu
 		return fmt.Errorf("ensure KAI podgrouper skip annotation: %w", err)
 	}
 
-	newPodGroup, err := b.buildPodGroupForPodGang(podGang)
+	newPodGroup, err := b.buildPodGroupForPodGang(ctx, podGang)
 	if err != nil {
 		b.recordWarning(podGang, "KAIBackendMappingFailed", err)
 		return err
@@ -147,9 +148,13 @@ func (b *schedulerBackend) ValidatePodCliqueSet(_ context.Context, _ *grovecorev
 }
 
 // buildPodGroupForPodGang translates a Grove PodGang into a KAI PodGroup object.
-func (b *schedulerBackend) buildPodGroupForPodGang(podGang *groveschedulerv1alpha1.PodGang) (*kaischedulingv2alpha2.PodGroup, error) {
+func (b *schedulerBackend) buildPodGroupForPodGang(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) (*kaischedulingv2alpha2.PodGroup, error) {
 	topologyName := getTopologyName(podGang)
 	topologyConstraint, err := toKAITopologyConstraint(podGang.Spec.TopologyConstraint, topologyName)
+	if err != nil {
+		return nil, err
+	}
+	queueName, err := b.resolveQueueName(ctx, podGang)
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +204,7 @@ func (b *schedulerBackend) buildPodGroupForPodGang(podGang *groveschedulerv1alph
 		},
 		Spec: kaischedulingv2alpha2.PodGroupSpec{
 			MinMember:         ptr.To(minMember),
-			Queue:             resolveQueueName(podGang),
+			Queue:             queueName,
 			PriorityClassName: podGang.Spec.PriorityClassName,
 			SubGroups:         subGroups,
 		},
@@ -263,13 +268,60 @@ func toKAITopologyConstraint(topologyConstraint *groveschedulerv1alpha1.Topology
 	return result, nil
 }
 
-// resolveQueueName returns queue from labels first, then falls back to annotations.
-func resolveQueueName(podGang *groveschedulerv1alpha1.PodGang) string {
-	if podGang.Labels != nil && podGang.Labels[labelKeyQueueName] != "" {
-		return podGang.Labels[labelKeyQueueName]
+// resolveQueueName returns the KAI queue configured by the PodGang's owning PodCliqueSet.
+// A queue set on the PodCliqueSet itself overrides the queues on its PodClique templates.
+func (b *schedulerBackend) resolveQueueName(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) (string, error) {
+	owner := metav1.GetControllerOf(podGang)
+	if owner == nil {
+		return "", fmt.Errorf("podgang %s/%s has no controlling PodCliqueSet", podGang.Namespace, podGang.Name)
 	}
-	if podGang.Annotations != nil {
-		return podGang.Annotations[labelKeyQueueName]
+	if owner.APIVersion != grovecorev1alpha1.SchemeGroupVersion.String() || owner.Kind != "PodCliqueSet" {
+		return "", fmt.Errorf("podgang %s/%s is controlled by %s %q, expected PodCliqueSet", podGang.Namespace, podGang.Name, owner.APIVersion, owner.Kind)
+	}
+
+	pcs := &grovecorev1alpha1.PodCliqueSet{}
+	if err := b.client.Get(ctx, client.ObjectKey{Namespace: podGang.Namespace, Name: owner.Name}, pcs); err != nil {
+		return "", fmt.Errorf("get controlling PodCliqueSet %s/%s: %w", podGang.Namespace, owner.Name, err)
+	}
+
+	if queueName := resolveQueueNameFromMetadata(pcs.Labels, pcs.Annotations); queueName != "" {
+		return queueName, nil
+	}
+
+	queueNames := map[string]struct{}{}
+	for _, clique := range pcs.Spec.Template.Cliques {
+		if clique == nil {
+			continue
+		}
+		if queueName := resolveQueueNameFromMetadata(clique.Labels, clique.Annotations); queueName != "" {
+			queueNames[queueName] = struct{}{}
+		}
+	}
+
+	switch len(queueNames) {
+	case 0:
+		return "", fmt.Errorf("no KAI queue is configured on PodCliqueSet %s/%s or its PodClique templates", pcs.Namespace, pcs.Name)
+	case 1:
+		for queueName := range queueNames {
+			return queueName, nil
+		}
+	}
+
+	queueNamesList := make([]string, 0, len(queueNames))
+	for queueName := range queueNames {
+		queueNamesList = append(queueNamesList, queueName)
+	}
+	sort.Strings(queueNamesList)
+	return "", fmt.Errorf("conflicting KAI queues on PodCliqueSet %s/%s PodClique templates: %v; set %s on the PodCliqueSet to choose one", pcs.Namespace, pcs.Name, queueNamesList, labelKeyQueueName)
+}
+
+// resolveQueueNameFromMetadata returns queue from labels first, then falls back to annotations.
+func resolveQueueNameFromMetadata(labels, annotations map[string]string) string {
+	if labels != nil && labels[labelKeyQueueName] != "" {
+		return labels[labelKeyQueueName]
+	}
+	if annotations != nil {
+		return annotations[labelKeyQueueName]
 	}
 	return ""
 }

--- a/operator/internal/scheduler/kai/backend.go
+++ b/operator/internal/scheduler/kai/backend.go
@@ -16,21 +16,28 @@ package kai
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 
+	apicommonconstants "github.com/ai-dynamo/grove/operator/api/common/constants"
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/ai-dynamo/grove/operator/internal/scheduler"
 
+	kaischedulingv2alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	kaitopologyv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // schedulerBackend implements the scheduler Backend interface (Backend in scheduler package) for KAI scheduler.
-// TODO: Converts PodGang → PodGroup
 type schedulerBackend struct {
 	client        client.Client
 	scheme        *runtime.Scheme
@@ -40,6 +47,13 @@ type schedulerBackend struct {
 }
 
 var _ scheduler.Backend = (*schedulerBackend)(nil)
+
+const (
+	labelKeyQueueName        = "kai.scheduler/queue"
+	labelKeyNodePoolName     = "kai.scheduler/node-pool"
+	annotationKeyIgnoreGrove = "grove.io/ignore"
+	annotationValIgnoreGrove = "true"
+)
 
 // New creates a new KAI backend instance. profile is the scheduler profile for kai-scheduler;
 // schedulerBackend uses profile.Name and may unmarshal profile.Config for kai-specific options.
@@ -65,10 +79,48 @@ func (b *schedulerBackend) Init(_ client.Client) error {
 }
 
 // SyncPodGang converts PodGang to KAI PodGroup and synchronizes it
-func (b *schedulerBackend) SyncPodGang(_ context.Context, _ *groveschedulerv1alpha1.PodGang) error {
-	return nil
+func (b *schedulerBackend) SyncPodGang(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) error {
+	if podGang == nil {
+		return fmt.Errorf("podGang is nil")
+	}
+	if err := b.ensurePodGangIgnoredByGrovePlugin(ctx, podGang); err != nil {
+		return err
+	}
+
+	newPodGroup, err := b.buildPodGroupForPodGang(podGang)
+	if err != nil {
+		return err
+	}
+
+	oldPodGroup := &kaischedulingv2alpha2.PodGroup{}
+	key := client.ObjectKeyFromObject(newPodGroup)
+	if err = b.client.Get(ctx, key, oldPodGroup); err != nil {
+		if apierrors.IsNotFound(err) {
+			return b.client.Create(ctx, newPodGroup)
+		}
+		return err
+	}
+
+	newPodGroup = b.inheritRuntimeManagedFields(oldPodGroup, newPodGroup)
+	if podGroupsEqual(oldPodGroup, newPodGroup) {
+		return nil
+	}
+	updatePodGroup(oldPodGroup, newPodGroup)
+	return b.client.Update(ctx, oldPodGroup)
 }
 
+// OnPodGangDelete removes the PodGroup owned by this PodGang
+func (b *schedulerBackend) OnPodGangDelete(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) error {
+	if podGang == nil {
+		return nil
+	}
+	return client.IgnoreNotFound(b.client.Delete(ctx, &kaischedulingv2alpha2.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podGang.Name,
+			Namespace: podGang.Namespace,
+		},
+	}))
+}
 // PreparePod adds KAI scheduler-specific configuration to the Pod.
 // Sets Pod.Spec.SchedulerName so the pod is scheduled by KAI.
 func (b *schedulerBackend) PreparePod(pod *corev1.Pod) error {
@@ -79,4 +131,199 @@ func (b *schedulerBackend) PreparePod(pod *corev1.Pod) error {
 // ValidatePodCliqueSet runs KAI-specific validations on the PodCliqueSet.
 func (b *schedulerBackend) ValidatePodCliqueSet(_ context.Context, _ *grovecorev1alpha1.PodCliqueSet) error {
 	return nil
+}
+
+// ensurePodGangIgnoredByGrovePlugin marks PodGang so legacy Grove podgrouper ignores it.
+func (b *schedulerBackend) ensurePodGangIgnoredByGrovePlugin(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) error {
+	if podGang.Annotations != nil && podGang.Annotations[annotationKeyIgnoreGrove] == annotationValIgnoreGrove {
+		return nil
+	}
+	patchBase := podGang.DeepCopy()
+	if podGang.Annotations == nil {
+		podGang.Annotations = map[string]string{}
+	}
+	podGang.Annotations[annotationKeyIgnoreGrove] = annotationValIgnoreGrove
+	return b.client.Patch(ctx, podGang, client.MergeFrom(patchBase))
+}
+
+// buildPodGroupForPodGang translates a Grove PodGang into a KAI PodGroup object.
+func (b *schedulerBackend) buildPodGroupForPodGang(podGang *groveschedulerv1alpha1.PodGang) (*kaischedulingv2alpha2.PodGroup, error) {
+	topologyName := getTopologyName(podGang)
+	topologyConstraint, err := toKAITopologyConstraint(podGang.Spec.TopologyConstraint, topologyName)
+	if err != nil {
+		return nil, err
+	}
+
+	parentBySubGroupName := map[string]string{}
+	subGroups := make([]kaischedulingv2alpha2.SubGroup, 0, len(podGang.Spec.TopologyConstraintGroupConfigs)+len(podGang.Spec.PodGroups))
+
+	for _, groupConfig := range podGang.Spec.TopologyConstraintGroupConfigs {
+		groupTopologyConstraint, groupErr := toKAITopologyConstraint(groupConfig.TopologyConstraint, topologyName)
+		if groupErr != nil {
+			return nil, groupErr
+		}
+		subGroups = append(subGroups, kaischedulingv2alpha2.SubGroup{
+			Name:               groupConfig.Name,
+			MinMember:          0,
+			TopologyConstraint: groupTopologyConstraint,
+		})
+		for _, podGroupName := range groupConfig.PodGroupNames {
+			parentBySubGroupName[podGroupName] = groupConfig.Name
+		}
+	}
+
+	var minMember int32
+	for _, podGroup := range podGang.Spec.PodGroups {
+		subGroupTopologyConstraint, groupErr := toKAITopologyConstraint(podGroup.TopologyConstraint, topologyName)
+		if groupErr != nil {
+			return nil, groupErr
+		}
+		subGroup := kaischedulingv2alpha2.SubGroup{
+			Name:               podGroup.Name,
+			MinMember:          podGroup.MinReplicas,
+			TopologyConstraint: subGroupTopologyConstraint,
+		}
+		if parentName, found := parentBySubGroupName[podGroup.Name]; found {
+			subGroup.Parent = ptr.To(parentName)
+		}
+		subGroups = append(subGroups, subGroup)
+		minMember += podGroup.MinReplicas
+	}
+
+	result := &kaischedulingv2alpha2.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        podGang.Name,
+			Namespace:   podGang.Namespace,
+			Labels:      cloneStringMap(podGang.Labels),
+			Annotations: cloneStringMap(podGang.Annotations),
+		},
+		Spec: kaischedulingv2alpha2.PodGroupSpec{
+			MinMember:         minMember,
+			Queue:             resolveQueueName(podGang),
+			PriorityClassName: podGang.Spec.PriorityClassName,
+			SubGroups:         subGroups,
+		},
+	}
+	if topologyConstraint != nil {
+		result.Spec.TopologyConstraint = *topologyConstraint
+	}
+	if err := controllerutil.SetControllerReference(podGang, result, b.scheme); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// getTopologyName resolves topology name from PodGang annotations with fallback keys.
+func getTopologyName(podGang *groveschedulerv1alpha1.PodGang) string {
+	if podGang.Annotations == nil {
+		return ""
+	}
+	if topologyName := podGang.Annotations[apicommonconstants.AnnotationTopologyName]; topologyName != "" {
+		return topologyName
+	}
+	// Backward compatibility with KAI annotation key.
+	return podGang.Annotations["kai.scheduler/topology"]
+}
+
+// toKAITopologyConstraint converts Grove topology constraint to KAI topology constraint.
+func toKAITopologyConstraint(topologyConstraint *groveschedulerv1alpha1.TopologyConstraint, topologyName string) (*kaischedulingv2alpha2.TopologyConstraint, error) {
+	if topologyConstraint == nil || topologyConstraint.PackConstraint == nil {
+		return nil, nil
+	}
+	if topologyName == "" {
+		return nil, fmt.Errorf("topology name cannot be empty when topology constraints are defined")
+	}
+	result := &kaischedulingv2alpha2.TopologyConstraint{
+		Topology: topologyName,
+	}
+	if topologyConstraint.PackConstraint.Preferred != nil {
+		result.PreferredTopologyLevel = *topologyConstraint.PackConstraint.Preferred
+	}
+	if topologyConstraint.PackConstraint.Required != nil {
+		result.RequiredTopologyLevel = *topologyConstraint.PackConstraint.Required
+	}
+	return result, nil
+}
+
+// resolveQueueName returns queue from labels first, then falls back to annotations.
+func resolveQueueName(podGang *groveschedulerv1alpha1.PodGang) string {
+	if podGang.Labels != nil && podGang.Labels[labelKeyQueueName] != "" {
+		return podGang.Labels[labelKeyQueueName]
+	}
+	if podGang.Annotations != nil {
+		return podGang.Annotations[labelKeyQueueName]
+	}
+	return ""
+}
+
+// inheritRuntimeManagedFields preserves fields that are managed by KAI runtime components.
+func (b *schedulerBackend) inheritRuntimeManagedFields(oldPodGroup, newPodGroup *kaischedulingv2alpha2.PodGroup) *kaischedulingv2alpha2.PodGroup {
+	newPodGroupCopy := newPodGroup.DeepCopy()
+	// These fields are managed by KAI components after initial creation.
+	newPodGroupCopy.Spec.MarkUnschedulable = oldPodGroup.Spec.MarkUnschedulable
+	newPodGroupCopy.Spec.SchedulingBackoff = oldPodGroup.Spec.SchedulingBackoff
+	newPodGroupCopy.Spec.Queue = oldPodGroup.Spec.Queue
+
+	if newPodGroupCopy.Labels == nil {
+		newPodGroupCopy.Labels = map[string]string{}
+	}
+	if nodePoolName := oldPodGroup.Labels[labelKeyNodePoolName]; nodePoolName != "" {
+		newPodGroupCopy.Labels[labelKeyNodePoolName] = nodePoolName
+	}
+	if queueName := oldPodGroup.Labels[labelKeyQueueName]; queueName != "" {
+		newPodGroupCopy.Labels[labelKeyQueueName] = queueName
+	}
+	return newPodGroupCopy
+}
+
+// podGroupsEqual compares spec plus source-owned metadata fields for update decisions.
+func podGroupsEqual(oldPodGroup, newPodGroup *kaischedulingv2alpha2.PodGroup) bool {
+	return reflect.DeepEqual(oldPodGroup.Spec, newPodGroup.Spec) &&
+		reflect.DeepEqual(oldPodGroup.OwnerReferences, newPodGroup.OwnerReferences) &&
+		mapsEqualBySourceKeys(newPodGroup.Labels, oldPodGroup.Labels) &&
+		mapsEqualBySourceKeys(newPodGroup.Annotations, oldPodGroup.Annotations)
+}
+
+// mapsEqualBySourceKeys checks whether target contains all key-values from source.
+func mapsEqualBySourceKeys(source, target map[string]string) bool {
+	if source != nil && target == nil {
+		return false
+	}
+	for key, sourceValue := range source {
+		if targetValue, exists := target[key]; !exists || targetValue != sourceValue {
+			return false
+		}
+	}
+	return true
+}
+
+// updatePodGroup copies desired fields from newPodGroup into existing object.
+func updatePodGroup(oldPodGroup, newPodGroup *kaischedulingv2alpha2.PodGroup) {
+	oldPodGroup.Annotations = copyStringMap(newPodGroup.Annotations, oldPodGroup.Annotations)
+	oldPodGroup.Labels = copyStringMap(newPodGroup.Labels, oldPodGroup.Labels)
+	oldPodGroup.Spec = newPodGroup.Spec
+	oldPodGroup.OwnerReferences = newPodGroup.OwnerReferences
+}
+
+// copyStringMap copies all key-values from source into target map.
+func copyStringMap(source, target map[string]string) map[string]string {
+	if source != nil && target == nil {
+		target = map[string]string{}
+	}
+	for k, v := range source {
+		target[k] = v
+	}
+	return target
+}
+
+// cloneStringMap returns a shallow copy of the input string map.
+func cloneStringMap(input map[string]string) map[string]string {
+	if input == nil {
+		return nil
+	}
+	cloned := make(map[string]string, len(input))
+	for k, v := range input {
+		cloned[k] = v
+	}
+	return cloned
 }

--- a/operator/internal/scheduler/kai/backend.go
+++ b/operator/internal/scheduler/kai/backend.go
@@ -17,6 +17,7 @@ package kai
 import (
 	"context"
 	"fmt"
+	"maps"
 	"reflect"
 	"sort"
 
@@ -25,6 +26,7 @@ import (
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/ai-dynamo/grove/operator/internal/scheduler"
+	"github.com/ai-dynamo/grove/operator/internal/utils"
 
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	kaitopologyv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
@@ -164,6 +166,9 @@ func (b *schedulerBackend) buildPodGroupForPodGang(ctx context.Context, podGang 
 	subGroups := make([]kaischedulingv2alpha2.SubGroup, 0, len(podGang.Spec.TopologyConstraintGroupConfigs)+len(podGang.Spec.PodGroups))
 
 	for _, groupConfig := range podGang.Spec.TopologyConstraintGroupConfigs {
+		if len(groupConfig.PodGroupNames) == 0 {
+			continue
+		}
 		groupTopologyConstraint, groupErr := toKAITopologyConstraint(groupConfig.TopologyConstraint, topologyName)
 		if groupErr != nil {
 			return nil, groupErr
@@ -189,6 +194,8 @@ func (b *schedulerBackend) buildPodGroupForPodGang(ctx context.Context, podGang 
 			MinMember:          ptr.To(podGroup.MinReplicas),
 			TopologyConstraint: subGroupTopologyConstraint,
 		}
+		// Group configs cover a strict subset of PodGroups. Unmatched PodGroups
+		// intentionally remain root-level KAI SubGroups.
 		if parentName, found := parentBySubGroupName[podGroup.Name]; found {
 			subGroup.Parent = ptr.To(parentName)
 		}
@@ -200,8 +207,8 @@ func (b *schedulerBackend) buildPodGroupForPodGang(ctx context.Context, podGang 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        podGang.Name,
 			Namespace:   podGang.Namespace,
-			Labels:      cloneStringMap(podGang.Labels),
-			Annotations: cloneStringMap(podGang.Annotations),
+			Labels:      maps.Clone(podGang.Labels),
+			Annotations: maps.Clone(podGang.Annotations),
 		},
 		Spec: kaischedulingv2alpha2.PodGroupSpec{
 			MinMember:         ptr.To(minMember),
@@ -365,50 +372,24 @@ func (b *schedulerBackend) inheritRuntimeManagedFields(oldPodGroup, newPodGroup 
 func podGroupsEqual(oldPodGroup, newPodGroup *kaischedulingv2alpha2.PodGroup) bool {
 	return reflect.DeepEqual(oldPodGroup.Spec, newPodGroup.Spec) &&
 		reflect.DeepEqual(oldPodGroup.OwnerReferences, newPodGroup.OwnerReferences) &&
-		mapsEqualBySourceKeys(newPodGroup.Labels, oldPodGroup.Labels) &&
-		mapsEqualBySourceKeys(newPodGroup.Annotations, oldPodGroup.Annotations)
-}
-
-// mapsEqualBySourceKeys checks whether target contains all key-values from source.
-func mapsEqualBySourceKeys(source, target map[string]string) bool {
-	if source != nil && target == nil {
-		return false
-	}
-	for key, sourceValue := range source {
-		if targetValue, exists := target[key]; !exists || targetValue != sourceValue {
-			return false
-		}
-	}
-	return true
+		utils.MapContainsAll(oldPodGroup.Labels, newPodGroup.Labels) &&
+		utils.MapContainsAll(oldPodGroup.Annotations, newPodGroup.Annotations)
 }
 
 // updatePodGroup copies desired fields from newPodGroup into existing object.
 func updatePodGroup(oldPodGroup, newPodGroup *kaischedulingv2alpha2.PodGroup) {
-	oldPodGroup.Annotations = copyStringMap(newPodGroup.Annotations, oldPodGroup.Annotations)
-	oldPodGroup.Labels = copyStringMap(newPodGroup.Labels, oldPodGroup.Labels)
+	if newPodGroup.Annotations != nil {
+		if oldPodGroup.Annotations == nil {
+			oldPodGroup.Annotations = map[string]string{}
+		}
+		maps.Copy(oldPodGroup.Annotations, newPodGroup.Annotations)
+	}
+	if newPodGroup.Labels != nil {
+		if oldPodGroup.Labels == nil {
+			oldPodGroup.Labels = map[string]string{}
+		}
+		maps.Copy(oldPodGroup.Labels, newPodGroup.Labels)
+	}
 	oldPodGroup.Spec = newPodGroup.Spec
 	oldPodGroup.OwnerReferences = newPodGroup.OwnerReferences
-}
-
-// copyStringMap copies all key-values from source into target map.
-func copyStringMap(source, target map[string]string) map[string]string {
-	if source != nil && target == nil {
-		target = map[string]string{}
-	}
-	for k, v := range source {
-		target[k] = v
-	}
-	return target
-}
-
-// cloneStringMap returns a shallow copy of the input string map.
-func cloneStringMap(input map[string]string) map[string]string {
-	if input == nil {
-		return nil
-	}
-	cloned := make(map[string]string, len(input))
-	for k, v := range input {
-		cloned[k] = v
-	}
-	return cloned
 }

--- a/operator/internal/scheduler/kai/backend.go
+++ b/operator/internal/scheduler/kai/backend.go
@@ -19,14 +19,15 @@ import (
 	"fmt"
 	"reflect"
 
+	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	apicommonconstants "github.com/ai-dynamo/grove/operator/api/common/constants"
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/ai-dynamo/grove/operator/internal/scheduler"
 
-	kaischedulingv2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	kaitopologyv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
+	kaischedulingv2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,10 +50,12 @@ type schedulerBackend struct {
 var _ scheduler.Backend = (*schedulerBackend)(nil)
 
 const (
-	labelKeyQueueName        = "kai.scheduler/queue"
-	labelKeyNodePoolName     = "kai.scheduler/node-pool"
-	annotationKeySkipPGR     = "kai.scheduler/skip-podgrouper"
-	annotationValSkipPGR     = "true"
+	labelKeyQueueName    = "kai.scheduler/queue"
+	labelKeyNodePoolName = "kai.scheduler/node-pool"
+	annotationKeySkipPGR = "kai.scheduler/skip-podgrouper"
+	annotationValSkipPGR = "true"
+	annotationPodGroup   = "pod-group-name"
+	labelSubGroup        = "kai.scheduler/subgroup-name"
 )
 
 // New creates a new KAI backend instance. profile is the scheduler profile for kai-scheduler;
@@ -86,9 +89,13 @@ func (b *schedulerBackend) SyncPodGang(ctx context.Context, podGang *groveschedu
 	if podGang == nil {
 		return fmt.Errorf("podGang is nil")
 	}
+	if err := b.ensurePodGangSkipAnnotation(ctx, podGang); err != nil {
+		return fmt.Errorf("ensure KAI podgrouper skip annotation: %w", err)
+	}
 
 	newPodGroup, err := b.buildPodGroupForPodGang(podGang)
 	if err != nil {
+		b.recordWarning(podGang, "KAIBackendMappingFailed", err)
 		return err
 	}
 
@@ -109,29 +116,28 @@ func (b *schedulerBackend) SyncPodGang(ctx context.Context, podGang *groveschedu
 	return b.client.Update(ctx, oldPodGroup)
 }
 
-// OnPodGangDelete removes the PodGroup owned by this PodGang
-func (b *schedulerBackend) OnPodGangDelete(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) error {
-	if podGang == nil {
-		return nil
-	}
-	return client.IgnoreNotFound(b.client.Delete(ctx, &kaischedulingv2alpha2.PodGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      podGang.Name,
-			Namespace: podGang.Namespace,
-		},
-	}))
-}
-
 // PreparePod adds KAI scheduler-specific configuration to the Pod.
-// Sets Pod.Spec.SchedulerName so the pod is scheduled by KAI.
+// It sets externally-created PodGroup membership because KAI's podgrouper is skipped.
 func (b *schedulerBackend) PreparePod(pod *corev1.Pod) error {
+	podGangName := pod.Labels[apicommon.LabelPodGang]
+	if podGangName == "" {
+		return fmt.Errorf("KAI scheduler requires pod label %q", apicommon.LabelPodGang)
+	}
+	subGroupName := pod.Labels[apicommon.LabelPodClique]
+	if subGroupName == "" {
+		return fmt.Errorf("KAI scheduler requires pod label %q", apicommon.LabelPodClique)
+	}
+
 	pod.Spec.SchedulerName = b.Name()
 	if pod.Annotations == nil {
 		pod.Annotations = map[string]string{}
 	}
-	if _, exists := pod.Annotations[annotationKeySkipPGR]; !exists {
-		pod.Annotations[annotationKeySkipPGR] = annotationValSkipPGR
+	if pod.Labels == nil {
+		pod.Labels = map[string]string{}
 	}
+	pod.Annotations[annotationKeySkipPGR] = annotationValSkipPGR
+	pod.Annotations[annotationPodGroup] = podGangName
+	pod.Labels[labelSubGroup] = subGroupName
 	return nil
 }
 
@@ -158,7 +164,7 @@ func (b *schedulerBackend) buildPodGroupForPodGang(podGang *groveschedulerv1alph
 		}
 		subGroups = append(subGroups, kaischedulingv2alpha2.SubGroup{
 			Name:               groupConfig.Name,
-			MinMember:          0,
+			MinSubGroup:        ptr.To(int32(len(groupConfig.PodGroupNames))),
 			TopologyConstraint: groupTopologyConstraint,
 		})
 		for _, podGroupName := range groupConfig.PodGroupNames {
@@ -174,7 +180,7 @@ func (b *schedulerBackend) buildPodGroupForPodGang(podGang *groveschedulerv1alph
 		}
 		subGroup := kaischedulingv2alpha2.SubGroup{
 			Name:               podGroup.Name,
-			MinMember:          podGroup.MinReplicas,
+			MinMember:          ptr.To(podGroup.MinReplicas),
 			TopologyConstraint: subGroupTopologyConstraint,
 		}
 		if parentName, found := parentBySubGroupName[podGroup.Name]; found {
@@ -192,7 +198,7 @@ func (b *schedulerBackend) buildPodGroupForPodGang(podGang *groveschedulerv1alph
 			Annotations: cloneStringMap(podGang.Annotations),
 		},
 		Spec: kaischedulingv2alpha2.PodGroupSpec{
-			MinMember:         minMember,
+			MinMember:         ptr.To(minMember),
 			Queue:             resolveQueueName(podGang),
 			PriorityClassName: podGang.Spec.PriorityClassName,
 			SubGroups:         subGroups,
@@ -205,6 +211,24 @@ func (b *schedulerBackend) buildPodGroupForPodGang(podGang *groveschedulerv1alph
 		return nil, err
 	}
 	return result, nil
+}
+
+func (b *schedulerBackend) ensurePodGangSkipAnnotation(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) error {
+	if podGang.Annotations != nil && podGang.Annotations[annotationKeySkipPGR] == annotationValSkipPGR {
+		return nil
+	}
+	before := podGang.DeepCopy()
+	if podGang.Annotations == nil {
+		podGang.Annotations = map[string]string{}
+	}
+	podGang.Annotations[annotationKeySkipPGR] = annotationValSkipPGR
+	return b.client.Patch(ctx, podGang, client.MergeFrom(before))
+}
+
+func (b *schedulerBackend) recordWarning(obj runtime.Object, reason string, err error) {
+	if b.eventRecorder != nil && obj != nil && err != nil {
+		b.eventRecorder.Eventf(obj, corev1.EventTypeWarning, reason, "%v", err)
+	}
 }
 
 // getTopologyName resolves topology name from PodGang annotations with fallback keys.

--- a/operator/internal/scheduler/kai/backend.go
+++ b/operator/internal/scheduler/kai/backend.go
@@ -24,7 +24,7 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/ai-dynamo/grove/operator/internal/scheduler"
 
-	kaischedulingv2alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+	kaischedulingv2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	kaitopologyv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -51,8 +51,8 @@ var _ scheduler.Backend = (*schedulerBackend)(nil)
 const (
 	labelKeyQueueName        = "kai.scheduler/queue"
 	labelKeyNodePoolName     = "kai.scheduler/node-pool"
-	annotationKeyIgnoreGrove = "grove.io/ignore"
-	annotationValIgnoreGrove = "true"
+	annotationKeySkipPGR     = "kai.scheduler/skip-podgrouper"
+	annotationValSkipPGR     = "true"
 )
 
 // New creates a new KAI backend instance. profile is the scheduler profile for kai-scheduler;
@@ -75,16 +75,16 @@ func (b *schedulerBackend) Name() string {
 // Init registers the KAI API types into b.scheme and must be called before
 // that scheme is used to serialize or deserialize KAI objects.
 func (b *schedulerBackend) Init(_ client.Client) error {
-	return kaitopologyv1alpha1.AddToScheme(b.scheme)
+	if err := kaitopologyv1alpha1.AddToScheme(b.scheme); err != nil {
+		return err
+	}
+	return kaischedulingv2alpha2.AddToScheme(b.scheme)
 }
 
 // SyncPodGang converts PodGang to KAI PodGroup and synchronizes it
 func (b *schedulerBackend) SyncPodGang(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) error {
 	if podGang == nil {
 		return fmt.Errorf("podGang is nil")
-	}
-	if err := b.ensurePodGangIgnoredByGrovePlugin(ctx, podGang); err != nil {
-		return err
 	}
 
 	newPodGroup, err := b.buildPodGroupForPodGang(podGang)
@@ -121,29 +121,23 @@ func (b *schedulerBackend) OnPodGangDelete(ctx context.Context, podGang *grovesc
 		},
 	}))
 }
+
 // PreparePod adds KAI scheduler-specific configuration to the Pod.
 // Sets Pod.Spec.SchedulerName so the pod is scheduled by KAI.
 func (b *schedulerBackend) PreparePod(pod *corev1.Pod) error {
 	pod.Spec.SchedulerName = b.Name()
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+	if _, exists := pod.Annotations[annotationKeySkipPGR]; !exists {
+		pod.Annotations[annotationKeySkipPGR] = annotationValSkipPGR
+	}
 	return nil
 }
 
 // ValidatePodCliqueSet runs KAI-specific validations on the PodCliqueSet.
 func (b *schedulerBackend) ValidatePodCliqueSet(_ context.Context, _ *grovecorev1alpha1.PodCliqueSet) error {
 	return nil
-}
-
-// ensurePodGangIgnoredByGrovePlugin marks PodGang so legacy Grove podgrouper ignores it.
-func (b *schedulerBackend) ensurePodGangIgnoredByGrovePlugin(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) error {
-	if podGang.Annotations != nil && podGang.Annotations[annotationKeyIgnoreGrove] == annotationValIgnoreGrove {
-		return nil
-	}
-	patchBase := podGang.DeepCopy()
-	if podGang.Annotations == nil {
-		podGang.Annotations = map[string]string{}
-	}
-	podGang.Annotations[annotationKeyIgnoreGrove] = annotationValIgnoreGrove
-	return b.client.Patch(ctx, podGang, client.MergeFrom(patchBase))
 }
 
 // buildPodGroupForPodGang translates a Grove PodGang into a KAI PodGroup object.

--- a/operator/internal/scheduler/kai/backend.go
+++ b/operator/internal/scheduler/kai/backend.go
@@ -143,8 +143,9 @@ func (b *schedulerBackend) PreparePod(pod *corev1.Pod) error {
 }
 
 // ValidatePodCliqueSet runs KAI-specific validations on the PodCliqueSet.
-func (b *schedulerBackend) ValidatePodCliqueSet(_ context.Context, _ *grovecorev1alpha1.PodCliqueSet) error {
-	return nil
+func (b *schedulerBackend) ValidatePodCliqueSet(_ context.Context, pcs *grovecorev1alpha1.PodCliqueSet) error {
+	_, err := resolveQueueNameForPodCliqueSet(pcs)
+	return err
 }
 
 // buildPodGroupForPodGang translates a Grove PodGang into a KAI PodGroup object.
@@ -269,7 +270,6 @@ func toKAITopologyConstraint(topologyConstraint *groveschedulerv1alpha1.Topology
 }
 
 // resolveQueueName returns the KAI queue configured by the PodGang's owning PodCliqueSet.
-// A queue set on the PodCliqueSet itself overrides the queues on its PodClique templates.
 func (b *schedulerBackend) resolveQueueName(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) (string, error) {
 	owner := metav1.GetControllerOf(podGang)
 	if owner == nil {
@@ -284,7 +284,22 @@ func (b *schedulerBackend) resolveQueueName(ctx context.Context, podGang *groves
 		return "", fmt.Errorf("get controlling PodCliqueSet %s/%s: %w", podGang.Namespace, owner.Name, err)
 	}
 
+	return resolveQueueNameForPodCliqueSet(pcs)
+}
+
+// resolveQueueNameForPodCliqueSet returns the KAI queue configured by a PodCliqueSet.
+// A queue set on the PodCliqueSet establishes the queue for the scheduling unit, so
+// every explicitly configured PodClique template queue must resolve to the same value.
+func resolveQueueNameForPodCliqueSet(pcs *grovecorev1alpha1.PodCliqueSet) (string, error) {
 	if queueName := resolveQueueNameFromMetadata(pcs.Labels, pcs.Annotations); queueName != "" {
+		for _, clique := range pcs.Spec.Template.Cliques {
+			if clique == nil {
+				continue
+			}
+			if templateQueueName := resolveQueueNameFromMetadata(clique.Labels, clique.Annotations); templateQueueName != "" && templateQueueName != queueName {
+				return "", fmt.Errorf("KAI queue on PodCliqueSet %s/%s is %q but PodClique template %q resolves to %q", pcs.Namespace, pcs.Name, queueName, clique.Name, templateQueueName)
+			}
+		}
 		return queueName, nil
 	}
 
@@ -312,7 +327,7 @@ func (b *schedulerBackend) resolveQueueName(ctx context.Context, podGang *groves
 		queueNamesList = append(queueNamesList, queueName)
 	}
 	sort.Strings(queueNamesList)
-	return "", fmt.Errorf("conflicting KAI queues on PodCliqueSet %s/%s PodClique templates: %v; set %s on the PodCliqueSet to choose one", pcs.Namespace, pcs.Name, queueNamesList, labelKeyQueueName)
+	return "", fmt.Errorf("conflicting KAI queues on PodCliqueSet %s/%s PodClique templates: %v", pcs.Namespace, pcs.Name, queueNamesList)
 }
 
 // resolveQueueNameFromMetadata returns queue from labels first, then falls back to annotations.

--- a/operator/internal/scheduler/kai/backend_test.go
+++ b/operator/internal/scheduler/kai/backend_test.go
@@ -15,14 +15,20 @@
 package kai
 
 import (
+	"context"
 	"testing"
 
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
+	kaischedulingv2alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestBackend_PreparePod(t *testing.T) {
@@ -38,4 +44,118 @@ func TestBackend_PreparePod(t *testing.T) {
 	require.NoError(t, b.PreparePod(pod))
 
 	assert.Equal(t, "kai-scheduler", pod.Spec.SchedulerName)
+}
+
+func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
+	podGang := testutils.NewPodGangBuilder("test-podgang", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		Build()
+	podGang.Labels["kai.scheduler/queue"] = "team-a"
+	podGang.Annotations = map[string]string{"grove.io/topology-name": "cluster-topology"}
+	podGang.Spec.PriorityClassName = "high-priority"
+	podGang.Spec.TopologyConstraint = &groveschedulerv1alpha1.TopologyConstraint{
+		PackConstraint: &groveschedulerv1alpha1.TopologyPackConstraint{
+			Required: ptr.To("zone"),
+		},
+	}
+	podGang.Spec.TopologyConstraintGroupConfigs = []groveschedulerv1alpha1.TopologyConstraintGroupConfig{
+		{
+			Name:          "decoder-group",
+			PodGroupNames: []string{"decoder"},
+			TopologyConstraint: &groveschedulerv1alpha1.TopologyConstraint{
+				PackConstraint: &groveschedulerv1alpha1.TopologyPackConstraint{
+					Preferred: ptr.To("rack"),
+				},
+			},
+		},
+	}
+	podGang.Spec.PodGroups = []groveschedulerv1alpha1.PodGroup{
+		{
+			Name:        "encoder",
+			MinReplicas: 2,
+			TopologyConstraint: &groveschedulerv1alpha1.TopologyConstraint{
+				PackConstraint: &groveschedulerv1alpha1.TopologyPackConstraint{
+					Required: ptr.To("host"),
+				},
+			},
+		},
+		{
+			Name:        "decoder",
+			MinReplicas: 3,
+		},
+	}
+
+	cl := testutils.NewTestClientBuilder().
+		WithObjects(podGang).
+		Build()
+	recorder := record.NewFakeRecorder(10)
+	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}
+	b := New(cl, cl.Scheme(), recorder, profile)
+
+	ctx := context.Background()
+	require.NoError(t, b.SyncPodGang(ctx, podGang))
+
+	syncedPodGang := &groveschedulerv1alpha1.PodGang{}
+	require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(podGang), syncedPodGang))
+	assert.Equal(t, "true", syncedPodGang.Annotations["grove.io/ignore"])
+
+	gotPodGroup := &kaischedulingv2alpha2.PodGroup{}
+	require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: podGang.Name, Namespace: podGang.Namespace}, gotPodGroup))
+
+	assert.Equal(t, int32(5), gotPodGroup.Spec.MinMember)
+	assert.Equal(t, "team-a", gotPodGroup.Spec.Queue)
+	assert.Equal(t, "high-priority", gotPodGroup.Spec.PriorityClassName)
+	assert.Equal(t, "zone", gotPodGroup.Spec.TopologyConstraint.RequiredTopologyLevel)
+
+	require.Len(t, gotPodGroup.Spec.SubGroups, 3)
+	assert.Equal(t, "decoder-group", gotPodGroup.Spec.SubGroups[0].Name)
+	assert.Equal(t, int32(0), gotPodGroup.Spec.SubGroups[0].MinMember)
+
+	assert.Equal(t, "encoder", gotPodGroup.Spec.SubGroups[1].Name)
+	assert.Equal(t, int32(2), gotPodGroup.Spec.SubGroups[1].MinMember)
+	assert.Nil(t, gotPodGroup.Spec.SubGroups[1].Parent)
+	assert.Equal(t, "host", gotPodGroup.Spec.SubGroups[1].TopologyConstraint.RequiredTopologyLevel)
+
+	assert.Equal(t, "decoder", gotPodGroup.Spec.SubGroups[2].Name)
+	require.NotNil(t, gotPodGroup.Spec.SubGroups[2].Parent)
+	assert.Equal(t, "decoder-group", *gotPodGroup.Spec.SubGroups[2].Parent)
+	assert.Equal(t, int32(3), gotPodGroup.Spec.SubGroups[2].MinMember)
+
+	// Update PodGang: remove queue label and change min replicas.
+	updatedPodGang := syncedPodGang.DeepCopy()
+	delete(updatedPodGang.Labels, "kai.scheduler/queue")
+	updatedPodGang.Spec.PodGroups[0].MinReplicas = 4
+	require.NoError(t, cl.Update(ctx, updatedPodGang))
+
+	require.NoError(t, b.SyncPodGang(ctx, updatedPodGang))
+	gotAfterUpdate := &kaischedulingv2alpha2.PodGroup{}
+	require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: podGang.Name, Namespace: podGang.Namespace}, gotAfterUpdate))
+
+	// Existing queue should be preserved even when source label is removed.
+	assert.Equal(t, "team-a", gotAfterUpdate.Spec.Queue)
+	assert.Equal(t, int32(7), gotAfterUpdate.Spec.MinMember)
+	assert.Equal(t, int32(4), gotAfterUpdate.Spec.SubGroups[1].MinMember)
+}
+
+func TestBackend_OnPodGangDelete(t *testing.T) {
+	podGang := testutils.NewPodGangBuilder("to-delete", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		Build()
+	podGroup := &kaischedulingv2alpha2.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-delete",
+			Namespace: "default",
+		},
+	}
+
+	cl := testutils.NewTestClientBuilder().WithObjects(podGang, podGroup).Build()
+	recorder := record.NewFakeRecorder(10)
+	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}
+	b := New(cl, cl.Scheme(), recorder, profile)
+
+	ctx := context.Background()
+	require.NoError(t, b.OnPodGangDelete(ctx, podGang))
+
+	err := cl.Get(ctx, client.ObjectKey{Name: podGroup.Name, Namespace: podGroup.Namespace}, &kaischedulingv2alpha2.PodGroup{})
+	assert.Error(t, err)
 }

--- a/operator/internal/scheduler/kai/backend_test.go
+++ b/operator/internal/scheduler/kai/backend_test.go
@@ -18,14 +18,14 @@ import (
 	"context"
 	"testing"
 
+	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
-	kaischedulingv2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
+	kaischedulingv2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,6 +40,10 @@ func TestBackend_PreparePod(t *testing.T) {
 	pod := testutils.NewPodBuilder("test-pod", "default").
 		WithSchedulerName("default-scheduler").
 		Build()
+	pod.Labels = map[string]string{
+		apicommon.LabelPodGang:   "test-podgang",
+		apicommon.LabelPodClique: "test-clique",
+	}
 	pod.Annotations = map[string]string{"keep": "me"}
 
 	require.NoError(t, b.PreparePod(pod))
@@ -47,6 +51,8 @@ func TestBackend_PreparePod(t *testing.T) {
 	assert.Equal(t, "kai-scheduler", pod.Spec.SchedulerName)
 	assert.Equal(t, "me", pod.Annotations["keep"])
 	assert.Equal(t, "true", pod.Annotations["kai.scheduler/skip-podgrouper"])
+	assert.Equal(t, "test-podgang", pod.Annotations["pod-group-name"])
+	assert.Equal(t, "test-clique", pod.Labels["kai.scheduler/subgroup-name"])
 }
 
 func TestBackend_PreparePod_PreservesExistingSkipAnnotation(t *testing.T) {
@@ -57,11 +63,15 @@ func TestBackend_PreparePod_PreservesExistingSkipAnnotation(t *testing.T) {
 
 	pod := testutils.NewPodBuilder("test-pod", "default").
 		Build()
+	pod.Labels = map[string]string{
+		apicommon.LabelPodGang:   "test-podgang",
+		apicommon.LabelPodClique: "test-clique",
+	}
 	pod.Annotations = map[string]string{"kai.scheduler/skip-podgrouper": "custom"}
 
-	b.PreparePod(pod)
+	require.NoError(t, b.PreparePod(pod))
 
-	assert.Equal(t, "custom", pod.Annotations["kai.scheduler/skip-podgrouper"])
+	assert.Equal(t, "true", pod.Annotations["kai.scheduler/skip-podgrouper"])
 }
 
 func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
@@ -109,6 +119,7 @@ func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
 	recorder := record.NewFakeRecorder(10)
 	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}
 	b := New(cl, cl.Scheme(), recorder, profile)
+	require.NoError(t, b.Init(cl))
 
 	ctx := context.Background()
 	require.NoError(t, b.SyncPodGang(ctx, podGang))
@@ -116,24 +127,28 @@ func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
 	gotPodGroup := &kaischedulingv2alpha2.PodGroup{}
 	require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: podGang.Name, Namespace: podGang.Namespace}, gotPodGroup))
 
-	assert.Equal(t, int32(5), gotPodGroup.Spec.MinMember)
+	require.NotNil(t, gotPodGroup.Spec.MinMember)
+	assert.Equal(t, int32(5), *gotPodGroup.Spec.MinMember)
 	assert.Equal(t, "team-a", gotPodGroup.Spec.Queue)
 	assert.Equal(t, "high-priority", gotPodGroup.Spec.PriorityClassName)
 	assert.Equal(t, "zone", gotPodGroup.Spec.TopologyConstraint.RequiredTopologyLevel)
 
 	require.Len(t, gotPodGroup.Spec.SubGroups, 3)
 	assert.Equal(t, "decoder-group", gotPodGroup.Spec.SubGroups[0].Name)
-	assert.Equal(t, int32(0), gotPodGroup.Spec.SubGroups[0].MinMember)
+	require.NotNil(t, gotPodGroup.Spec.SubGroups[0].MinSubGroup)
+	assert.Equal(t, int32(1), *gotPodGroup.Spec.SubGroups[0].MinSubGroup)
 
 	assert.Equal(t, "encoder", gotPodGroup.Spec.SubGroups[1].Name)
-	assert.Equal(t, int32(2), gotPodGroup.Spec.SubGroups[1].MinMember)
+	require.NotNil(t, gotPodGroup.Spec.SubGroups[1].MinMember)
+	assert.Equal(t, int32(2), *gotPodGroup.Spec.SubGroups[1].MinMember)
 	assert.Nil(t, gotPodGroup.Spec.SubGroups[1].Parent)
 	assert.Equal(t, "host", gotPodGroup.Spec.SubGroups[1].TopologyConstraint.RequiredTopologyLevel)
 
 	assert.Equal(t, "decoder", gotPodGroup.Spec.SubGroups[2].Name)
 	require.NotNil(t, gotPodGroup.Spec.SubGroups[2].Parent)
 	assert.Equal(t, "decoder-group", *gotPodGroup.Spec.SubGroups[2].Parent)
-	assert.Equal(t, int32(3), gotPodGroup.Spec.SubGroups[2].MinMember)
+	require.NotNil(t, gotPodGroup.Spec.SubGroups[2].MinMember)
+	assert.Equal(t, int32(3), *gotPodGroup.Spec.SubGroups[2].MinMember)
 
 	// Update PodGang: remove queue label and change min replicas.
 	updatedPodGang := podGang.DeepCopy()
@@ -147,29 +162,32 @@ func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
 
 	// Existing queue should be preserved even when source label is removed.
 	assert.Equal(t, "team-a", gotAfterUpdate.Spec.Queue)
-	assert.Equal(t, int32(7), gotAfterUpdate.Spec.MinMember)
-	assert.Equal(t, int32(4), gotAfterUpdate.Spec.SubGroups[1].MinMember)
+	require.NotNil(t, gotAfterUpdate.Spec.MinMember)
+	assert.Equal(t, int32(7), *gotAfterUpdate.Spec.MinMember)
+	require.NotNil(t, gotAfterUpdate.Spec.SubGroups[1].MinMember)
+	assert.Equal(t, int32(4), *gotAfterUpdate.Spec.SubGroups[1].MinMember)
 }
 
-func TestBackend_OnPodGangDelete(t *testing.T) {
-	podGang := testutils.NewPodGangBuilder("to-delete", "default").
+func TestBackend_SyncPodGangSetsOwnerReferenceAndSkipAnnotation(t *testing.T) {
+	podGang := testutils.NewPodGangBuilder("owned", "default").
 		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
 		Build()
-	podGroup := &kaischedulingv2alpha2.PodGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "to-delete",
-			Namespace: "default",
-		},
-	}
 
-	cl := testutils.NewTestClientBuilder().WithObjects(podGang, podGroup).Build()
+	cl := testutils.NewTestClientBuilder().WithObjects(podGang).Build()
 	recorder := record.NewFakeRecorder(10)
 	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}
 	b := New(cl, cl.Scheme(), recorder, profile)
+	require.NoError(t, b.Init(cl))
 
 	ctx := context.Background()
-	require.NoError(t, b.OnPodGangDelete(ctx, podGang))
+	require.NoError(t, b.SyncPodGang(ctx, podGang))
 
-	err := cl.Get(ctx, client.ObjectKey{Name: podGroup.Name, Namespace: podGroup.Namespace}, &kaischedulingv2alpha2.PodGroup{})
-	assert.Error(t, err)
+	podGroup := &kaischedulingv2alpha2.PodGroup{}
+	require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: podGang.Name, Namespace: podGang.Namespace}, podGroup))
+	require.Len(t, podGroup.OwnerReferences, 1)
+	assert.Equal(t, podGang.Name, podGroup.OwnerReferences[0].Name)
+
+	updatedPodGang := &groveschedulerv1alpha1.PodGang{}
+	require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(podGang), updatedPodGang))
+	assert.Equal(t, annotationValSkipPGR, updatedPodGang.Annotations[annotationKeySkipPGR])
 }

--- a/operator/internal/scheduler/kai/backend_test.go
+++ b/operator/internal/scheduler/kai/backend_test.go
@@ -178,6 +178,44 @@ func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
 	assert.Equal(t, int32(4), *gotAfterUpdate.Spec.SubGroups[1].MinMember)
 }
 
+func TestBackend_SyncPodGang_SkipsEmptyTopologyConstraintGroups(t *testing.T) {
+	pcs := newPodCliqueSet(
+		"empty-group-pcs",
+		"team-a",
+		podCliqueTemplateWithQueue("worker-template", "team-a"),
+	)
+	podGang := testutils.NewPodGangBuilder("empty-group-podgang", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		Build()
+	setPodCliqueSetControllerOwner(podGang, pcs)
+	podGang.Spec.TopologyConstraintGroupConfigs = []groveschedulerv1alpha1.TopologyConstraintGroupConfig{
+		{
+			Name: "empty-group",
+			TopologyConstraint: &groveschedulerv1alpha1.TopologyConstraint{
+				PackConstraint: &groveschedulerv1alpha1.TopologyPackConstraint{
+					Required: ptr.To("host"),
+				},
+			},
+		},
+	}
+	podGang.Spec.PodGroups = []groveschedulerv1alpha1.PodGroup{
+		{Name: "worker", MinReplicas: 1},
+	}
+
+	cl := testutils.NewTestClientBuilder().WithObjects(pcs, podGang).Build()
+	b := New(cl, cl.Scheme(), record.NewFakeRecorder(10), configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai})
+	require.NoError(t, b.Init(cl))
+
+	ctx := context.Background()
+	require.NoError(t, b.SyncPodGang(ctx, podGang))
+
+	podGroup := &kaischedulingv2alpha2.PodGroup{}
+	require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(podGang), podGroup))
+	require.Len(t, podGroup.Spec.SubGroups, 1)
+	assert.Equal(t, "worker", podGroup.Spec.SubGroups[0].Name)
+	assert.Nil(t, podGroup.Spec.SubGroups[0].Parent)
+}
+
 func TestBackend_SyncPodGangSetsOwnerReferenceAndSkipAnnotation(t *testing.T) {
 	pcs := newPodCliqueSet(
 		"owned-pcs",
@@ -399,6 +437,45 @@ func TestBackend_SyncPodGang_QueueResolutionFailuresDoNotCreatePodGroup(t *testi
 			assert.True(t, apierrors.IsNotFound(err), "PodGroup must not be created when queue resolution fails")
 		})
 	}
+}
+
+func TestPodGroupsEqual_AllowsTargetOnlyMetadata(t *testing.T) {
+	desired := &kaischedulingv2alpha2.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      map[string]string{"source-label": "desired"},
+			Annotations: map[string]string{"source-annotation": "desired"},
+		},
+	}
+	existing := desired.DeepCopy()
+	existing.Labels[labelKeyNodePoolName] = "runtime-node-pool"
+	existing.Annotations["kai.scheduler/runtime"] = "preserve"
+
+	assert.True(t, podGroupsEqual(existing, desired))
+
+	existing.Labels["source-label"] = "stale"
+	assert.False(t, podGroupsEqual(existing, desired))
+}
+
+func TestUpdatePodGroup_CopiesDesiredMetadataAndPreservesTargetOnlyMetadata(t *testing.T) {
+	existing := &kaischedulingv2alpha2.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{labelKeyNodePoolName: "runtime-node-pool"},
+		},
+	}
+	desired := &kaischedulingv2alpha2.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      map[string]string{"source-label": "desired"},
+			Annotations: map[string]string{"source-annotation": "desired"},
+		},
+	}
+
+	updatePodGroup(existing, desired)
+
+	assert.Equal(t, map[string]string{
+		labelKeyNodePoolName: "runtime-node-pool",
+		"source-label":       "desired",
+	}, existing.Labels)
+	assert.Equal(t, map[string]string{"source-annotation": "desired"}, existing.Annotations)
 }
 
 func newPodCliqueSet(name, queue string, cliques ...*grovecorev1alpha1.PodCliqueTemplateSpec) *grovecorev1alpha1.PodCliqueSet {

--- a/operator/internal/scheduler/kai/backend_test.go
+++ b/operator/internal/scheduler/kai/backend_test.go
@@ -20,12 +20,16 @@ import (
 
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	kaischedulingv2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -75,10 +79,17 @@ func TestBackend_PreparePod_PreservesExistingSkipAnnotation(t *testing.T) {
 }
 
 func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
+	pcs := newPodCliqueSet(
+		"test-pcs",
+		"team-a",
+		podCliqueTemplateWithQueue("encoder-template", "team-b"),
+		podCliqueTemplateWithQueue("decoder-template", "team-c"),
+	)
 	podGang := testutils.NewPodGangBuilder("test-podgang", "default").
 		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
 		Build()
-	podGang.Labels["kai.scheduler/queue"] = "team-a"
+	setPodCliqueSetControllerOwner(podGang, pcs)
+	podGang.Labels[labelKeyQueueName] = "legacy-queue"
 	podGang.Annotations = map[string]string{"grove.io/topology-name": "cluster-topology"}
 	podGang.Spec.PriorityClassName = "high-priority"
 	podGang.Spec.TopologyConstraint = &groveschedulerv1alpha1.TopologyConstraint{
@@ -114,7 +125,7 @@ func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
 	}
 
 	cl := testutils.NewTestClientBuilder().
-		WithObjects(podGang).
+		WithObjects(pcs, podGang).
 		Build()
 	recorder := record.NewFakeRecorder(10)
 	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}
@@ -150,9 +161,8 @@ func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
 	require.NotNil(t, gotPodGroup.Spec.SubGroups[2].MinMember)
 	assert.Equal(t, int32(3), *gotPodGroup.Spec.SubGroups[2].MinMember)
 
-	// Update PodGang: remove queue label and change min replicas.
+	// Update PodGang: change min replicas. Queue remains sourced from the owning PCS.
 	updatedPodGang := podGang.DeepCopy()
-	delete(updatedPodGang.Labels, "kai.scheduler/queue")
 	updatedPodGang.Spec.PodGroups[0].MinReplicas = 4
 	require.NoError(t, cl.Update(ctx, updatedPodGang))
 
@@ -160,7 +170,7 @@ func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
 	gotAfterUpdate := &kaischedulingv2alpha2.PodGroup{}
 	require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: podGang.Name, Namespace: podGang.Namespace}, gotAfterUpdate))
 
-	// Existing queue should be preserved even when source label is removed.
+	// The owning PCS label overrides both template and legacy PodGang queues.
 	assert.Equal(t, "team-a", gotAfterUpdate.Spec.Queue)
 	require.NotNil(t, gotAfterUpdate.Spec.MinMember)
 	assert.Equal(t, int32(7), *gotAfterUpdate.Spec.MinMember)
@@ -169,11 +179,17 @@ func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
 }
 
 func TestBackend_SyncPodGangSetsOwnerReferenceAndSkipAnnotation(t *testing.T) {
+	pcs := newPodCliqueSet(
+		"owned-pcs",
+		"team-a",
+		podCliqueTemplateWithQueue("worker-template", "team-b"),
+	)
 	podGang := testutils.NewPodGangBuilder("owned", "default").
 		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
 		Build()
+	setPodCliqueSetControllerOwner(podGang, pcs)
 
-	cl := testutils.NewTestClientBuilder().WithObjects(podGang).Build()
+	cl := testutils.NewTestClientBuilder().WithObjects(pcs, podGang).Build()
 	recorder := record.NewFakeRecorder(10)
 	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}
 	b := New(cl, cl.Scheme(), recorder, profile)
@@ -190,4 +206,127 @@ func TestBackend_SyncPodGangSetsOwnerReferenceAndSkipAnnotation(t *testing.T) {
 	updatedPodGang := &groveschedulerv1alpha1.PodGang{}
 	require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(podGang), updatedPodGang))
 	assert.Equal(t, annotationValSkipPGR, updatedPodGang.Annotations[annotationKeySkipPGR])
+}
+
+func TestBackend_SyncPodGang_UsesUniquePodCliqueTemplateQueue(t *testing.T) {
+	pcs := newPodCliqueSet(
+		"template-queue-pcs",
+		"",
+		podCliqueTemplateWithQueue("worker-a", "team-a"),
+		podCliqueTemplateWithQueue("worker-b", "team-a"),
+	)
+	podGang := testutils.NewPodGangBuilder("template-queue-podgang", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		Build()
+	setPodCliqueSetControllerOwner(podGang, pcs)
+
+	cl := testutils.NewTestClientBuilder().WithObjects(pcs, podGang).Build()
+	b := New(cl, cl.Scheme(), record.NewFakeRecorder(10), configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai})
+	require.NoError(t, b.Init(cl))
+
+	ctx := context.Background()
+	require.NoError(t, b.SyncPodGang(ctx, podGang))
+
+	podGroup := &kaischedulingv2alpha2.PodGroup{}
+	require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(podGang), podGroup))
+	assert.Equal(t, "team-a", podGroup.Spec.Queue)
+}
+
+func TestBackend_SyncPodGang_QueueResolutionFailuresDoNotCreatePodGroup(t *testing.T) {
+	tests := []struct {
+		name          string
+		pcs           *grovecorev1alpha1.PodCliqueSet
+		omitPCS       bool
+		wantErrSubstr string
+	}{
+		{
+			name:          "missing PodCliqueSet controller owner",
+			wantErrSubstr: "has no controlling PodCliqueSet",
+		},
+		{
+			name: "controlling PodCliqueSet is absent",
+			pcs: newPodCliqueSet(
+				"absent-pcs",
+				"team-a",
+				podCliqueTemplateWithQueue("worker", "team-b"),
+			),
+			omitPCS:       true,
+			wantErrSubstr: "get controlling PodCliqueSet default/absent-pcs",
+		},
+		{
+			name: "missing queue",
+			pcs: newPodCliqueSet(
+				"missing-queue-pcs",
+				"",
+				podCliqueTemplateWithQueue("worker", ""),
+			),
+			wantErrSubstr: "no KAI queue is configured",
+		},
+		{
+			name: "conflicting template queues without PodCliqueSet override",
+			pcs: newPodCliqueSet(
+				"conflicting-queues-pcs",
+				"",
+				podCliqueTemplateWithQueue("worker-a", "team-a"),
+				podCliqueTemplateWithQueue("worker-b", "team-b"),
+			),
+			wantErrSubstr: "conflicting KAI queues",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			podGang := testutils.NewPodGangBuilder("test-podgang", "default").
+				WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+				Build()
+			objects := []client.Object{podGang}
+			if tt.pcs != nil {
+				setPodCliqueSetControllerOwner(podGang, tt.pcs)
+				if !tt.omitPCS {
+					objects = append(objects, tt.pcs)
+				}
+			}
+
+			cl := testutils.NewTestClientBuilder().WithObjects(objects...).Build()
+			b := New(cl, cl.Scheme(), record.NewFakeRecorder(10), configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai})
+			require.NoError(t, b.Init(cl))
+
+			err := b.SyncPodGang(context.Background(), podGang)
+			require.ErrorContains(t, err, tt.wantErrSubstr)
+
+			podGroup := &kaischedulingv2alpha2.PodGroup{}
+			err = cl.Get(context.Background(), client.ObjectKeyFromObject(podGang), podGroup)
+			assert.True(t, apierrors.IsNotFound(err), "PodGroup must not be created when queue resolution fails")
+		})
+	}
+}
+
+func newPodCliqueSet(name, queue string, cliques ...*grovecorev1alpha1.PodCliqueTemplateSpec) *grovecorev1alpha1.PodCliqueSet {
+	builder := testutils.NewPodCliqueSetBuilder(name, "default", types.UID(name+"-uid"))
+	for _, clique := range cliques {
+		builder.WithPodCliqueTemplateSpec(clique)
+	}
+	pcs := builder.Build()
+	if queue != "" {
+		pcs.Labels = map[string]string{labelKeyQueueName: queue}
+	}
+	return pcs
+}
+
+func podCliqueTemplateWithQueue(name, queue string) *grovecorev1alpha1.PodCliqueTemplateSpec {
+	labels := map[string]string{}
+	if queue != "" {
+		labels[labelKeyQueueName] = queue
+	}
+	return testutils.NewPodCliqueTemplateSpecBuilder(name).WithLabels(labels).Build()
+}
+
+func setPodCliqueSetControllerOwner(podGang *groveschedulerv1alpha1.PodGang, pcs *grovecorev1alpha1.PodCliqueSet) {
+	podGang.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: grovecorev1alpha1.SchemeGroupVersion.String(),
+		Kind:       "PodCliqueSet",
+		Name:       pcs.Name,
+		UID:        pcs.UID,
+		Controller: ptr.To(true),
+	}}
 }

--- a/operator/internal/scheduler/kai/backend_test.go
+++ b/operator/internal/scheduler/kai/backend_test.go
@@ -21,7 +21,7 @@ import (
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
-	kaischedulingv2alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+	kaischedulingv2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,10 +40,28 @@ func TestBackend_PreparePod(t *testing.T) {
 	pod := testutils.NewPodBuilder("test-pod", "default").
 		WithSchedulerName("default-scheduler").
 		Build()
+	pod.Annotations = map[string]string{"keep": "me"}
 
 	require.NoError(t, b.PreparePod(pod))
 
 	assert.Equal(t, "kai-scheduler", pod.Spec.SchedulerName)
+	assert.Equal(t, "me", pod.Annotations["keep"])
+	assert.Equal(t, "true", pod.Annotations["kai.scheduler/skip-podgrouper"])
+}
+
+func TestBackend_PreparePod_PreservesExistingSkipAnnotation(t *testing.T) {
+	cl := testutils.CreateDefaultFakeClient(nil)
+	recorder := record.NewFakeRecorder(10)
+	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}
+	b := New(cl, cl.Scheme(), recorder, profile)
+
+	pod := testutils.NewPodBuilder("test-pod", "default").
+		Build()
+	pod.Annotations = map[string]string{"kai.scheduler/skip-podgrouper": "custom"}
+
+	b.PreparePod(pod)
+
+	assert.Equal(t, "custom", pod.Annotations["kai.scheduler/skip-podgrouper"])
 }
 
 func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
@@ -95,10 +113,6 @@ func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, b.SyncPodGang(ctx, podGang))
 
-	syncedPodGang := &groveschedulerv1alpha1.PodGang{}
-	require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(podGang), syncedPodGang))
-	assert.Equal(t, "true", syncedPodGang.Annotations["grove.io/ignore"])
-
 	gotPodGroup := &kaischedulingv2alpha2.PodGroup{}
 	require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: podGang.Name, Namespace: podGang.Namespace}, gotPodGroup))
 
@@ -122,7 +136,7 @@ func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
 	assert.Equal(t, int32(3), gotPodGroup.Spec.SubGroups[2].MinMember)
 
 	// Update PodGang: remove queue label and change min replicas.
-	updatedPodGang := syncedPodGang.DeepCopy()
+	updatedPodGang := podGang.DeepCopy()
 	delete(updatedPodGang.Labels, "kai.scheduler/queue")
 	updatedPodGang.Spec.PodGroups[0].MinReplicas = 4
 	require.NoError(t, cl.Update(ctx, updatedPodGang))

--- a/operator/internal/scheduler/kai/backend_test.go
+++ b/operator/internal/scheduler/kai/backend_test.go
@@ -82,8 +82,8 @@ func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
 	pcs := newPodCliqueSet(
 		"test-pcs",
 		"team-a",
-		podCliqueTemplateWithQueue("encoder-template", "team-b"),
-		podCliqueTemplateWithQueue("decoder-template", "team-c"),
+		podCliqueTemplateWithQueue("encoder-template", "team-a"),
+		podCliqueTemplateWithQueue("decoder-template", "team-a"),
 	)
 	podGang := testutils.NewPodGangBuilder("test-podgang", "default").
 		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
@@ -170,7 +170,7 @@ func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
 	gotAfterUpdate := &kaischedulingv2alpha2.PodGroup{}
 	require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: podGang.Name, Namespace: podGang.Namespace}, gotAfterUpdate))
 
-	// The owning PCS label overrides both template and legacy PodGang queues.
+	// The owning PCS label supplies the queue, consistently with its templates.
 	assert.Equal(t, "team-a", gotAfterUpdate.Spec.Queue)
 	require.NotNil(t, gotAfterUpdate.Spec.MinMember)
 	assert.Equal(t, int32(7), *gotAfterUpdate.Spec.MinMember)
@@ -182,7 +182,7 @@ func TestBackend_SyncPodGangSetsOwnerReferenceAndSkipAnnotation(t *testing.T) {
 	pcs := newPodCliqueSet(
 		"owned-pcs",
 		"team-a",
-		podCliqueTemplateWithQueue("worker-template", "team-b"),
+		podCliqueTemplateWithQueue("worker-template", "team-a"),
 	)
 	podGang := testutils.NewPodGangBuilder("owned", "default").
 		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
@@ -230,6 +230,106 @@ func TestBackend_SyncPodGang_UsesUniquePodCliqueTemplateQueue(t *testing.T) {
 	podGroup := &kaischedulingv2alpha2.PodGroup{}
 	require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(podGang), podGroup))
 	assert.Equal(t, "team-a", podGroup.Spec.Queue)
+}
+
+func TestBackend_ValidatePodCliqueSetQueues(t *testing.T) {
+	tests := []struct {
+		name          string
+		pcs           *grovecorev1alpha1.PodCliqueSet
+		wantErrSubstr string
+	}{
+		{
+			name: "matching PodCliqueSet and template queues",
+			pcs: newPodCliqueSet(
+				"matching-queues-pcs",
+				"team-a",
+				podCliqueTemplateWithQueue("worker", "team-a"),
+			),
+		},
+		{
+			name: "PodCliqueSet queue without template queue",
+			pcs: newPodCliqueSet(
+				"pcs-only-queue-pcs",
+				"team-a",
+				podCliqueTemplateWithQueue("worker", ""),
+			),
+		},
+		{
+			name: "matching template-only queues",
+			pcs: newPodCliqueSet(
+				"template-only-queue-pcs",
+				"",
+				podCliqueTemplateWithQueue("worker-a", "team-a"),
+				podCliqueTemplateWithQueue("worker-b", "team-a"),
+			),
+		},
+		{
+			name: "different PodCliqueSet and template queues",
+			pcs: newPodCliqueSet(
+				"conflicting-pcs-template-queues-pcs",
+				"team-a",
+				podCliqueTemplateWithQueue("worker", "team-b"),
+			),
+			wantErrSubstr: "is \"team-a\" but PodClique template \"worker\" resolves to \"team-b\"",
+		},
+		{
+			name: "conflicting template-only queues",
+			pcs: newPodCliqueSet(
+				"conflicting-template-queues-pcs",
+				"",
+				podCliqueTemplateWithQueue("worker-a", "team-a"),
+				podCliqueTemplateWithQueue("worker-b", "team-b"),
+			),
+			wantErrSubstr: "conflicting KAI queues",
+		},
+		{
+			name: "missing queue",
+			pcs: newPodCliqueSet(
+				"missing-queue-pcs",
+				"",
+				podCliqueTemplateWithQueue("worker", ""),
+			),
+			wantErrSubstr: "no KAI queue is configured",
+		},
+		{
+			name: "labels override annotations",
+			pcs: func() *grovecorev1alpha1.PodCliqueSet {
+				pcs := newPodCliqueSet(
+					"label-precedence-pcs",
+					"team-a",
+					podCliqueTemplateWithQueue("worker", "team-a"),
+				)
+				pcs.Annotations = map[string]string{labelKeyQueueName: "team-b"}
+				pcs.Spec.Template.Cliques[0].Annotations = map[string]string{labelKeyQueueName: "team-b"}
+				return pcs
+			}(),
+		},
+		{
+			name: "annotations are used when labels are absent",
+			pcs: func() *grovecorev1alpha1.PodCliqueSet {
+				pcs := newPodCliqueSet(
+					"annotation-fallback-pcs",
+					"",
+					podCliqueTemplateWithQueue("worker", ""),
+				)
+				pcs.Annotations = map[string]string{labelKeyQueueName: "team-a"}
+				pcs.Spec.Template.Cliques[0].Annotations = map[string]string{labelKeyQueueName: "team-a"}
+				return pcs
+			}(),
+		},
+	}
+
+	b := &schedulerBackend{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := b.ValidatePodCliqueSet(context.Background(), tt.pcs)
+			if tt.wantErrSubstr != "" {
+				require.ErrorContains(t, err, tt.wantErrSubstr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestBackend_SyncPodGang_QueueResolutionFailuresDoNotCreatePodGroup(t *testing.T) {

--- a/operator/internal/utils/maps.go
+++ b/operator/internal/utils/maps.go
@@ -1,0 +1,29 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+// MapContainsAll reports whether target contains every key-value pair from expected.
+// Target-only entries are ignored. A non-nil expected map requires a non-nil target.
+func MapContainsAll[K comparable, V comparable](target, expected map[K]V) bool {
+	if expected != nil && target == nil {
+		return false
+	}
+	for key, expectedValue := range expected {
+		if targetValue, exists := target[key]; !exists || targetValue != expectedValue {
+			return false
+		}
+	}
+	return true
+}

--- a/operator/internal/utils/maps_test.go
+++ b/operator/internal/utils/maps_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import "testing"
+
+func TestMapContainsAll(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   map[string]string
+		expected map[string]string
+		want     bool
+	}{
+		{
+			name: "exact match",
+			target: map[string]string{
+				"key": "value",
+			},
+			expected: map[string]string{
+				"key": "value",
+			},
+			want: true,
+		},
+		{
+			name: "target contains extra entries",
+			target: map[string]string{
+				"key":   "value",
+				"extra": "preserved",
+			},
+			expected: map[string]string{
+				"key": "value",
+			},
+			want: true,
+		},
+		{
+			name: "target is missing an entry",
+			target: map[string]string{
+				"other": "value",
+			},
+			expected: map[string]string{
+				"key": "value",
+			},
+		},
+		{
+			name: "target value differs",
+			target: map[string]string{
+				"key": "stale",
+			},
+			expected: map[string]string{
+				"key": "value",
+			},
+		},
+		{
+			name:     "nil expected map",
+			target:   nil,
+			expected: nil,
+			want:     true,
+		},
+		{
+			name:     "non-nil expected map requires non-nil target",
+			target:   nil,
+			expected: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MapContainsAll(tt.target, tt.expected); got != tt.want {
+				t.Fatalf("MapContainsAll() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Continuation of [Daisy's original KAI scheduler backend implementation (PR #524)](https://github.com/ai-dynamo/grove/pull/524).

Adds the KAI scheduler backend and moves KAI PodGroup lifecycle ownership into it.

The initial strategy deliberately preserves current behavior: each Grove PodGang is synchronized to exactly one KAI PodGroup. Pods are configured to join that PodGroup, and standard owner-reference garbage collection cleans it up.

#### Which issue(s) this PR fixes:

Partly implements #525 

#### Special notes for your reviewer:

This is PR1 of a stacked rollout. It intentionally excludes:

- persisted layout/version markers and upgrade coexistence behavior;
- one-PodGroup-per-PCS-replica aggregation;
- deletion finalizers for aggregate layouts; and
- runtime KAI version enforcement.

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
