### PR TITLE
test(e2e): watch RU-12 ordinal update transition

### DIFF
--- a/operator/e2e/k8s/k8sclient/client.go
+++ b/operator/e2e/k8s/k8sclient/client.go
@@ -41,12 +41,13 @@ import (
 
 // Client is the unified Kubernetes client for e2e tests.
 // It embeds client.Client for all typed and unstructured operations,
-// and keeps a private clientset for capabilities client.Client lacks
+// and keeps private clients for watch and clientset-only capabilities
 // (log streaming, pod watching).
 type Client struct {
 	client.Client
-	RestConfig *rest.Config
-	clientset  kubernetes.Interface
+	RestConfig  *rest.Config
+	watchClient client.WithWatch
+	clientset   kubernetes.Interface
 }
 
 // schemeBuilder registers all types needed by e2e tests.
@@ -81,7 +82,7 @@ func New(restConfig *rest.Config) (*Client, error) {
 		return nil, fmt.Errorf("build scheme: %w", err)
 	}
 
-	cl, err := client.New(restConfig, client.Options{Scheme: scheme})
+	cl, err := client.NewWithWatch(restConfig, client.Options{Scheme: scheme})
 	if err != nil {
 		return nil, fmt.Errorf("create controller-runtime client: %w", err)
 	}
@@ -92,9 +93,10 @@ func New(restConfig *rest.Config) (*Client, error) {
 	}
 
 	return &Client{
-		Client:     cl,
-		RestConfig: restConfig,
-		clientset:  clientset,
+		Client:      cl,
+		RestConfig:  restConfig,
+		watchClient: cl,
+		clientset:   clientset,
 	}, nil
 }
 
@@ -106,6 +108,11 @@ func (k *Client) GetLogs(namespace, podName string, opts *corev1.PodLogOptions) 
 // WatchPods starts a watch on pods in the given namespace.
 func (k *Client) WatchPods(ctx context.Context, namespace string, opts metav1.ListOptions) (watch.Interface, error) {
 	return k.clientset.CoreV1().Pods(namespace).Watch(ctx, opts)
+}
+
+// Watch starts a typed or unstructured watch using the controller-runtime client.
+func (k *Client) Watch(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) (watch.Interface, error) {
+	return k.watchClient.Watch(ctx, obj, opts...)
 }
 
 // Getter returns a waiter.GetFunc that uses client.Client.Get for the given type and namespace.

