### PR TITLE
feat: aggregate KAI PodGroups by PodCliqueSet replica

### DIFF
--- a/.github/workflows/build-check-test.yaml
+++ b/.github/workflows/build-check-test.yaml
@@ -137,6 +137,8 @@ jobs:
             test_pattern: "^Test_RS"
           - test_name: upgrade_from_latest_release
             make_target: "run-upgrade-e2e"
+          - test_name: kai_backend_upgrade
+            make_target: "run-kai-backend-upgrade-e2e"
     name: E2E - ${{ matrix.test_name }}
     steps:
       # print runner specs so we have a record in case of failures
@@ -207,6 +209,7 @@ jobs:
           - test_name: crd_installer
           - test_name: resource_sharing
           - test_name: upgrade_from_latest_release
+          - test_name: kai_backend_upgrade
     name: E2E - ${{ matrix.test_name }}
     steps:
       - name: Skip E2E (no relevant changes)

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,12 @@ run-upgrade-e2e:
 	@echo "> Running operator upgrade e2e test"
 	@make --directory=operator run-upgrade-e2e
 
+# Runs the standalone KAI backend migration upgrade test.
+.PHONY: run-kai-backend-upgrade-e2e
+run-kai-backend-upgrade-e2e:
+	@echo "> Running KAI backend upgrade e2e test"
+	@make --directory=operator run-kai-backend-upgrade-e2e
+
 # Runs all tests
 .PHONY: test
 test: test-unit

