### PR TITLE
Pass Grove context to scheduler Pod preparation

### DIFF
--- a/docs/proposals/375-scheduler-backend-framework/README.md
+++ b/docs/proposals/375-scheduler-backend-framework/README.md
@@ -157,6 +157,10 @@ The core of the framework is the `Backend` interface, which defines all operatio
 ```go
 package scheduler
 
+type PreparePodContext struct {
+	PodGang *groveschedulerv1alpha1.PodGang
+}
+
 // SchedulerBackend defines the interface that different scheduler backends must implement.
 //
 // Architecture: Backend validates PodCliqueSet at admission, converts
@@ -192,7 +196,7 @@ type Backend interface {
 	// prior to its creation. This includes setting schedulerName,
 	// annotations, etc.
 	// This is called during Pod creation in the PodClique controller.
-	PreparePod(pod *corev1.Pod)
+	PreparePod(pod *corev1.Pod, preparation PreparePodContext) error
 
 	// ValidatePodCliqueSet provides an ability to the scheduler backends to run additional
 	// validations on the PodCliqueSet resource. For example - if a scheduler does not yet support

--- a/operator/internal/controller/clustertopology/reconciler_test.go
+++ b/operator/internal/controller/clustertopology/reconciler_test.go
@@ -83,7 +83,9 @@ func (f *fakeBackend) SyncPodGang(_ context.Context, _ *groveschedulerv1alpha1.P
 	return nil
 }
 
-func (f *fakeBackend) PreparePod(_ *corev1.Pod) error { return nil }
+func (f *fakeBackend) PreparePod(_ *corev1.Pod, _ scheduler.PreparePodContext) error {
+	return nil
+}
 
 func (f *fakeBackend) ValidatePodCliqueSet(_ context.Context, _ *grovecorev1alpha1.PodCliqueSet) error {
 	return nil

--- a/operator/internal/controller/podclique/components/pod/pod.go
+++ b/operator/internal/controller/podclique/components/pod/pod.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ai-dynamo/grove/operator/internal/utils"
 	k8sutils "github.com/ai-dynamo/grove/operator/internal/utils/kubernetes"
 
+	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
@@ -135,7 +136,7 @@ func (r _resource) Sync(ctx context.Context, logger logr.Logger, pclq *grovecore
 }
 
 // buildResource constructs a Pod resource from PodClique specifications, setting up metadata, labels, scheduling gates, and dependencies
-func (r _resource) buildResource(pcs *grovecorev1alpha1.PodCliqueSet, pclq *grovecorev1alpha1.PodClique, podGangName string, pod *corev1.Pod, podIndex int) error {
+func (r _resource) buildResource(pcs *grovecorev1alpha1.PodCliqueSet, pclq *grovecorev1alpha1.PodClique, podGang *groveschedulerv1alpha1.PodGang, podGangName string, pod *corev1.Pod, podIndex int) error {
 	// Extract PCS replica index from PodClique FQN
 	pcsName := componentutils.GetPodCliqueSetName(pclq.ObjectMeta)
 	pcsReplicaIndex, err := utils.GetPodCliqueSetReplicaIndexFromPodCliqueFQN(pcsName, pclq.Name)
@@ -176,7 +177,10 @@ func (r _resource) buildResource(pcs *grovecorev1alpha1.PodCliqueSet, pclq *grov
 			"failed to prepare pod spec with scheduler backend",
 		)
 	}
-	if err = backend.PreparePod(pod); err != nil {
+	preparation := scheduler.PreparePodContext{
+		PodGang: podGang,
+	}
+	if err = backend.PreparePod(pod, preparation); err != nil {
 		return groveerr.WrapError(
 			err,
 			errCodeBuildPodResource,

--- a/operator/internal/controller/podclique/components/pod/pod_test.go
+++ b/operator/internal/controller/podclique/components/pod/pod_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ai-dynamo/grove/operator/internal/scheduler/lpx"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
+	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -103,7 +104,7 @@ func TestBuildResourceWithLPXBackend(t *testing.T) {
 	resource := &_resource{scheme: scheme, schedRegistry: registry}
 	pod := &corev1.Pod{}
 
-	require.NoError(t, resource.buildResource(pcs, pclq, podGangName, pod, 0))
+	require.NoError(t, resource.buildResource(pcs, pclq, nil, podGangName, pod, 0))
 
 	assert.Equal(t, string(configv1alpha1.SchedulerNameLPX), pod.Spec.SchedulerName)
 	assert.Equal(t, pclq.Name+"-", pod.GenerateName)
@@ -117,6 +118,48 @@ func TestBuildResourceWithLPXBackend(t *testing.T) {
 
 	pod.Annotations["example.com/source"] = "pod"
 	assert.Equal(t, "podclique", pclq.Annotations["example.com/source"])
+}
+
+func TestBuildResourcePassesPreparePodContext(t *testing.T) {
+	const (
+		namespace   = "default"
+		pcsName     = "model"
+		cliqueName  = "worker"
+		podGangName = "model-0"
+		backendName = "capture"
+	)
+
+	uid := types.UID("test-uid")
+	pcs := testutils.NewPodCliqueSetBuilder(pcsName, namespace, uid).
+		WithPodCliqueTemplateSpec(
+			testutils.NewPodCliqueTemplateSpecBuilder(cliqueName).Build(),
+		).
+		Build()
+	pclq := testutils.NewPodCliqueBuilder(pcsName, uid, cliqueName, namespace, 0).Build()
+	pclq.Spec.PodSpec.SchedulerName = backendName
+	podGang := &groveschedulerv1alpha1.PodGang{
+		ObjectMeta: metav1.ObjectMeta{Name: podGangName, Namespace: namespace},
+	}
+
+	var captured scheduler.PreparePodContext
+	backend := testutils.NewFakeSchedulerBackendWithPreparePod(
+		backendName,
+		func(_ *corev1.Pod, preparation scheduler.PreparePodContext) error {
+			captured = preparation
+			return nil
+		},
+	)
+	registry := &testutils.FakeSchedulerRegistry{
+		Backends:       map[string]scheduler.Backend{backendName: backend},
+		DefaultBackend: backendName,
+	}
+	scheme := runtime.NewScheme()
+	require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
+	resource := &_resource{scheme: scheme, schedRegistry: registry}
+
+	require.NoError(t, resource.buildResource(pcs, pclq, podGang, podGangName, &corev1.Pod{}, 0))
+
+	assert.Same(t, podGang, captured.PodGang)
 }
 
 // TestGetSelectorLabelsForPods_PCSGOwnedPodClique tests that getSelectorLabelsForPods

--- a/operator/internal/controller/podclique/components/pod/syncflow.go
+++ b/operator/internal/controller/podclique/components/pod/syncflow.go
@@ -84,6 +84,7 @@ func (r _resource) prepareSyncFlow(ctx context.Context, logger logr.Logger, pclq
 	if err = lo.Ternary(apierrors.IsNotFound(err), nil, err); err != nil {
 		return nil, err
 	}
+	sc.podGang = existingPodGang
 
 	// initialize the Pod names that are updated in the PodGang resource for this PCLQ.
 	sc.podNamesUpdatedInPCLQPodGangs = r.getPodNamesUpdatedInAssociatedPodGang(existingPodGang, pclq.Name)
@@ -442,7 +443,7 @@ func (r _resource) createPods(ctx context.Context, logger logr.Logger, sc *syncC
 		// Get the available Pod host name index. This ensures that we fill the holes in the indices if there are any when creating
 		// new pods.
 		podHostNameIndex := availableIndices[i]
-		createTasks = append(createTasks, r.createPodCreationTask(logger, sc.pcs, sc.pclq, sc.associatedPodGangName, sc.pclqExpectationsStoreKey, i, podHostNameIndex))
+		createTasks = append(createTasks, r.createPodCreationTask(logger, sc.pcs, sc.pclq, sc.podGang, sc.associatedPodGangName, sc.pclqExpectationsStoreKey, i, podHostNameIndex))
 	}
 	runResult := utils.RunConcurrentlyWithSlowStart(ctx, logger, 1, createTasks)
 	if runResult.HasErrors() {
@@ -461,6 +462,7 @@ type syncContext struct {
 	ctx                             context.Context
 	pcs                             *grovecorev1alpha1.PodCliqueSet
 	pclq                            *grovecorev1alpha1.PodClique
+	podGang                         *groveschedulerv1alpha1.PodGang
 	associatedPodGangName           string
 	existingPCLQPods                []*corev1.Pod
 	podNamesUpdatedInPCLQPodGangs   []string

--- a/operator/internal/controller/podclique/components/pod/task.go
+++ b/operator/internal/controller/podclique/components/pod/task.go
@@ -24,6 +24,7 @@ import (
 	groveerr "github.com/ai-dynamo/grove/operator/internal/errors"
 	"github.com/ai-dynamo/grove/operator/internal/utils"
 
+	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -32,14 +33,14 @@ import (
 )
 
 // createPodCreationTask creates a utils.Task which will create a Pod, capture the create-expectation and also emit a success/failed event post creation.
-func (r _resource) createPodCreationTask(logger logr.Logger, pcs *grovecorev1alpha1.PodCliqueSet, pclq *grovecorev1alpha1.PodClique, podGangName, pclqExpectationsKey string, taskIndex, podHostNameIndex int) utils.Task {
+func (r _resource) createPodCreationTask(logger logr.Logger, pcs *grovecorev1alpha1.PodCliqueSet, pclq *grovecorev1alpha1.PodClique, podGang *groveschedulerv1alpha1.PodGang, podGangName, pclqExpectationsKey string, taskIndex, podHostNameIndex int) utils.Task {
 	pclqObjKey := client.ObjectKeyFromObject(pclq)
 	return utils.Task{
 		Name: fmt.Sprintf("CreatePod-%s-%d", pclq.Name, taskIndex),
 		Fn: func(ctx context.Context) error {
 			pod := &corev1.Pod{}
 			// build the Pod resource
-			if err := r.buildResource(pcs, pclq, podGangName, pod, podHostNameIndex); err != nil {
+			if err := r.buildResource(pcs, pclq, podGang, podGangName, pod, podHostNameIndex); err != nil {
 				return groveerr.WrapError(err,
 					errCodeBuildPodResource,
 					component.OperationSync,

--- a/operator/internal/scheduler/kai/backend.go
+++ b/operator/internal/scheduler/kai/backend.go
@@ -121,7 +121,7 @@ func (b *schedulerBackend) SyncPodGang(ctx context.Context, podGang *groveschedu
 
 // PreparePod adds KAI scheduler-specific configuration to the Pod.
 // It sets externally-created PodGroup membership because KAI's podgrouper is skipped.
-func (b *schedulerBackend) PreparePod(pod *corev1.Pod) error {
+func (b *schedulerBackend) PreparePod(pod *corev1.Pod, _ scheduler.PreparePodContext) error {
 	podGangName := pod.Labels[apicommon.LabelPodGang]
 	if podGangName == "" {
 		return fmt.Errorf("KAI scheduler requires pod label %q", apicommon.LabelPodGang)

--- a/operator/internal/scheduler/kai/backend_test.go
+++ b/operator/internal/scheduler/kai/backend_test.go
@@ -21,6 +21,7 @@ import (
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/ai-dynamo/grove/operator/internal/scheduler"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
@@ -50,7 +51,7 @@ func TestBackend_PreparePod(t *testing.T) {
 	}
 	pod.Annotations = map[string]string{"keep": "me"}
 
-	require.NoError(t, b.PreparePod(pod))
+	require.NoError(t, b.PreparePod(pod, scheduler.PreparePodContext{}))
 
 	assert.Equal(t, "kai-scheduler", pod.Spec.SchedulerName)
 	assert.Equal(t, "me", pod.Annotations["keep"])
@@ -73,7 +74,7 @@ func TestBackend_PreparePod_PreservesExistingSkipAnnotation(t *testing.T) {
 	}
 	pod.Annotations = map[string]string{"kai.scheduler/skip-podgrouper": "custom"}
 
-	require.NoError(t, b.PreparePod(pod))
+	require.NoError(t, b.PreparePod(pod, scheduler.PreparePodContext{}))
 
 	assert.Equal(t, "true", pod.Annotations["kai.scheduler/skip-podgrouper"])
 }

--- a/operator/internal/scheduler/kube/backend.go
+++ b/operator/internal/scheduler/kube/backend.go
@@ -71,7 +71,7 @@ func (b *schedulerBackend) SyncPodGang(_ context.Context, _ *groveschedulerv1alp
 }
 
 // PreparePod prepares the Pod by setting the relevant schedulerName field with the chosen scheduler backend.
-func (b *schedulerBackend) PreparePod(pod *corev1.Pod) error {
+func (b *schedulerBackend) PreparePod(pod *corev1.Pod, _ scheduler.PreparePodContext) error {
 	pod.Spec.SchedulerName = b.name
 	return nil
 }

--- a/operator/internal/scheduler/kube/backend_test.go
+++ b/operator/internal/scheduler/kube/backend_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
+	"github.com/ai-dynamo/grove/operator/internal/scheduler"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
 	"github.com/stretchr/testify/assert"
@@ -33,7 +34,7 @@ func TestBackend_PreparePod(t *testing.T) {
 
 	pod := testutils.NewPodBuilder("test-pod", "default").Build()
 
-	require.NoError(t, b.PreparePod(pod))
+	require.NoError(t, b.PreparePod(pod, scheduler.PreparePodContext{}))
 
 	assert.Equal(t, string(configv1alpha1.SchedulerNameKube), pod.Spec.SchedulerName)
 }

--- a/operator/internal/scheduler/lpx/backend.go
+++ b/operator/internal/scheduler/lpx/backend.go
@@ -60,7 +60,7 @@ func (b *schedulerBackend) SyncPodGang(
 	return nil
 }
 
-func (b *schedulerBackend) PreparePod(pod *corev1.Pod) error {
+func (b *schedulerBackend) PreparePod(pod *corev1.Pod, _ scheduler.PreparePodContext) error {
 	pod.Spec.SchedulerName = b.name
 	return nil
 }

--- a/operator/internal/scheduler/lpx/backend_test.go
+++ b/operator/internal/scheduler/lpx/backend_test.go
@@ -20,6 +20,7 @@ import (
 
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/ai-dynamo/grove/operator/internal/scheduler"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
 	"github.com/stretchr/testify/assert"
@@ -40,7 +41,7 @@ func TestBackendPreparePod(t *testing.T) {
 		ResourceClaimName: ptr.To("model-partition-000"),
 	}}
 
-	require.NoError(t, backend.PreparePod(pod))
+	require.NoError(t, backend.PreparePod(pod, scheduler.PreparePodContext{}))
 
 	assert.Equal(t, string(configv1alpha1.SchedulerNameLPX), pod.Spec.SchedulerName)
 	require.Len(t, pod.Spec.SchedulingGates, 1)

--- a/operator/internal/scheduler/types.go
+++ b/operator/internal/scheduler/types.go
@@ -46,10 +46,15 @@ type Backend interface {
 
 	// PreparePod adds scheduler-backend-specific configuration to the given Pod object
 	// prior to its creation (schedulerName, annotations, etc.).
-	PreparePod(pod *corev1.Pod) error
+	PreparePod(pod *corev1.Pod, preparation PreparePodContext) error
 
 	// ValidatePodCliqueSet runs scheduler-specific validations on the PodCliqueSet (e.g. TAS required but not supported).
 	ValidatePodCliqueSet(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet) error
+}
+
+// PreparePodContext contains the PodGang associated with a Pod being prepared.
+type PreparePodContext struct {
+	PodGang *groveschedulerv1alpha1.PodGang
 }
 
 // TopologyAwareBackend is an optional interface that Backend

--- a/operator/internal/scheduler/volcano/backend.go
+++ b/operator/internal/scheduler/volcano/backend.go
@@ -129,7 +129,7 @@ func recordCapabilityEvent(eventRecorder record.EventRecorder, obj runtime.Objec
 	eventRecorder.Eventf(obj, corev1.EventTypeWarning, "VolcanoCapabilityUnavailable", "%v", err)
 }
 
-func (b *schedulerBackend) PreparePod(pod *corev1.Pod) error {
+func (b *schedulerBackend) PreparePod(pod *corev1.Pod, _ scheduler.PreparePodContext) error {
 	pod.Spec.SchedulerName = b.Name()
 	podGangName := pod.Labels[apicommon.LabelPodGang]
 	if podGangName == "" {

--- a/operator/internal/scheduler/volcano/backend_test.go
+++ b/operator/internal/scheduler/volcano/backend_test.go
@@ -21,6 +21,7 @@ import (
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/ai-dynamo/grove/operator/internal/scheduler"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 	schedulertest "github.com/ai-dynamo/grove/operator/test/utils/scheduler"
 
@@ -43,7 +44,7 @@ func TestBackend_PreparePod(t *testing.T) {
 	pod := testutils.NewPodBuilder("test-pod", "default").Build()
 	pod.Labels = map[string]string{apicommon.LabelPodGang: "pg-1"}
 
-	require.NoError(t, b.PreparePod(pod))
+	require.NoError(t, b.PreparePod(pod, scheduler.PreparePodContext{}))
 
 	assert.Equal(t, string(configv1alpha1.SchedulerNameVolcano), pod.Spec.SchedulerName)
 	assert.Equal(t, "pg-1", pod.Annotations[volcanov1beta1.VolcanoGroupNameAnnotationKey])
@@ -58,7 +59,7 @@ func TestBackend_PreparePodFailsWhenPodGangLabelMissing(t *testing.T) {
 
 	pod := testutils.NewPodBuilder("test-pod", "default").Build()
 
-	require.ErrorContains(t, b.PreparePod(pod), "volcano scheduler requires pod label")
+	require.ErrorContains(t, b.PreparePod(pod, scheduler.PreparePodContext{}), "volcano scheduler requires pod label")
 }
 
 func TestBackend_Init(t *testing.T) {

--- a/operator/test/utils/scheduler.go
+++ b/operator/test/utils/scheduler.go
@@ -81,10 +81,18 @@ func (r *FakeSchedulerRegistry) AllTopologyAware() map[string]scheduler.Topology
 }
 
 // FakeSchedulerBackend is a minimal scheduler.Backend implementation for unit tests.
-type FakeSchedulerBackend struct{ name string }
+type FakeSchedulerBackend struct {
+	name         string
+	preparePodFn func(*corev1.Pod, scheduler.PreparePodContext) error
+}
 
 // NewFakeSchedulerBackend creates a new instance of FakeSchedulerBackend.
 func NewFakeSchedulerBackend(name string) scheduler.Backend { return &FakeSchedulerBackend{name: name} }
+
+// NewFakeSchedulerBackendWithPreparePod creates a fake backend with custom Pod preparation behavior.
+func NewFakeSchedulerBackendWithPreparePod(name string, preparePodFn func(*corev1.Pod, scheduler.PreparePodContext) error) scheduler.Backend {
+	return &FakeSchedulerBackend{name: name, preparePodFn: preparePodFn}
+}
 
 // Name returns the backend name.
 func (s *FakeSchedulerBackend) Name() string { return s.name }
@@ -97,8 +105,13 @@ func (s *FakeSchedulerBackend) SyncPodGang(_ context.Context, _ *groveschedulerv
 	return nil
 }
 
-// PreparePod is a no-op for the fake backend.
-func (s *FakeSchedulerBackend) PreparePod(_ *corev1.Pod) error { return nil }
+// PreparePod invokes the configured Pod preparation behavior.
+func (s *FakeSchedulerBackend) PreparePod(pod *corev1.Pod, preparation scheduler.PreparePodContext) error {
+	if s.preparePodFn != nil {
+		return s.preparePodFn(pod, preparation)
+	}
+	return nil
+}
 
 // ValidatePodCliqueSet is a no-op for the fake backend.
 func (s *FakeSchedulerBackend) ValidatePodCliqueSet(_ context.Context, _ *grovecorev1alpha1.PodCliqueSet) error {


### PR DESCRIPTION
## Summary
- add `PreparePodContext` to provide PodCliqueSet, PodClique, and PodGang data to scheduler backends
- pass the PodGang already loaded by the PodClique sync flow without adding another API request
- update backend implementations, test fakes, framework documentation, and controller coverage

Fixes #731

## Test plan
- [x] `go test ./... -count=1` from `operator/`
- [x] focused scheduler, PodClique Pod controller, and ClusterTopology controller tests
- [ ] CI end-to-end tests