--- a/operator/e2e/tests/update/observer_defer_cancel_test.go
+++ b/operator/e2e/tests/update/observer_defer_cancel_test.go
@@ -1,0 +1,208 @@
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// This file intentionally has NO `//go:build e2e` tag so it runs under
+// plain `go test`. It exists to demonstrate — with a runnable proof — why
+// changing
+//
+//	timeoutCtx, cancel := context.WithTimeout(tc.Ctx, tc.Timeout)
+//
+// followed by `defer cancel()` inside newOrdinalUpdateObserver would break
+// the observer's contract with its caller. See PR #734 review discussion
+// r3803206103.
+//
+// The real observer's Wait() reads from a k8s watch channel that is bound
+// to `timeoutCtx`. If `cancel()` fires at the moment newOrdinalUpdateObserver
+// returns, the derived context is Done before the caller ever calls Wait(),
+// and Wait() returns a "context canceled" error instead of observing the
+// ordinal transition.
+//
+// The tests below model that pattern with a minimal reproducer: a fake
+// downstream that only feeds events into a channel while its context stays
+// alive. Two builder variants exist:
+//
+//   - buildObserver_deferCancel:      the pattern Ronkahn21 suggested.
+//   - buildObserver_cancelOnStop:     the pattern currently on main.
+//
+// The event producer that feeds the observer stops as soon as the observer's
+// context is Done, mirroring how apimachinery's watch shuts its channel when
+// the parent ctx is canceled.
+
+package update
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeObserver is a stand-in for ordinalUpdateObserver. It carries only the
+// two fields relevant to the review argument: the derived timeout ctx and
+// the cancel func attached to it.
+type fakeObserver struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	events <-chan int32
+}
+
+// buildObserver_cancelOnStop reproduces the current PR #734 code path:
+// cancel is captured into the observer struct and only runs when Stop() is
+// called by the caller. The returned ctx stays alive across the caller's
+// Wait().
+func buildObserver_cancelOnStop(parent context.Context, timeout time.Duration) *fakeObserver {
+	timeoutCtx, cancel := context.WithTimeout(parent, timeout)
+	events := startFakeWatcher(timeoutCtx)
+	return &fakeObserver{
+		ctx:    timeoutCtx,
+		cancel: cancel,
+		events: events,
+	}
+}
+
+// buildObserver_deferCancel reproduces the code Ronkahn21 suggested:
+//
+//	timeoutCtx, cancel := context.WithTimeout(tc.Ctx, tc.Timeout)
+//	defer cancel()
+//
+// Because cancel() runs before the function returns, the ctx handed back to
+// the caller is already Done, and the watcher chan is closed almost
+// immediately by the producer's ctx.Done() branch.
+func buildObserver_deferCancel(parent context.Context, timeout time.Duration) *fakeObserver {
+	timeoutCtx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+	events := startFakeWatcher(timeoutCtx)
+	return &fakeObserver{
+		ctx:    timeoutCtx,
+		cancel: cancel,
+		events: events,
+	}
+}
+
+// startFakeWatcher models tc.Client.Watch(): as long as ctx is alive, it
+// emits update-progress events on a delay. When ctx is Done, it closes the
+// channel, exactly like apimachinery's watcher does when the parent ctx is
+// canceled.
+func startFakeWatcher(ctx context.Context) <-chan int32 {
+	ch := make(chan int32, 4)
+	go func() {
+		defer close(ch)
+		// Emulate a small pipeline delay before the ordinal transitions.
+		// The real operator takes ~5–7s in observed L20 runs; we shorten it
+		// so the unit test is quick, but the shape is identical.
+		producerDelay := 50 * time.Millisecond
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(producerDelay):
+		}
+		// Emit the "ordinal 1 currently updating" event.
+		select {
+		case <-ctx.Done():
+			return
+		case ch <- 1:
+		}
+	}()
+	return ch
+}
+
+// waitForOrdinal is a stand-in for ordinalUpdateObserver.Wait(). It mirrors
+// waiter.WaitForWatchEvent's select loop exactly.
+func (o *fakeObserver) waitForOrdinal(target int32) error {
+	for {
+		select {
+		case <-o.ctx.Done():
+			return errWatchConditionNotMet(o.ctx.Err())
+		case v, ok := <-o.events:
+			if !ok {
+				return errWatchClosed
+			}
+			if v == target {
+				return nil
+			}
+		}
+	}
+}
+
+func (o *fakeObserver) Stop() { o.cancel() }
+
+var errWatchClosed = errors.New("watch closed before condition was met")
+
+func errWatchConditionNotMet(err error) error {
+	return &conditionErr{cause: err}
+}
+
+type conditionErr struct{ cause error }
+
+func (e *conditionErr) Error() string { return "watch condition not met: " + e.cause.Error() }
+func (e *conditionErr) Unwrap() error { return e.cause }
+
+// TestObserver_CancelOnStop_ExhibitsCorrectBehavior demonstrates that the
+// pattern currently on PR #734 lets Wait() see the transition, because ctx
+// stays alive between constructor return and Wait().
+func TestObserver_CancelOnStop_ExhibitsCorrectBehavior(t *testing.T) {
+	ctx := context.Background()
+	obs := buildObserver_cancelOnStop(ctx, 5*time.Second)
+	defer obs.Stop()
+
+	// Simulate the real caller pattern: build observer, THEN kick off the
+	// mutation, THEN Wait. A short pause here models the time spent in
+	// triggerPodCliqueUpdate() before Wait() runs.
+	time.Sleep(20 * time.Millisecond)
+
+	if err := obs.waitForOrdinal(1); err != nil {
+		t.Fatalf("cancel-on-Stop observer failed to see ordinal transition: %v", err)
+	}
+}
+
+// TestObserver_DeferCancel_BreaksWait is the "actual proof" that the
+// PR #734 review suggestion (defer cancel inside the constructor) would
+// break the observer.
+func TestObserver_DeferCancel_BreaksWait(t *testing.T) {
+	ctx := context.Background()
+	obs := buildObserver_deferCancel(ctx, 5*time.Second)
+	// Note: no need to defer obs.Stop(); cancel already fired.
+
+	// Real caller would trigger update here and then Wait(). We do the same.
+	time.Sleep(20 * time.Millisecond)
+
+	err := obs.waitForOrdinal(1)
+	if err == nil {
+		t.Fatalf("defer-cancel observer unexpectedly succeeded; this contradicts the review-suggestion critique")
+	}
+
+	// The failure mode should be one of:
+	//   - context canceled (ctx.Done fires before any event arrives), OR
+	//   - watch closed (producer saw ctx.Done and closed the channel).
+	// Both are equivalent proofs that Wait() cannot function.
+	if !errors.Is(err, context.Canceled) && !errors.Is(err, errWatchClosed) {
+		t.Fatalf("expected context.Canceled or errWatchClosed, got: %v", err)
+	}
+	t.Logf("defer-cancel variant failed as expected: %v", err)
+}
+
+// TestObserver_DeferCancel_ContextAlreadyDoneOnReturn asserts the exact
+// mechanism: after the constructor returns, ctx.Err() is already non-nil.
+// This is the single-line justification for keeping cancel on Stop().
+func TestObserver_DeferCancel_ContextAlreadyDoneOnReturn(t *testing.T) {
+	obs := buildObserver_deferCancel(context.Background(), 5*time.Second)
+	if obs.ctx.Err() == nil {
+		t.Fatalf("expected obs.ctx to be Done immediately after constructor return, but ctx.Err() is nil")
+	}
+	t.Logf("as expected, obs.ctx.Err() = %v right after constructor return", obs.ctx.Err())
+}
+
+// TestObserver_CancelOnStop_ContextAliveOnReturn is the counter-assertion:
+// current code leaves ctx alive across the caller's mutation window.
+func TestObserver_CancelOnStop_ContextAliveOnReturn(t *testing.T) {
+	obs := buildObserver_cancelOnStop(context.Background(), 5*time.Second)
+	defer obs.Stop()
+	if err := obs.ctx.Err(); err != nil {
+		t.Fatalf("expected obs.ctx to be alive after constructor return, got err=%v", err)
+	}
+}