--- a/docs/proposals/525-KAI-Scheduler-Backend/README.md
+++ b/docs/proposals/525-KAI-Scheduler-Backend/README.md
@@ -19,6 +19,7 @@
   - [PodCliqueSet to PodGroup Mapping](#podcliqueset-to-podgroup-mapping)
     - [KAI Queue Resolution](#kai-queue-resolution)
     - [SubGroup Mapping Rules](#subgroup-mapping-rules)
+    - [Topology Mapping](#topology-mapping)
   - [Pod Preparation](#pod-preparation)
   - [PodGroup Update Semantics](#podgroup-update-semantics)
   - [Reconciliation Flow](#reconciliation-flow)
@@ -26,7 +27,7 @@
   - [RBAC Matrix](#rbac-matrix)
   - [Dynamic RBAC Strategy](#dynamic-rbac-strategy)
   - [Test Plan](#test-plan)
-    - [Phase 1 (Current): Unit Tests](#phase-1-current-unit-tests)
+    - [Phase 1 (Current): Unit and Upgrade E2E Tests](#phase-1-current-unit-and-upgrade-e2e-tests)
     - [Phase 2 (Follow-up): E2E Tests](#phase-2-follow-up-e2e-tests)
   - [Graduation Criteria](#graduation-criteria)
     - [Alpha](#alpha)
@@ -37,7 +38,7 @@
 
 ## Summary
 
-This proposal adds a dedicated KAI scheduler backend to Grove's Scheduler Backend Framework so Grove can natively create, update, and delete KAI PodGroup resources for Grove PodGang workloads. This proposal is intentionally limited to PodGroup creation and management; it does not add new topology-aware scheduling support and does not change existing KAI Topology synchronization behavior from Grove ClusterTopology. The change improves maintainability, clarifies ownership boundaries, and enables predictable KAI-specific lifecycle handling for PodGang workloads by relying on KAI-Scheduler's externally-created PodGroup support.
+This proposal adds a dedicated KAI scheduler backend to Grove's Scheduler Backend Framework. Grove creates one KAI PodGroup per PodCliqueSet replica, represents Base and Scaled PodGangs as subgroups, and relies on KAI-Scheduler's externally-created PodGroup support. Topology constraints follow the PodGang representation defined by [GREP-244](../244-topology-aware-scheduling/README.md).
 
 ## Motivation
 
@@ -47,8 +48,8 @@ GREP-375 introduced a generic Scheduler Backend Framework, but the KAI integrati
 
 - Define the KAI backend behavior under the Scheduler Backend Framework lifecycle.
 - Define `PreparePod` behavior so Pods are scheduled by KAI consistently with Grove's scheduling gate flow and opt out of KAI podgrouper reconciliation when Grove owns the PodGroup.
-- Specify PodGang to KAI PodGroup translation and reconciliation responsibilities.
-- Define deletion-time cleanup behavior for KAI-owned scheduling resources.
+- Specify PodCliqueSet-replica to KAI PodGroup translation, migration, and reconciliation responsibilities.
+- Define ownership-based cleanup behavior for KAI-owned scheduling resources.
 - Document the minimum supported KAI-Scheduler version and required PodGroup capabilities.
 - Clarify required RBAC, scheme registration, and dependency/version expectations for KAI resources.
 - Establish test expectations for pod preparation, PodGroup sync, and delete paths.
@@ -62,19 +63,16 @@ GREP-375 introduced a generic Scheduler Backend Framework, but the KAI integrati
 - Replacing or deprecating non-KAI backends.
 - Defining how scheduler backends are enabled, selected, or resolved from operator configuration and workload templates. This proposal assumes the `kai-scheduler` backend is already enabled by the Scheduler Backend Framework.
 - Requiring PodGang status-only updates to trigger backend reconciliation. The current backend controller reacts to create, delete, and generation-changing updates.
-- Extending or refactoring existing KAI Topology resource management from Grove `ClusterTopology`/`ClusterTopologyBinding`.
-- Defining topology-aware scheduling behavior for KAI. That functionality is out of scope for this proposal and should be covered separately.
+- Extending or refactoring KAI Topology resource management defined by GREP-244.
 
 ## Proposal
 
-Grove will ship a built-in `kai-scheduler` backend that implements the Scheduler Backend Framework lifecycle hooks needed to manage KAI PodGroups. The backend is responsible for converting Grove PodGang intent to KAI PodGroup resources, preparing Pods to use KAI, participating in admission validation, and keeping KAI PodGroups in sync with Grove lifecycle events.
-
-This proposal only covers KAI PodGroup creation and management. It does not propose any KAI Topology creation/update flow, does not add startup-time topology synchronization, and does not define topology-aware scheduling behavior.
+Grove will ship a built-in `kai-scheduler` backend that uses the existing Scheduler Backend Framework hooks. The backend converts all PodGangs belonging to one PodCliqueSet replica into one KAI PodGroup, prepares Pods to use that aggregate, and keeps the representation synchronized from PodGang events. No new backend interface or status condition is introduced.
 
 At a high level, the proposal introduces:
 
 1. **KAI backend ownership model**: Grove backend controller is the single owner of KAI PodGroup reconciliation for PodGang resources that select `kai-scheduler`.
-2. **Deterministic lifecycle behavior**: backend initialization happens during operator startup, `PreparePod` sets the scheduler name and pod-level podgrouper skip annotation during Pod construction, `SyncPodGang` ensures the PodGang-level podgrouper skip annotation and handles create/update reconciliation, and `OnPodGangDelete` handles cleanup.
+2. **Deterministic lifecycle behavior**: `PreparePod` routes new Pods to the aggregate PodGroup, while `SyncPodGang` reconciles the complete PCS-replica representation. Aggregate PodGroups are owned by the PodCliqueSet and cleaned up by Kubernetes garbage collection.
 3. **KAI version dependency**: This backend requires KAI-Scheduler `v0.15.0` or newer, because that version supports both PodGroup subgroups and externally-created PodGroups, including `kai.scheduler/skip-podgrouper`.
 4. **Operator readiness requirements**: KAI PodGroup API types are registered in Grove scheme and RBAC allows backend operations on KAI PodGroups.
 5. **Update safety**: Grove preserves fields that KAI runtime components own so backend reconciliation does not erase scheduler decisions or mutable runtime state.
@@ -106,6 +104,7 @@ Operational behavior:
 
 - During backend `Init()`, Grove checks that the detected KAI version is `v0.15.0` or newer.
 - If KAI is below `v0.15.0`, backend startup returns an unsupported-version error and does not enable KAI PodGroup ownership reconciliation.
+- Operators must disable KAI stale-gang eviction with `--default-staleness-grace-period=-1` before upgrading. Otherwise KAI can evict a transitioning gang while Grove moves Pods between PodGroups.
 - Grove release notes MUST publish and maintain a Grove-to-KAI compatibility matrix whenever the minimum supported KAI version changes.
 
 ## Design Details
@@ -123,9 +122,9 @@ flowchart TD
     I[PodClique controller] --> J[PreparePod sets schedulerName and Pod skip-podgrouper annotation]
     H --> K[PodGang backend controller]
     K --> L[KAI Backend SyncPodGang sets PodGang skip-podgrouper annotation]
-    L --> M[Create or update KAI PodGroup]
-    K --> O[OnPodGangDelete]
-    O --> P[Delete KAI PodGroup]
+    L --> M[Create or update PCS-replica KAI PodGroup]
+    M --> N[Patch existing Pod membership]
+    N --> O[Delete legacy per-PodGang PodGroups]
 ```
 
 ### Backend Lifecycle Contract
@@ -135,9 +134,9 @@ The backend must cover the PodGroup-related backend surface from GREP-375:
 | Lifecycle surface | Trigger | KAI backend responsibility |
 | --- | --- | --- |
 | Backend initialization | Operator startup | Validate KAI-Scheduler version is `v0.15.0` or newer; otherwise fail closed and do not enable backend ownership mode. |
-| Pod preparation | PodClique controller builds a Pod | Set Pod `schedulerName` to `kai-scheduler` and ensure Pod annotation `kai.scheduler/skip-podgrouper` is present. |
-| PodGang sync | PodGang create or generation-changing update | Ensure PodGang annotation `kai.scheduler/skip-podgrouper` is present and reconcile the Grove-owned KAI PodGroup. |
-| PodGang deletion | PodGang delete event | Delete associated KAI PodGroup, ignoring not-found errors. |
+| Pod preparation | PodClique controller builds a Pod | Set `schedulerName`, skip-podgrouper annotation, aggregate `pod-group-name`, and leaf subgroup label. |
+| PodGang sync | PodGang create, generation-changing update, or deletion start | Ensure KAI metadata and reconcile the complete PCS-replica KAI PodGroup. |
+| PodCliqueSet deletion | Kubernetes owner deletion | Garbage-collect the PCS-owned aggregate PodGroups. |
 
 ### Precondition: KAI Backend Enabled
 
@@ -154,32 +153,36 @@ Under that assumption, this proposal only relies on the resolved backend identit
 - Rely on KAI-Scheduler external PodGroup support, ensure prepared Pods and Grove PodGangs have `kai.scheduler/skip-podgrouper` annotation so KAI podgrouper does not create or overwrite PodGroups that Grove owns.
 - Enforce compatibility guardrails during `Init()`: require KAI-Scheduler `v0.15.0` or newer and fail closed when the minimum supported version is not met.
 - Translate Grove Base PodGang and Scaled PodGang semantics to KAI PodGroup subgroup semantics.
-- Reconcile KAI PodGroup state on PodGang create and update.
-- Handle KAI resource cleanup on PodGang delete.
+- Reconcile KAI PodGroup state on PodGang create, update, and deletion start.
+- Migrate existing Pod membership before removing legacy per-PodGang PodGroups.
 
 ### PodCliqueSet to PodGroup Mapping
 
-The KAI backend creates one Grove-owned KAI PodGroup for the PodCliqueSet scheduling unit, then maps Grove PodGang structure into the KAI PodGroup subgroup layer. This follows Grove's existing PodGang construction model:
+The KAI backend creates one Grove-owned KAI PodGroup for each PodCliqueSet replica, then maps that replica's Grove PodGang structure into the KAI PodGroup subgroup layer. This follows Grove's existing PodGang construction model:
 
 - **Base PodGang (BPG)**: the foundational PodGang created for each PodCliqueSet replica. It contains standalone PodCliques and the PodCliqueScalingGroup replicas that are within `[0, minAvailable-1]`.
 - **Scaled PodGang (SPG)**: a PodGang created for a PodCliqueScalingGroup replica above `minAvailable`. These are the scaled-out PCSG replicas that Grove schedules as independent PodGang resources today.
 
 In the KAI representation, BPG and SPG are not separate KAI PodGroups. They are subgroup branches under the same PCS-level KAI PodGroup.
 
+The PodGang controller labels every PodGang with `grove.io/podcliqueset-replica-index`. It also labels each Scaled PodGang with its `grove.io/podcliquescalinggroup`; the Base PodGang omits that label because it can contain multiple scaling groups. The KAI backend uses the replica label to select one replica's PodGangs and validates the scaling-group label on each Scaled PodGang without parsing generated resource names or re-reading the PCS scaling-group configuration. When Scaled PodGangs exist, they are placed under one shared `scaled-podgangs` collection subgroup; the label value does not partition that hierarchy.
+
+Because different PodGangs can reconcile concurrently while targeting the same aggregate PodGroup, the backend serializes the complete aggregate reconciliation by `<namespace>/<aggregate-podgroup-name>`. PodGangs from different PodCliqueSet replicas continue reconciling concurrently.
+
 | Grove source | KAI PodGroup target |
 | --- | --- |
-| PodCliqueSet scheduling unit | One KAI PodGroup name and namespace |
+| PodCliqueSet replica | One KAI PodGroup named `grove-<pcs-name>-<replica>` |
 | PodCliqueSet and PodGang labels/annotations | PodGroup labels and annotations, preserving existing target-only keys |
-| Sum of all mapped subgroup minimum replicas | PodGroup `minMember` |
+| Required Base PodGang branch | PodGroup `minSubGroup: 1` before scale-out and `2` while the zero-minimum Scaled PodGang collection exists, leaving the Base PodGang as the required branch |
 | PodGang priority class | PodGroup priority class |
 | PodCliqueSet `kai.scheduler/queue` metadata, or a shared PodClique-template queue | PodGroup queue on initial creation |
 | Base PodGang | Top-level KAI subgroup, usually named from the BPG name |
-| Scaled PodGang collection for a PCSG | Top-level KAI subgroup that groups scaled PodGang replicas |
+| Scaled PodGangs for the PCS replica | One shared top-level KAI subgroup named `scaled-podgangs` that groups all Scaled PodGang replicas |
 | Individual Scaled PodGang replica | Child KAI subgroup under the SPG collection subgroup |
 | PodGang `spec.podgroups[]` / constituent PodCliques | Leaf KAI subgroups with `name`, `minMember`, and `parent` |
-| PodGang owner reference | Preserved through PodGroup ownership metadata so cleanup follows Grove lifecycle |
+| PodCliqueSet owner reference | Aggregate PodGroup ownership and garbage collection |
 
-This mapping focuses on PodGroup ownership and gang membership. KAI Topology resources and topology-aware scheduling semantics are outside the scope of this proposal.
+Topology constraints use translated PodGang fields; the backend does not retranslate user-facing topology domains.
 
 #### KAI Queue Resolution
 
@@ -198,12 +201,12 @@ SubGroup mapping is always used for KAI backend PodGroup generation.
 The intended subgroup tree is:
 
 ```text
-KAI PodGroup for one PCS scheduling unit
-├── BPG
+KAI PodGroup for one PCS scheduling unit (minSubGroup: 2 after scale-out)
+├── BPG (minSubGroup: number of required direct children)
 │   ├── PodClique / PodGang podgroup leaf
 │   ├── PodClique / PodGang podgroup leaf
 │   └── PodClique / PodGang podgroup leaf
-└── SPG
+└── scaled-podgangs collection (minSubGroup: 0)
     ├── SPG-1
     │   ├── PodClique / PodGang podgroup leaf
     │   ├── PodClique / PodGang podgroup leaf
@@ -219,7 +222,9 @@ This mirrors Grove's current split between base PodGangs and scaled PodGangs whi
 Mapping contract:
 
 - The Base PodGang maps to a top-level KAI subgroup.
-- The Scaled PodGang collection maps to a top-level KAI subgroup when scaled PodGangs exist.
+- One shared Scaled PodGang collection named `scaled-podgangs` maps to the other top-level KAI subgroup whenever Scaled PodGangs exist. It is omitted when empty because KAI v0.15.2 rejects `minSubGroup` on a SubGroup without children.
+- The aggregate PodGroup sets `minSubGroup: 1` while only the Base PodGang exists and `minSubGroup: 2` while the shared Scaled PodGang collection exists. KAI counts the shared `minSubGroup: 0` collection as satisfied without allocated Pods, leaving the Base PodGang as the remaining required branch regardless of subgroup ordering.
+- The shared Scaled PodGang collection sets `minSubGroup: 0`, making all scaled-out PodGang branches elastic while retaining their own branch and leaf minimums.
 - Each individual Scaled PodGang maps to a child subgroup under the SPG collection subgroup by setting the KAI subgroup `parent` to the SPG collection subgroup name.
 - Each constituent Grove PodGang `spec.podgroups[]` entry maps to a leaf KAI subgroup under its BPG or SPG replica subgroup.
 - Subgroup names must be DNS-label compatible, lowercase, and unique within the generated KAI PodGroup.
@@ -231,12 +236,24 @@ Mapping contract:
 Validation behavior:
 
 - Because KAI-Scheduler `v0.15.0` is the minimum supported version, subgroup support is assumed to be available when this backend is enabled.
-- If a pod points to a subgroup name that does not exist in the generated KAI PodGroup spec, backend treats this as configuration error and surfaces an event (do not silently remap).
+- If a pod points to a subgroup name that does not exist in the generated KAI PodGroup spec, backend returns a retryable error and emits a Warning Event on the triggering PodGang.
 - If the backend cannot derive a valid Base PodGang / Scaled PodGang subgroup tree, backend validation fails.
 
 Out of scope for this GREP:
 
 - Defining arbitrary user-authored multi-level subgroup trees beyond the Base PodGang / Scaled PodGang structure represented by Grove PodGang semantics. Future GREP can extend parent/minSubGroup authoring semantics if Grove needs direct user-facing control.
+
+#### Topology Mapping
+
+Topology behavior follows GREP-244:
+
+- Base PodGang `spec.topologyConstraint` maps to the aggregate PodGroup root.
+- Base PodGang `spec.topologyConstraintGroupConfigs` map to per-PCSG-replica subgroups.
+- A Scaled PodGang root constraint maps to that Scaled PodGang branch. Its collection subgroup remains topology-free because each PCSG replica is an independent placement unit.
+- `spec.podgroups[].topologyConstraint` maps to the corresponding PodClique leaf subgroup.
+- Required and preferred levels are copied from PodGang fields after Grove has translated topology domains to node-label keys.
+- `grove.io/topology-name` identifies the ClusterTopologyBinding. The backend uses its `schedulerTopologyBindings` entry for `kai-scheduler`, or the ClusterTopologyBinding name for an auto-managed KAI Topology.
+- Missing or inconsistent bindings are retried and reported through Warning Events on the triggering PodGang. When GREP-244 removes invalid PodGang constraints, the backend removes them from the aggregate without recreating Pods.
 
 ### Pod Preparation
 
@@ -244,6 +261,8 @@ When the KAI backend prepares a Pod, it must:
 
 - Set `pod.spec.schedulerName` to `kai-scheduler`.
 - Ensure `pod.metadata.annotations["kai.scheduler/skip-podgrouper"]` is present when missing.
+- Set `pod.metadata.annotations["pod-group-name"]` to `grove-<pcs-name>-<replica>`.
+- Set `pod.metadata.labels["kai.scheduler/subgroup-name"]` to the normalized PodClique leaf name.
 - Preserve any existing user or controller annotations on the Pod.
 
 The KAI backend must also ensure the routed PodGang itself has `podGang.metadata.annotations["kai.scheduler/skip-podgrouper"]` during `SyncPodGang()`.
@@ -266,17 +285,20 @@ For source-owned labels and annotations, Grove ensures values from the desired P
 1. During startup, backend `Init()` checks that KAI-Scheduler is `v0.15.0` or newer; initialization fails closed when the minimum supported version is not met.
 2. Backend controller receives PodGang event and resolves `kai-scheduler` backend.
 3. KAI backend ensures the PodGang has `kai.scheduler/skip-podgrouper`.
-4. KAI backend computes the desired PCS-level PodGroup representation from PodGang state, including Base PodGang and Scaled PodGang subgroup translation.
-5. Backend creates the KAI PodGroup if none exists.
-6. Backend inherits KAI runtime-managed fields from the existing PodGroup before comparing desired and actual state.
-7. Backend updates only when source-owned fields or desired scheduling intent changed.
-8. On PodGang deletion, backend removes the associated KAI PodGroup and ignores not-found errors.
+4. KAI backend lists sibling PodGangs and computes the desired PCS-replica PodGroup, including GREP-244 topology constraints.
+5. Backend creates or updates the aggregate while preserving KAI runtime-managed fields.
+6. Backend patches existing Pods to the aggregate PodGroup and verifies every Pod references a valid leaf subgroup.
+7. Only after verification, backend deletes legacy per-PodGang PodGroups.
+8. PodGang deletion updates the aggregate tree; PodCliqueSet deletion garbage-collects the aggregate.
+
+This same flow performs automatic upgrades from both legacy one-PodGroup-per-PodGang layouts: Grove-created PodGroups named after the PodGang, and KAI podgrouper-created PodGroups named `pg-<podgang>-<uid>`. Legacy groups are discovered through their PodGang ownership so cleanup remains retryable after Pods have already moved to the aggregate. There is no compatibility switch, migration phase, or migration condition. Failures remain retryable, are logged, and emit Warning Events on the triggering PodGang.
 
 The backend controller only handles PodGang create, delete, and generation-changing update events. Status-only transitions, such as the PodGang `Initialized` condition, do not trigger backend reconciliation. The KAI backend design must therefore rely on spec and metadata changes for PodGroup reconciliation.
 
 ### API and Registration Requirements
 
 - Grove runtime scheme includes KAI PodGroup API types for backend client operations.
+- Existing `PreparePod` and `SyncPodGang` interfaces are sufficient; no scheduler-backend API extension is required.
 - Phase 1 uses static minimal RBAC for enabled `kai-scheduler` support. Dynamic RBAC generation is planned for Phase 2 (Beta).
 - KAI-Scheduler version is `v0.15.0` or newer, which includes subgroup and externally-created PodGroup support.
 - Backend initialization must validate required API availability and the minimum supported KAI version before normal reconciliation.
@@ -315,26 +337,29 @@ Operational implications:
 
 ### Test Plan
 
-#### Phase 1 (Current): Unit Tests
+#### Phase 1 (Current): Unit and Upgrade E2E Tests
 
 - Validate `PreparePod` sets Pod `schedulerName` to `kai-scheduler` and adds Pod annotation `kai.scheduler/skip-podgrouper` when missing without dropping existing annotations.
 - Validate `Init()` compatibility guardrails: KAI versions below `v0.15.0` fail closed.
-- Validate `SyncPodGang` creates and updates KAI PodGroup state, including required field mapping, queue resolution, and runtime-managed field preservation.
+- Validate `SyncPodGang` creates and updates one aggregate KAI PodGroup per PCS replica, including queue resolution and runtime-managed field preservation.
 - Validate PodCliqueSet queue precedence, consistent PodClique-template queue fallback, and mapping failures for missing or conflicting queue configuration.
 - Validate `SyncPodGang` adds PodGang annotation `kai.scheduler/skip-podgrouper` when missing without dropping existing annotations.
-- Validate subgroup translation: Base PodGang and Scaled PodGang structure maps to KAI subgroups with correct `name`, `minSubGroup` / `minMember`, and parent relationships.
+- Validate subgroup and GREP-244 topology translation across PCS, PCSG replica, Scaled PodGang, and PodClique levels.
+- Validate the aggregate root transitions from `minSubGroup: 1` without Scaled PodGangs to `2` with one shared elastic Scaled PodGang collection, and returns to `1` after the last Scaled PodGang is removed.
 - Validate subgroup-name constraints (lowercase/unique/valid label) and explicit error surfacing on invalid subgroup references.
-- Validate `OnPodGangDelete` removes the associated KAI PodGroup and ignores already-deleted resources.
+- Validate existing Pods migrate before legacy PodGroups are deleted, partial failures retry safely, and scale-down removes obsolete branches.
+- Run a pinned upgrade E2E from Grove `v0.1.0-alpha.11`: preserve existing Pod UIDs and node assignments, migrate KAI podgrouper-created PodGroups, and validate the complete PCS-derived aggregate hierarchy and topology.
 
 #### Phase 2 (Follow-up): E2E Tests
 
-Phase 2 adds two deliverables that are explicitly out of scope for Phase 1:
+Phase 2 adds broader backend lifecycle coverage and dynamic RBAC beyond the focused upgrade E2E delivered in Phase 1:
 
 - Dynamic RBAC implementation:
   - synthesize RBAC rules from enabled scheduler backends only,
   - remove rules when a backend is disabled,
   - fail closed when managed RBAC reconciliation fails.
 - E2E coverage in cluster environments for PodGroup create/update/delete, subgroup behavior, and ownership/compatibility guardrails.
+- Gang-scheduling E2E coverage for a required Base PodGang followed by incremental admission of elastic Scaled PodGangs.
 
 Phase 2 test plan includes unit/integration tests for dynamic RBAC and E2E tests for end-to-end scheduler-backend behavior.
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -25,6 +25,8 @@ INSTALL_CRDS_NAME    := "grove-install-crds"
 K3S_IMAGE       ?= rancher/k3s:v1.35.5-k3s1
 E2E_REGISTRY_PORT ?= 5001
 E2E_CREATE_FLAGS  ?=
+E2E_UPGRADE_KAI_ENABLED ?= false
+UPGRADE_E2E_TEST_PATTERN ?= ^TestUpgradeFromLatestGitHubRelease$$
 ifndef DIAG_DIR
 DIAG_DIR := $(if $(GROVE_E2E_DIAG_DIR),$(GROVE_E2E_DIAG_DIR),$(MODULE_ROOT)/e2e-diagnostics)
 endif
@@ -139,11 +141,16 @@ run-upgrade-e2e: export GROVE_E2E_DIAG_DIR = $(DIAG_DIR)
 run-upgrade-e2e: export GROVE_E2E_DIAG_MODE = $(DIAG_MODE)
 run-upgrade-e2e: $(GOTESTSUM)
 	@echo "> Running e2e upgrade tests (verbose)..."
-	@$(MAKE) e2e-cluster-up E2E_CREATE_FLAGS="$(E2E_CREATE_FLAGS) --set grove.enabled=false --set scheduler.kai.enabled=false"
-	$(GOTESTSUM) --format short-verbose -- -count=1 -tags=e2e,e2eupgrade ./e2e/tests/upgrade/ -timeout 45m $(if $(TEST_PATTERN),-run '$(TEST_PATTERN)') || \
+	@$(MAKE) e2e-cluster-up E2E_CREATE_FLAGS="$(E2E_CREATE_FLAGS) --set grove.enabled=false --set scheduler.kai.enabled=$(E2E_UPGRADE_KAI_ENABLED)"
+	$(GOTESTSUM) --format short-verbose -- -count=1 -tags=e2e,e2eupgrade ./e2e/tests/upgrade/ -timeout 45m -run '$(if $(TEST_PATTERN),$(TEST_PATTERN),$(UPGRADE_E2E_TEST_PATTERN))' || \
 		(echo "Tests failed, cleaning up cluster..."; $(MAKE) e2e-cluster-down; exit 1)
 	@echo "> Tests passed, cleaning up cluster..."
 	@$(MAKE) e2e-cluster-down
+
+# Run the KAI backend migration scenario in its own KAI-enabled cluster.
+.PHONY: run-kai-backend-upgrade-e2e
+run-kai-backend-upgrade-e2e:
+	@$(MAKE) run-upgrade-e2e E2E_UPGRADE_KAI_ENABLED=true UPGRADE_E2E_TEST_PATTERN='^TestKAIBackendUpgradeFromAlpha11$$'
 
 # Create a k3d cluster for e2e testing (with Grove and Kai scheduler deployed)
 # This is optional - tests work with any Kubernetes cluster that has the required components

--- a/operator/e2e/grove/podgroup/podgroup.go
+++ b/operator/e2e/grove/podgroup/podgroup.go
@@ -19,6 +19,8 @@ package podgroup
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strconv"
 	"time"
 
 	nameutils "github.com/ai-dynamo/grove/operator/api/common"
@@ -29,10 +31,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const scaledPodGangsSubGroupName = "scaled-podgangs"
+
 // ExpectedSubGroup defines the expected structure of a KAI PodGroup SubGroup for verification.
 type ExpectedSubGroup struct {
 	Name                   string
 	MinMember              int32
+	MinSubGroup            *int32
 	Parent                 *string
 	RequiredTopologyLevel  string
 	PreferredTopologyLevel string
@@ -40,19 +45,21 @@ type ExpectedSubGroup struct {
 
 // PCSGCliqueConfig defines configuration for a single clique in a PCSG.
 type PCSGCliqueConfig struct {
-	Name       string
-	PodCount   int32
-	Constraint string
+	Name                string
+	PodCount            int32
+	Constraint          string
+	PreferredConstraint string
 }
 
 // ScaledPCSGConfig defines configuration for verifying a scaled PCSG replica.
 type ScaledPCSGConfig struct {
-	Name          string
-	PCSGName      string
-	PCSGReplica   int
-	MinAvailable  int
-	CliqueConfigs []PCSGCliqueConfig
-	Constraint    string
+	Name                string
+	PCSGName            string
+	PCSGReplica         int
+	MinAvailable        int
+	CliqueConfigs       []PCSGCliqueConfig
+	Constraint          string
+	PreferredConstraint string
 }
 
 // PodGroupVerifier provides KAI PodGroup verification using a controller-runtime client.
@@ -66,8 +73,9 @@ func NewPodGroupVerifier(cl client.Client, logger *log.Logger) *PodGroupVerifier
 	return &PodGroupVerifier{cl: cl, logger: logger}
 }
 
-// CreateExpectedStandalonePCLQSubGroup creates an ExpectedSubGroup for a standalone PodClique (not in PCSG).
+// CreateExpectedStandalonePCLQSubGroup creates an ExpectedSubGroup for a standalone PodClique under the base PodGang branch.
 func CreateExpectedStandalonePCLQSubGroup(pcsName string, pcsReplica int, cliqueName string, minMember int32, topologyLevel string) ExpectedSubGroup {
+	baseBranch := nameutils.GenerateBasePodGangName(nameutils.ResourceNameReplica{Name: pcsName, Replica: pcsReplica})
 	name := nameutils.GeneratePodCliqueName(
 		nameutils.ResourceNameReplica{Name: pcsName, Replica: pcsReplica},
 		cliqueName,
@@ -75,13 +83,14 @@ func CreateExpectedStandalonePCLQSubGroup(pcsName string, pcsReplica int, clique
 	return ExpectedSubGroup{
 		Name:                  name,
 		MinMember:             minMember,
-		Parent:                nil,
+		Parent:                &baseBranch,
 		RequiredTopologyLevel: topologyLevel,
 	}
 }
 
-// CreateExpectedPCSGParentSubGroup creates an ExpectedSubGroup for a PCSG parent (scaling group replica).
+// CreateExpectedPCSGParentSubGroup creates an ExpectedSubGroup for a PCSG topology group under the base PodGang branch.
 func CreateExpectedPCSGParentSubGroup(pcsName string, pcsReplica int, sgName string, sgReplica int, topologyLevel string) ExpectedSubGroup {
+	baseBranch := nameutils.GenerateBasePodGangName(nameutils.ResourceNameReplica{Name: pcsName, Replica: pcsReplica})
 	pcsgFQN := nameutils.GeneratePodCliqueScalingGroupName(
 		nameutils.ResourceNameReplica{Name: pcsName, Replica: pcsReplica},
 		sgName,
@@ -90,7 +99,7 @@ func CreateExpectedPCSGParentSubGroup(pcsName string, pcsReplica int, sgName str
 	return ExpectedSubGroup{
 		Name:                  name,
 		MinMember:             0,
-		Parent:                nil,
+		Parent:                &baseBranch,
 		RequiredTopologyLevel: topologyLevel,
 	}
 }
@@ -100,9 +109,13 @@ func CreateExpectedPCLQInPCSGSubGroup(pcsName string, pcsReplica int, sgName str
 	return createExpectedPCLQInPCSGSubGroup(pcsName, pcsReplica, sgName, sgReplica, cliqueName, minMember, topologyLevel, true)
 }
 
-// CreateExpectedPCLQInPCSGSubGroupNoParent creates an ExpectedSubGroup for a PodClique within a PCSG without parent.
-func CreateExpectedPCLQInPCSGSubGroupNoParent(pcsName string, pcsReplica int, sgName string, sgReplica int, cliqueName string, minMember int32, topologyLevel string) ExpectedSubGroup {
-	return createExpectedPCLQInPCSGSubGroup(pcsName, pcsReplica, sgName, sgReplica, cliqueName, minMember, topologyLevel, false)
+// CreateExpectedPCLQInPCSGBaseSubGroup creates an ExpectedSubGroup for a PodClique whose PCSG has no topology group.
+// Such cliques are direct children of the base PodGang branch in the aggregate PodGroup.
+func CreateExpectedPCLQInPCSGBaseSubGroup(pcsName string, pcsReplica int, sgName string, sgReplica int, cliqueName string, minMember int32, topologyLevel string) ExpectedSubGroup {
+	subGroup := createExpectedPCLQInPCSGSubGroup(pcsName, pcsReplica, sgName, sgReplica, cliqueName, minMember, topologyLevel, false)
+	baseBranch := nameutils.GenerateBasePodGangName(nameutils.ResourceNameReplica{Name: pcsName, Replica: pcsReplica})
+	subGroup.Parent = &baseBranch
+	return subGroup
 }
 
 func createExpectedPCLQInPCSGSubGroup(pcsName string, pcsReplica int, sgName string, sgReplica int, cliqueName string,
@@ -161,16 +174,35 @@ func (pv *PodGroupVerifier) WaitForKAIPodGroups(ctx context.Context, namespace, 
 	return podGroups, nil
 }
 
-// FilterPodGroupByOwner filters a list of PodGroups to find the one owned by the specified PodGang.
-func FilterPodGroupByOwner(podGroups []kaischedulingv2alpha2.PodGroup, podGangName string) (*kaischedulingv2alpha2.PodGroup, error) {
+// FilterAggregatePodGroupForPCSReplica selects the aggregate PodGroup by its PCS controller and replica label.
+func FilterAggregatePodGroupForPCSReplica(podGroups []kaischedulingv2alpha2.PodGroup, pcsName string, pcsReplica int) (*kaischedulingv2alpha2.PodGroup, error) {
+	replica := strconv.Itoa(pcsReplica)
+	matches := make([]int, 0, 1)
 	for i := range podGroups {
+		if podGroups[i].Labels[nameutils.LabelPodCliqueSetReplicaIndex] != replica {
+			continue
+		}
 		for _, ref := range podGroups[i].OwnerReferences {
-			if ref.Kind == "PodGang" && ref.Name == podGangName {
-				return &podGroups[i], nil
+			if ref.Kind == "PodCliqueSet" && ref.Name == pcsName && ptr.Deref(ref.Controller, false) {
+				matches = append(matches, i)
+				break
 			}
 		}
 	}
-	return nil, fmt.Errorf("no PodGroup found owned by PodGang %s", podGangName)
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no aggregate PodGroup found controlled by PodCliqueSet %s with %s=%s",
+			pcsName, nameutils.LabelPodCliqueSetReplicaIndex, replica)
+	}
+	if len(matches) > 1 {
+		names := make([]string, 0, len(matches))
+		for _, i := range matches {
+			names = append(names, podGroups[i].Name)
+		}
+		sort.Strings(names)
+		return nil, fmt.Errorf("found multiple aggregate PodGroups controlled by PodCliqueSet %s with %s=%s: %v",
+			pcsName, nameutils.LabelPodCliqueSetReplicaIndex, replica, names)
+	}
+	return &podGroups[matches[0]], nil
 }
 
 // VerifyTopologyConstraint verifies the top-level TopologyConstraint of a KAI PodGroup.
@@ -221,10 +253,20 @@ func (pv *PodGroupVerifier) VerifySubGroups(podGroup *kaischedulingv2alpha2.PodG
 			return fmt.Errorf("SubGroup %q Parent: got %q, expected %q", expected.Name, *actual.Parent, *expected.Parent)
 		}
 
-		actualMinMember := ptr.Deref(actual.MinMember, 0)
-		if actualMinMember != expected.MinMember {
-			return fmt.Errorf("SubGroup %q MinMember: got %d, expected %d", expected.Name, actualMinMember, expected.MinMember)
+		if expected.MinMember == 0 && actual.MinMember != nil {
+			return fmt.Errorf("SubGroup %q MinMember: got %d, expected nil", expected.Name, *actual.MinMember)
 		}
+		if expected.MinMember != 0 && (actual.MinMember == nil || *actual.MinMember != expected.MinMember) {
+			return fmt.Errorf("SubGroup %q MinMember: got %v, expected %d", expected.Name, actual.MinMember, expected.MinMember)
+		}
+		if expected.MinSubGroup == nil && actual.MinSubGroup != nil {
+			return fmt.Errorf("SubGroup %q MinSubGroup: got %d, expected nil", expected.Name, *actual.MinSubGroup)
+		}
+		if expected.MinSubGroup != nil && (actual.MinSubGroup == nil || *actual.MinSubGroup != *expected.MinSubGroup) {
+			return fmt.Errorf("SubGroup %q MinSubGroup: got %v, expected %d",
+				expected.Name, actual.MinSubGroup, *expected.MinSubGroup)
+		}
+		actualMinMember := ptr.Deref(actual.MinMember, 0)
 
 		actualRequired := ""
 		actualPreferred := ""
@@ -250,20 +292,18 @@ func (pv *PodGroupVerifier) VerifySubGroups(podGroup *kaischedulingv2alpha2.PodG
 	return nil
 }
 
-// GetPodGroupForBasePodGangReplica retrieves the KAI PodGroup for a PodGangSet replica's base PodGang.
-func (pv *PodGroupVerifier) GetPodGroupForBasePodGangReplica(ctx context.Context, namespace, workloadName string, pgsReplica int, timeout, interval time.Duration) (*kaischedulingv2alpha2.PodGroup, error) {
+// GetAggregatePodGroupForPCSReplica retrieves the PCS-owned aggregate KAI PodGroup for one PCS replica.
+func (pv *PodGroupVerifier) GetAggregatePodGroupForPCSReplica(ctx context.Context, namespace, workloadName string, pcsReplica int, timeout, interval time.Duration) (*kaischedulingv2alpha2.PodGroup, error) {
 	podGroups, err := pv.WaitForKAIPodGroups(ctx, namespace, workloadName, timeout, interval)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get KAI PodGroups: %w", err)
 	}
 
-	basePodGangName := nameutils.GenerateBasePodGangName(nameutils.ResourceNameReplica{Name: workloadName, Replica: pgsReplica})
-	basePodGroup, err := FilterPodGroupByOwner(podGroups, basePodGangName)
+	aggregatePodGroup, err := FilterAggregatePodGroupForPCSReplica(podGroups, workloadName, pcsReplica)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find PodGroup for PodGang %s: %w", basePodGangName, err)
+		return nil, err
 	}
-
-	return basePodGroup, nil
+	return aggregatePodGroup, nil
 }
 
 // VerifyPodGroupTopology verifies both top-level topology constraint and SubGroups structure.
@@ -279,35 +319,135 @@ func (pv *PodGroupVerifier) VerifyPodGroupTopology(podGroup *kaischedulingv2alph
 	return nil
 }
 
-// VerifyScaledPCSGReplicaTopology verifies KAI PodGroup for one scaled PCSG replica.
-func (pv *PodGroupVerifier) VerifyScaledPCSGReplicaTopology(ctx context.Context, namespace, pcsName string, pcsReplica int, pcsgConfig ScaledPCSGConfig, pcsConstraint string) error {
-	podGroups, err := pv.GetKAIPodGroupsForPCS(ctx, namespace, pcsName)
-	if err != nil {
-		return fmt.Errorf("failed to get KAI PodGroups: %w", err)
+// VerifyAggregatePodGroupTopology verifies aggregate identity, root thresholds, topology, and the exact subgroup tree.
+func (pv *PodGroupVerifier) VerifyAggregatePodGroupTopology(
+	podGroup *kaischedulingv2alpha2.PodGroup,
+	pcsName string,
+	pcsReplica int,
+	requiredLevel string,
+	preferredLevel string,
+	baseSubGroups []ExpectedSubGroup,
+	scaledPCSGs []ScaledPCSGConfig,
+) error {
+	if _, err := FilterAggregatePodGroupForPCSReplica([]kaischedulingv2alpha2.PodGroup{*podGroup}, pcsName, pcsReplica); err != nil {
+		return fmt.Errorf("aggregate identity verification failed: %w", err)
 	}
-
-	pcsgFQN := nameutils.GeneratePodCliqueScalingGroupName(
-		nameutils.ResourceNameReplica{Name: pcsName, Replica: pcsReplica},
-		pcsgConfig.PCSGName,
+	if podGroup.Spec.MinMember != nil {
+		return fmt.Errorf("aggregate PodGroup %s MinMember: got %d, expected nil", podGroup.Name, *podGroup.Spec.MinMember)
+	}
+	expectedSubGroups, err := createExpectedAggregateSubGroups(
+		pcsName, pcsReplica, requiredLevel, preferredLevel, baseSubGroups, scaledPCSGs,
 	)
-
-	scaledPodGangName := nameutils.CreatePodGangNameFromPCSGFQN(pcsgFQN, pcsgConfig.PCSGReplica-pcsgConfig.MinAvailable)
-
-	scaledPodGroup, err := FilterPodGroupByOwner(podGroups, scaledPodGangName)
 	if err != nil {
-		return fmt.Errorf("failed to find scaled PodGroup for %s: %w", scaledPodGangName, err)
+		return fmt.Errorf("failed to build expected aggregate hierarchy: %w", err)
+	}
+	expectedRootMinSubGroup := int32(1)
+	if len(scaledPCSGs) > 0 {
+		expectedRootMinSubGroup = 2
+	}
+	if podGroup.Spec.MinSubGroup == nil || *podGroup.Spec.MinSubGroup != expectedRootMinSubGroup {
+		return fmt.Errorf("aggregate PodGroup %s MinSubGroup: got %v, expected %d", podGroup.Name, podGroup.Spec.MinSubGroup, expectedRootMinSubGroup)
+	}
+	return pv.VerifyPodGroupTopology(podGroup, requiredLevel, preferredLevel, expectedSubGroups)
+}
+
+func createExpectedAggregateSubGroups(
+	pcsName string,
+	pcsReplica int,
+	rootRequired string,
+	rootPreferred string,
+	baseSubGroups []ExpectedSubGroup,
+	scaledPCSGs []ScaledPCSGConfig,
+) ([]ExpectedSubGroup, error) {
+	baseBranch := nameutils.GenerateBasePodGangName(nameutils.ResourceNameReplica{Name: pcsName, Replica: pcsReplica})
+	baseSubGroups = append([]ExpectedSubGroup(nil), baseSubGroups...)
+	directBaseChildren := int32(0)
+	childCounts := map[string]int32{}
+	usedNames := map[string]struct{}{baseBranch: {}}
+	for i := range baseSubGroups {
+		if _, found := usedNames[baseSubGroups[i].Name]; found {
+			return nil, fmt.Errorf("duplicate expected SubGroup %q", baseSubGroups[i].Name)
+		}
+		usedNames[baseSubGroups[i].Name] = struct{}{}
+		if baseSubGroups[i].Parent != nil {
+			childCounts[*baseSubGroups[i].Parent]++
+			if *baseSubGroups[i].Parent == baseBranch {
+				directBaseChildren++
+			}
+		}
+	}
+	for i := range baseSubGroups {
+		if count := childCounts[baseSubGroups[i].Name]; count > 0 {
+			baseSubGroups[i].MinSubGroup = ptr.To(count)
+		}
 	}
 
-	var expectedSubGroups []ExpectedSubGroup
-	for _, cliqueConfig := range pcsgConfig.CliqueConfigs {
-		expectedSubGroups = append(expectedSubGroups,
-			CreateExpectedPCLQInPCSGSubGroupNoParent(pcsName, pcsReplica, pcsgConfig.PCSGName, pcsgConfig.PCSGReplica, cliqueConfig.Name, cliqueConfig.PodCount, cliqueConfig.Constraint))
+	expected := []ExpectedSubGroup{{Name: baseBranch, MinSubGroup: ptr.To(directBaseChildren)}}
+	expected = append(expected, baseSubGroups...)
+	if _, found := usedNames[scaledPodGangsSubGroupName]; found {
+		return nil, fmt.Errorf("duplicate expected SubGroup %q", scaledPodGangsSubGroupName)
+	}
+	usedNames[scaledPodGangsSubGroupName] = struct{}{}
+	if len(scaledPCSGs) > 0 {
+		expected = append(expected, ExpectedSubGroup{Name: scaledPodGangsSubGroupName, MinSubGroup: ptr.To[int32](0)})
 	}
 
-	scaledTopConstraint := pcsConstraint
-	if pcsgConfig.Constraint != "" {
-		scaledTopConstraint = pcsgConfig.Constraint
+	sort.Slice(scaledPCSGs, func(i, j int) bool {
+		if scaledPCSGs[i].PCSGName == scaledPCSGs[j].PCSGName {
+			return scaledPCSGs[i].PCSGReplica < scaledPCSGs[j].PCSGReplica
+		}
+		return scaledPCSGs[i].PCSGName < scaledPCSGs[j].PCSGName
+	})
+	for _, config := range scaledPCSGs {
+		if config.PCSGReplica < config.MinAvailable {
+			return nil, fmt.Errorf("scaled PCSG %q replica %d is below minAvailable %d", config.PCSGName, config.PCSGReplica, config.MinAvailable)
+		}
+		pcsgFQN := nameutils.GeneratePodCliqueScalingGroupName(
+			nameutils.ResourceNameReplica{Name: pcsName, Replica: pcsReplica}, config.PCSGName,
+		)
+		podGangName := nameutils.CreatePodGangNameFromPCSGFQN(pcsgFQN, config.PCSGReplica-config.MinAvailable)
+		branchName := expectedStructuralName(podGangName, "gang", usedNames)
+		branchRequired := config.Constraint
+		branchPreferred := config.PreferredConstraint
+		if branchRequired == rootRequired && branchPreferred == rootPreferred {
+			branchRequired = ""
+			branchPreferred = ""
+		}
+		expected = append(expected, ExpectedSubGroup{
+			Name:                   branchName,
+			Parent:                 ptr.To(scaledPodGangsSubGroupName),
+			MinSubGroup:            ptr.To(int32(len(config.CliqueConfigs))),
+			RequiredTopologyLevel:  branchRequired,
+			PreferredTopologyLevel: branchPreferred,
+		})
+		for _, clique := range config.CliqueConfigs {
+			leafName := nameutils.GeneratePodCliqueName(
+				nameutils.ResourceNameReplica{Name: pcsgFQN, Replica: config.PCSGReplica}, clique.Name,
+			)
+			if _, found := usedNames[leafName]; found {
+				return nil, fmt.Errorf("duplicate expected SubGroup %q", leafName)
+			}
+			usedNames[leafName] = struct{}{}
+			expected = append(expected, ExpectedSubGroup{
+				Name:                   leafName,
+				Parent:                 ptr.To(branchName),
+				MinMember:              clique.PodCount,
+				RequiredTopologyLevel:  clique.Constraint,
+				PreferredTopologyLevel: clique.PreferredConstraint,
+			})
+		}
 	}
+	return expected, nil
+}
 
-	return pv.VerifyPodGroupTopology(scaledPodGroup, scaledTopConstraint, "", expectedSubGroups)
+// expectedStructuralName mirrors the producer's collision role suffix while names remain in the
+// short, already-valid form generated by Grove's public name helpers, as all topology E2Es do.
+func expectedStructuralName(name, role string, usedNames map[string]struct{}) string {
+	if _, found := usedNames[name]; !found {
+		usedNames[name] = struct{}{}
+		return name
+	}
+	name += "-" + role
+	usedNames[name] = struct{}{}
+	return name
 }

--- a/operator/e2e/k8s/pods/pods.go
+++ b/operator/e2e/k8s/pods/pods.go
@@ -135,6 +135,14 @@ func (pm *PodManager) WaitForPhases(ctx context.Context, namespace, labelSelecto
 	return err
 }
 
+// WaitForAtLeastPhases waits for at least minimumCount pods to enter one of the supplied phases.
+func (pm *PodManager) WaitForAtLeastPhases(ctx context.Context, namespace, labelSelector string, minimumCount int, phases []v1.PodPhase, timeout, interval time.Duration) error {
+	fetchPods := pm.FetchFunc(ctx, namespace, labelSelector)
+	w := waiter.New[*v1.PodList]().WithTimeout(timeout).WithInterval(interval)
+	_, err := w.WaitFor(ctx, fetchPods, AtLeastCountInPhases(minimumCount, phases...))
+	return err
+}
+
 // WaitForReadyCount waits for a specific number of ready pods.
 func (pm *PodManager) WaitForReadyCount(ctx context.Context, namespace, labelSelector string, expectedReady int, timeout, interval time.Duration) error {
 	fetchPods := pm.FetchFunc(ctx, namespace, labelSelector)

--- a/operator/e2e/k8s/pods/predicates.go
+++ b/operator/e2e/k8s/pods/predicates.go
@@ -65,6 +65,25 @@ func MatchPhases(expectedTotal, expectedRunning, expectedPending int) waiter.Pre
 	}
 }
 
+// AtLeastCountInPhases returns a Predicate that checks that at least minimumCount pods
+// are in one of the supplied phases.
+func AtLeastCountInPhases(minimumCount int, phases ...v1.PodPhase) waiter.Predicate[*v1.PodList] {
+	allowedPhases := make(map[v1.PodPhase]struct{}, len(phases))
+	for _, phase := range phases {
+		allowedPhases[phase] = struct{}{}
+	}
+
+	return func(pods *v1.PodList) bool {
+		matching := 0
+		for i := range pods.Items {
+			if _, allowed := allowedPhases[pods.Items[i].Status.Phase]; allowed {
+				matching++
+			}
+		}
+		return matching >= minimumCount
+	}
+}
+
 // ReadyCount returns a Predicate that checks exactly n pods are ready.
 func ReadyCount(expected int) waiter.Predicate[*v1.PodList] {
 	return func(pods *v1.PodList) bool {

--- a/operator/e2e/k8s/pods/predicates_test.go
+++ b/operator/e2e/k8s/pods/predicates_test.go
@@ -1,0 +1,64 @@
+//go:build e2e
+
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pods
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestAtLeastCountInPhases(t *testing.T) {
+	pods := podListWithPhases(7, 5, 2)
+
+	tests := []struct {
+		name         string
+		minimumCount int
+		phases       []v1.PodPhase
+		want         bool
+	}{
+		{name: "matches exact count", minimumCount: 7, phases: []v1.PodPhase{v1.PodRunning}, want: true},
+		{name: "matches lower count", minimumCount: 6, phases: []v1.PodPhase{v1.PodRunning}, want: true},
+		{name: "combines supplied phases", minimumCount: 9, phases: []v1.PodPhase{v1.PodRunning, v1.PodSucceeded}, want: true},
+		{name: "rejects insufficient matching pods", minimumCount: 10, phases: []v1.PodPhase{v1.PodRunning, v1.PodSucceeded}, want: false},
+		{name: "does not count excluded phases", minimumCount: 6, phases: []v1.PodPhase{v1.PodPending}, want: false},
+		{name: "does not double count duplicate phases", minimumCount: 8, phases: []v1.PodPhase{v1.PodRunning, v1.PodRunning}, want: false},
+		{name: "zero minimum matches", minimumCount: 0, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AtLeastCountInPhases(tt.minimumCount, tt.phases...)(pods); got != tt.want {
+				t.Fatalf("AtLeastCountInPhases(%d, %v) = %t, want %t", tt.minimumCount, tt.phases, got, tt.want)
+			}
+		})
+	}
+}
+
+func podListWithPhases(running, pending, succeeded int) *v1.PodList {
+	pods := &v1.PodList{Items: make([]v1.Pod, 0, running+pending+succeeded)}
+	for range running {
+		pods.Items = append(pods.Items, v1.Pod{Status: v1.PodStatus{Phase: v1.PodRunning}})
+	}
+	for range pending {
+		pods.Items = append(pods.Items, v1.Pod{Status: v1.PodStatus{Phase: v1.PodPending}})
+	}
+	for range succeeded {
+		pods.Items = append(pods.Items, v1.Pod{Status: v1.PodStatus{Phase: v1.PodSucceeded}})
+	}
+	return pods
+}

--- a/operator/e2e/testctx/context.go
+++ b/operator/e2e/testctx/context.go
@@ -221,6 +221,11 @@ func (tc *TestContext) WaitForPodPhases(expectedRunning, expectedPending int) er
 	return tc.newPodManager().WaitForPhases(tc.Ctx, tc.Namespace, tc.GetLabelSelector(), expectedRunning, expectedPending, tc.Timeout, tc.Interval)
 }
 
+// WaitForAtLeastPodPhases waits for at least minimumCount pods to enter one of the supplied phases.
+func (tc *TestContext) WaitForAtLeastPodPhases(minimumCount int, phases ...v1.PodPhase) error {
+	return tc.newPodManager().WaitForAtLeastPhases(tc.Ctx, tc.Namespace, tc.GetLabelSelector(), minimumCount, phases, tc.Timeout, tc.Interval)
+}
+
 // WaitForReadyPods waits for a specific number of pods to be ready.
 func (tc *TestContext) WaitForReadyPods(expectedReady int) error {
 	tc.T.Helper()
@@ -231,6 +236,12 @@ func (tc *TestContext) WaitForReadyPods(expectedReady int) error {
 func (tc *TestContext) WaitForRunningPods(expectedRunning int) error {
 	tc.T.Helper()
 	return tc.newPodManager().WaitForPhases(tc.Ctx, tc.Namespace, tc.GetLabelSelector(), expectedRunning, -1, tc.Timeout, tc.Interval)
+}
+
+// WaitForAtLeastRunningPods waits for at least the specified number of pods to be in Running phase.
+func (tc *TestContext) WaitForAtLeastRunningPods(minimumRunning int) error {
+	tc.T.Helper()
+	return tc.WaitForAtLeastPodPhases(minimumRunning, v1.PodRunning)
 }
 
 // WaitForFailedPod polls until a pod matching the label selector is not Ready and has terminated or restarted.

--- a/operator/e2e/tests/gang_scheduling_test.go
+++ b/operator/e2e/tests/gang_scheduling_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/ai-dynamo/grove/operator/e2e/testctx"
+	v1 "k8s.io/api/core/v1"
 )
 
 // Test_GS1_GangSchedulingWithFullReplicas tests gang-scheduling behavior with insufficient resources
@@ -578,8 +579,8 @@ func Test_GS7_GangSchedulingWithPCSGScalingMinReplicasAdvanced1(t *testing.T) {
 // 5. Verify all 14 newly created pods are pending due to insufficient resources
 // 6. Uncordon 1 node and verify a total of 3 pods get scheduled (pcs-0-{pc-a=1, sg-x-0-pc-b=1, sg-x-0-pc-c=1})
 // 7. Wait for scheduled pods to become ready
-// 8. Uncordon 4 nodes and verify 4 more pods get scheduled (pcs-0-{sg-x-1-pc-b=1, sg-x-1-pc-c=1}, pcs-0-{sg-x-2-pc-b=1, sg-x-2-pc-c=1})
-// 9. Wait for scheduled pods to become ready
+// 8. Uncordon 4 nodes and verify at least 6 pods are no longer Pending
+// 9. Verify at least 6 pods are Running
 // 10. Uncordon 7 nodes and verify the remaining workload pods get scheduled
 func Test_GS8_GangSchedulingWithPCSGScalingMinReplicasAdvanced2(t *testing.T) {
 	ctx := context.Background()
@@ -633,19 +634,24 @@ func Test_GS8_GangSchedulingWithPCSGScalingMinReplicasAdvanced2(t *testing.T) {
 		t.Fatalf("Failed to wait for 3 scheduled pods to become ready: %v", err)
 	}
 
-	Logger.Info("8. Uncordon 4 nodes and verify 4 more pods get scheduled")
+	Logger.Info("8. Uncordon 4 nodes and verify at least 6 pods are no longer Pending")
 	fourNodesToUncordon := nodesToCordon[1:5]
 	tc.UncordonNodes(fourNodesToUncordon)
 
-	// Wait for exactly 4 more pods to be scheduled (sg-x-1 and sg-x-2 min-replicas)
-	// Total is 14, so 14-7 = 7 pending
-	if err := tc.WaitForPodPhases(7, 7); err != nil {
-		t.Fatalf("Failed to wait for exactly 4 more pods to be scheduled: %v", err)
+	const minimumPodsAfterThirdAllocationStage = 6
+	if err := tc.WaitForAtLeastPodPhases(
+		minimumPodsAfterThirdAllocationStage,
+		v1.PodRunning,
+		v1.PodSucceeded,
+		v1.PodFailed,
+		v1.PodUnknown,
+	); err != nil {
+		t.Fatalf("Failed to wait for at least %d non-pending pods: %v", minimumPodsAfterThirdAllocationStage, err)
 	}
 
-	Logger.Info("9. Wait for scheduled pods to become ready")
-	if err := tc.WaitForReadyPods(7); err != nil {
-		t.Fatalf("Failed to wait for 7 scheduled pods to become ready: %v", err)
+	Logger.Info("9. Wait for at least 6 pods to be running")
+	if err := tc.WaitForAtLeastRunningPods(minimumPodsAfterThirdAllocationStage); err != nil {
+		t.Fatalf("Failed to wait for at least %d running pods: %v", minimumPodsAfterThirdAllocationStage, err)
 	}
 
 	Logger.Info("10. Uncordon 7 nodes and verify the remaining workload pods get scheduled")

--- a/operator/e2e/tests/topology_test.go
+++ b/operator/e2e/tests/topology_test.go
@@ -81,9 +81,9 @@ func DeployWorkloadAndGetPods(tc *testctx.TestContext, expectedPods int) ([]v1.P
 	return podList.Items, nil
 }
 
-// GetPodGroupOrFail retrieves a PodGroup for the specified PCS replica or fails the test.
+// GetPodGroupOrFail retrieves the aggregate PodGroup for the specified PCS replica or fails the test.
 func GetPodGroupOrFail(t *testing.T, tc *testctx.TestContext, podGroupVerifier *podgroup.PodGroupVerifier, pcsReplica int) *kaischedulingv2alpha2.PodGroup {
-	podGroup, err := podGroupVerifier.GetPodGroupForBasePodGangReplica(
+	podGroup, err := podGroupVerifier.GetAggregatePodGroupForPCSReplica(
 		tc.Ctx, tc.Namespace, tc.Workload.Name,
 		pcsReplica, tc.Timeout, tc.Interval,
 	)
@@ -208,7 +208,7 @@ func Test_TAS2_MultipleCliquesWithDifferentConstraints(t *testing.T) {
 		podgroup.CreateExpectedStandalonePCLQSubGroup(tc.Workload.Name, 0, "worker-rack", 3, setup.TopologyLabelRack),
 		podgroup.CreateExpectedStandalonePCLQSubGroup(tc.Workload.Name, 0, "worker-block", 4, setup.TopologyLabelBlock),
 	}
-	if err := podGroupVerifier.VerifyPodGroupTopology(podGroup, "", "", expectedSubGroups); err != nil {
+	if err := podGroupVerifier.VerifyAggregatePodGroupTopology(podGroup, tc.Workload.Name, 0, "", "", expectedSubGroups, nil); err != nil {
 		t.Fatalf("Failed to verify KAI PodGroup topology: %v", err)
 	}
 
@@ -266,7 +266,7 @@ func Test_TAS3_PCSOnlyConstraint(t *testing.T) {
 		// Router (standalone)
 		podgroup.CreateExpectedStandalonePCLQSubGroup(tc.Workload.Name, 0, "router", 2, ""),
 	}
-	if err := podGroupVerifier.VerifyPodGroupTopology(podGroup, setup.TopologyLabelRack, "", expectedSubGroups); err != nil {
+	if err := podGroupVerifier.VerifyAggregatePodGroupTopology(podGroup, tc.Workload.Name, 0, setup.TopologyLabelRack, "", expectedSubGroups, nil); err != nil {
 		t.Fatalf("Failed to verify KAI PodGroup topology: %v", err)
 	}
 
@@ -322,7 +322,7 @@ func Test_TAS4_PCSGOnlyConstraint(t *testing.T) {
 		// Router (standalone, no constraint)
 		podgroup.CreateExpectedStandalonePCLQSubGroup(tc.Workload.Name, 0, "router", 2, ""),
 	}
-	if err := podGroupVerifier.VerifyPodGroupTopology(podGroup, "", "", expectedSubGroups); err != nil {
+	if err := podGroupVerifier.VerifyAggregatePodGroupTopology(podGroup, tc.Workload.Name, 0, "", "", expectedSubGroups, nil); err != nil {
 		t.Fatalf("Failed to verify KAI PodGroup topology: %v", err)
 	}
 
@@ -388,7 +388,7 @@ func Test_TAS5_HostLevelConstraint(t *testing.T) {
 	expectedSubGroups := []podgroup.ExpectedSubGroup{
 		podgroup.CreateExpectedStandalonePCLQSubGroup(tc.Workload.Name, 0, "worker", 2, setup.TopologyLabelHostname),
 	}
-	if err := podGroupVerifier.VerifyPodGroupTopology(podGroup, "", "", expectedSubGroups); err != nil {
+	if err := podGroupVerifier.VerifyAggregatePodGroupTopology(podGroup, tc.Workload.Name, 0, "", "", expectedSubGroups, nil); err != nil {
 		t.Fatalf("Failed to verify KAI PodGroup topology: %v", err)
 	}
 
@@ -442,7 +442,7 @@ func Test_TAS6_StandalonePCLQOnlyPCSZoneConstraint(t *testing.T) {
 	expectedSubGroups := []podgroup.ExpectedSubGroup{
 		podgroup.CreateExpectedStandalonePCLQSubGroup(tc.Workload.Name, 0, "worker", 4, ""),
 	}
-	if err := podGroupVerifier.VerifyPodGroupTopology(podGroup, setup.TopologyLabelZone, "", expectedSubGroups); err != nil {
+	if err := podGroupVerifier.VerifyAggregatePodGroupTopology(podGroup, tc.Workload.Name, 0, setup.TopologyLabelZone, "", expectedSubGroups, nil); err != nil {
 		t.Fatalf("Failed to verify KAI PodGroup topology: %v", err)
 	}
 
@@ -491,7 +491,7 @@ func Test_TAS7_NoTopologyConstraint(t *testing.T) {
 		podgroup.CreateExpectedStandalonePCLQSubGroup(tc.Workload.Name, 0, "workers-0-worker", 2, ""),
 		podgroup.CreateExpectedStandalonePCLQSubGroup(tc.Workload.Name, 0, "workers-1-worker", 2, ""),
 	}
-	if err = podGroupVerifier.VerifyPodGroupTopology(podGroup, "", "", expectedSubGroups); err != nil {
+	if err = podGroupVerifier.VerifyAggregatePodGroupTopology(podGroup, tc.Workload.Name, 0, "", "", expectedSubGroups, nil); err != nil {
 		t.Fatalf("Failed to verify KAI PodGroup topology: %v", err)
 	}
 
@@ -570,7 +570,7 @@ func Test_TAS8_FullHierarchyWithCascadingConstraints(t *testing.T) {
 		podgroup.CreateExpectedPCLQInPCSGSubGroup(tc.Workload.Name, 0, "inference-group", 1, "prefill", 2, setup.TopologyLabelHostname),
 		podgroup.CreateExpectedPCLQInPCSGSubGroup(tc.Workload.Name, 0, "inference-group", 1, "decode", 2, setup.TopologyLabelHostname),
 	}
-	if err := podGroupVerifier.VerifyPodGroupTopology(podGroup, setup.TopologyLabelBlock, "", expectedSubGroups); err != nil {
+	if err := podGroupVerifier.VerifyAggregatePodGroupTopology(podGroup, tc.Workload.Name, 0, setup.TopologyLabelBlock, "", expectedSubGroups, nil); err != nil {
 		t.Fatalf("Failed to verify KAI PodGroup topology: %v", err)
 	}
 
@@ -618,7 +618,7 @@ func Test_TAS9_PCSPlusPCLQConstraint(t *testing.T) {
 	expectedSubGroups := []podgroup.ExpectedSubGroup{
 		podgroup.CreateExpectedStandalonePCLQSubGroup(tc.Workload.Name, 0, "worker", 2, setup.TopologyLabelHostname),
 	}
-	if err := podGroupVerifier.VerifyPodGroupTopology(podGroup, setup.TopologyLabelBlock, "", expectedSubGroups); err != nil {
+	if err := podGroupVerifier.VerifyAggregatePodGroupTopology(podGroup, tc.Workload.Name, 0, setup.TopologyLabelBlock, "", expectedSubGroups, nil); err != nil {
 		t.Fatalf("Failed to verify KAI PodGroup topology: %v", err)
 	}
 
@@ -630,8 +630,7 @@ func Test_TAS9_PCSPlusPCLQConstraint(t *testing.T) {
 // 2. 6 pods total (2 per PCSG replica)
 // 3. Verify each PCSG replica's pods in same rack
 // 4. Verify all pods respect PCS-level rack constraint (all in same rack)
-// 5. Verify base PodGang KAI PodGroup topology constraints
-// 6. Verify scaled PodGangs' KAI PodGroups (replicas 1-2)
+// 5. Verify the aggregate KAI PodGroup contains the base and scaled PodGang branches
 func Test_TAS10_PCSGScalingWithTopologyConstraints(t *testing.T) {
 	ctx := context.Background()
 
@@ -670,7 +669,7 @@ func Test_TAS10_PCSGScalingWithTopologyConstraints(t *testing.T) {
 		t.Fatalf("Failed to verify all pods in same block: %v", err)
 	}
 
-	Logger.Info("5. Verify KAI PodGroup has correct SubGroups with topology constraints")
+	Logger.Info("5. Verify aggregate KAI PodGroup has correct base and scaled SubGroups")
 	podGroup := GetPodGroupOrFail(t, tc, podGroupVerifier, 0)
 
 	// Verify top-level TopologyConstraint (PCS level: block)
@@ -681,28 +680,24 @@ func Test_TAS10_PCSGScalingWithTopologyConstraints(t *testing.T) {
 		podgroup.CreateExpectedPCSGParentSubGroup(tc.Workload.Name, 0, "inference-group", 0, setup.TopologyLabelRack),
 		podgroup.CreateExpectedPCLQInPCSGSubGroup(tc.Workload.Name, 0, "inference-group", 0, "worker", 2, ""),
 	}
-	if err := podGroupVerifier.VerifyPodGroupTopology(podGroup, setup.TopologyLabelBlock, "", expectedSubGroups); err != nil {
-		t.Fatalf("Failed to verify KAI PodGroup topology: %v", err)
+	scaledPCSGs := make([]podgroup.ScaledPCSGConfig, 0, 2)
+	for _, pcsgReplica := range []int{1, 2} {
+		scaledPCSGs = append(scaledPCSGs, podgroup.ScaledPCSGConfig{
+			Name:         "inference-group",
+			PCSGName:     "inference-group",
+			PCSGReplica:  pcsgReplica,
+			MinAvailable: 1,
+			CliqueConfigs: []podgroup.PCSGCliqueConfig{
+				{Name: "worker", PodCount: 2},
+			},
+			Constraint: setup.TopologyLabelRack,
+		})
 	}
-
-	Logger.Info("6. Verify scaled PodGangs' KAI PodGroups (replicas 1-2)")
-
-	// Verify PCSG replicas 1-2 (minAvailable=1, totalReplicas=3)
-	lo.ForEach([]int{1, 2}, func(pcsgReplica int, _ int) {
-		if err := podGroupVerifier.VerifyScaledPCSGReplicaTopology(tc.Ctx, tc.Namespace, tc.Workload.Name, 0,
-			podgroup.ScaledPCSGConfig{
-				Name:         "inference-group",
-				PCSGName:     "inference-group",
-				PCSGReplica:  pcsgReplica,
-				MinAvailable: 1,
-				CliqueConfigs: []podgroup.PCSGCliqueConfig{
-					{Name: "worker", PodCount: 2, Constraint: ""},
-				},
-				Constraint: setup.TopologyLabelRack,
-			}, setup.TopologyLabelBlock); err != nil {
-			t.Fatalf("Failed to verify scaled PCSG replica %d topology: %v", pcsgReplica, err)
-		}
-	})
+	if err := podGroupVerifier.VerifyAggregatePodGroupTopology(
+		podGroup, tc.Workload.Name, 0, setup.TopologyLabelBlock, "", expectedSubGroups, scaledPCSGs,
+	); err != nil {
+		t.Fatalf("Failed to verify aggregate KAI PodGroup topology: %v", err)
+	}
 
 	Logger.Info("TAS10: PCSG Scaling with Topology Constraints test completed successfully!")
 }
@@ -757,7 +752,7 @@ func Test_TAS11_PCSGPlusPCLQNoParentConstraint(t *testing.T) {
 		podgroup.CreateExpectedPCLQInPCSGSubGroup(tc.Workload.Name, 0, "workers", 0, "worker", 2, setup.TopologyLabelHostname),
 		podgroup.CreateExpectedPCLQInPCSGSubGroup(tc.Workload.Name, 0, "workers", 1, "worker", 2, setup.TopologyLabelHostname),
 	}
-	if err := podGroupVerifier.VerifyPodGroupTopology(podGroup, "", "", expectedSubGroups); err != nil {
+	if err := podGroupVerifier.VerifyAggregatePodGroupTopology(podGroup, tc.Workload.Name, 0, "", "", expectedSubGroups, nil); err != nil {
 		t.Fatalf("Failed to verify KAI PodGroup topology: %v", err)
 	}
 
@@ -769,8 +764,8 @@ func Test_TAS11_PCSGPlusPCLQNoParentConstraint(t *testing.T) {
 // 2. 20 pods expected (only minAvailable=3 replicas × 2 pods from base PodGang + 7 scaled PodGangs × 2 pods)
 // 3. Verify each PCSG replica's pods on same host
 // 4. Verify all pods in same block (PCS constraint)
-// 5. Verify base PodGang KAI PodGroup contains minAvailable=3 replicas
-// 6. Verify 7 scaled PodGangs' KAI PodGroups (replicas 3-9)
+// 5. Verify the aggregate KAI PodGroup contains the required base branch
+// 6. Verify the same aggregate contains 7 optional scaled PodGang branches (replicas 3-9)
 func Test_TAS12_LargeScalingRatio(t *testing.T) {
 	ctx := context.Background()
 
@@ -811,49 +806,35 @@ func Test_TAS12_LargeScalingRatio(t *testing.T) {
 
 	// Verify top-level TopologyConstraint (PCS level: block)
 	// SubGroups (3 worker PCLQs with host constraint, no PCSG parent since no rack constraint)
-	pcsgFQN := nameutils.GeneratePodCliqueScalingGroupName(
-		nameutils.ResourceNameReplica{Name: tc.Workload.Name, Replica: 0},
-		"workers",
-	)
 	expectedSubGroups := []podgroup.ExpectedSubGroup{
-		podgroup.CreateExpectedPCLQInPCSGSubGroupNoParent(tc.Workload.Name, 0, "workers", 0, "worker", 2, setup.TopologyLabelHostname),
-		podgroup.CreateExpectedPCLQInPCSGSubGroupNoParent(tc.Workload.Name, 0, "workers", 1, "worker", 2, setup.TopologyLabelHostname),
-		podgroup.CreateExpectedPCLQInPCSGSubGroupNoParent(tc.Workload.Name, 0, "workers", 2, "worker", 2, setup.TopologyLabelHostname),
+		podgroup.CreateExpectedPCLQInPCSGBaseSubGroup(tc.Workload.Name, 0, "workers", 0, "worker", 2, setup.TopologyLabelHostname),
+		podgroup.CreateExpectedPCLQInPCSGBaseSubGroup(tc.Workload.Name, 0, "workers", 1, "worker", 2, setup.TopologyLabelHostname),
+		podgroup.CreateExpectedPCLQInPCSGBaseSubGroup(tc.Workload.Name, 0, "workers", 2, "worker", 2, setup.TopologyLabelHostname),
 	}
-	if err := podGroupVerifier.VerifyPodGroupTopology(podGroup, setup.TopologyLabelBlock, "", expectedSubGroups); err != nil {
-		t.Fatalf("Failed to verify KAI PodGroup topology: %v", err)
-	}
-
-	Logger.Info("6. Verify scaled PodGangs' KAI PodGroups (replicas 3-9)")
-	kaiPodGroups, err := podGroupVerifier.GetKAIPodGroupsForPCS(tc.Ctx, tc.Namespace, tc.Workload.Name)
-	if err != nil {
-		t.Fatalf("Failed to get KAI PodGroups: %v", err)
-	}
+	Logger.Info("6. Verify scaled PodGang branches in the aggregate KAI PodGroup (replicas 3-9)")
 
 	// PCSG config: replicas=10, minAvailable=3
-	// Base PodGang contains replicas 0-2, scaled PodGangs contain replicas 3-9 (reuse pcsgFQN from above)
+	// Base PodGang contains replicas 0-2, scaled PodGangs contain replicas 3-9.
 	pcsgMinAvailable := 3
 	pcsgTotalReplicas := 10
 	scaledPodGangCount := pcsgTotalReplicas - pcsgMinAvailable
-
+	scaledPCSGs := make([]podgroup.ScaledPCSGConfig, 0, scaledPodGangCount)
 	for scaledIndex := 0; scaledIndex < scaledPodGangCount; scaledIndex++ {
 		pcsgReplicaIndex := pcsgMinAvailable + scaledIndex
-		scaledPodGangName := nameutils.CreatePodGangNameFromPCSGFQN(pcsgFQN, scaledIndex)
-
-		scaledPodGroup, err := podgroup.FilterPodGroupByOwner(kaiPodGroups, scaledPodGangName)
-		if err != nil {
-			t.Fatalf("Failed to find scaled PodGroup for %s: %v", scaledPodGangName, err)
-		}
-
-		// Each scaled PodGang contains 1 PCSG replica with 1 PCLQ SubGroup (host constraint)
-		expectedSubGroups := []podgroup.ExpectedSubGroup{
-			podgroup.CreateExpectedPCLQInPCSGSubGroupNoParent(tc.Workload.Name, 0, "workers", pcsgReplicaIndex, "worker", 2, setup.TopologyLabelHostname),
-		}
-
-		if err := podGroupVerifier.VerifyPodGroupTopology(scaledPodGroup, setup.TopologyLabelBlock, "", expectedSubGroups); err != nil {
-			t.Fatalf("Failed to verify scaled PodGroup %s (PCSG replica %d) topology: %v",
-				scaledPodGangName, pcsgReplicaIndex, err)
-		}
+		scaledPCSGs = append(scaledPCSGs, podgroup.ScaledPCSGConfig{
+			Name:         "workers",
+			PCSGName:     "workers",
+			PCSGReplica:  pcsgReplicaIndex,
+			MinAvailable: pcsgMinAvailable,
+			CliqueConfigs: []podgroup.PCSGCliqueConfig{
+				{Name: "worker", PodCount: 2, Constraint: setup.TopologyLabelHostname},
+			},
+		})
+	}
+	if err := podGroupVerifier.VerifyAggregatePodGroupTopology(
+		podGroup, tc.Workload.Name, 0, setup.TopologyLabelBlock, "", expectedSubGroups, scaledPCSGs,
+	); err != nil {
+		t.Fatalf("Failed to verify aggregate KAI PodGroup topology: %v", err)
 	}
 
 	Logger.Info("TAS12: Large Scaling Ratio test completed successfully!")
@@ -912,7 +893,7 @@ func Test_TAS13_InsufficientNodesForConstraint(t *testing.T) {
 	expectedSubGroups := []podgroup.ExpectedSubGroup{
 		podgroup.CreateExpectedStandalonePCLQSubGroup(tc.Workload.Name, 0, "worker", 10, ""),
 	}
-	if err := podGroupVerifier.VerifyPodGroupTopology(podGroup, setup.TopologyLabelRack, "", expectedSubGroups); err != nil {
+	if err := podGroupVerifier.VerifyAggregatePodGroupTopology(podGroup, tc.Workload.Name, 0, setup.TopologyLabelRack, "", expectedSubGroups, nil); err != nil {
 		t.Fatalf("Failed to verify KAI PodGroup topology: %v", err)
 	}
 
@@ -966,7 +947,7 @@ func Test_TAS14_MultiReplicaWithRackConstraint(t *testing.T) {
 		expectedSubGroups := []podgroup.ExpectedSubGroup{
 			podgroup.CreateExpectedStandalonePCLQSubGroup(tc.Workload.Name, pcsReplica, "worker", 2, ""),
 		}
-		if err := podGroupVerifier.VerifyPodGroupTopology(podGroup, setup.TopologyLabelRack, "", expectedSubGroups); err != nil {
+		if err := podGroupVerifier.VerifyAggregatePodGroupTopology(podGroup, tc.Workload.Name, pcsReplica, setup.TopologyLabelRack, "", expectedSubGroups, nil); err != nil {
 			t.Fatalf("Failed to verify PodGroup-%d topology: %v", pcsReplica, err)
 		}
 	}
@@ -980,8 +961,8 @@ func Test_TAS14_MultiReplicaWithRackConstraint(t *testing.T) {
 // 3. PCS: block constraint
 // 4. 10 pods total: decoder (2×2) + prefill (2×2) + router (2)
 // 5. Verify all in same block, each PCSG replica in same rack
-// 6. Verify base PodGang KAI PodGroup topology for complex multi-PCSG workload
-// 7. Verify scaled PodGangs' KAI PodGroups (decoder replica 1, prefill replica 1)
+// 6. Verify the aggregate KAI PodGroup base branch for the complex multi-PCSG workload
+// 7. Verify the same aggregate contains the scaled decoder and prefill PodGang branches
 func Test_TAS15_DisaggregatedInferenceMultiplePCSGs(t *testing.T) {
 	ctx := context.Background()
 
@@ -1047,11 +1028,7 @@ func Test_TAS15_DisaggregatedInferenceMultiplePCSGs(t *testing.T) {
 		podgroup.CreateExpectedPCLQInPCSGSubGroup(tc.Workload.Name, 0, "prefill", 0, "pleader", 1, ""),
 		podgroup.CreateExpectedStandalonePCLQSubGroup(tc.Workload.Name, 0, "router", 2, ""),
 	}
-	if err := podGroupVerifier.VerifyPodGroupTopology(podGroup, setup.TopologyLabelBlock, "", expectedSubGroups); err != nil {
-		t.Fatalf("Failed to verify KAI PodGroup topology: %v", err)
-	}
-
-	Logger.Info("7. Verify scaled PodGangs' KAI PodGroups (decoder replica 1, prefill replica 1)")
+	Logger.Info("7. Verify scaled PodGang branches in the aggregate KAI PodGroup (decoder replica 1, prefill replica 1)")
 
 	// Define PCSG configurations (minAvailable=1, totalReplicas=2 for each)
 	pcsgConfigs := []podgroup.ScaledPCSGConfig{
@@ -1079,13 +1056,11 @@ func Test_TAS15_DisaggregatedInferenceMultiplePCSGs(t *testing.T) {
 		},
 	}
 
-	// Verify each PCSG's scaled replica
-	lo.ForEach(pcsgConfigs, func(pcsgConfig podgroup.ScaledPCSGConfig, _ int) {
-		if err := podGroupVerifier.VerifyScaledPCSGReplicaTopology(tc.Ctx, tc.Namespace, tc.Workload.Name, 0,
-			pcsgConfig, setup.TopologyLabelBlock); err != nil {
-			t.Fatalf("Failed to verify scaled PCSG %s topology: %v", pcsgConfig.Name, err)
-		}
-	})
+	if err := podGroupVerifier.VerifyAggregatePodGroupTopology(
+		podGroup, tc.Workload.Name, 0, setup.TopologyLabelBlock, "", expectedSubGroups, pcsgConfigs,
+	); err != nil {
+		t.Fatalf("Failed to verify aggregate KAI PodGroup topology: %v", err)
+	}
 
 	Logger.Info("TAS15: Disaggregated Inference with Multiple PCSGs test completed successfully!")
 }
@@ -1181,7 +1156,33 @@ func Test_TAS16_MultiReplicaPCSWithThreeLevelHierarchy(t *testing.T) {
 			podgroup.CreateExpectedPCLQInPCSGSubGroup(tc.Workload.Name, pcsReplica, "prefill", 0, "pleader", 1, ""),
 			podgroup.CreateExpectedStandalonePCLQSubGroup(tc.Workload.Name, pcsReplica, "router", 2, ""),
 		}
-		if err := podGroupVerifier.VerifyPodGroupTopology(podGroup, setup.TopologyLabelBlock, "", expectedSubGroups); err != nil {
+		scaledPCSGs := []podgroup.ScaledPCSGConfig{
+			{
+				Name:         "decoder",
+				PCSGName:     "decoder",
+				PCSGReplica:  1,
+				MinAvailable: 1,
+				CliqueConfigs: []podgroup.PCSGCliqueConfig{
+					{Name: "dworker", PodCount: 1},
+					{Name: "dleader", PodCount: 1},
+				},
+				Constraint: setup.TopologyLabelRack,
+			},
+			{
+				Name:         "prefill",
+				PCSGName:     "prefill",
+				PCSGReplica:  1,
+				MinAvailable: 1,
+				CliqueConfigs: []podgroup.PCSGCliqueConfig{
+					{Name: "pworker", PodCount: 1, Constraint: setup.TopologyLabelHostname},
+					{Name: "pleader", PodCount: 1},
+				},
+				Constraint: setup.TopologyLabelRack,
+			},
+		}
+		if err := podGroupVerifier.VerifyAggregatePodGroupTopology(
+			podGroup, tc.Workload.Name, pcsReplica, setup.TopologyLabelBlock, "", expectedSubGroups, scaledPCSGs,
+		); err != nil {
 			t.Fatalf("Failed to verify KAI PodGroup-%d topology: %v", pcsReplica, err)
 		}
 	}
@@ -1607,7 +1608,7 @@ func Test_TAS20_PCSTopologyLevelsUnavailableCondition(t *testing.T) {
 	expectedSubGroups := []podgroup.ExpectedSubGroup{
 		podgroup.CreateExpectedStandalonePCLQSubGroup(tc.Workload.Name, 0, "worker", 2, ""),
 	}
-	if err := podGroupVerifier.VerifyPodGroupTopology(podGroup, "", "", expectedSubGroups); err != nil {
+	if err := podGroupVerifier.VerifyAggregatePodGroupTopology(podGroup, tc.Workload.Name, 0, "", "", expectedSubGroups, nil); err != nil {
 		t.Fatalf("Failed to verify topology constraints were removed from new PodGroup: %v", err)
 	}
 
@@ -1927,7 +1928,7 @@ func Test_TAS23_PreferredPackConstraintPropagation(t *testing.T) {
 		t.Fatalf("Setup failed: %v", err)
 	}
 
-	Logger.Info("3. Verify base KAI PodGroup required and preferred topology constraints")
+	Logger.Info("3. Verify aggregate KAI PodGroup required and preferred topology constraints")
 	basePodGroup := GetPodGroupOrFail(t, tc, podGroupVerifier, 0)
 
 	workersParent := podgroup.CreateExpectedPCSGParentSubGroup(tc.Workload.Name, 0, "workers", 0, "")
@@ -1939,29 +1940,23 @@ func Test_TAS23_PreferredPackConstraintPropagation(t *testing.T) {
 		podgroup.CreateExpectedPCLQInPCSGSubGroup(tc.Workload.Name, 0, "workers", 0, "worker", 1, ""),
 		router,
 	}
-	if err := podGroupVerifier.VerifyPodGroupTopology(basePodGroup, setup.TopologyLabelBlock, setup.TopologyLabelRack, expectedBaseSubGroups); err != nil {
-		t.Fatalf("Failed to verify base KAI PodGroup topology: %v", err)
+	Logger.Info("4. Verify scaled PCSG branch preferred topology constraint in the aggregate")
+	scaledPCSGs := []podgroup.ScaledPCSGConfig{
+		{
+			Name:                "workers",
+			PCSGName:            "workers",
+			PCSGReplica:         1,
+			MinAvailable:        1,
+			PreferredConstraint: setup.TopologyLabelHostname,
+			CliqueConfigs: []podgroup.PCSGCliqueConfig{
+				{Name: "worker", PodCount: 1},
+			},
+		},
 	}
-
-	Logger.Info("4. Verify scaled PCSG KAI PodGroup preferred topology constraint")
-	podGroups, err := podGroupVerifier.GetKAIPodGroupsForPCS(tc.Ctx, tc.Namespace, tc.Workload.Name)
-	if err != nil {
-		t.Fatalf("Failed to get KAI PodGroups: %v", err)
-	}
-	workersFQN := nameutils.GeneratePodCliqueScalingGroupName(
-		nameutils.ResourceNameReplica{Name: tc.Workload.Name, Replica: 0},
-		"workers",
-	)
-	scaledPodGangName := nameutils.CreatePodGangNameFromPCSGFQN(workersFQN, 0)
-	scaledPodGroup, err := podgroup.FilterPodGroupByOwner(podGroups, scaledPodGangName)
-	if err != nil {
-		t.Fatalf("Failed to find scaled PodGroup %s: %v", scaledPodGangName, err)
-	}
-	expectedScaledSubGroups := []podgroup.ExpectedSubGroup{
-		podgroup.CreateExpectedPCLQInPCSGSubGroupNoParent(tc.Workload.Name, 0, "workers", 1, "worker", 1, ""),
-	}
-	if err := podGroupVerifier.VerifyPodGroupTopology(scaledPodGroup, "", setup.TopologyLabelHostname, expectedScaledSubGroups); err != nil {
-		t.Fatalf("Failed to verify scaled KAI PodGroup topology: %v", err)
+	if err := podGroupVerifier.VerifyAggregatePodGroupTopology(
+		basePodGroup, tc.Workload.Name, 0, setup.TopologyLabelBlock, setup.TopologyLabelRack, expectedBaseSubGroups, scaledPCSGs,
+	); err != nil {
+		t.Fatalf("Failed to verify aggregate KAI PodGroup topology: %v", err)
 	}
 
 	Logger.Info("5. Verify TopologyLevelsUnavailable = False")

--- a/operator/e2e/tests/upgrade/kai_backend_upgrade_test.go
+++ b/operator/e2e/tests/upgrade/kai_backend_upgrade_test.go
@@ -1,0 +1,265 @@
+//go:build e2e && e2eupgrade
+
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	nameutils "github.com/ai-dynamo/grove/operator/api/common"
+	corev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/ai-dynamo/grove/operator/e2e/grove/topology"
+	"github.com/ai-dynamo/grove/operator/e2e/setup"
+	"github.com/ai-dynamo/grove/operator/e2e/testctx"
+	kaischedulingv2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	kaiUpgradeFromVersion = "v0.1.0-alpha.11"
+	kaiUpgradePCSName     = "kai-backend-upgrade"
+)
+
+var kaiUpgradeTopologyLevels = []corev1alpha1.TopologyLevel{
+	{Domain: corev1alpha1.TopologyDomainZone, Key: setup.TopologyLabelZone},
+	{Domain: corev1alpha1.TopologyDomainBlock, Key: setup.TopologyLabelBlock},
+	{Domain: corev1alpha1.TopologyDomainRack, Key: setup.TopologyLabelRack},
+	{Domain: corev1alpha1.TopologyDomainHost, Key: setup.TopologyLabelHostname},
+}
+
+type kaiUpgradePodSnapshot struct {
+	UID      types.UID
+	NodeName string
+}
+
+// TestKAIBackendUpgradeFromAlpha11 verifies the in-place migration from
+// PodGang-owned KAI PodGroups to one PCS-owned aggregate PodGroup per PCS replica.
+func TestKAIBackendUpgradeFromAlpha11(t *testing.T) {
+	workload := &testctx.WorkloadConfig{
+		Name:         kaiUpgradePCSName,
+		YAMLPath:     "../../yaml/kai-backend-upgrade.yaml",
+		Namespace:    "default",
+		ExpectedPods: 6,
+	}
+	cfg := testConfig{
+		fromVersion:         kaiUpgradeFromVersion,
+		workload:            workload,
+		requiredWorkerNodes: 8,
+		customizeHelmValues: configureKAIUpgradeHelmValues,
+		beforeDeploy:        prepareKAIUpgradeTopology,
+	}
+
+	tc := setupTest(t, cfg)
+	baselinePods, legacyPodGroups := waitForLegacyKAIPodGroups(t, tc)
+	snapshots := snapshotKAIUpgradePods(baselinePods)
+
+	upgradeGrove(t, tc, cfg)
+
+	waitForKAIUpgradeMigration(t, tc, snapshots, legacyPodGroups)
+}
+
+func configureKAIUpgradeHelmValues(values map[string]any) {
+	values["config"] = map[string]any{
+		"leaderElection": map[string]any{"enabled": false},
+		"scheduler": map[string]any{
+			"defaultProfileName": "kai-scheduler",
+			"profiles":           []any{map[string]any{"name": "kai-scheduler"}},
+		},
+		"server": map[string]any{
+			"healthProbes": map[string]any{"enable": true},
+		},
+		"topologyAwareScheduling": map[string]any{"enabled": true},
+	}
+}
+
+func prepareKAIUpgradeTopology(t *testing.T, tc *testctx.TestContext) {
+	t.Helper()
+
+	verifier := topology.NewTopologyVerifier(tc.Client, testctx.Logger)
+	require.NoError(t, verifier.EnsureClusterTopology(tc.Ctx, "grove-topology", kaiUpgradeTopologyLevels))
+	require.NoError(t, verifier.WaitForKAITopology(
+		tc.Ctx,
+		"grove-topology",
+		[]string{setup.TopologyLabelZone, setup.TopologyLabelBlock, setup.TopologyLabelRack, setup.TopologyLabelHostname},
+		tc.Timeout,
+		tc.Interval,
+	))
+}
+
+func waitForLegacyKAIPodGroups(t *testing.T, tc *testctx.TestContext) ([]corev1.Pod, map[string]struct{}) {
+	t.Helper()
+
+	var pods []corev1.Pod
+	legacyPodGroups := map[string]struct{}{}
+	waitForKAIUpgradeCondition(t, tc, func(ctx context.Context) error {
+		podList, err := tc.ListPods()
+		if err != nil {
+			return err
+		}
+		if len(podList.Items) != 6 {
+			return fmt.Errorf("found %d Pods, expected 6", len(podList.Items))
+		}
+
+		currentLegacyPodGroups := map[string]struct{}{}
+		for i := range podList.Items {
+			pod := &podList.Items[i]
+			podGroupName := pod.Annotations["pod-group-name"]
+			if !strings.HasPrefix(podGroupName, "pg-") {
+				return fmt.Errorf("Pod %s has not converged to a KAI podgrouper PodGroup: %q", pod.Name, podGroupName)
+			}
+
+			podGroup := &kaischedulingv2alpha2.PodGroup{}
+			if err = tc.Client.Get(ctx, client.ObjectKey{Namespace: pod.Namespace, Name: podGroupName}, podGroup); err != nil {
+				return err
+			}
+			owner := findPodGangOwner(podGroup)
+			if owner == nil || owner.Name != pod.Labels[nameutils.LabelPodGang] {
+				return fmt.Errorf("legacy PodGroup %s has unexpected owner %v", podGroupName, owner)
+			}
+			currentLegacyPodGroups[podGroupName] = struct{}{}
+		}
+		if len(currentLegacyPodGroups) != 4 {
+			return fmt.Errorf("found %d legacy PodGroups, expected 4", len(currentLegacyPodGroups))
+		}
+
+		pods = append([]corev1.Pod(nil), podList.Items...)
+		legacyPodGroups = currentLegacyPodGroups
+		return nil
+	})
+	return pods, legacyPodGroups
+}
+
+func snapshotKAIUpgradePods(pods []corev1.Pod) map[string]kaiUpgradePodSnapshot {
+	snapshots := make(map[string]kaiUpgradePodSnapshot, len(pods))
+	for i := range pods {
+		snapshots[pods[i].Name] = kaiUpgradePodSnapshot{
+			UID:      pods[i].UID,
+			NodeName: pods[i].Spec.NodeName,
+		}
+	}
+	return snapshots
+}
+
+func waitForKAIUpgradeMigration(
+	t *testing.T,
+	tc *testctx.TestContext,
+	snapshots map[string]kaiUpgradePodSnapshot,
+	legacyPodGroups map[string]struct{},
+) {
+	t.Helper()
+
+	pcs := &corev1alpha1.PodCliqueSet{}
+	require.NoError(t, tc.Client.Get(tc.Ctx, client.ObjectKey{Namespace: tc.Namespace, Name: kaiUpgradePCSName}, pcs))
+
+	waitForKAIUpgradeCondition(t, tc, func(ctx context.Context) error {
+		podList, err := tc.ListPods()
+		if err != nil {
+			return err
+		}
+		if len(podList.Items) != len(snapshots) {
+			return fmt.Errorf("found %d Pods, expected %d", len(podList.Items), len(snapshots))
+		}
+
+		for i := range podList.Items {
+			pod := &podList.Items[i]
+			snapshot, found := snapshots[pod.Name]
+			if !found {
+				return fmt.Errorf("Pod %s was created during the upgrade", pod.Name)
+			}
+			if snapshot.UID != pod.UID || snapshot.NodeName != pod.Spec.NodeName {
+				return fmt.Errorf("Pod %s was recreated or moved during the upgrade", pod.Name)
+			}
+			if pod.Status.Phase != corev1.PodRunning {
+				return fmt.Errorf("Pod %s is in phase %s, expected Running", pod.Name, pod.Status.Phase)
+			}
+
+			replica := pod.Labels[nameutils.LabelPodCliqueSetReplicaIndex]
+			expectedPodGroup := fmt.Sprintf("grove-%s-%s", kaiUpgradePCSName, replica)
+			if pod.Annotations["pod-group-name"] != expectedPodGroup {
+				return fmt.Errorf("Pod %s references PodGroup %q, expected %q", pod.Name, pod.Annotations["pod-group-name"], expectedPodGroup)
+			}
+			if pod.Annotations["kai.scheduler/skip-podgrouper"] != "true" {
+				return fmt.Errorf("Pod %s does not skip the KAI podgrouper", pod.Name)
+			}
+			if pod.Labels["kai.scheduler/subgroup-name"] != pod.Labels[nameutils.LabelPodClique] {
+				return fmt.Errorf("Pod %s has not migrated to its PodClique subgroup", pod.Name)
+			}
+		}
+
+		for legacyName := range legacyPodGroups {
+			err = tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: legacyName}, &kaischedulingv2alpha2.PodGroup{})
+			if err == nil {
+				return fmt.Errorf("legacy PodGroup %s still exists", legacyName)
+			}
+			if !apierrors.IsNotFound(err) {
+				return fmt.Errorf("checking legacy PodGroup %s deletion: %w", legacyName, err)
+			}
+		}
+
+		podGroups := &kaischedulingv2alpha2.PodGroupList{}
+		if err = tc.Client.List(ctx, podGroups, client.InNamespace(tc.Namespace)); err != nil {
+			return err
+		}
+		if len(podGroups.Items) != 2 {
+			return fmt.Errorf("found %d PodGroups after migration, expected 2", len(podGroups.Items))
+		}
+		byName := make(map[string]*kaischedulingv2alpha2.PodGroup, len(podGroups.Items))
+		for i := range podGroups.Items {
+			byName[podGroups.Items[i].Name] = &podGroups.Items[i]
+		}
+		for replica := range 2 {
+			expectedName := fmt.Sprintf("grove-%s-%d", kaiUpgradePCSName, replica)
+			podGroup, found := byName[expectedName]
+			if !found {
+				return fmt.Errorf("aggregate PodGroup %s does not exist", expectedName)
+			}
+			if !metav1.IsControlledBy(podGroup, pcs) {
+				return fmt.Errorf("aggregate PodGroup %s is not controlled by PodCliqueSet %s", expectedName, pcs.Name)
+			}
+		}
+		return nil
+	})
+}
+
+func findPodGangOwner(podGroup *kaischedulingv2alpha2.PodGroup) *metav1.OwnerReference {
+	for i := range podGroup.OwnerReferences {
+		if podGroup.OwnerReferences[i].Kind == "PodGang" {
+			return &podGroup.OwnerReferences[i]
+		}
+	}
+	return nil
+}
+
+func waitForKAIUpgradeCondition(t *testing.T, tc *testctx.TestContext, check func(context.Context) error) {
+	t.Helper()
+
+	var lastErr error
+	err := wait.PollUntilContextTimeout(tc.Ctx, tc.Interval, tc.Timeout, true, func(ctx context.Context) (bool, error) {
+		lastErr = check(ctx)
+		return lastErr == nil, nil
+	})
+	require.NoError(t, errors.Join(err, lastErr))
+}

--- a/operator/e2e/tests/upgrade/upgrade.go
+++ b/operator/e2e/tests/upgrade/upgrade.go
@@ -41,6 +41,15 @@ type testConfig struct {
 
 	// Required - workload that will be installed before and verified after an upgrade.
 	workload *testctx.WorkloadConfig
+
+	// Optional - number of worker nodes required by the workload. Defaults to one.
+	requiredWorkerNodes int
+
+	// Optional - customizes the Helm values used for both the released and checkout charts.
+	customizeHelmValues func(map[string]any)
+
+	// Optional - prepares dependencies that must exist before the workload is deployed.
+	beforeDeploy func(*testing.T, *testctx.TestContext)
 }
 
 // setupTest initializes an upgrade test with the given configuration.
@@ -67,18 +76,34 @@ func setupTest(t *testing.T, cfg testConfig) *testctx.TestContext {
 		t.Fatalf("TestConfig.Workload is required")
 	}
 
+	requiredWorkerNodes := cfg.requiredWorkerNodes
+	if requiredWorkerNodes == 0 {
+		requiredWorkerNodes = 1
+	}
+
 	testctx.Logger.Infof("preparing test cluster")
 
 	tc, cleanup := testctx.PrepareTest(
 		t.Context(),
 		t,
-		1,
+		requiredWorkerNodes,
 		testctx.WithWorkload(cfg.workload),
 	)
 	t.Cleanup(cleanup)
 
 	testctx.Logger.Infof("testing Grove upgrade from %s to the current checkout", cfg.fromVersion)
 	testctx.Logger.Info("installing released Grove operator")
+
+	values := map[string]any{
+		"config": map[string]any{
+			"server": map[string]any{
+				"healthProbes": map[string]any{"enable": true},
+			},
+		},
+	}
+	if cfg.customizeHelmValues != nil {
+		cfg.customizeHelmValues(values)
+	}
 
 	_, err := setup.InstallHelmChart(&setup.HelmInstallConfig{
 		RestConfig:      tc.Client.RestConfig,
@@ -89,7 +114,7 @@ func setupTest(t *testing.T, cfg testConfig) *testctx.TestContext {
 		CreateNamespace: true,
 		Wait:            true,
 		Timeout:         defaultPollTimeout,
-		Values:          map[string]any{"config": map[string]any{"server": map[string]any{"healthProbes": map[string]any{"enable": true}}}},
+		Values:          values,
 		HelmLoggerFunc:  testctx.Logger.Infof,
 	})
 	require.NoError(t, err, "install released Grove chart")
@@ -98,19 +123,23 @@ func setupTest(t *testing.T, cfg testConfig) *testctx.TestContext {
 	err = podsManager.WaitForReadyInNamespace(t.Context(), "grove-system", 1, defaultPollTimeout, defaultPollInterval)
 	require.NoError(t, err, "waiting for Grove to become ready")
 
+	if cfg.beforeDeploy != nil {
+		cfg.beforeDeploy(t, tc)
+	}
+
 	testctx.Logger.Info("applying workload before upgrade")
 
 	_, err = tc.DeployAndVerifyWorkload()
 	require.NoError(t, err, "applying workload")
 
-	err = podsManager.WaitForReadyInNamespace(t.Context(), cfg.workload.Namespace, 2, defaultPollTimeout, defaultPollInterval)
+	err = podsManager.WaitForReadyInNamespace(t.Context(), cfg.workload.Namespace, cfg.workload.ExpectedPods, defaultPollTimeout, defaultPollInterval)
 	require.NoError(t, err, "waiting for workload to become ready")
 
 	return tc
 }
 
 // upgradeGrove handles the upgrade of Grove to the current codebase.
-func upgradeGrove(t *testing.T, tc *testctx.TestContext) {
+func upgradeGrove(t *testing.T, tc *testctx.TestContext, cfg testConfig) {
 	t.Helper()
 
 	testctx.Logger.Info("building current Grove operator")
@@ -140,36 +169,45 @@ func upgradeGrove(t *testing.T, tc *testctx.TestContext) {
 	require.NoError(t, err, "locate current Grove chart")
 	chartVersion, err := setup.GetGroveChartVersion(chartDir)
 	require.NoError(t, err, "read current Grove chart version")
-	_, err = setup.UpgradeHelmChart(&setup.HelmInstallConfig{
-		RestConfig:   tc.Client.RestConfig,
-		ReleaseName:  "grove",
-		Namespace:    "grove-system",
-		ChartRef:     chartDir,
-		ChartVersion: chartVersion,
-		Wait:         true,
-		Timeout:      defaultPollTimeout,
-		Values: map[string]any{
-			"config": map[string]any{"server": map[string]any{"healthProbes": map[string]any{"enable": true}}},
-			"image": map[string]any{
-				"repository": "registry:5001/grove-operator",
-				"tag":        "latest",
+	values := map[string]any{
+		"config": map[string]any{
+			"server": map[string]any{
+				"healthProbes": map[string]any{"enable": true},
 			},
-			"deployment": map[string]any{
-				"env": []any{
-					map[string]any{
-						"name":  "GROVE_INIT_CONTAINER_IMAGE",
-						"value": "registry:5001/grove-initc",
-					},
-				},
-			},
-			"crdInstaller": map[string]any{
-				"enabled": true,
-				"image": map[string]any{
-					"repository": "registry:5001/grove-install-crds",
-					"tag":        "latest",
+		},
+		"image": map[string]any{
+			"repository": "registry:5001/grove-operator",
+			"tag":        "latest",
+		},
+		"deployment": map[string]any{
+			"env": []any{
+				map[string]any{
+					"name":  "GROVE_INIT_CONTAINER_IMAGE",
+					"value": "registry:5001/grove-initc",
 				},
 			},
 		},
+		"crdInstaller": map[string]any{
+			"enabled": true,
+			"image": map[string]any{
+				"repository": "registry:5001/grove-install-crds",
+				"tag":        "latest",
+			},
+		},
+	}
+	if cfg.customizeHelmValues != nil {
+		cfg.customizeHelmValues(values)
+	}
+
+	_, err = setup.UpgradeHelmChart(&setup.HelmInstallConfig{
+		RestConfig:     tc.Client.RestConfig,
+		ReleaseName:    "grove",
+		Namespace:      "grove-system",
+		ChartRef:       chartDir,
+		ChartVersion:   chartVersion,
+		Wait:           true,
+		Timeout:        defaultPollTimeout,
+		Values:         values,
 		HelmLoggerFunc: testctx.Logger.Infof,
 	})
 	require.NoError(t, err, "upgrade Grove chart to current checkout")

--- a/operator/e2e/tests/upgrade/upgrade_test.go
+++ b/operator/e2e/tests/upgrade/upgrade_test.go
@@ -55,15 +55,16 @@ func TestUpgradeFromLatestGitHubRelease(t *testing.T) {
 		ExpectedPods: 2,
 	}
 
-	tc := setupTest(t, testConfig{
+	cfg := testConfig{
 		fromVersion: fromVersion,
 		workload:    workload,
-	})
+	}
+	tc := setupTest(t, cfg)
 
 	podsList, err := tc.ListPods()
 	require.NoError(t, err, "listing workload pods")
 
-	upgradeGrove(t, tc)
+	upgradeGrove(t, tc, cfg)
 
 	tc.ScalePCSAndWait(workload.Name, 2, 4, 0)
 

--- a/operator/e2e/yaml/kai-backend-upgrade.yaml
+++ b/operator/e2e/yaml/kai-backend-upgrade.yaml
@@ -1,0 +1,104 @@
+# Copyright 2026 The Grove Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: grove.io/v1alpha1
+kind: PodCliqueSet
+metadata:
+  name: kai-backend-upgrade
+  labels:
+    kai.scheduler/queue: test
+spec:
+  replicas: 2
+  template:
+    topologyConstraint:
+      topologyName: grove-topology
+      pack:
+        required: block
+    podCliqueScalingGroups:
+      - name: workers
+        replicas: 2
+        minAvailable: 1
+        topologyConstraint:
+          topologyName: grove-topology
+          pack:
+            required: rack
+        cliqueNames:
+          - worker
+    cliques:
+      - name: router
+        topologyConstraint:
+          topologyName: grove-topology
+          pack:
+            required: host
+        spec:
+          roleName: router
+          replicas: 1
+          minAvailable: 1
+          podSpec:
+            schedulerName: kai-scheduler
+            terminationGracePeriodSeconds: 5
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node_role.e2e.grove.nvidia.com
+                          operator: In
+                          values:
+                            - agent
+            tolerations:
+              - key: node_role.e2e.grove.nvidia.com
+                operator: Equal
+                value: agent
+                effect: NoSchedule
+            containers:
+              - name: router
+                image: registry:5001/busybox:latest
+                command: ["sleep", "infinity"]
+                resources:
+                  requests:
+                    memory: 10Mi
+      - name: worker
+        topologyConstraint:
+          topologyName: grove-topology
+          pack:
+            required: host
+        spec:
+          roleName: worker
+          replicas: 1
+          minAvailable: 1
+          podSpec:
+            schedulerName: kai-scheduler
+            terminationGracePeriodSeconds: 5
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node_role.e2e.grove.nvidia.com
+                          operator: In
+                          values:
+                            - agent
+            tolerations:
+              - key: node_role.e2e.grove.nvidia.com
+                operator: Equal
+                value: agent
+                effect: NoSchedule
+            containers:
+              - name: worker
+                image: registry:5001/busybox:latest
+                command: ["sleep", "infinity"]
+                resources:
+                  requests:
+                    memory: 10Mi

--- a/operator/internal/controller/podcliqueset/components/podgang/podgang.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/podgang.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
@@ -132,7 +133,10 @@ func (r _resource) buildResource(pcs *grovecorev1alpha1.PodCliqueSet, pgi *podGa
 	// propagate. grove.io/-prefixed entries are operator-managed and have a
 	// lifecycle independent of the PCS, so they are preserved across reconciles
 	// and (for PCS keys with that prefix) skipped on mirror.
-	pg.Labels = mirrorPCSMetadata(pg.Labels, pcs.Labels, getLabels(pcs.Name))
+	pg.Labels = mirrorPCSMetadata(pg.Labels, pcs.Labels, getLabels(pcs.Name, pgi))
+	if pgi.podCliqueScalingGroupName == "" {
+		delete(pg.Labels, apicommon.LabelPodCliqueScalingGroup)
+	}
 	// Set scheduler name so the podgang controller can resolve the correct backend.
 	// When no scheduler can be resolved, drop any stale label from a previous reconcile.
 	if schedName := r.getSchedulerNameForPCS(pcs); schedName != "" {
@@ -212,12 +216,17 @@ func emptyPodGang(objKey client.ObjectKey) *groveschedulerv1alpha1.PodGang {
 }
 
 // getLabels constructs labels for a PodGang resource.
-func getLabels(pcsName string) map[string]string {
-	return lo.Assign(
+func getLabels(pcsName string, pgi *podGangInfo) map[string]string {
+	labels := lo.Assign(
 		apicommon.GetDefaultLabelsForPodCliqueSetManagedResources(pcsName),
 		map[string]string{
-			apicommon.LabelComponentKey: apicommon.LabelComponentNamePodGang,
+			apicommon.LabelComponentKey:             apicommon.LabelComponentNamePodGang,
+			apicommon.LabelPodCliqueSetReplicaIndex: strconv.Itoa(pgi.pcsReplicaIndex),
 		})
+	if pgi.podCliqueScalingGroupName != "" {
+		labels[apicommon.LabelPodCliqueScalingGroup] = pgi.podCliqueScalingGroupName
+	}
+	return labels
 }
 
 // mirrorPCSMetadata returns the result of mirroring PCS-owned labels or annotations

--- a/operator/internal/controller/podcliqueset/components/podgang/podgang_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/podgang_test.go
@@ -126,7 +126,7 @@ func TestBuildResource(t *testing.T) {
 	// the operator-managed label set from getLabels plus the scheduler name resolved
 	// from the fake registry (testutils.NewDefaultFakeRegistry returns "default-scheduler").
 	expectedDefaultLabels := lo.Assign(
-		getLabels(pcsName),
+		getLabels(pcsName, &podGangInfo{}),
 		map[string]string{apicommon.LabelSchedulerName: defaultSchedulerName},
 	)
 
@@ -137,6 +137,8 @@ func TestBuildResource(t *testing.T) {
 		pcsAnnotations            map[string]string
 		pcsTopologyConstraint     *grovecorev1alpha1.TopologyConstraint
 		pgiTopologyConstraint     *groveschedulerv1alpha1.TopologyConstraint
+		pcsReplicaIndex           int
+		podCliqueScalingGroupName string
 		initialPodGangLabels      map[string]string
 		initialPodGangAnnotations map[string]string
 		expectedLabels            map[string]string
@@ -151,6 +153,27 @@ func TestBuildResource(t *testing.T) {
 			expectedAnnotations: map[string]string{
 				"nvidia.com/kai-scheduler-queue": "worker-queue",
 			},
+		},
+		{
+			name:                      "create path: labels scaled podgang with PCS replica and PCSG",
+			pcsReplicaIndex:           2,
+			podCliqueScalingGroupName: "test-pcs-2-workers",
+			expectedLabels: lo.Assign(
+				getLabels(pcsName, &podGangInfo{
+					pcsReplicaIndex:           2,
+					podCliqueScalingGroupName: "test-pcs-2-workers",
+				}),
+				map[string]string{apicommon.LabelSchedulerName: defaultSchedulerName},
+			),
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name: "mirror path: removes stale PCSG label from base podgang",
+			initialPodGangLabels: map[string]string{
+				apicommon.LabelPodCliqueScalingGroup: "stale-pcsg",
+			},
+			expectedLabels:      expectedDefaultLabels,
+			expectedAnnotations: map[string]string{},
 		},
 		{
 			name: "create path: mirrors multiple PCS annotations onto empty podgang",
@@ -331,8 +354,10 @@ func TestBuildResource(t *testing.T) {
 			}
 
 			pgi := &podGangInfo{
-				fqn:                "test-pcs-0",
-				topologyConstraint: test.pgiTopologyConstraint,
+				fqn:                       "test-pcs-0",
+				pcsReplicaIndex:           test.pcsReplicaIndex,
+				podCliqueScalingGroupName: test.podCliqueScalingGroupName,
+				topologyConstraint:        test.pgiTopologyConstraint,
 				pclqs: []pclqInfo{
 					{
 						fqn:      "test-clique-0",

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
@@ -191,7 +191,8 @@ func buildExpectedBasePodGangForPCSReplicas(sc *syncContext) ([]*podGangInfo, er
 func buildExpectedBasePodGangForPCSReplica(sc *syncContext, pcsReplica int) (*podGangInfo, error) {
 	podGangFQN := apicommon.GenerateBasePodGangName(apicommon.ResourceNameReplica{Name: sc.pcs.Name, Replica: pcsReplica})
 	pg := &podGangInfo{
-		fqn: podGangFQN,
+		fqn:             podGangFQN,
+		pcsReplicaIndex: pcsReplica,
 		// TopologyConstraint for the base PodGang comes from the topology constraint defined at the PCS level.
 		topologyConstraint: createTopologyPackConstraint(sc, client.ObjectKeyFromObject(sc.pcs), sc.pcs.Spec.Template.TopologyConstraint),
 	}
@@ -284,7 +285,7 @@ func (r _resource) buildExpectedScaledPodGangsForPCSG(sc *syncContext, pcsReplic
 		minAvailable := int(*pcsgConfig.MinAvailable)
 		scaledReplicas := replicas - minAvailable
 		for podGangIndex, pcsgReplica := 0, minAvailable; podGangIndex < scaledReplicas; podGangIndex, pcsgReplica = podGangIndex+1, pcsgReplica+1 {
-			pg, err := doBuildExpectedScaledPodGangForPCSG(sc, pcsgFQN, pcsgConfig, pcsgReplica, podGangIndex)
+			pg, err := doBuildExpectedScaledPodGangForPCSG(sc, pcsReplica, pcsgFQN, pcsgConfig, pcsgReplica, podGangIndex)
 			if err != nil {
 				return nil, fmt.Errorf("failed to build expected scaled PodGang for PCSG %q replica %d: %w", pcsgFQN, pcsgReplica, err)
 			}
@@ -294,7 +295,7 @@ func (r _resource) buildExpectedScaledPodGangsForPCSG(sc *syncContext, pcsReplic
 	return expectedPodGangs, nil
 }
 
-func doBuildExpectedScaledPodGangForPCSG(sc *syncContext, pcsgFQN string, pcsgConfig grovecorev1alpha1.PodCliqueScalingGroupConfig, pcsgReplica int, podGangIndex int) (*podGangInfo, error) {
+func doBuildExpectedScaledPodGangForPCSG(sc *syncContext, pcsReplica int, pcsgFQN string, pcsgConfig grovecorev1alpha1.PodCliqueScalingGroupConfig, pcsgReplica int, podGangIndex int) (*podGangInfo, error) {
 	var (
 		pclqInfos          = make([]pclqInfo, 0, len(pcsgConfig.CliqueNames))
 		topologyConstraint *groveschedulerv1alpha1.TopologyConstraint
@@ -326,9 +327,11 @@ func doBuildExpectedScaledPodGangForPCSG(sc *syncContext, pcsgFQN string, pcsgCo
 	}
 
 	pg := &podGangInfo{
-		fqn:                apicommon.CreatePodGangNameFromPCSGFQN(pcsgFQN, podGangIndex),
-		topologyConstraint: topologyConstraint,
-		pclqs:              pclqInfos,
+		fqn:                       apicommon.CreatePodGangNameFromPCSGFQN(pcsgFQN, podGangIndex),
+		pcsReplicaIndex:           pcsReplica,
+		podCliqueScalingGroupName: pcsgFQN,
+		topologyConstraint:        topologyConstraint,
+		pclqs:                     pclqInfos,
 	}
 
 	return pg, nil
@@ -780,6 +783,11 @@ func (sfr *syncFlowResult) getAggregatedError() error {
 type podGangInfo struct {
 	// fqn is a fully qualified name of a PodGang.
 	fqn string
+	// pcsReplicaIndex identifies the PodCliqueSet replica containing this PodGang.
+	pcsReplicaIndex int
+	// podCliqueScalingGroupName identifies the PodCliqueScalingGroup containing a scaled PodGang.
+	// It is empty for a base PodGang because a base PodGang can contain multiple PodCliqueScalingGroups.
+	podCliqueScalingGroupName string
 	// pclqs holds the relevant information for all constituent PodCliques for this PodGang.
 	pclqs []pclqInfo
 	// topologyConstraint holds the topology pack constraint applicable at the PodGang level.

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow_test.go
@@ -1962,7 +1962,7 @@ func TestCreateOrUpdatePodGangs_ClearsStaleTopologyStateOnExistingPodGang(t *tes
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      pgName,
 				Namespace: ns,
-				Labels:    getLabels(pcsName),
+				Labels:    getLabels(pcsName, &podGangInfo{}),
 			},
 			Spec: groveschedulerv1alpha1.PodGangSpec{
 				PodGroups: []groveschedulerv1alpha1.PodGroup{{Name: pclqName, MinReplicas: 1}},

--- a/operator/internal/controller/podgang/reconciler.go
+++ b/operator/internal/controller/podgang/reconciler.go
@@ -73,10 +73,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	logger := log.FromContext(ctx).WithValues("scheduler", backend.Name(), "podGang", req.NamespacedName)
-	if !podGang.DeletionTimestamp.IsZero() {
-		return ctrl.Result{}, nil
-	}
-
 	if err := backend.SyncPodGang(ctx, podGang); err != nil {
 		logger.Error(err, "Failed to SyncPodGang on spec change")
 		return ctrl.Result{}, err

--- a/operator/internal/controller/podgang/register.go
+++ b/operator/internal/controller/podgang/register.go
@@ -49,7 +49,8 @@ func podGangSpecChangePredicate() predicate.Predicate {
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return grovectrlutils.IsManagedPodGang(e.ObjectOld) &&
 				grovectrlutils.IsManagedPodGang(e.ObjectNew) &&
-				(e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration())
+				(e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() ||
+					e.ObjectOld.GetDeletionTimestamp().IsZero() != e.ObjectNew.GetDeletionTimestamp().IsZero())
 		},
 		GenericFunc: func(_ event.GenericEvent) bool { return false },
 	}

--- a/operator/internal/controller/podgang/register_test.go
+++ b/operator/internal/controller/podgang/register_test.go
@@ -20,6 +20,7 @@ import (
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
@@ -29,6 +30,7 @@ type predicateTestCase struct {
 	managedOld              bool
 	managedNew              bool
 	generationChanged       bool
+	deletionStarted         bool
 	shouldAllowCreateEvent  bool
 	shouldAllowDeleteEvent  bool
 	shouldAllowGenericEvent bool
@@ -78,6 +80,16 @@ func TestPodGangSpecChangePredicate(t *testing.T) {
 			shouldAllowUpdateEvent:  false,
 		},
 		{
+			name:                    "managed PodGang starts deletion",
+			managedOld:              true,
+			managedNew:              true,
+			deletionStarted:         true,
+			shouldAllowCreateEvent:  true,
+			shouldAllowDeleteEvent:  true,
+			shouldAllowGenericEvent: false,
+			shouldAllowUpdateEvent:  true,
+		},
+		{
 			name:                    "update with old managed and new unmanaged",
 			managedOld:              true,
 			managedNew:              false,
@@ -122,6 +134,10 @@ func TestPodGangSpecChangePredicate(t *testing.T) {
 				Build()
 			if tc.generationChanged {
 				newPG.SetGeneration(oldPG.GetGeneration() + 1)
+			}
+			if tc.deletionStarted {
+				now := metav1.Now()
+				newPG.DeletionTimestamp = &now
 			}
 
 			assert.Equal(t, tc.shouldAllowCreateEvent, pred.Create(event.CreateEvent{Object: newPG}), "Create")

--- a/operator/internal/scheduler/kai/aggregate.go
+++ b/operator/internal/scheduler/kai/aggregate.go
@@ -1,0 +1,646 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kai
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"maps"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+
+	apicommon "github.com/ai-dynamo/grove/operator/api/common"
+	apicommonconstants "github.com/ai-dynamo/grove/operator/api/common/constants"
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	k8sutils "github.com/ai-dynamo/grove/operator/internal/utils/kubernetes"
+
+	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
+	kaischedulingv2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	podGangFinalizer           = "kai.scheduler/aggregate-podgroup"
+	aggregatePrefix            = "grove-"
+	scaledPodGangsSubGroupName = "scaled-podgangs"
+)
+
+func (b *schedulerBackend) syncAggregatePodGroup(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet, trigger *groveschedulerv1alpha1.PodGang) error {
+	replica, err := podCliqueSetReplicaFromObjectMeta(trigger.ObjectMeta)
+	if err != nil {
+		return fmt.Errorf("get PodCliqueSet replica index from PodGang %s/%s: %w", trigger.Namespace, trigger.Name, err)
+	}
+	basePodGangName := apicommon.GenerateBasePodGangName(apicommon.ResourceNameReplica{Name: pcs.Name, Replica: replica})
+	aggregateName := aggregatePodGroupName(pcs.Name, replica)
+	unlock := b.aggregateLocks.Lock(client.ObjectKey{Namespace: pcs.Namespace, Name: aggregateName})
+	defer unlock()
+
+	podGangs, err := b.listActivePodGangsForReplica(ctx, pcs, replica)
+	if err != nil {
+		return err
+	}
+	if len(podGangs) == 0 {
+		if err = b.verifyNoActivePodsForReplica(ctx, pcs, replica); err != nil {
+			return err
+		}
+		return b.deleteAggregatePodGroup(ctx, pcs, aggregateName)
+	}
+	for i := range podGangs {
+		if err = b.ensurePodGangMetadata(ctx, &podGangs[i]); err != nil {
+			return fmt.Errorf("ensure KAI metadata on PodGang %s/%s: %w", podGangs[i].Namespace, podGangs[i].Name, err)
+		}
+	}
+
+	basePodGang, found := findPodGangByName(podGangs, basePodGangName)
+	if !found {
+		return fmt.Errorf("base PodGang %s/%s not found while reconciling aggregate KAI PodGroup", pcs.Namespace, basePodGangName)
+	}
+	topologyReference, err := b.resolveKAITopologyReference(ctx, podGangs)
+	if err != nil {
+		return err
+	}
+	desired, err := b.buildAggregatePodGroup(pcs, replica, basePodGang, podGangs, topologyReference)
+	if err != nil {
+		return err
+	}
+	if err = b.syncPodGroup(ctx, pcs, desired); err != nil {
+		return err
+	}
+
+	legacyReferences, err := b.migratePods(ctx, pcs, replica, podGangs, desired)
+	if err != nil {
+		return err
+	}
+	if err = b.deleteLegacyPodGroups(ctx, pcs, replica, podGangs, aggregateName, legacyReferences); err != nil {
+		return err
+	}
+	log.FromContext(ctx).Info("Synced aggregate KAI PodGroup", "podCliqueSet", client.ObjectKeyFromObject(pcs), "replica", replica, "podGroup", aggregateName)
+	return nil
+}
+
+func (b *schedulerBackend) listActivePodGangsForReplica(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet, replica int) ([]groveschedulerv1alpha1.PodGang, error) {
+	list := &groveschedulerv1alpha1.PodGangList{}
+	labels := apicommon.GetDefaultLabelsForPodCliqueSetManagedResources(pcs.Name)
+	labels[apicommon.LabelPodCliqueSetReplicaIndex] = strconv.Itoa(replica)
+	labels[apicommon.LabelSchedulerName] = b.Name()
+	if err := b.client.List(ctx, list,
+		client.InNamespace(pcs.Namespace),
+		client.MatchingLabels(labels),
+	); err != nil {
+		return nil, fmt.Errorf("list PodGangs for PodCliqueSet %s/%s: %w", pcs.Namespace, pcs.Name, err)
+	}
+
+	result := make([]groveschedulerv1alpha1.PodGang, 0, len(list.Items))
+	for i := range list.Items {
+		podGang := &list.Items[i]
+		if !metav1.IsControlledBy(podGang, pcs) || !podGang.DeletionTimestamp.IsZero() {
+			continue
+		}
+		result = append(result, *podGang)
+	}
+	return result, nil
+}
+
+func (b *schedulerBackend) buildAggregatePodGroup(
+	pcs *grovecorev1alpha1.PodCliqueSet,
+	replica int,
+	basePodGang *groveschedulerv1alpha1.PodGang,
+	podGangs []groveschedulerv1alpha1.PodGang,
+	topologyReference string,
+) (*kaischedulingv2alpha2.PodGroup, error) {
+	queueName, err := resolveQueueNameForPodCliqueSet(pcs)
+	if err != nil {
+		return nil, err
+	}
+	rootTopology, err := toKAITopologyConstraint(basePodGang.Spec.TopologyConstraint, topologyReference)
+	if err != nil {
+		return nil, err
+	}
+
+	builder := newSubGroupBuilder(topologyReference)
+	baseBranch := stableKAIName(basePodGang.Name)
+	if err = builder.appendPodGangBranch(basePodGang, baseBranch, nil, nil); err != nil {
+		return nil, err
+	}
+	if _, found := builder.names[scaledPodGangsSubGroupName]; found {
+		return nil, fmt.Errorf("base PodGang %s/%s conflicts with reserved KAI subgroup name %q", basePodGang.Namespace, basePodGang.Name, scaledPodGangsSubGroupName)
+	}
+
+	scaledPodGangs := make([]groveschedulerv1alpha1.PodGang, 0, len(podGangs))
+	for i := range podGangs {
+		podGang := &podGangs[i]
+		if podGang.Name == basePodGang.Name {
+			continue
+		}
+		if podGang.Spec.PriorityClassName != basePodGang.Spec.PriorityClassName {
+			return nil, fmt.Errorf("PodGangs %s and %s have conflicting priority classes", basePodGang.Name, podGang.Name)
+		}
+		if podGang.Labels[apicommon.LabelPodCliqueScalingGroup] == "" {
+			return nil, fmt.Errorf("scaled PodGang %s/%s is missing required label %q", podGang.Namespace, podGang.Name, apicommon.LabelPodCliqueScalingGroup)
+		}
+		scaledPodGangs = append(scaledPodGangs, *podGang)
+	}
+
+	sort.Slice(scaledPodGangs, func(i, j int) bool { return scaledPodGangs[i].Name < scaledPodGangs[j].Name })
+	rootMinSubGroup := int32(1)
+	if len(scaledPodGangs) > 0 {
+		if err = builder.add(kaischedulingv2alpha2.SubGroup{
+			Name:        scaledPodGangsSubGroupName,
+			MinSubGroup: ptr.To[int32](0),
+		}); err != nil {
+			return nil, err
+		}
+		rootMinSubGroup = 2
+	}
+	for i := range scaledPodGangs {
+		podGang := &scaledPodGangs[i]
+		if stableKAIName(podGang.Name) == scaledPodGangsSubGroupName {
+			return nil, fmt.Errorf("scaled PodGang %s/%s conflicts with reserved KAI subgroup name %q", podGang.Namespace, podGang.Name, scaledPodGangsSubGroupName)
+		}
+		branchTopology, topologyErr := toKAITopologyConstraint(podGang.Spec.TopologyConstraint, topologyReference)
+		if topologyErr != nil {
+			return nil, topologyErr
+		}
+		if reflect.DeepEqual(rootTopology, branchTopology) {
+			branchTopology = nil
+		}
+		parent := scaledPodGangsSubGroupName
+		if err = builder.appendPodGangBranch(podGang, builder.structuralName(podGang.Name, "gang"), &parent, branchTopology); err != nil {
+			return nil, err
+		}
+	}
+
+	result := &kaischedulingv2alpha2.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        aggregatePodGroupName(pcs.Name, replica),
+			Namespace:   basePodGang.Namespace,
+			Labels:      maps.Clone(basePodGang.Labels),
+			Annotations: maps.Clone(basePodGang.Annotations),
+		},
+		Spec: kaischedulingv2alpha2.PodGroupSpec{
+			MinSubGroup:       ptr.To(rootMinSubGroup),
+			Queue:             queueName,
+			PriorityClassName: basePodGang.Spec.PriorityClassName,
+			SubGroups:         builder.subGroups,
+		},
+	}
+	if rootTopology != nil {
+		result.Spec.TopologyConstraint = *rootTopology
+	}
+	if err = controllerutil.SetControllerReference(pcs, result, b.scheme); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+type subGroupBuilder struct {
+	topologyReference string
+	names             map[string]struct{}
+	subGroups         []kaischedulingv2alpha2.SubGroup
+}
+
+func newSubGroupBuilder(topologyReference string) *subGroupBuilder {
+	return &subGroupBuilder{topologyReference: topologyReference, names: map[string]struct{}{}}
+}
+
+func (b *subGroupBuilder) add(subGroup kaischedulingv2alpha2.SubGroup) error {
+	if _, found := b.names[subGroup.Name]; found {
+		return fmt.Errorf("duplicate KAI subgroup name %q", subGroup.Name)
+	}
+	b.names[subGroup.Name] = struct{}{}
+	b.subGroups = append(b.subGroups, subGroup)
+	return nil
+}
+
+func (b *subGroupBuilder) structuralName(value, role string) string {
+	name := stableKAIName(value)
+	if _, found := b.names[name]; !found {
+		return name
+	}
+	return stableKAIName(value + "-" + role)
+}
+
+func (b *subGroupBuilder) appendPodGangBranch(podGang *groveschedulerv1alpha1.PodGang, branchName string, parent *string, branchTopology *kaischedulingv2alpha2.TopologyConstraint) error {
+	podGroups := append([]groveschedulerv1alpha1.PodGroup(nil), podGang.Spec.PodGroups...)
+	sort.Slice(podGroups, func(i, j int) bool { return podGroups[i].Name < podGroups[j].Name })
+	groups := make([]groveschedulerv1alpha1.TopologyConstraintGroupConfig, 0, len(podGang.Spec.TopologyConstraintGroupConfigs))
+	for _, group := range podGang.Spec.TopologyConstraintGroupConfigs {
+		if len(group.PodGroupNames) > 0 {
+			groups = append(groups, group)
+		}
+	}
+	sort.Slice(groups, func(i, j int) bool { return groups[i].Name < groups[j].Name })
+
+	podGroupNames := map[string]struct{}{}
+	for _, podGroup := range podGroups {
+		podGroupNames[podGroup.Name] = struct{}{}
+	}
+	parentByPodGroup := map[string]string{}
+	for _, group := range groups {
+		groupName := stableKAIName(group.Name)
+		for _, podGroupName := range group.PodGroupNames {
+			if _, found := podGroupNames[podGroupName]; !found {
+				return fmt.Errorf("topology group %q references unknown PodGroup %q", group.Name, podGroupName)
+			}
+			if previous, found := parentByPodGroup[podGroupName]; found {
+				return fmt.Errorf("PodGroup %q belongs to topology groups %q and %q", podGroupName, previous, group.Name)
+			}
+			parentByPodGroup[podGroupName] = groupName
+		}
+	}
+	directChildren := len(groups)
+	for _, podGroup := range podGroups {
+		if _, grouped := parentByPodGroup[podGroup.Name]; !grouped {
+			directChildren++
+		}
+	}
+	if err := b.add(kaischedulingv2alpha2.SubGroup{
+		Name:               branchName,
+		Parent:             parent,
+		MinSubGroup:        ptr.To(int32(directChildren)),
+		TopologyConstraint: branchTopology,
+	}); err != nil {
+		return err
+	}
+
+	for _, group := range groups {
+		groupTopology, err := toKAITopologyConstraint(group.TopologyConstraint, b.topologyReference)
+		if err != nil {
+			return err
+		}
+		branch := branchName
+		if err = b.add(kaischedulingv2alpha2.SubGroup{
+			Name:               stableKAIName(group.Name),
+			Parent:             &branch,
+			MinSubGroup:        ptr.To(int32(len(group.PodGroupNames))),
+			TopologyConstraint: groupTopology,
+		}); err != nil {
+			return err
+		}
+	}
+	for _, podGroup := range podGroups {
+		leafTopology, err := toKAITopologyConstraint(podGroup.TopologyConstraint, b.topologyReference)
+		if err != nil {
+			return err
+		}
+		leafParent := branchName
+		if groupParent, found := parentByPodGroup[podGroup.Name]; found {
+			leafParent = groupParent
+		}
+		if err = b.add(kaischedulingv2alpha2.SubGroup{
+			Name:               stableKAIName(podGroup.Name),
+			Parent:             &leafParent,
+			MinMember:          ptr.To(podGroup.MinReplicas),
+			TopologyConstraint: leafTopology,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *schedulerBackend) resolveKAITopologyReference(ctx context.Context, podGangs []groveschedulerv1alpha1.PodGang) (string, error) {
+	clusterTopologyName := ""
+	for i := range podGangs {
+		podGang := &podGangs[i]
+		if !podGangHasTopologyConstraints(podGang) {
+			continue
+		}
+		name := getTopologyName(podGang)
+		if name == "" {
+			return "", fmt.Errorf("PodGang %s/%s has topology constraints without %q annotation", podGang.Namespace, podGang.Name, apicommonconstants.AnnotationTopologyName)
+		}
+		if clusterTopologyName != "" && clusterTopologyName != name {
+			return "", fmt.Errorf("PodGangs for one PCS replica reference multiple ClusterTopologyBindings: %q and %q", clusterTopologyName, name)
+		}
+		clusterTopologyName = name
+	}
+	if clusterTopologyName == "" {
+		return "", nil
+	}
+
+	ct := &grovecorev1alpha1.ClusterTopologyBinding{}
+	if err := b.client.Get(ctx, client.ObjectKey{Name: clusterTopologyName}, ct); err != nil {
+		return "", fmt.Errorf("get ClusterTopologyBinding %q: %w", clusterTopologyName, err)
+	}
+	for _, binding := range ct.Spec.SchedulerTopologyBindings {
+		if binding.SchedulerName == b.Name() {
+			return binding.TopologyReference, nil
+		}
+	}
+	return b.TopologyResourceName(ct), nil
+}
+
+func podGangHasTopologyConstraints(podGang *groveschedulerv1alpha1.PodGang) bool {
+	if podGang.Spec.TopologyConstraint != nil {
+		return true
+	}
+	for _, group := range podGang.Spec.TopologyConstraintGroupConfigs {
+		if len(group.PodGroupNames) > 0 && group.TopologyConstraint != nil {
+			return true
+		}
+	}
+	for _, podGroup := range podGang.Spec.PodGroups {
+		if podGroup.TopologyConstraint != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *schedulerBackend) syncPodGroup(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet, desired *kaischedulingv2alpha2.PodGroup) error {
+	existing := &kaischedulingv2alpha2.PodGroup{}
+	if err := b.client.Get(ctx, client.ObjectKeyFromObject(desired), existing); err != nil {
+		if apierrors.IsNotFound(err) {
+			return b.client.Create(ctx, desired)
+		}
+		return err
+	}
+	if !metav1.IsControlledBy(existing, pcs) {
+		return fmt.Errorf("KAI PodGroup %s/%s already exists and is not controlled by PodCliqueSet %s", existing.Namespace, existing.Name, pcs.Name)
+	}
+	desired = b.inheritRuntimeManagedFields(existing, desired)
+	if podGroupsEqual(existing, desired) {
+		return nil
+	}
+	updatePodGroup(existing, desired)
+	return b.client.Update(ctx, existing)
+}
+
+func (b *schedulerBackend) migratePods(
+	ctx context.Context,
+	pcs *grovecorev1alpha1.PodCliqueSet,
+	replica int,
+	podGangs []groveschedulerv1alpha1.PodGang,
+	desired *kaischedulingv2alpha2.PodGroup,
+) (map[string]bool, error) {
+	podGangNames := map[string]struct{}{}
+	for i := range podGangs {
+		podGangNames[podGangs[i].Name] = struct{}{}
+	}
+	leaves := map[string]struct{}{}
+	for _, subGroup := range desired.Spec.SubGroups {
+		if subGroup.MinMember != nil {
+			leaves[subGroup.Name] = struct{}{}
+		}
+	}
+
+	pods, err := b.listActivePodsForReplica(ctx, pcs, replica)
+	if err != nil {
+		return nil, err
+	}
+	legacyReferences := map[string]bool{}
+	for i := range pods {
+		pod := &pods[i]
+		podGangName := pod.Labels[apicommon.LabelPodGang]
+		if _, found := podGangNames[podGangName]; !found {
+			return nil, fmt.Errorf("pod %s/%s references PodGang %q outside aggregate %q", pod.Namespace, pod.Name, podGangName, desired.Name)
+		}
+		leaf := stableKAIName(pod.Labels[apicommon.LabelPodClique])
+		if _, found := leaves[leaf]; !found {
+			return nil, fmt.Errorf("pod %s/%s maps to missing KAI subgroup %q", pod.Namespace, pod.Name, leaf)
+		}
+		if oldPodGroup := pod.Annotations[annotationPodGroup]; oldPodGroup != "" && oldPodGroup != desired.Name {
+			legacyReferences[oldPodGroup] = true
+		}
+		if pod.Annotations[annotationPodGroup] == desired.Name && pod.Labels[labelSubGroup] == leaf && pod.Annotations[annotationKeySkipPGR] == annotationValSkipPGR {
+			continue
+		}
+		before := pod.DeepCopy()
+		if pod.Annotations == nil {
+			pod.Annotations = map[string]string{}
+		}
+		if pod.Labels == nil {
+			pod.Labels = map[string]string{}
+		}
+		pod.Annotations[annotationKeySkipPGR] = annotationValSkipPGR
+		pod.Annotations[annotationPodGroup] = desired.Name
+		pod.Labels[labelSubGroup] = leaf
+		if err = b.client.Patch(ctx, pod, client.MergeFrom(before)); err != nil {
+			return nil, fmt.Errorf("migrate Pod %s/%s to KAI PodGroup %q: %w", pod.Namespace, pod.Name, desired.Name, err)
+		}
+	}
+	return legacyReferences, nil
+}
+
+func (b *schedulerBackend) listActivePodsForReplica(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet, replica int) ([]corev1.Pod, error) {
+	list := &corev1.PodList{}
+	if err := b.client.List(ctx, list,
+		client.InNamespace(pcs.Namespace),
+		client.MatchingLabels(apicommon.GetDefaultLabelsForPodCliqueSetManagedResources(pcs.Name)),
+	); err != nil {
+		return nil, fmt.Errorf("list Pods for PodCliqueSet %s/%s: %w", pcs.Namespace, pcs.Name, err)
+	}
+	result := make([]corev1.Pod, 0, len(list.Items))
+	for i := range list.Items {
+		pod := &list.Items[i]
+		if !pod.DeletionTimestamp.IsZero() {
+			continue
+		}
+		podReplica, err := podCliqueSetReplicaFromObjectMeta(pod.ObjectMeta)
+		if err != nil {
+			return nil, fmt.Errorf("pod %s/%s: %w", pod.Namespace, pod.Name, err)
+		}
+		if podReplica == replica {
+			result = append(result, *pod.DeepCopy())
+		}
+	}
+	return result, nil
+}
+
+func (b *schedulerBackend) verifyNoActivePodsForReplica(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet, replica int) error {
+	pods, err := b.listActivePodsForReplica(ctx, pcs, replica)
+	if err != nil {
+		return err
+	}
+	if len(pods) > 0 {
+		return fmt.Errorf("waiting for %d Pods in PodCliqueSet %s/%s replica %d to terminate", len(pods), pcs.Namespace, pcs.Name, replica)
+	}
+	return nil
+}
+
+func (b *schedulerBackend) deleteLegacyPodGroups(
+	ctx context.Context,
+	pcs *grovecorev1alpha1.PodCliqueSet,
+	replica int,
+	podGangs []groveschedulerv1alpha1.PodGang,
+	aggregateName string,
+	referenced map[string]bool,
+) error {
+	activePods, err := b.listActivePodsForReplica(ctx, pcs, replica)
+	if err != nil {
+		return err
+	}
+	activeReferences := make(map[string]struct{}, len(activePods))
+	for i := range activePods {
+		if name := activePods[i].Annotations[annotationPodGroup]; name != "" {
+			activeReferences[name] = struct{}{}
+		}
+	}
+
+	podGroups := &kaischedulingv2alpha2.PodGroupList{}
+	if err = b.client.List(ctx, podGroups, client.InNamespace(pcs.Namespace)); err != nil {
+		return fmt.Errorf("list KAI PodGroups while cleaning legacy groups for PodCliqueSet %s/%s replica %d: %w",
+			pcs.Namespace, pcs.Name, replica, err)
+	}
+	legacyByName := make(map[string]*kaischedulingv2alpha2.PodGroup)
+	for i := range podGroups.Items {
+		podGroup := &podGroups.Items[i]
+		if podGroup.Name == aggregateName {
+			continue
+		}
+		if _, owned := owningPodGang(podGroup, podGangs); owned {
+			legacyByName[podGroup.Name] = podGroup
+		}
+	}
+
+	// PR #725 used the PodGang name directly. Keep looking up those deterministic
+	// names as well, including objects that predate or lost their controller reference.
+	for i := range podGangs {
+		podGang := &podGangs[i]
+		if podGang.Name == aggregateName {
+			continue
+		}
+		legacy := &kaischedulingv2alpha2.PodGroup{}
+		key := client.ObjectKey{Namespace: podGang.Namespace, Name: podGang.Name}
+		if err = b.client.Get(ctx, key, legacy); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return err
+		}
+		legacyByName[legacy.Name] = legacy
+	}
+
+	legacyNames := make([]string, 0, len(legacyByName))
+	for name := range legacyByName {
+		legacyNames = append(legacyNames, name)
+	}
+	sort.Strings(legacyNames)
+	for _, name := range legacyNames {
+		legacy := legacyByName[name]
+		key := client.ObjectKeyFromObject(legacy)
+		podGang, owned := owningPodGang(legacy, podGangs)
+		if !owned && !referenced[legacy.Name] {
+			return fmt.Errorf("refusing to delete KAI PodGroup %s: it is neither owned by a sibling PodGang nor referenced by its Grove Pods", key)
+		}
+		if _, active := activeReferences[legacy.Name]; active {
+			return fmt.Errorf("refusing to delete legacy KAI PodGroup %s while an active Grove Pod still references it", key)
+		}
+		if err = b.client.Delete(ctx, legacy); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete legacy KAI PodGroup %s: %w", key, err)
+		}
+		if owned {
+			log.FromContext(ctx).V(1).Info("Deleted legacy KAI PodGroup", "podGroup", key, "podGang", client.ObjectKeyFromObject(podGang))
+		}
+	}
+	return nil
+}
+
+func owningPodGang(
+	podGroup *kaischedulingv2alpha2.PodGroup,
+	podGangs []groveschedulerv1alpha1.PodGang,
+) (*groveschedulerv1alpha1.PodGang, bool) {
+	for i := range podGangs {
+		for _, owner := range podGroup.OwnerReferences {
+			if owner.Kind == "PodGang" &&
+				owner.Name == podGangs[i].Name &&
+				owner.UID == podGangs[i].UID {
+				return &podGangs[i], true
+			}
+		}
+	}
+	return nil, false
+}
+
+func (b *schedulerBackend) deleteAggregatePodGroup(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet, name string) error {
+	podGroup := &kaischedulingv2alpha2.PodGroup{}
+	key := client.ObjectKey{Namespace: pcs.Namespace, Name: name}
+	if err := b.client.Get(ctx, key, podGroup); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if !metav1.IsControlledBy(podGroup, pcs) {
+		return fmt.Errorf("refusing to delete KAI PodGroup %s not controlled by PodCliqueSet %s", key, pcs.Name)
+	}
+	return client.IgnoreNotFound(b.client.Delete(ctx, podGroup))
+}
+
+func findPodGangByName(podGangs []groveschedulerv1alpha1.PodGang, name string) (*groveschedulerv1alpha1.PodGang, bool) {
+	for i := range podGangs {
+		if podGangs[i].Name == name {
+			return &podGangs[i], true
+		}
+	}
+	return nil, false
+}
+
+func podCliqueSetReplicaFromObjectMeta(objMeta metav1.ObjectMeta) (int, error) {
+	replica, err := k8sutils.GetPodCliqueSetReplicaIndex(objMeta)
+	if err != nil {
+		return 0, err
+	}
+	if replica < 0 {
+		return 0, fmt.Errorf("invalid %s value %q", apicommon.LabelPodCliqueSetReplicaIndex, objMeta.Labels[apicommon.LabelPodCliqueSetReplicaIndex])
+	}
+	return replica, nil
+}
+
+func aggregatePodGroupName(pcsName string, replica int) string {
+	return stableKAIName(fmt.Sprintf("%s%s-%d", aggregatePrefix, pcsName, replica))
+}
+
+func stableKAIName(value string) string {
+	lower := strings.ToLower(value)
+	var sanitized strings.Builder
+	lastDash := false
+	for _, char := range lower {
+		valid := char >= 'a' && char <= 'z' || char >= '0' && char <= '9' || char == '-'
+		if !valid {
+			char = '-'
+		}
+		if char == '-' {
+			if lastDash {
+				continue
+			}
+			lastDash = true
+		} else {
+			lastDash = false
+		}
+		sanitized.WriteRune(char)
+	}
+	name := strings.Trim(sanitized.String(), "-")
+	if name == value && len(name) <= 63 {
+		return name
+	}
+	hash := sha256.Sum256([]byte(value))
+	suffix := hex.EncodeToString(hash[:])[:10]
+	if name == "" {
+		return "kai-" + suffix
+	}
+	if len(name) > 52 {
+		name = strings.TrimRight(name[:52], "-")
+	}
+	return name + "-" + suffix
+}

--- a/operator/internal/scheduler/kai/aggregate_test.go
+++ b/operator/internal/scheduler/kai/aggregate_test.go
@@ -1,0 +1,584 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kai
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	apicommon "github.com/ai-dynamo/grove/operator/api/common"
+	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	testutils "github.com/ai-dynamo/grove/operator/test/utils"
+
+	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
+	kaischedulingv2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func TestSyncAggregatePodGroupSerializesPodGangsForSameReplica(t *testing.T) {
+	ctx := context.Background()
+	pcs := newPodCliqueSet("job", "team-a")
+	base := testutils.NewPodGangBuilder("job-0", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		Build()
+	setPodCliqueSetControllerOwner(base, pcs)
+	scaled := testutils.NewPodGangBuilder("job-0-workers-0", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		Build()
+	setPodCliqueSetControllerOwner(scaled, pcs)
+	scaled.Labels[apicommon.LabelPodCliqueScalingGroup] = "job-0-workers"
+
+	baseClient := testutils.NewTestClientBuilder().WithObjects(pcs, base, scaled).Build()
+	blockingClient := &blockingPodGangListClient{
+		Client:            baseClient,
+		firstListStarted:  make(chan struct{}),
+		secondListStarted: make(chan struct{}),
+		releaseFirstList:  make(chan struct{}),
+	}
+	backend := New(blockingClient, baseClient.Scheme(), record.NewFakeRecorder(10), configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}).(*schedulerBackend)
+	require.NoError(t, backend.Init(blockingClient))
+
+	firstResult := make(chan error, 1)
+	go func() {
+		firstResult <- backend.syncAggregatePodGroup(ctx, pcs, base)
+	}()
+	require.Eventually(t, func() bool {
+		select {
+		case <-blockingClient.firstListStarted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+
+	secondInvoked := make(chan struct{})
+	secondResult := make(chan error, 1)
+	go func() {
+		close(secondInvoked)
+		secondResult <- backend.syncAggregatePodGroup(ctx, pcs, scaled)
+	}()
+	<-secondInvoked
+	assert.Never(t, func() bool {
+		select {
+		case <-blockingClient.secondListStarted:
+			return true
+		default:
+			return false
+		}
+	}, 50*time.Millisecond, time.Millisecond)
+
+	close(blockingClient.releaseFirstList)
+	require.NoError(t, <-firstResult)
+	require.NoError(t, <-secondResult)
+}
+
+func TestBuildAggregatePodGroupBaseOnlyOmitsScaledPodGangCollection(t *testing.T) {
+	pcs := newPodCliqueSet("job", "team-a")
+	base := testutils.NewPodGangBuilder("job-0", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		WithPodGroup("base-a", 1).
+		WithPodGroup("base-b", 2).
+		Build()
+	setPodCliqueSetControllerOwner(base, pcs)
+
+	cl := testutils.NewTestClientBuilder().Build()
+	backend := New(cl, cl.Scheme(), record.NewFakeRecorder(10), configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}).(*schedulerBackend)
+	require.NoError(t, backend.Init(cl))
+
+	aggregate, err := backend.buildAggregatePodGroup(
+		pcs,
+		0,
+		base,
+		[]groveschedulerv1alpha1.PodGang{*base},
+		"",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, aggregate.Spec.MinSubGroup)
+	assert.Equal(t, int32(1), *aggregate.Spec.MinSubGroup)
+	assert.Nil(t, aggregate.Spec.MinMember)
+	assert.Nil(t, findSubGroup(aggregate, scaledPodGangsSubGroupName))
+
+	baseBranch := requireSubGroup(t, aggregate, stableKAIName(base.Name))
+	assert.Nil(t, baseBranch.Parent)
+	require.NotNil(t, baseBranch.MinSubGroup)
+	assert.Equal(t, int32(2), *baseBranch.MinSubGroup)
+}
+
+func TestBuildAggregatePodGroupUsesSharedScaledPodGangCollection(t *testing.T) {
+	pcs := newPodCliqueSet("job", "team-a")
+	base := testutils.NewPodGangBuilder("job-0", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		WithPodGroup("base-a", 1).
+		WithPodGroup("base-b", 2).
+		Build()
+	setPodCliqueSetControllerOwner(base, pcs)
+
+	scaledA := testutils.NewPodGangBuilder("job-0-workers-0", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		WithPodGroup("scaled-a", 1).
+		Build()
+	setPodCliqueSetControllerOwner(scaledA, pcs)
+	scaledA.Labels[apicommon.LabelPodCliqueScalingGroup] = "job-0-workers"
+
+	scaledB := testutils.NewPodGangBuilder("job-0-workers-1", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		WithPodGroup("scaled-b", 1).
+		Build()
+	setPodCliqueSetControllerOwner(scaledB, pcs)
+	scaledB.Labels[apicommon.LabelPodCliqueScalingGroup] = "job-0-workers"
+
+	cl := testutils.NewTestClientBuilder().Build()
+	backend := New(cl, cl.Scheme(), record.NewFakeRecorder(10), configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}).(*schedulerBackend)
+	require.NoError(t, backend.Init(cl))
+
+	aggregate, err := backend.buildAggregatePodGroup(
+		pcs,
+		0,
+		base,
+		[]groveschedulerv1alpha1.PodGang{*base, *scaledA, *scaledB},
+		"",
+	)
+	require.NoError(t, err)
+
+	require.NotNil(t, aggregate.Spec.MinSubGroup)
+	assert.Equal(t, int32(2), *aggregate.Spec.MinSubGroup)
+	assert.Nil(t, aggregate.Spec.MinMember)
+
+	baseBranch := requireSubGroup(t, aggregate, stableKAIName(base.Name))
+	assert.Equal(t, base.Name, baseBranch.Name)
+	assert.Nil(t, baseBranch.Parent)
+	require.NotNil(t, baseBranch.MinSubGroup)
+	assert.Equal(t, int32(2), *baseBranch.MinSubGroup)
+
+	scaledCollection := requireSubGroup(t, aggregate, scaledPodGangsSubGroupName)
+	assert.Nil(t, scaledCollection.Parent)
+	require.NotNil(t, scaledCollection.MinSubGroup)
+	assert.Equal(t, int32(0), *scaledCollection.MinSubGroup)
+	assert.Nil(t, scaledCollection.MinMember)
+	assert.Nil(t, scaledCollection.TopologyConstraint)
+
+	rootSubGroups := make([]string, 0, 2)
+	for i := range aggregate.Spec.SubGroups {
+		if aggregate.Spec.SubGroups[i].Parent == nil {
+			rootSubGroups = append(rootSubGroups, aggregate.Spec.SubGroups[i].Name)
+		}
+	}
+	assert.ElementsMatch(t, []string{baseBranch.Name, scaledPodGangsSubGroupName}, rootSubGroups)
+
+	for _, scaledPodGang := range []*groveschedulerv1alpha1.PodGang{scaledA, scaledB} {
+		branch := requireSubGroup(t, aggregate, stableKAIName(scaledPodGang.Name))
+		require.NotNil(t, branch.Parent)
+		assert.Equal(t, scaledCollection.Name, *branch.Parent)
+	}
+}
+
+func TestBuildAggregatePodGroupSharesScaledCollectionAcrossPCSGLabels(t *testing.T) {
+	pcs := newPodCliqueSet("job", "team-a")
+	base := testutils.NewPodGangBuilder("job-0", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		WithPodGroup("base", 1).
+		Build()
+	setPodCliqueSetControllerOwner(base, pcs)
+
+	scaledA := testutils.NewPodGangBuilder("job-0-workers-0", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		WithPodGroup("worker", 1).
+		Build()
+	setPodCliqueSetControllerOwner(scaledA, pcs)
+	scaledA.Labels[apicommon.LabelPodCliqueScalingGroup] = "job-0-workers"
+
+	scaledB := testutils.NewPodGangBuilder("job-0-evaluators-0", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		WithPodGroup("evaluator", 1).
+		Build()
+	setPodCliqueSetControllerOwner(scaledB, pcs)
+	scaledB.Labels[apicommon.LabelPodCliqueScalingGroup] = "job-0-evaluators"
+
+	cl := testutils.NewTestClientBuilder().Build()
+	backend := New(cl, cl.Scheme(), record.NewFakeRecorder(10), configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}).(*schedulerBackend)
+	require.NoError(t, backend.Init(cl))
+
+	aggregate, err := backend.buildAggregatePodGroup(
+		pcs,
+		0,
+		base,
+		[]groveschedulerv1alpha1.PodGang{*base, *scaledA, *scaledB},
+		"",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, aggregate.Spec.MinSubGroup)
+	assert.Equal(t, int32(2), *aggregate.Spec.MinSubGroup)
+	assert.Nil(t, aggregate.Spec.MinMember)
+
+	collection := requireSubGroup(t, aggregate, scaledPodGangsSubGroupName)
+	assert.Nil(t, collection.Parent)
+	require.NotNil(t, collection.MinSubGroup)
+	assert.Equal(t, int32(0), *collection.MinSubGroup)
+	assert.Nil(t, collection.MinMember)
+	assert.Nil(t, collection.TopologyConstraint)
+	assert.Nil(t, findSubGroup(aggregate, scaledA.Labels[apicommon.LabelPodCliqueScalingGroup]))
+	assert.Nil(t, findSubGroup(aggregate, scaledB.Labels[apicommon.LabelPodCliqueScalingGroup]))
+
+	for _, scaledPodGang := range []*groveschedulerv1alpha1.PodGang{scaledA, scaledB} {
+		branch := requireSubGroup(t, aggregate, stableKAIName(scaledPodGang.Name))
+		require.NotNil(t, branch.Parent)
+		assert.Equal(t, collection.Name, *branch.Parent)
+	}
+
+	rootSubGroups := make([]string, 0, 2)
+	for i := range aggregate.Spec.SubGroups {
+		if aggregate.Spec.SubGroups[i].Parent == nil {
+			rootSubGroups = append(rootSubGroups, aggregate.Spec.SubGroups[i].Name)
+		}
+	}
+	assert.ElementsMatch(t, []string{stableKAIName(base.Name), scaledPodGangsSubGroupName}, rootSubGroups)
+}
+
+func TestBuildAggregatePodGroupRequiresPCSGLabelForScaledPodGang(t *testing.T) {
+	pcs := newPodCliqueSet("job", "team-a")
+	base := testutils.NewPodGangBuilder("job-0", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		WithPodGroup("base", 1).
+		Build()
+	setPodCliqueSetControllerOwner(base, pcs)
+
+	scaled := testutils.NewPodGangBuilder("job-0-workers-0", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		WithPodGroup("worker", 1).
+		Build()
+	setPodCliqueSetControllerOwner(scaled, pcs)
+
+	cl := testutils.NewTestClientBuilder().Build()
+	backend := New(cl, cl.Scheme(), record.NewFakeRecorder(10), configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}).(*schedulerBackend)
+	require.NoError(t, backend.Init(cl))
+
+	_, err := backend.buildAggregatePodGroup(
+		pcs,
+		0,
+		base,
+		[]groveschedulerv1alpha1.PodGang{*base, *scaled},
+		"",
+	)
+	require.ErrorContains(t, err, "missing required label")
+	assert.ErrorContains(t, err, apicommon.LabelPodCliqueScalingGroup)
+}
+
+func TestBuildAggregatePodGroupRejectsReservedScaledCollectionName(t *testing.T) {
+	pcs := newPodCliqueSet("job", "team-a")
+	base := testutils.NewPodGangBuilder("job-0", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		WithPodGroup("base", 1).
+		Build()
+	setPodCliqueSetControllerOwner(base, pcs)
+
+	scaled := testutils.NewPodGangBuilder(scaledPodGangsSubGroupName, "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		WithPodGroup("worker", 1).
+		Build()
+	setPodCliqueSetControllerOwner(scaled, pcs)
+	scaled.Labels[apicommon.LabelPodCliqueScalingGroup] = "job-0-workers"
+
+	cl := testutils.NewTestClientBuilder().Build()
+	backend := New(cl, cl.Scheme(), record.NewFakeRecorder(10), configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}).(*schedulerBackend)
+	require.NoError(t, backend.Init(cl))
+
+	_, err := backend.buildAggregatePodGroup(
+		pcs,
+		0,
+		base,
+		[]groveschedulerv1alpha1.PodGang{*base, *scaled},
+		"",
+	)
+	require.ErrorContains(t, err, "conflicts with reserved KAI subgroup name")
+}
+
+func TestSyncAggregatePodGroupMigratesLegacyResourcesAndMapsTopology(t *testing.T) {
+	ctx := context.Background()
+	pcs := newPodCliqueSet("job", "team-a")
+
+	base := testutils.NewPodGangBuilder("job-0", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		WithPodGroup("job-0-workers-0-trainer", 2).
+		Build()
+	base.UID = types.UID("base-uid")
+	setPodCliqueSetControllerOwner(base, pcs)
+	base.Annotations = map[string]string{"grove.io/topology-name": "grove-topology"}
+	base.Spec.TopologyConstraint = topologyConstraint("zone")
+	base.Spec.TopologyConstraintGroupConfigs = []groveschedulerv1alpha1.TopologyConstraintGroupConfig{{
+		Name:               "job-0-workers-0",
+		PodGroupNames:      []string{"job-0-workers-0-trainer"},
+		TopologyConstraint: topologyConstraint("rack"),
+	}}
+	base.Spec.PodGroups[0].TopologyConstraint = topologyConstraint("host")
+
+	scaled := testutils.NewPodGangBuilder("job-0-workers-0", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		WithPodGroup("job-0-workers-1-trainer", 2).
+		Build()
+	scaled.UID = types.UID("scaled-uid")
+	setPodCliqueSetControllerOwner(scaled, pcs)
+	scaled.Labels[apicommon.LabelPodCliqueScalingGroup] = "job-0-workers"
+	scaled.Annotations = map[string]string{"grove.io/topology-name": "grove-topology"}
+	scaled.Spec.TopologyConstraint = topologyConstraint("rack")
+	scaled.Spec.PodGroups[0].TopologyConstraint = topologyConstraint("host")
+
+	clusterTopology := &grovecorev1alpha1.ClusterTopologyBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "grove-topology"},
+		Spec: grovecorev1alpha1.ClusterTopologyBindingSpec{
+			SchedulerTopologyBindings: []grovecorev1alpha1.SchedulerTopologyBinding{{
+				SchedulerName:     string(configv1alpha1.SchedulerNameKai),
+				TopologyReference: "external-kai-topology",
+			}},
+		},
+	}
+	basePod := testAggregatePod("base-pod", pcs.Name, "job-0", "job-0-workers-0-trainer")
+	scaledPod := testAggregatePod("scaled-pod", pcs.Name, "job-0-workers-0", "job-0-workers-1-trainer")
+	legacyBase := &kaischedulingv2alpha2.PodGroup{ObjectMeta: metav1.ObjectMeta{Name: base.Name, Namespace: base.Namespace}}
+	legacyScaled := &kaischedulingv2alpha2.PodGroup{ObjectMeta: metav1.ObjectMeta{Name: scaled.Name, Namespace: scaled.Namespace}}
+	stableLegacyBase := &kaischedulingv2alpha2.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "pg-" + base.Name + "-" + string(base.UID),
+			Namespace:       base.Namespace,
+			OwnerReferences: []metav1.OwnerReference{podGangOwnerReference(base)},
+		},
+	}
+	stableLegacyScaled := &kaischedulingv2alpha2.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "pg-" + scaled.Name + "-" + string(scaled.UID),
+			Namespace:       scaled.Namespace,
+			OwnerReferences: []metav1.OwnerReference{podGangOwnerReference(scaled)},
+		},
+	}
+	basePod.Annotations[annotationPodGroup] = stableLegacyBase.Name
+	scaledPod.Annotations[annotationPodGroup] = stableLegacyScaled.Name
+	unrelated := &kaischedulingv2alpha2.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "unrelated", Namespace: base.Namespace},
+	}
+
+	cl := testutils.NewTestClientBuilder().Build()
+	recorder := record.NewFakeRecorder(10)
+	backend := New(cl, cl.Scheme(), recorder, configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}).(*schedulerBackend)
+	require.NoError(t, backend.Init(cl))
+	require.NoError(t, controllerutil.SetControllerReference(base, legacyBase, cl.Scheme()))
+	require.NoError(t, controllerutil.SetControllerReference(scaled, legacyScaled, cl.Scheme()))
+	for _, object := range []client.Object{
+		pcs,
+		clusterTopology,
+		base,
+		scaled,
+		basePod,
+		scaledPod,
+		legacyBase,
+		legacyScaled,
+		stableLegacyBase,
+		stableLegacyScaled,
+		unrelated,
+	} {
+		require.NoError(t, cl.Create(ctx, object))
+	}
+
+	require.NoError(t, backend.SyncPodGang(ctx, base))
+
+	aggregate := &kaischedulingv2alpha2.PodGroup{}
+	require.NoError(t, cl.Get(ctx, client.ObjectKey{Namespace: pcs.Namespace, Name: "grove-job-0"}, aggregate))
+	assert.True(t, metav1.IsControlledBy(aggregate, pcs))
+	assert.Equal(t, "external-kai-topology", aggregate.Spec.TopologyConstraint.Topology)
+	assert.Equal(t, "zone", aggregate.Spec.TopologyConstraint.RequiredTopologyLevel)
+
+	collection := requireSubGroup(t, aggregate, scaledPodGangsSubGroupName)
+	assert.Nil(t, collection.TopologyConstraint, "scaled collection is structural, not one PCSG placement unit")
+	basePCSGReplica := requireSubGroup(t, aggregate, "job-0-workers-0")
+	require.NotNil(t, basePCSGReplica.TopologyConstraint)
+	assert.Equal(t, "external-kai-topology", basePCSGReplica.TopologyConstraint.Topology)
+	assert.Equal(t, "rack", basePCSGReplica.TopologyConstraint.RequiredTopologyLevel)
+	scaledBranch := requireSubGroup(t, aggregate, "job-0-workers-0-gang")
+	require.NotNil(t, scaledBranch.Parent)
+	assert.Equal(t, collection.Name, *scaledBranch.Parent)
+	require.NotNil(t, scaledBranch.TopologyConstraint)
+	assert.Equal(t, "rack", scaledBranch.TopologyConstraint.RequiredTopologyLevel)
+	assert.Equal(t, "external-kai-topology", requireSubGroup(t, aggregate, "job-0-workers-1-trainer").TopologyConstraint.Topology)
+
+	for _, pod := range []*corev1.Pod{basePod, scaledPod} {
+		current := &corev1.Pod{}
+		require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(pod), current))
+		assert.Equal(t, aggregate.Name, current.Annotations[annotationPodGroup])
+		assert.Equal(t, current.Labels[apicommon.LabelPodClique], current.Labels[labelSubGroup])
+	}
+	for _, name := range []string{base.Name, scaled.Name, stableLegacyBase.Name, stableLegacyScaled.Name} {
+		err := cl.Get(ctx, client.ObjectKey{Namespace: pcs.Namespace, Name: name}, &kaischedulingv2alpha2.PodGroup{})
+		assert.True(t, apierrors.IsNotFound(err), "legacy PodGroup %s must be deleted", name)
+	}
+	require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(unrelated), &kaischedulingv2alpha2.PodGroup{}))
+
+	currentScaled := &groveschedulerv1alpha1.PodGang{}
+	require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(scaled), currentScaled))
+	require.Contains(t, currentScaled.Finalizers, podGangFinalizer)
+	require.NoError(t, cl.Delete(ctx, currentScaled))
+	require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(scaled), currentScaled))
+	require.ErrorContains(t, backend.SyncPodGang(ctx, currentScaled), "outside aggregate")
+	require.Len(t, recorder.Events, 1)
+	event := <-recorder.Events
+	assert.Contains(t, event, "Warning "+eventReasonSyncFailed)
+	assert.Contains(t, event, "outside aggregate")
+	require.NoError(t, cl.Delete(ctx, scaledPod))
+	require.NoError(t, backend.SyncPodGang(ctx, currentScaled))
+	require.NoError(t, cl.Get(ctx, client.ObjectKey{Namespace: pcs.Namespace, Name: "grove-job-0"}, aggregate))
+	require.NotNil(t, aggregate.Spec.MinSubGroup)
+	assert.Equal(t, int32(1), *aggregate.Spec.MinSubGroup)
+	assert.Nil(t, findSubGroup(aggregate, scaledPodGangsSubGroupName), "scaled collection must be removed after final scale-down")
+	assert.Nil(t, findSubGroup(aggregate, scaledBranch.Name), "scaled PodGang branch must be removed after scale-down")
+}
+
+func TestSyncAggregatePodGroupDeletesOwnerControlledLegacyPodGroupOnRetry(t *testing.T) {
+	ctx := context.Background()
+	pcs := newPodCliqueSet("retry-job", "team-a")
+	base := testutils.NewPodGangBuilder("retry-job-0", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		WithPodGroup("worker", 1).
+		Build()
+	base.UID = types.UID("base-uid")
+	setPodCliqueSetControllerOwner(base, pcs)
+
+	aggregateName := "grove-retry-job-0"
+	pod := testAggregatePod("worker-pod", pcs.Name, base.Name, "worker")
+	pod.Annotations[annotationPodGroup] = aggregateName
+	pod.Annotations[annotationKeySkipPGR] = annotationValSkipPGR
+	pod.Labels[labelSubGroup] = "worker"
+
+	legacy := &kaischedulingv2alpha2.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "pg-" + base.Name + "-" + string(base.UID),
+			Namespace:       base.Namespace,
+			OwnerReferences: []metav1.OwnerReference{podGangOwnerReference(base)},
+		},
+	}
+	unrelated := &kaischedulingv2alpha2.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "unrelated-retry-group", Namespace: base.Namespace},
+	}
+
+	cl := testutils.NewTestClientBuilder().Build()
+	backend := New(
+		cl,
+		cl.Scheme(),
+		record.NewFakeRecorder(10),
+		configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai},
+	).(*schedulerBackend)
+	require.NoError(t, backend.Init(cl))
+	for _, object := range []client.Object{pcs, base, pod, legacy, unrelated} {
+		require.NoError(t, cl.Create(ctx, object))
+	}
+
+	require.NoError(t, backend.SyncPodGang(ctx, base))
+
+	err := cl.Get(ctx, client.ObjectKeyFromObject(legacy), &kaischedulingv2alpha2.PodGroup{})
+	assert.True(t, apierrors.IsNotFound(err), "owner-controlled legacy PodGroup must be deleted on retry")
+	require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(unrelated), &kaischedulingv2alpha2.PodGroup{}))
+
+	currentPod := &corev1.Pod{}
+	require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(pod), currentPod))
+	assert.Equal(t, aggregateName, currentPod.Annotations[annotationPodGroup])
+	assert.Equal(t, "worker", currentPod.Labels[labelSubGroup])
+}
+
+func podGangOwnerReference(podGang *groveschedulerv1alpha1.PodGang) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: groveschedulerv1alpha1.SchemeGroupVersion.String(),
+		Kind:       "PodGang",
+		Name:       podGang.Name,
+		UID:        podGang.UID,
+	}
+}
+
+func topologyConstraint(required string) *groveschedulerv1alpha1.TopologyConstraint {
+	return &groveschedulerv1alpha1.TopologyConstraint{
+		PackConstraint: &groveschedulerv1alpha1.TopologyPackConstraint{Required: ptr.To(required)},
+	}
+}
+
+func testAggregatePod(name, pcsName, podGangName, podCliqueName string) *corev1.Pod {
+	labels := apicommon.GetDefaultLabelsForPodCliqueSetManagedResources(pcsName)
+	labels[apicommon.LabelPodCliqueSetReplicaIndex] = "0"
+	labels[apicommon.LabelPodGang] = podGangName
+	labels[apicommon.LabelPodClique] = podCliqueName
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "default",
+			Labels:      labels,
+			Annotations: map[string]string{annotationPodGroup: podGangName},
+		},
+	}
+}
+
+func requireSubGroup(t *testing.T, podGroup *kaischedulingv2alpha2.PodGroup, name string) *kaischedulingv2alpha2.SubGroup {
+	t.Helper()
+	subGroup := findSubGroup(podGroup, name)
+	require.NotNil(t, subGroup, "subgroup %q not found", name)
+	return subGroup
+}
+
+func findSubGroup(podGroup *kaischedulingv2alpha2.PodGroup, name string) *kaischedulingv2alpha2.SubGroup {
+	for i := range podGroup.Spec.SubGroups {
+		if podGroup.Spec.SubGroups[i].Name == name {
+			return &podGroup.Spec.SubGroups[i]
+		}
+	}
+	return nil
+}
+
+type blockingPodGangListClient struct {
+	client.Client
+
+	mu                sync.Mutex
+	podGangListCalls  int
+	firstListStarted  chan struct{}
+	secondListStarted chan struct{}
+	releaseFirstList  chan struct{}
+}
+
+func (c *blockingPodGangListClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if _, isPodGangList := list.(*groveschedulerv1alpha1.PodGangList); isPodGangList {
+		c.mu.Lock()
+		c.podGangListCalls++
+		call := c.podGangListCalls
+		switch call {
+		case 1:
+			close(c.firstListStarted)
+		case 2:
+			close(c.secondListStarted)
+		}
+		c.mu.Unlock()
+		if call == 1 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-c.releaseFirstList:
+			}
+		}
+	}
+	return c.Client.List(ctx, list, opts...)
+}

--- a/operator/internal/scheduler/kai/backend.go
+++ b/operator/internal/scheduler/kai/backend.go
@@ -26,7 +26,7 @@ import (
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/ai-dynamo/grove/operator/internal/scheduler"
-	"github.com/ai-dynamo/grove/operator/internal/utils"
+	operatorutils "github.com/ai-dynamo/grove/operator/internal/utils"
 
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	kaitopologyv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
@@ -36,29 +36,30 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // schedulerBackend implements the scheduler Backend interface (Backend in scheduler package) for KAI scheduler.
 type schedulerBackend struct {
-	client        client.Client
-	scheme        *runtime.Scheme
-	name          string
-	eventRecorder record.EventRecorder
-	profile       configv1alpha1.SchedulerProfile
+	client         client.Client
+	scheme         *runtime.Scheme
+	name           string
+	eventRecorder  record.EventRecorder
+	profile        configv1alpha1.SchedulerProfile
+	aggregateLocks operatorutils.KeyedMutex[client.ObjectKey]
 }
 
 var _ scheduler.Backend = (*schedulerBackend)(nil)
 
 const (
-	labelKeyQueueName    = "kai.scheduler/queue"
-	labelKeyNodePoolName = "kai.scheduler/node-pool"
-	annotationKeySkipPGR = "kai.scheduler/skip-podgrouper"
-	annotationValSkipPGR = "true"
-	annotationPodGroup   = "pod-group-name"
-	labelSubGroup        = "kai.scheduler/subgroup-name"
+	labelKeyQueueName     = "kai.scheduler/queue"
+	labelKeyNodePoolName  = "kai.scheduler/node-pool"
+	annotationKeySkipPGR  = "kai.scheduler/skip-podgrouper"
+	annotationValSkipPGR  = "true"
+	annotationPodGroup    = "pod-group-name"
+	labelSubGroup         = "kai.scheduler/subgroup-name"
+	eventReasonSyncFailed = "KAIBackendSyncFailed"
 )
 
 // New creates a new KAI backend instance. profile is the scheduler profile for kai-scheduler;
@@ -92,31 +93,44 @@ func (b *schedulerBackend) SyncPodGang(ctx context.Context, podGang *groveschedu
 	if podGang == nil {
 		return fmt.Errorf("podGang is nil")
 	}
-	if err := b.ensurePodGangSkipAnnotation(ctx, podGang); err != nil {
-		return fmt.Errorf("ensure KAI podgrouper skip annotation: %w", err)
-	}
-
-	newPodGroup, err := b.buildPodGroupForPodGang(ctx, podGang)
+	pcs, err := b.getOwningPodCliqueSet(ctx, podGang)
 	if err != nil {
-		b.recordWarning(podGang, "KAIBackendMappingFailed", err)
-		return err
-	}
-
-	oldPodGroup := &kaischedulingv2alpha2.PodGroup{}
-	key := client.ObjectKeyFromObject(newPodGroup)
-	if err = b.client.Get(ctx, key, oldPodGroup); err != nil {
-		if apierrors.IsNotFound(err) {
-			return b.client.Create(ctx, newPodGroup)
+		// The aggregate PodGroup is owned by the PCS, so it is already being garbage-collected
+		// when the owner is gone. Do not strand a deleting PodGang on our finalizer.
+		if apierrors.IsNotFound(err) && !podGang.DeletionTimestamp.IsZero() {
+			if finalizerErr := b.removePodGangFinalizer(ctx, podGang); finalizerErr != nil {
+				b.recordWarning(podGang, finalizerErr)
+				return finalizerErr
+			}
+			return nil
 		}
+		b.recordWarning(podGang, err)
 		return err
 	}
-
-	newPodGroup = b.inheritRuntimeManagedFields(oldPodGroup, newPodGroup)
-	if podGroupsEqual(oldPodGroup, newPodGroup) {
+	if !pcs.DeletionTimestamp.IsZero() {
+		if err = b.removePodGangFinalizer(ctx, podGang); err != nil {
+			b.recordWarning(podGang, err)
+			return err
+		}
 		return nil
 	}
-	updatePodGroup(oldPodGroup, newPodGroup)
-	return b.client.Update(ctx, oldPodGroup)
+	if podGang.DeletionTimestamp.IsZero() {
+		if err = b.ensurePodGangMetadata(ctx, podGang); err != nil {
+			b.recordWarning(podGang, err)
+			return err
+		}
+	}
+	if err = b.syncAggregatePodGroup(ctx, pcs, podGang); err != nil {
+		b.recordWarning(podGang, err)
+		return err
+	}
+	if !podGang.DeletionTimestamp.IsZero() {
+		if err = b.removePodGangFinalizer(ctx, podGang); err != nil {
+			b.recordWarning(podGang, err)
+			return err
+		}
+	}
+	return nil
 }
 
 // PreparePod adds KAI scheduler-specific configuration to the Pod.
@@ -130,6 +144,14 @@ func (b *schedulerBackend) PreparePod(pod *corev1.Pod) error {
 	if subGroupName == "" {
 		return fmt.Errorf("KAI scheduler requires pod label %q", apicommon.LabelPodClique)
 	}
+	pcsName := pod.Labels[apicommon.LabelPartOfKey]
+	if pcsName == "" {
+		return fmt.Errorf("KAI scheduler requires pod label %q", apicommon.LabelPartOfKey)
+	}
+	pcsReplica, err := podCliqueSetReplicaFromObjectMeta(pod.ObjectMeta)
+	if err != nil {
+		return err
+	}
 
 	pod.Spec.SchedulerName = b.Name()
 	if pod.Annotations == nil {
@@ -139,8 +161,8 @@ func (b *schedulerBackend) PreparePod(pod *corev1.Pod) error {
 		pod.Labels = map[string]string{}
 	}
 	pod.Annotations[annotationKeySkipPGR] = annotationValSkipPGR
-	pod.Annotations[annotationPodGroup] = podGangName
-	pod.Labels[labelSubGroup] = subGroupName
+	pod.Annotations[annotationPodGroup] = aggregatePodGroupName(pcsName, pcsReplica)
+	pod.Labels[labelSubGroup] = stableKAIName(subGroupName)
 	return nil
 }
 
@@ -150,84 +172,8 @@ func (b *schedulerBackend) ValidatePodCliqueSet(_ context.Context, pcs *grovecor
 	return err
 }
 
-// buildPodGroupForPodGang translates a Grove PodGang into a KAI PodGroup object.
-func (b *schedulerBackend) buildPodGroupForPodGang(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) (*kaischedulingv2alpha2.PodGroup, error) {
-	topologyName := getTopologyName(podGang)
-	topologyConstraint, err := toKAITopologyConstraint(podGang.Spec.TopologyConstraint, topologyName)
-	if err != nil {
-		return nil, err
-	}
-	queueName, err := b.resolveQueueName(ctx, podGang)
-	if err != nil {
-		return nil, err
-	}
-
-	parentBySubGroupName := map[string]string{}
-	subGroups := make([]kaischedulingv2alpha2.SubGroup, 0, len(podGang.Spec.TopologyConstraintGroupConfigs)+len(podGang.Spec.PodGroups))
-
-	for _, groupConfig := range podGang.Spec.TopologyConstraintGroupConfigs {
-		if len(groupConfig.PodGroupNames) == 0 {
-			continue
-		}
-		groupTopologyConstraint, groupErr := toKAITopologyConstraint(groupConfig.TopologyConstraint, topologyName)
-		if groupErr != nil {
-			return nil, groupErr
-		}
-		subGroups = append(subGroups, kaischedulingv2alpha2.SubGroup{
-			Name:               groupConfig.Name,
-			MinSubGroup:        ptr.To(int32(len(groupConfig.PodGroupNames))),
-			TopologyConstraint: groupTopologyConstraint,
-		})
-		for _, podGroupName := range groupConfig.PodGroupNames {
-			parentBySubGroupName[podGroupName] = groupConfig.Name
-		}
-	}
-
-	var minMember int32
-	for _, podGroup := range podGang.Spec.PodGroups {
-		subGroupTopologyConstraint, groupErr := toKAITopologyConstraint(podGroup.TopologyConstraint, topologyName)
-		if groupErr != nil {
-			return nil, groupErr
-		}
-		subGroup := kaischedulingv2alpha2.SubGroup{
-			Name:               podGroup.Name,
-			MinMember:          ptr.To(podGroup.MinReplicas),
-			TopologyConstraint: subGroupTopologyConstraint,
-		}
-		// Group configs cover a strict subset of PodGroups. Unmatched PodGroups
-		// intentionally remain root-level KAI SubGroups.
-		if parentName, found := parentBySubGroupName[podGroup.Name]; found {
-			subGroup.Parent = ptr.To(parentName)
-		}
-		subGroups = append(subGroups, subGroup)
-		minMember += podGroup.MinReplicas
-	}
-
-	result := &kaischedulingv2alpha2.PodGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        podGang.Name,
-			Namespace:   podGang.Namespace,
-			Labels:      maps.Clone(podGang.Labels),
-			Annotations: maps.Clone(podGang.Annotations),
-		},
-		Spec: kaischedulingv2alpha2.PodGroupSpec{
-			MinMember:         ptr.To(minMember),
-			Queue:             queueName,
-			PriorityClassName: podGang.Spec.PriorityClassName,
-			SubGroups:         subGroups,
-		},
-	}
-	if topologyConstraint != nil {
-		result.Spec.TopologyConstraint = *topologyConstraint
-	}
-	if err := controllerutil.SetControllerReference(podGang, result, b.scheme); err != nil {
-		return nil, err
-	}
-	return result, nil
-}
-
-func (b *schedulerBackend) ensurePodGangSkipAnnotation(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) error {
-	if podGang.Annotations != nil && podGang.Annotations[annotationKeySkipPGR] == annotationValSkipPGR {
+func (b *schedulerBackend) ensurePodGangMetadata(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) error {
+	if podGang.Annotations != nil && podGang.Annotations[annotationKeySkipPGR] == annotationValSkipPGR && controllerutil.ContainsFinalizer(podGang, podGangFinalizer) {
 		return nil
 	}
 	before := podGang.DeepCopy()
@@ -235,12 +181,22 @@ func (b *schedulerBackend) ensurePodGangSkipAnnotation(ctx context.Context, podG
 		podGang.Annotations = map[string]string{}
 	}
 	podGang.Annotations[annotationKeySkipPGR] = annotationValSkipPGR
+	controllerutil.AddFinalizer(podGang, podGangFinalizer)
 	return b.client.Patch(ctx, podGang, client.MergeFrom(before))
 }
 
-func (b *schedulerBackend) recordWarning(obj runtime.Object, reason string, err error) {
+func (b *schedulerBackend) removePodGangFinalizer(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) error {
+	if !controllerutil.ContainsFinalizer(podGang, podGangFinalizer) {
+		return nil
+	}
+	before := podGang.DeepCopy()
+	controllerutil.RemoveFinalizer(podGang, podGangFinalizer)
+	return b.client.Patch(ctx, podGang, client.MergeFrom(before))
+}
+
+func (b *schedulerBackend) recordWarning(obj runtime.Object, err error) {
 	if b.eventRecorder != nil && obj != nil && err != nil {
-		b.eventRecorder.Eventf(obj, corev1.EventTypeWarning, reason, "%v", err)
+		b.eventRecorder.Eventf(obj, corev1.EventTypeWarning, eventReasonSyncFailed, "%v", err)
 	}
 }
 
@@ -276,27 +232,22 @@ func toKAITopologyConstraint(topologyConstraint *groveschedulerv1alpha1.Topology
 	return result, nil
 }
 
-// resolveQueueName returns the KAI queue configured by the PodGang's owning PodCliqueSet.
-func (b *schedulerBackend) resolveQueueName(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) (string, error) {
+func (b *schedulerBackend) getOwningPodCliqueSet(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) (*grovecorev1alpha1.PodCliqueSet, error) {
 	owner := metav1.GetControllerOf(podGang)
 	if owner == nil {
-		return "", fmt.Errorf("podgang %s/%s has no controlling PodCliqueSet", podGang.Namespace, podGang.Name)
+		return nil, fmt.Errorf("podgang %s/%s has no controlling PodCliqueSet", podGang.Namespace, podGang.Name)
 	}
 	if owner.APIVersion != grovecorev1alpha1.SchemeGroupVersion.String() || owner.Kind != "PodCliqueSet" {
-		return "", fmt.Errorf("podgang %s/%s is controlled by %s %q, expected PodCliqueSet", podGang.Namespace, podGang.Name, owner.APIVersion, owner.Kind)
+		return nil, fmt.Errorf("podgang %s/%s is controlled by %s %q, expected PodCliqueSet", podGang.Namespace, podGang.Name, owner.APIVersion, owner.Kind)
 	}
 
 	pcs := &grovecorev1alpha1.PodCliqueSet{}
 	if err := b.client.Get(ctx, client.ObjectKey{Namespace: podGang.Namespace, Name: owner.Name}, pcs); err != nil {
-		return "", fmt.Errorf("get controlling PodCliqueSet %s/%s: %w", podGang.Namespace, owner.Name, err)
+		return nil, fmt.Errorf("get controlling PodCliqueSet %s/%s: %w", podGang.Namespace, owner.Name, err)
 	}
-
-	return resolveQueueNameForPodCliqueSet(pcs)
+	return pcs, nil
 }
 
-// resolveQueueNameForPodCliqueSet returns the KAI queue configured by a PodCliqueSet.
-// A queue set on the PodCliqueSet establishes the queue for the scheduling unit, so
-// every explicitly configured PodClique template queue must resolve to the same value.
 func resolveQueueNameForPodCliqueSet(pcs *grovecorev1alpha1.PodCliqueSet) (string, error) {
 	if queueName := resolveQueueNameFromMetadata(pcs.Labels, pcs.Annotations); queueName != "" {
 		for _, clique := range pcs.Spec.Template.Cliques {
@@ -372,8 +323,8 @@ func (b *schedulerBackend) inheritRuntimeManagedFields(oldPodGroup, newPodGroup 
 func podGroupsEqual(oldPodGroup, newPodGroup *kaischedulingv2alpha2.PodGroup) bool {
 	return reflect.DeepEqual(oldPodGroup.Spec, newPodGroup.Spec) &&
 		reflect.DeepEqual(oldPodGroup.OwnerReferences, newPodGroup.OwnerReferences) &&
-		utils.MapContainsAll(oldPodGroup.Labels, newPodGroup.Labels) &&
-		utils.MapContainsAll(oldPodGroup.Annotations, newPodGroup.Annotations)
+		operatorutils.MapContainsAll(oldPodGroup.Labels, newPodGroup.Labels) &&
+		operatorutils.MapContainsAll(oldPodGroup.Annotations, newPodGroup.Annotations)
 }
 
 // updatePodGroup copies desired fields from newPodGroup into existing object.

--- a/operator/internal/scheduler/kai/backend_test.go
+++ b/operator/internal/scheduler/kai/backend_test.go
@@ -45,8 +45,10 @@ func TestBackend_PreparePod(t *testing.T) {
 		WithSchedulerName("default-scheduler").
 		Build()
 	pod.Labels = map[string]string{
-		apicommon.LabelPodGang:   "test-podgang",
-		apicommon.LabelPodClique: "test-clique",
+		apicommon.LabelPodGang:                  "different-podgang-name",
+		apicommon.LabelPodClique:                "test-clique",
+		apicommon.LabelPartOfKey:                "test-pcs",
+		apicommon.LabelPodCliqueSetReplicaIndex: "0",
 	}
 	pod.Annotations = map[string]string{"keep": "me"}
 
@@ -55,8 +57,23 @@ func TestBackend_PreparePod(t *testing.T) {
 	assert.Equal(t, "kai-scheduler", pod.Spec.SchedulerName)
 	assert.Equal(t, "me", pod.Annotations["keep"])
 	assert.Equal(t, "true", pod.Annotations["kai.scheduler/skip-podgrouper"])
-	assert.Equal(t, "test-podgang", pod.Annotations["pod-group-name"])
+	assert.Equal(t, "grove-test-pcs-0", pod.Annotations["pod-group-name"])
 	assert.Equal(t, "test-clique", pod.Labels["kai.scheduler/subgroup-name"])
+}
+
+func TestAggregatePodGroupNameUsesPCSNameAndReplica(t *testing.T) {
+	pcsName := "My.Very_Long_PCS_Name_With_Invalid_Characters_And_Enough_Content_To_Require_Hashing"
+
+	replicaZero := aggregatePodGroupName(pcsName, 0)
+	replicaOne := aggregatePodGroupName(pcsName, 1)
+
+	assert.Equal(t, replicaZero, aggregatePodGroupName(pcsName, 0), "aggregate names must be deterministic")
+	assert.NotEqual(t, replicaZero, replicaOne, "PCS replicas must have distinct aggregate names")
+	assert.LessOrEqual(t, len(replicaZero), 63)
+	assert.LessOrEqual(t, len(replicaOne), 63)
+	assert.Regexp(t, `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`, replicaZero)
+	assert.Regexp(t, `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`, replicaOne)
+	assert.Contains(t, replicaZero, "grove-my-very-long-pcs-name")
 }
 
 func TestBackend_PreparePod_PreservesExistingSkipAnnotation(t *testing.T) {
@@ -68,8 +85,10 @@ func TestBackend_PreparePod_PreservesExistingSkipAnnotation(t *testing.T) {
 	pod := testutils.NewPodBuilder("test-pod", "default").
 		Build()
 	pod.Labels = map[string]string{
-		apicommon.LabelPodGang:   "test-podgang",
-		apicommon.LabelPodClique: "test-clique",
+		apicommon.LabelPodGang:                  "test-pcs-0",
+		apicommon.LabelPodClique:                "test-clique",
+		apicommon.LabelPartOfKey:                "test-pcs",
+		apicommon.LabelPodCliqueSetReplicaIndex: "0",
 	}
 	pod.Annotations = map[string]string{"kai.scheduler/skip-podgrouper": "custom"}
 
@@ -85,10 +104,11 @@ func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
 		podCliqueTemplateWithQueue("encoder-template", "team-a"),
 		podCliqueTemplateWithQueue("decoder-template", "team-a"),
 	)
-	podGang := testutils.NewPodGangBuilder("test-podgang", "default").
+	podGang := testutils.NewPodGangBuilder("test-pcs-2", "default").
 		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
 		Build()
 	setPodCliqueSetControllerOwner(podGang, pcs)
+	podGang.Labels[apicommon.LabelPodCliqueSetReplicaIndex] = "2"
 	podGang.Labels[labelKeyQueueName] = "legacy-queue"
 	podGang.Annotations = map[string]string{"grove.io/topology-name": "cluster-topology"}
 	podGang.Spec.PriorityClassName = "high-priority"
@@ -125,7 +145,7 @@ func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
 	}
 
 	cl := testutils.NewTestClientBuilder().
-		WithObjects(pcs, podGang).
+		WithObjects(pcs, podGang, &grovecorev1alpha1.ClusterTopologyBinding{ObjectMeta: metav1.ObjectMeta{Name: "cluster-topology"}}).
 		Build()
 	recorder := record.NewFakeRecorder(10)
 	profile := configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai}
@@ -136,30 +156,37 @@ func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
 	require.NoError(t, b.SyncPodGang(ctx, podGang))
 
 	gotPodGroup := &kaischedulingv2alpha2.PodGroup{}
-	require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: podGang.Name, Namespace: podGang.Namespace}, gotPodGroup))
+	require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "grove-test-pcs-2", Namespace: podGang.Namespace}, gotPodGroup))
 
-	require.NotNil(t, gotPodGroup.Spec.MinMember)
-	assert.Equal(t, int32(5), *gotPodGroup.Spec.MinMember)
+	require.NotNil(t, gotPodGroup.Spec.MinSubGroup)
+	assert.Equal(t, int32(1), *gotPodGroup.Spec.MinSubGroup)
+	assert.Nil(t, gotPodGroup.Spec.MinMember)
 	assert.Equal(t, "team-a", gotPodGroup.Spec.Queue)
 	assert.Equal(t, "high-priority", gotPodGroup.Spec.PriorityClassName)
 	assert.Equal(t, "zone", gotPodGroup.Spec.TopologyConstraint.RequiredTopologyLevel)
 
-	require.Len(t, gotPodGroup.Spec.SubGroups, 3)
-	assert.Equal(t, "decoder-group", gotPodGroup.Spec.SubGroups[0].Name)
-	require.NotNil(t, gotPodGroup.Spec.SubGroups[0].MinSubGroup)
-	assert.Equal(t, int32(1), *gotPodGroup.Spec.SubGroups[0].MinSubGroup)
+	require.Len(t, gotPodGroup.Spec.SubGroups, 4)
+	baseBranch := requireSubGroup(t, gotPodGroup, podGang.Name)
+	assert.Nil(t, baseBranch.Parent)
 
-	assert.Equal(t, "encoder", gotPodGroup.Spec.SubGroups[1].Name)
-	require.NotNil(t, gotPodGroup.Spec.SubGroups[1].MinMember)
-	assert.Equal(t, int32(2), *gotPodGroup.Spec.SubGroups[1].MinMember)
-	assert.Nil(t, gotPodGroup.Spec.SubGroups[1].Parent)
-	assert.Equal(t, "host", gotPodGroup.Spec.SubGroups[1].TopologyConstraint.RequiredTopologyLevel)
+	decoderGroup := requireSubGroup(t, gotPodGroup, "decoder-group")
+	require.NotNil(t, decoderGroup.MinSubGroup)
+	assert.Equal(t, int32(1), *decoderGroup.MinSubGroup)
 
-	assert.Equal(t, "decoder", gotPodGroup.Spec.SubGroups[2].Name)
-	require.NotNil(t, gotPodGroup.Spec.SubGroups[2].Parent)
-	assert.Equal(t, "decoder-group", *gotPodGroup.Spec.SubGroups[2].Parent)
-	require.NotNil(t, gotPodGroup.Spec.SubGroups[2].MinMember)
-	assert.Equal(t, int32(3), *gotPodGroup.Spec.SubGroups[2].MinMember)
+	decoder := requireSubGroup(t, gotPodGroup, "decoder")
+	require.NotNil(t, decoder.Parent)
+	assert.Equal(t, decoderGroup.Name, *decoder.Parent)
+	require.NotNil(t, decoder.MinMember)
+	assert.Equal(t, int32(3), *decoder.MinMember)
+
+	encoder := requireSubGroup(t, gotPodGroup, "encoder")
+	require.NotNil(t, encoder.MinMember)
+	assert.Equal(t, int32(2), *encoder.MinMember)
+	require.NotNil(t, encoder.Parent)
+	assert.Equal(t, baseBranch.Name, *encoder.Parent)
+	assert.Equal(t, "host", encoder.TopologyConstraint.RequiredTopologyLevel)
+
+	assert.Nil(t, findSubGroup(gotPodGroup, scaledPodGangsSubGroupName))
 
 	// Update PodGang: change min replicas. Queue remains sourced from the owning PCS.
 	updatedPodGang := podGang.DeepCopy()
@@ -168,14 +195,64 @@ func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
 
 	require.NoError(t, b.SyncPodGang(ctx, updatedPodGang))
 	gotAfterUpdate := &kaischedulingv2alpha2.PodGroup{}
-	require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: podGang.Name, Namespace: podGang.Namespace}, gotAfterUpdate))
+	require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "grove-test-pcs-2", Namespace: podGang.Namespace}, gotAfterUpdate))
 
 	// The owning PCS label supplies the queue, consistently with its templates.
 	assert.Equal(t, "team-a", gotAfterUpdate.Spec.Queue)
-	require.NotNil(t, gotAfterUpdate.Spec.MinMember)
-	assert.Equal(t, int32(7), *gotAfterUpdate.Spec.MinMember)
-	require.NotNil(t, gotAfterUpdate.Spec.SubGroups[1].MinMember)
-	assert.Equal(t, int32(4), *gotAfterUpdate.Spec.SubGroups[1].MinMember)
+	require.NotNil(t, gotAfterUpdate.Spec.MinSubGroup)
+	assert.Equal(t, int32(1), *gotAfterUpdate.Spec.MinSubGroup)
+	assert.Nil(t, gotAfterUpdate.Spec.MinMember)
+	updatedEncoder := requireSubGroup(t, gotAfterUpdate, "encoder")
+	require.NotNil(t, updatedEncoder.MinMember)
+	assert.Equal(t, int32(4), *updatedEncoder.MinMember)
+	assert.Nil(t, findSubGroup(gotAfterUpdate, scaledPodGangsSubGroupName))
+}
+
+func TestBackend_SyncPodGang_RemovesFinalizerWhenDeletingAndOwningPodCliqueSetIsMissing(t *testing.T) {
+	missingPCS := newPodCliqueSet("missing-pcs", "team-a")
+	podGang := testutils.NewPodGangBuilder("missing-pcs-0", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		Build()
+	setPodCliqueSetControllerOwner(podGang, missingPCS)
+	podGang.Finalizers = []string{podGangFinalizer}
+	now := metav1.Now()
+	podGang.DeletionTimestamp = &now
+
+	cl := testutils.NewTestClientBuilder().WithObjects(podGang).Build()
+	b := New(cl, cl.Scheme(), record.NewFakeRecorder(10), configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai})
+	require.NoError(t, b.Init(cl))
+
+	require.NoError(t, b.SyncPodGang(context.Background(), podGang))
+	assert.NotContains(t, podGang.Finalizers, podGangFinalizer)
+
+	current := &groveschedulerv1alpha1.PodGang{}
+	err := cl.Get(context.Background(), client.ObjectKeyFromObject(podGang), current)
+	if !apierrors.IsNotFound(err) {
+		require.NoError(t, err)
+		assert.NotContains(t, current.Finalizers, podGangFinalizer)
+	}
+}
+
+func TestBackend_SyncPodGang_ReturnsNotFoundWhenActiveAndOwningPodCliqueSetIsMissing(t *testing.T) {
+	missingPCS := newPodCliqueSet("missing-active-pcs", "team-a")
+	podGang := testutils.NewPodGangBuilder("missing-active-pcs-0", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
+		Build()
+	setPodCliqueSetControllerOwner(podGang, missingPCS)
+	podGang.Finalizers = []string{podGangFinalizer}
+
+	cl := testutils.NewTestClientBuilder().WithObjects(podGang).Build()
+	b := New(cl, cl.Scheme(), record.NewFakeRecorder(10), configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai})
+	require.NoError(t, b.Init(cl))
+
+	err := b.SyncPodGang(context.Background(), podGang)
+	require.Error(t, err)
+	assert.True(t, apierrors.IsNotFound(err))
+	assert.Contains(t, podGang.Finalizers, podGangFinalizer)
+
+	current := &groveschedulerv1alpha1.PodGang{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(podGang), current))
+	assert.Contains(t, current.Finalizers, podGangFinalizer)
 }
 
 func TestBackend_SyncPodGang_SkipsEmptyTopologyConstraintGroups(t *testing.T) {
@@ -184,7 +261,7 @@ func TestBackend_SyncPodGang_SkipsEmptyTopologyConstraintGroups(t *testing.T) {
 		"team-a",
 		podCliqueTemplateWithQueue("worker-template", "team-a"),
 	)
-	podGang := testutils.NewPodGangBuilder("empty-group-podgang", "default").
+	podGang := testutils.NewPodGangBuilder("empty-group-pcs-0", "default").
 		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
 		Build()
 	setPodCliqueSetControllerOwner(podGang, pcs)
@@ -210,10 +287,15 @@ func TestBackend_SyncPodGang_SkipsEmptyTopologyConstraintGroups(t *testing.T) {
 	require.NoError(t, b.SyncPodGang(ctx, podGang))
 
 	podGroup := &kaischedulingv2alpha2.PodGroup{}
-	require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(podGang), podGroup))
-	require.Len(t, podGroup.Spec.SubGroups, 1)
-	assert.Equal(t, "worker", podGroup.Spec.SubGroups[0].Name)
-	assert.Nil(t, podGroup.Spec.SubGroups[0].Parent)
+	require.NoError(t, cl.Get(ctx, client.ObjectKey{Namespace: podGang.Namespace, Name: aggregatePodGroupName(pcs.Name, 0)}, podGroup))
+	require.NotNil(t, podGroup.Spec.MinSubGroup)
+	assert.Equal(t, int32(1), *podGroup.Spec.MinSubGroup)
+	require.Len(t, podGroup.Spec.SubGroups, 2)
+	assert.Nil(t, findSubGroup(podGroup, "empty-group"))
+	worker := requireSubGroup(t, podGroup, "worker")
+	require.NotNil(t, worker.Parent)
+	assert.Equal(t, podGang.Name, *worker.Parent)
+	assert.Nil(t, findSubGroup(podGroup, scaledPodGangsSubGroupName))
 }
 
 func TestBackend_SyncPodGangSetsOwnerReferenceAndSkipAnnotation(t *testing.T) {
@@ -222,7 +304,7 @@ func TestBackend_SyncPodGangSetsOwnerReferenceAndSkipAnnotation(t *testing.T) {
 		"team-a",
 		podCliqueTemplateWithQueue("worker-template", "team-a"),
 	)
-	podGang := testutils.NewPodGangBuilder("owned", "default").
+	podGang := testutils.NewPodGangBuilder("owned-pcs-0", "default").
 		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
 		Build()
 	setPodCliqueSetControllerOwner(podGang, pcs)
@@ -237,9 +319,9 @@ func TestBackend_SyncPodGangSetsOwnerReferenceAndSkipAnnotation(t *testing.T) {
 	require.NoError(t, b.SyncPodGang(ctx, podGang))
 
 	podGroup := &kaischedulingv2alpha2.PodGroup{}
-	require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: podGang.Name, Namespace: podGang.Namespace}, podGroup))
+	require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: aggregatePodGroupName(pcs.Name, 0), Namespace: podGang.Namespace}, podGroup))
 	require.Len(t, podGroup.OwnerReferences, 1)
-	assert.Equal(t, podGang.Name, podGroup.OwnerReferences[0].Name)
+	assert.Equal(t, pcs.Name, podGroup.OwnerReferences[0].Name)
 
 	updatedPodGang := &groveschedulerv1alpha1.PodGang{}
 	require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(podGang), updatedPodGang))
@@ -253,7 +335,7 @@ func TestBackend_SyncPodGang_UsesUniquePodCliqueTemplateQueue(t *testing.T) {
 		podCliqueTemplateWithQueue("worker-a", "team-a"),
 		podCliqueTemplateWithQueue("worker-b", "team-a"),
 	)
-	podGang := testutils.NewPodGangBuilder("template-queue-podgang", "default").
+	podGang := testutils.NewPodGangBuilder("template-queue-pcs-0", "default").
 		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
 		Build()
 	setPodCliqueSetControllerOwner(podGang, pcs)
@@ -266,7 +348,7 @@ func TestBackend_SyncPodGang_UsesUniquePodCliqueTemplateQueue(t *testing.T) {
 	require.NoError(t, b.SyncPodGang(ctx, podGang))
 
 	podGroup := &kaischedulingv2alpha2.PodGroup{}
-	require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(podGang), podGroup))
+	require.NoError(t, cl.Get(ctx, client.ObjectKey{Namespace: podGang.Namespace, Name: aggregatePodGroupName(pcs.Name, 0)}, podGroup))
 	assert.Equal(t, "team-a", podGroup.Spec.Queue)
 }
 
@@ -414,7 +496,11 @@ func TestBackend_SyncPodGang_QueueResolutionFailuresDoNotCreatePodGroup(t *testi
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			podGang := testutils.NewPodGangBuilder("test-podgang", "default").
+			podGangName := "test-podgang"
+			if tt.pcs != nil {
+				podGangName = tt.pcs.Name + "-0"
+			}
+			podGang := testutils.NewPodGangBuilder(podGangName, "default").
 				WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).
 				Build()
 			objects := []client.Object{podGang}
@@ -433,7 +519,12 @@ func TestBackend_SyncPodGang_QueueResolutionFailuresDoNotCreatePodGroup(t *testi
 			require.ErrorContains(t, err, tt.wantErrSubstr)
 
 			podGroup := &kaischedulingv2alpha2.PodGroup{}
-			err = cl.Get(context.Background(), client.ObjectKeyFromObject(podGang), podGroup)
+			pcsName := podGang.Name
+			if tt.pcs != nil {
+				pcsName = tt.pcs.Name
+			}
+			podGroupName := aggregatePodGroupName(pcsName, 0)
+			err = cl.Get(context.Background(), client.ObjectKey{Namespace: podGang.Namespace, Name: podGroupName}, podGroup)
 			assert.True(t, apierrors.IsNotFound(err), "PodGroup must not be created when queue resolution fails")
 		})
 	}
@@ -499,6 +590,13 @@ func podCliqueTemplateWithQueue(name, queue string) *grovecorev1alpha1.PodClique
 }
 
 func setPodCliqueSetControllerOwner(podGang *groveschedulerv1alpha1.PodGang, pcs *grovecorev1alpha1.PodCliqueSet) {
+	if podGang.Labels == nil {
+		podGang.Labels = map[string]string{}
+	}
+	for key, value := range apicommon.GetDefaultLabelsForPodCliqueSetManagedResources(pcs.Name) {
+		podGang.Labels[key] = value
+	}
+	podGang.Labels[apicommon.LabelPodCliqueSetReplicaIndex] = "0"
 	podGang.OwnerReferences = []metav1.OwnerReference{{
 		APIVersion: grovecorev1alpha1.SchemeGroupVersion.String(),
 		Kind:       "PodCliqueSet",

--- a/operator/internal/utils/keyedmutex.go
+++ b/operator/internal/utils/keyedmutex.go
@@ -1,0 +1,60 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import "sync"
+
+// KeyedMutex serializes work sharing the same comparable key while allowing work on different keys to proceed concurrently.
+// Its zero value is ready for use.
+type KeyedMutex[K comparable] struct {
+	mu      sync.Mutex
+	entries map[K]*keyedMutexEntry
+}
+
+type keyedMutexEntry struct {
+	mu   sync.Mutex
+	refs int
+}
+
+// Lock acquires the mutex associated with key and returns its unlock function.
+// The returned function must be called exactly once.
+func (m *KeyedMutex[K]) Lock(key K) func() {
+	m.mu.Lock()
+	if m.entries == nil {
+		m.entries = make(map[K]*keyedMutexEntry)
+	}
+	entry := m.entries[key]
+	if entry == nil {
+		entry = &keyedMutexEntry{}
+		m.entries[key] = entry
+	}
+	// Count both the current holder and waiters so an entry cannot be removed
+	// while another goroutine is waiting to acquire it.
+	entry.refs++
+	m.mu.Unlock()
+
+	entry.mu.Lock()
+
+	return func() {
+		entry.mu.Unlock()
+
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		entry.refs--
+		if entry.refs == 0 && m.entries[key] == entry {
+			delete(m.entries, key)
+		}
+	}
+}

--- a/operator/internal/utils/keyedmutex_test.go
+++ b/operator/internal/utils/keyedmutex_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyedMutexSerializesSameKeyAndCleansEntry(t *testing.T) {
+	var mutex KeyedMutex[string]
+	unlockFirst := mutex.Lock("shared")
+
+	acquired := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		unlock := mutex.Lock("shared")
+		close(acquired)
+		<-release
+		unlock()
+	}()
+
+	require.Eventually(t, func() bool {
+		mutex.mu.Lock()
+		defer mutex.mu.Unlock()
+		return mutex.entries["shared"].refs == 2
+	}, time.Second, time.Millisecond)
+	assert.Never(t, func() bool {
+		select {
+		case <-acquired:
+			return true
+		default:
+			return false
+		}
+	}, 50*time.Millisecond, time.Millisecond)
+
+	unlockFirst()
+	require.Eventually(t, func() bool {
+		select {
+		case <-acquired:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+
+	close(release)
+	require.Eventually(t, func() bool {
+		mutex.mu.Lock()
+		defer mutex.mu.Unlock()
+		return len(mutex.entries) == 0
+	}, time.Second, time.Millisecond)
+}
+
+func TestKeyedMutexAllowsDifferentKeysConcurrently(t *testing.T) {
+	var mutex KeyedMutex[string]
+	unlockFirst := mutex.Lock("first")
+
+	acquiredSecond := make(chan struct{})
+	releaseSecond := make(chan struct{})
+	go func() {
+		unlock := mutex.Lock("second")
+		close(acquiredSecond)
+		<-releaseSecond
+		unlock()
+	}()
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-acquiredSecond:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+
+	close(releaseSecond)
+	unlockFirst()
+	require.Eventually(t, func() bool {
+		mutex.mu.Lock()
+		defer mutex.mu.Unlock()
+		return len(mutex.entries) == 0
+	}, time.Second, time.Millisecond)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Implements the aggregate KAI PodGroup representation described by GREP-525.

- Creates one KAI PodGroup per PodCliqueSet replica instead of one per Grove PodGang.
- Represents Base and Scaled PodGangs through a hierarchical KAI subgroup tree.
- Maps topology constraints according to GREP-244, including ClusterTopologyBinding resolution.
- Points newly created Pods at the aggregate PodGroup and migrates existing Pods from legacy per-PodGang PodGroups.
- Verifies Pod migration before deleting legacy PodGroups.
- Reconciles scale-down through a PodGang finalizer and garbage-collects aggregate PodGroups through PodCliqueSet ownership.
- Preserves KAI runtime-managed PodGroup fields during updates.
- Keeps synchronization failures retryable and reports them through logs and Warning Events on the triggering PodGang.

#### Which issue(s) this PR fixes:

Fixes #525 
Relates to #648 - Fixing it for KAI

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
docs/proposals/525-KAI-Scheduler-Backend/README.md
docs/proposals/244-topology-aware-scheduling/README.md
```