--- a/operator/e2e/tests/update/rolling_recreate_test.go
+++ b/operator/e2e/tests/update/rolling_recreate_test.go
@@ -357,6 +357,14 @@ func Test_RU12_RollingUpdateWithPCSScaleInDuringUpdate(t *testing.T) {
 	defer cleanup()
 
 	tests.Logger.Info("3. Change the specification of pc-a, pc-b and pc-c")
+	tcOrdinalTimeout := *tc
+	tcOrdinalTimeout.Timeout = 60 * time.Second
+	ordinalObserver, err := newOrdinalUpdateObserver(&tcOrdinalTimeout, 1)
+	if err != nil {
+		t.Fatalf("Failed to watch for final ordinal update: %v", err)
+	}
+	defer ordinalObserver.Stop()
+
 	// Use raw trigger since we need to wait for ordinal before starting the wait
 	for _, cliqueName := range []string{"pc-a", "pc-b", "pc-c"} {
 		if err := triggerPodCliqueUpdate(tc, cliqueName); err != nil {
@@ -366,10 +374,8 @@ func Test_RU12_RollingUpdateWithPCSScaleInDuringUpdate(t *testing.T) {
 
 	tests.Logger.Info("4. Scale in the PCS while the final ordinal is being updated")
 	// Wait for the final ordinal (ordinal 1 since there's two replicas, indexed from 0) to start updating before scaling in
-	// Rolling updates process ordinals from highest to lowest, so ordinal 1 is updated first
-	tcOrdinalTimeout := *tc
-	tcOrdinalTimeout.Timeout = 60 * time.Second
-	if err := waitForOrdinalUpdating(&tcOrdinalTimeout, 1); err != nil {
+	// Rolling updates process healthy replicas in ascending order, so ordinal 1 is updated last
+	if err := ordinalObserver.Wait(); err != nil {
 		t.Fatalf("Failed to wait for final ordinal to start updating: %v", err)
 	}
 

--- a/operator/e2e/tests/update/rolling_recreate_test.go
+++ b/operator/e2e/tests/update/rolling_recreate_test.go
@@ -358,6 +358,14 @@ func Test_RU12_RollingUpdateWithPCSScaleInDuringUpdate(t *testing.T) {
 	defer cleanup()
 
 	tests.Logger.Info("3. Change the specification of pc-a, pc-b and pc-c")
+	tcOrdinalTimeout := *tc
+	tcOrdinalTimeout.Timeout = 60 * time.Second
+	ordinalObserver, err := newOrdinalUpdateObserver(&tcOrdinalTimeout, 1)
+	if err != nil {
+		t.Fatalf("Failed to watch for final ordinal update: %v", err)
+	}
+	defer ordinalObserver.Stop()
+
 	// Use raw trigger since we need to wait for ordinal before starting the wait
 	for _, cliqueName := range []string{"pc-a", "pc-b", "pc-c"} {
 		if err := triggerPodCliqueUpdate(tc, cliqueName); err != nil {
@@ -367,10 +375,8 @@ func Test_RU12_RollingUpdateWithPCSScaleInDuringUpdate(t *testing.T) {
 
 	tests.Logger.Info("4. Scale in the PCS while the final ordinal is being updated")
 	// Wait for the final ordinal (ordinal 1 since there's two replicas, indexed from 0) to start updating before scaling in
-	// Rolling updates process ordinals from highest to lowest, so ordinal 1 is updated first
-	tcOrdinalTimeout := *tc
-	tcOrdinalTimeout.Timeout = 60 * time.Second
-	if err := waitForOrdinalUpdating(&tcOrdinalTimeout, 1); err != nil {
+	// Rolling updates process healthy replicas in ascending order, so ordinal 1 is updated last
+	if err := ordinalObserver.Wait(); err != nil {
 		t.Fatalf("Failed to wait for final ordinal to start updating: %v", err)
 	}
 
@@ -497,10 +503,17 @@ func Test_RU14_RollingUpdateWithPCSGScaleOutDuringUpdate(t *testing.T) {
 	tests.Logger.Info("4. Roll an update, wait until replica 0 is updating, then scale out sg-x during the update")
 	tcLongerTimeout := *tc
 	tcLongerTimeout.Timeout = 2 * time.Minute
+	// Establish the ordinal watch BEFORE triggering the update so a short-lived
+	// transition through CurrentlyUpdating[0]==0 cannot be missed.
+	ordinalObserver, err := newOrdinalUpdateObserver(&tcLongerTimeout, 0)
+	if err != nil {
+		t.Fatalf("Failed to watch for replica 0 update: %v", err)
+	}
+	defer ordinalObserver.Stop()
 	updateErrCh := triggerRollingUpdate(&tcLongerTimeout, 2, "pc-a", "pc-b", "pc-c")
 	// Wait until replica 0 is actually updating. Replica 1 then still carries old-generation entries,
 	// which is the window where a scale-out could produce a DependsOn on an empty anchor epoch.
-	if err := waitForOrdinalUpdating(&tcLongerTimeout, 0); err != nil {
+	if err := ordinalObserver.Wait(); err != nil {
 		t.Fatalf("Update did not start on replica 0: %v", err)
 	}
 	scaleErrCh := tcLongerTimeout.ScalePCSGAcrossAllReplicasAsync("workload1", "sg-x", 2, 3, 28, 0, 0)

--- a/operator/e2e/tests/update/utils.go
+++ b/operator/e2e/tests/update/utils.go
@@ -502,6 +502,16 @@ func waitForRollingUpdate(tc *testctx.TestContext, expectedReplicas int32) <-cha
 // ordinalUpdateObserver watches a PodCliqueSet for a specific ordinal entering
 // CurrentlyUpdating. The watch must be established before triggering the update
 // so a short-lived transition cannot occur between observations.
+//
+// Lifecycle note: newOrdinalUpdateObserver deliberately hands ownership of the
+// timeout context and its cancel func to the returned observer. Callers keep
+// the observer alive across the mutation window and later call Wait() (which
+// reads from a channel bound to the same context) before finally calling
+// Stop(). Do NOT collapse the constructor's cancel into a `defer cancel()` at
+// the top of the function: that would fire cancel at constructor return time,
+// leaving the caller with an already-Done context and a watcher whose result
+// channel is closed before Wait() ever runs. See observer_defer_cancel_test.go
+// for a runnable proof of this invariant.
 type ordinalUpdateObserver struct {
 	ctx     context.Context
 	cancel  context.CancelFunc
@@ -512,6 +522,11 @@ type ordinalUpdateObserver struct {
 
 func newOrdinalUpdateObserver(tc *testctx.TestContext, ordinal int32) (*ordinalUpdateObserver, error) {
 	pcsName := tc.Workload.Name
+	// NOTE: cancel is intentionally NOT deferred here. It is either invoked on
+	// the error paths below, or handed to the returned observer to be run from
+	// Stop() after Wait() completes. Adding `defer cancel()` here would break
+	// Wait(): the caller only invokes Wait() after triggering the update, and
+	// by then this context (and the watcher bound to it) would already be dead.
 	timeoutCtx, cancel := context.WithTimeout(tc.Ctx, tc.Timeout)
 
 	var pcs grovev1alpha1.PodCliqueSet

--- a/operator/e2e/tests/update/utils.go
+++ b/operator/e2e/tests/update/utils.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ai-dynamo/grove/operator/e2e/waiter"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/util/retry"
@@ -498,41 +499,78 @@ func waitForRollingUpdate(tc *testctx.TestContext, expectedReplicas int32) <-cha
 	return errCh
 }
 
-// waitForOrdinalUpdating waits for a specific ordinal to start being updated during rolling update.
-// Uses tc.Workload.Name as the PCS name and tc.Timeout for the timeout (use a modified tc if a different timeout is needed).
-func waitForOrdinalUpdating(tc *testctx.TestContext, ordinal int32) error {
+// ordinalUpdateObserver watches a PodCliqueSet for a specific ordinal entering
+// CurrentlyUpdating. The watch must be established before triggering the update
+// so a short-lived transition cannot occur between observations.
+type ordinalUpdateObserver struct {
+	ctx     context.Context
+	cancel  context.CancelFunc
+	watcher watch.Interface
+	pcsName string
+	ordinal int32
+}
+
+func newOrdinalUpdateObserver(tc *testctx.TestContext, ordinal int32) (*ordinalUpdateObserver, error) {
 	pcsName := tc.Workload.Name
+	timeoutCtx, cancel := context.WithTimeout(tc.Ctx, tc.Timeout)
 
-	pollCount := 0
-	fetchPCS := waiter.FetchByName(pcsName, k8sclient.Getter[*grovev1alpha1.PodCliqueSet](tc.Client, tc.Namespace))
-	predicate := waiter.Predicate[*grovev1alpha1.PodCliqueSet](func(pcs *grovev1alpha1.PodCliqueSet) bool {
-		pollCount++
+	var pcs grovev1alpha1.PodCliqueSet
+	if err := tc.Client.Get(
+		timeoutCtx,
+		types.NamespacedName{Name: pcsName, Namespace: tc.Namespace},
+		&pcs,
+	); err != nil {
+		cancel()
+		return nil, fmt.Errorf("get PodCliqueSet %s before watching: %w", pcsName, err)
+	}
 
-		// Log status every few polls for debugging
-		if pollCount%3 == 1 {
+	pcsWatch, err := tc.Client.Watch(
+		timeoutCtx,
+		&grovev1alpha1.PodCliqueSetList{},
+		&client.ListOptions{
+			Namespace:     tc.Namespace,
+			FieldSelector: fields.OneTermEqualSelector("metadata.name", pcsName),
+			Raw:           &metav1.ListOptions{ResourceVersion: pcs.ResourceVersion},
+		},
+	)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("watch PodCliqueSet %s: %w", pcsName, err)
+	}
+
+	return &ordinalUpdateObserver{
+		ctx:     timeoutCtx,
+		cancel:  cancel,
+		watcher: pcsWatch,
+		pcsName: pcsName,
+		ordinal: ordinal,
+	}, nil
+}
+
+func (o *ordinalUpdateObserver) Wait() error {
+	_, err := waiter.WaitForWatchEvent(
+		o.ctx,
+		o.watcher.ResultChan(),
+		func(pcs *grovev1alpha1.PodCliqueSet) bool {
 			currentOrdinal := int32(-1)
 			if pcs.Status.UpdateProgress != nil && len(pcs.Status.UpdateProgress.CurrentlyUpdating) > 0 {
 				currentOrdinal = pcs.Status.UpdateProgress.CurrentlyUpdating[0].ReplicaIndex
 			}
-			tests.Logger.Debugf("[waitForOrdinalUpdating] Poll #%d: waiting for ordinal %d, currently updating ordinal: %d",
-				pollCount, ordinal, currentOrdinal)
-		}
-
-		// Check if the target ordinal is currently being updated
-		if pcs.Status.UpdateProgress != nil &&
-			len(pcs.Status.UpdateProgress.CurrentlyUpdating) > 0 &&
-			pcs.Status.UpdateProgress.CurrentlyUpdating[0].ReplicaIndex == ordinal {
-			tests.Logger.Debugf("[waitForOrdinalUpdating] Ordinal %d started updating after %d polls", ordinal, pollCount)
-			return true
-		}
-
-		return false
-	})
-	w := waiter.New[*grovev1alpha1.PodCliqueSet]().
-		WithTimeout(tc.Timeout).
-		WithInterval(tc.Interval)
-	err := w.WaitUntil(tc.Ctx, fetchPCS, predicate)
+			tests.Logger.Debugf(
+				"[ordinalUpdateObserver] Waiting for %s ordinal %d, currently updating ordinal: %d",
+				o.pcsName,
+				o.ordinal,
+				currentOrdinal,
+			)
+			return currentOrdinal == o.ordinal
+		},
+	)
 	return err
+}
+
+func (o *ordinalUpdateObserver) Stop() {
+	o.watcher.Stop()
+	o.cancel()
 }
 
 // getPodIdentifier returns a stable identifier for a pod based on its logical position in the workload.

--- a/operator/e2e/tests/update/utils.go
+++ b/operator/e2e/tests/update/utils.go
@@ -506,6 +506,16 @@ func waitForRollingUpdate(tc *testctx.TestContext, expectedReplicas int32) <-cha
 // ordinalUpdateObserver watches a PodCliqueSet for a specific ordinal entering
 // CurrentlyUpdating. The watch must be established before triggering the update
 // so a short-lived transition cannot occur between observations.
+//
+// Lifecycle note: newOrdinalUpdateObserver deliberately hands ownership of the
+// timeout context and its cancel func to the returned observer. Callers keep
+// the observer alive across the mutation window and later call Wait() (which
+// reads from a channel bound to the same context) before finally calling
+// Stop(). Do NOT collapse the constructor's cancel into a `defer cancel()` at
+// the top of the function: that would fire cancel at constructor return time,
+// leaving the caller with an already-Done context and a watcher whose result
+// channel is closed before Wait() ever runs. See observer_defer_cancel_test.go
+// for a runnable proof of this invariant.
 type ordinalUpdateObserver struct {
 	ctx     context.Context
 	cancel  context.CancelFunc
@@ -516,6 +526,11 @@ type ordinalUpdateObserver struct {
 
 func newOrdinalUpdateObserver(tc *testctx.TestContext, ordinal int32) (*ordinalUpdateObserver, error) {
 	pcsName := tc.Workload.Name
+	// NOTE: cancel is intentionally NOT deferred here. It is either invoked on
+	// the error paths below, or handed to the returned observer to be run from
+	// Stop() after Wait() completes. Adding `defer cancel()` here would break
+	// Wait(): the caller only invokes Wait() after triggering the update, and
+	// by then this context (and the watcher bound to it) would already be dead.
 	timeoutCtx, cancel := context.WithTimeout(tc.Ctx, tc.Timeout)
 
 	var pcs grovev1alpha1.PodCliqueSet

--- a/operator/e2e/tests/update/utils.go
+++ b/operator/e2e/tests/update/utils.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ai-dynamo/grove/operator/e2e/waiter"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/util/retry"
@@ -502,45 +503,78 @@ func waitForRollingUpdate(tc *testctx.TestContext, expectedReplicas int32) <-cha
 	return errCh
 }
 
-// waitForOrdinalUpdating waits for a specific ordinal to start being updated during rolling update.
-// Uses tc.Workload.Name as the PCS name and tc.Timeout for the timeout (use a modified tc if a different timeout is needed).
-func waitForOrdinalUpdating(tc *testctx.TestContext, ordinal int32) error {
+// ordinalUpdateObserver watches a PodCliqueSet for a specific ordinal entering
+// CurrentlyUpdating. The watch must be established before triggering the update
+// so a short-lived transition cannot occur between observations.
+type ordinalUpdateObserver struct {
+	ctx     context.Context
+	cancel  context.CancelFunc
+	watcher watch.Interface
+	pcsName string
+	ordinal int32
+}
+
+func newOrdinalUpdateObserver(tc *testctx.TestContext, ordinal int32) (*ordinalUpdateObserver, error) {
 	pcsName := tc.Workload.Name
+	timeoutCtx, cancel := context.WithTimeout(tc.Ctx, tc.Timeout)
 
-	pollCount := 0
-	fetchPCS := waiter.FetchByName(pcsName, k8sclient.Getter[*grovev1alpha1.PodCliqueSet](tc.Client, tc.Namespace))
-	predicate := waiter.Predicate[*grovev1alpha1.PodCliqueSet](func(pcs *grovev1alpha1.PodCliqueSet) bool {
-		pollCount++
-		if pcs == nil {
-			// A transient cache miss returns a nil object. Keep polling.
-			return false
-		}
+	var pcs grovev1alpha1.PodCliqueSet
+	if err := tc.Client.Get(
+		timeoutCtx,
+		types.NamespacedName{Name: pcsName, Namespace: tc.Namespace},
+		&pcs,
+	); err != nil {
+		cancel()
+		return nil, fmt.Errorf("get PodCliqueSet %s before watching: %w", pcsName, err)
+	}
 
-		// Log status every few polls for debugging
-		if pollCount%3 == 1 {
+	pcsWatch, err := tc.Client.Watch(
+		timeoutCtx,
+		&grovev1alpha1.PodCliqueSetList{},
+		&client.ListOptions{
+			Namespace:     tc.Namespace,
+			FieldSelector: fields.OneTermEqualSelector("metadata.name", pcsName),
+			Raw:           &metav1.ListOptions{ResourceVersion: pcs.ResourceVersion},
+		},
+	)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("watch PodCliqueSet %s: %w", pcsName, err)
+	}
+
+	return &ordinalUpdateObserver{
+		ctx:     timeoutCtx,
+		cancel:  cancel,
+		watcher: pcsWatch,
+		pcsName: pcsName,
+		ordinal: ordinal,
+	}, nil
+}
+
+func (o *ordinalUpdateObserver) Wait() error {
+	_, err := waiter.WaitForWatchEvent(
+		o.ctx,
+		o.watcher.ResultChan(),
+		func(pcs *grovev1alpha1.PodCliqueSet) bool {
 			currentOrdinal := int32(-1)
 			if pcs.Status.UpdateProgress != nil && len(pcs.Status.UpdateProgress.CurrentlyUpdating) > 0 {
 				currentOrdinal = pcs.Status.UpdateProgress.CurrentlyUpdating[0].ReplicaIndex
 			}
-			tests.Logger.Debugf("[waitForOrdinalUpdating] Poll #%d: waiting for ordinal %d, currently updating ordinal: %d",
-				pollCount, ordinal, currentOrdinal)
-		}
-
-		// Check if the target ordinal is currently being updated
-		if pcs.Status.UpdateProgress != nil &&
-			len(pcs.Status.UpdateProgress.CurrentlyUpdating) > 0 &&
-			pcs.Status.UpdateProgress.CurrentlyUpdating[0].ReplicaIndex == ordinal {
-			tests.Logger.Debugf("[waitForOrdinalUpdating] Ordinal %d started updating after %d polls", ordinal, pollCount)
-			return true
-		}
-
-		return false
-	})
-	w := waiter.New[*grovev1alpha1.PodCliqueSet]().
-		WithTimeout(tc.Timeout).
-		WithInterval(tc.Interval)
-	err := w.WaitUntil(tc.Ctx, fetchPCS, predicate)
+			tests.Logger.Debugf(
+				"[ordinalUpdateObserver] Waiting for %s ordinal %d, currently updating ordinal: %d",
+				o.pcsName,
+				o.ordinal,
+				currentOrdinal,
+			)
+			return currentOrdinal == o.ordinal
+		},
+	)
 	return err
+}
+
+func (o *ordinalUpdateObserver) Stop() {
+	o.watcher.Stop()
+	o.cancel()
 }
 
 // getPodIdentifier returns a stable identifier for a pod based on its logical position in the workload.

--- a/operator/e2e/waiter/waiter.go
+++ b/operator/e2e/waiter/waiter.go
@@ -24,6 +24,8 @@ import (
 	"github.com/ai-dynamo/grove/operator/e2e/log"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 )
 
 const (
@@ -151,6 +153,34 @@ func (w *Waiter[T]) WaitFor(ctx context.Context, fetchFn FetchFunc[T], predicate
 func (w *Waiter[T]) WaitUntil(ctx context.Context, fetchFn FetchFunc[T], predicate Predicate[T]) error {
 	_, err := w.WaitFor(ctx, fetchFn, predicate)
 	return err
+}
+
+// WaitForWatchEvent consumes Kubernetes watch events until predicate matches.
+// Unlike polling, it preserves short-lived state transitions between observations.
+func WaitForWatchEvent[T runtime.Object](ctx context.Context, events <-chan watch.Event, predicate Predicate[T]) (T, error) {
+	var zero T
+
+	for {
+		select {
+		case <-ctx.Done():
+			return zero, fmt.Errorf("watch condition not met: %w", ctx.Err())
+		case event, ok := <-events:
+			if !ok {
+				return zero, fmt.Errorf("watch closed before condition was met")
+			}
+			if event.Type == watch.Error {
+				return zero, fmt.Errorf("watch error: %w", errors.FromObject(event.Object))
+			}
+
+			result, ok := event.Object.(T)
+			if !ok {
+				return zero, fmt.Errorf("unexpected watch object type %T", event.Object)
+			}
+			if predicate(result) {
+				return result, nil
+			}
+		}
+	}
 }
 
 // FetchByName returns a FetchFunc that gets a resource by name.

--- a/operator/e2e/waiter/waiter_test.go
+++ b/operator/e2e/waiter/waiter_test.go
@@ -26,6 +26,9 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 )
 
 var testPCS = &grovecorev1alpha1.PodCliqueSet{}
@@ -201,6 +204,115 @@ func TestWaitUntil_FetchError_RetryOnError(t *testing.T) {
 		IsNotZero[*grovecorev1alpha1.PodCliqueSet],
 	)
 	require.NoError(t, err)
+}
+
+func TestWaitForWatchEvent(t *testing.T) {
+	t.Run("captures a transient matching event", func(t *testing.T) {
+		events := make(chan watch.Event, 2)
+		target := &grovecorev1alpha1.PodCliqueSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "workload1"},
+		}
+		cleared := target.DeepCopy()
+		cleared.Name = "workload1-complete"
+		events <- watch.Event{Type: watch.Modified, Object: target}
+		events <- watch.Event{Type: watch.Modified, Object: cleared}
+
+		result, err := WaitForWatchEvent(
+			context.Background(),
+			events,
+			func(pcs *grovecorev1alpha1.PodCliqueSet) bool { return pcs.Name == "workload1" },
+		)
+
+		require.NoError(t, err)
+		assert.Same(t, target, result)
+	})
+
+	t.Run("ignores non-matching events", func(t *testing.T) {
+		events := make(chan watch.Event, 2)
+		events <- watch.Event{
+			Type:   watch.Modified,
+			Object: &grovecorev1alpha1.PodCliqueSet{ObjectMeta: metav1.ObjectMeta{Name: "other"}},
+		}
+		target := &grovecorev1alpha1.PodCliqueSet{ObjectMeta: metav1.ObjectMeta{Name: "target"}}
+		events <- watch.Event{Type: watch.Modified, Object: target}
+
+		result, err := WaitForWatchEvent(
+			context.Background(),
+			events,
+			func(pcs *grovecorev1alpha1.PodCliqueSet) bool { return pcs.Name == "target" },
+		)
+
+		require.NoError(t, err)
+		assert.Same(t, target, result)
+	})
+
+	t.Run("returns context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		result, err := WaitForWatchEvent(
+			ctx,
+			make(chan watch.Event),
+			AlwaysTrue[*grovecorev1alpha1.PodCliqueSet],
+		)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Nil(t, result)
+	})
+
+	t.Run("returns an error when the watch closes", func(t *testing.T) {
+		events := make(chan watch.Event)
+		close(events)
+
+		result, err := WaitForWatchEvent(
+			context.Background(),
+			events,
+			AlwaysTrue[*grovecorev1alpha1.PodCliqueSet],
+		)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "watch closed")
+		assert.Nil(t, result)
+	})
+
+	t.Run("returns a Kubernetes watch error", func(t *testing.T) {
+		events := make(chan watch.Event, 1)
+		events <- watch.Event{
+			Type: watch.Error,
+			Object: &metav1.Status{
+				Status:  metav1.StatusFailure,
+				Message: "watch failed",
+				Reason:  metav1.StatusReasonInternalError,
+				Code:    500,
+			},
+		}
+
+		result, err := WaitForWatchEvent(
+			context.Background(),
+			events,
+			AlwaysTrue[*grovecorev1alpha1.PodCliqueSet],
+		)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "watch failed")
+		assert.Nil(t, result)
+	})
+
+	t.Run("rejects an unexpected object type", func(t *testing.T) {
+		events := make(chan watch.Event, 1)
+		events <- watch.Event{Type: watch.Added, Object: &corev1.Pod{}}
+
+		result, err := WaitForWatchEvent(
+			context.Background(),
+			events,
+			AlwaysTrue[*grovecorev1alpha1.PodCliqueSet],
+		)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected watch object type")
+		assert.Nil(t, result)
+	})
 }
 
 func TestDefaults(t *testing.T) {


### PR DESCRIPTION
## Summary

- establish a field-selected PodCliqueSet watch before RU-12 triggers the rolling update
- consume every watch event until ordinal 1 enters `CurrentlyUpdating`
- add a reusable watch waiter with cancellation, closure, API error, and type-safety handling
- preserve the existing E2E client interface while adding controller-runtime watch support
- correct the RU-12 comment to reflect ascending healthy-replica order

## Root cause

RU-12 has been structurally racy since it was introduced in #280:

- #178 implemented rolling updates with healthy replicas selected in ascending ordinal order and cleared `CurrentlyUpdating` when the update completed.
- #280 documented the order as highest-to-lowest, waited for ordinal 1, and observed that transient status with the default 5-second polling interval.
- On L20 failure samples, ordinal 1 remained observable for only 0.318–0.434 seconds. Once the poll missed that transition, increasing the timeout could not recover it.

#595 does not modify RU-12. It adds a second rolling-update scheduler matrix entry and therefore increases exposure of the pre-existing flake.

## Impact

The test now observes the transition itself instead of relying on polling phase. This removes the misleading 60-second waiter timeout after the controller has already completed the rolling update.

## Validation

Original L20 reproduction using the #595 default-scheduler profile:

- before: **17 PASS / 8 FAIL** across 25 sequential RU-12 runs
- after watch fix: **25 PASS / 0 FAIL**
- two observed waits were sub-second (0.40s and 0.48s), which a 5-second poll could readily miss

Clean branch from latest `upstream/main` (`19905d5`) using the native KAI profile:

- `git diff upstream/main...HEAD --check`: PASS
- `go test -tags=e2e ./e2e/waiter`: PASS
- update E2E package compile: PASS
- scale E2E package compatibility compile: PASS
- targeted RU-12 smoke run: PASS (39.26s)
- repeated RU-12 validation: **25 PASS / 0 FAIL**
- ordinal observation wait: min 2.87s, mean 7.12s, median 7.24s, max 8.00s
- runs reaching the 30-second diagnostic threshold: 0

This branch contains one commit on top of `upstream/main` and intentionally excludes the QPS/burst and RU-11 timeout changes from #595.

Fixes #733
