### PR TITLE
fix: prevent panic in ExtractScalingGroupNameFromPCSGFQN and reuse

### DIFF
--- a/operator/api/common/namegen.go
+++ b/operator/api/common/namegen.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 )
@@ -124,7 +125,10 @@ func GeneratePodGangNameForPodCliqueOwnedByPCSG(pcs *v1alpha1.PodCliqueSet, pcsR
 
 // ExtractScalingGroupNameFromPCSGFQN extracts the scaling group name from a PodCliqueScalingGroup FQN.
 // For example, "simple1-0-sga" with pcsNameReplica="simple1-0" returns "sga".
-func ExtractScalingGroupNameFromPCSGFQN(pcsgFQN string, pcsNameReplica ResourceNameReplica) string {
+func ExtractScalingGroupNameFromPCSGFQN(pcsgFQN string, pcsNameReplica ResourceNameReplica) (string, error) {
 	prefix := fmt.Sprintf("%s-%d-", pcsNameReplica.Name, pcsNameReplica.Replica)
-	return pcsgFQN[len(prefix):]
+	if !strings.HasPrefix(pcsgFQN, prefix) {
+		return "", fmt.Errorf("FQN %q does not have expected prefix %q", pcsgFQN, prefix)
+	}
+	return pcsgFQN[len(prefix):], nil
 }

--- a/operator/api/common/namegen_test.go
+++ b/operator/api/common/namegen_test.go
@@ -112,7 +112,8 @@ func TestExtractScalingGroupNameFromPCSGFQN(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ExtractScalingGroupNameFromPCSGFQN(tt.pcsgName, tt.pcsNameReplica)
+			result, err := ExtractScalingGroupNameFromPCSGFQN(tt.pcsgName, tt.pcsNameReplica)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -175,7 +176,8 @@ func TestExtractScalingGroupNameFromPCSGFQN_Consistency(t *testing.T) {
 			generatedPCSGName := GeneratePodCliqueScalingGroupName(tc.pcsNameReplica, tc.scalingGroupName)
 
 			// Extract scaling group name back
-			extractedScalingGroupName := ExtractScalingGroupNameFromPCSGFQN(generatedPCSGName, tc.pcsNameReplica)
+			extractedScalingGroupName, err := ExtractScalingGroupNameFromPCSGFQN(generatedPCSGName, tc.pcsNameReplica)
+			assert.NoError(t, err)
 
 			// They should match
 			assert.Equal(t, tc.scalingGroupName, extractedScalingGroupName)

--- a/operator/internal/utils/componentname.go
+++ b/operator/internal/utils/componentname.go
@@ -46,8 +46,11 @@ func GetPodCliqueNameFromPodCliqueFQN(pclqObjectMeta metav1.ObjectMeta) (string,
 		if !replicaIndexLabelFound {
 			return "", fmt.Errorf("missing label %s on PodClique: %v", apicommon.LabelPodCliqueScalingGroupReplicaIndex, pclqObjectKey)
 		}
-		pclqNamePrefix := fmt.Sprintf("%s-%s-", pcsgName, pcsgReplicaIndex)
-		return pclqObjectMeta.Name[len(pclqNamePrefix):], nil
+		pcsgReplicaIndexInt, err := strconv.Atoi(pcsgReplicaIndex)
+		if err != nil {
+			return "", fmt.Errorf("invalid label %s on PodClique: %v: %w", apicommon.LabelPodCliqueScalingGroupReplicaIndex, pclqObjectKey, err)
+		}
+		return apicommon.ExtractScalingGroupNameFromPCSGFQN(pclqObjectMeta.Name, apicommon.ResourceNameReplica{Name: pcsgName, Replica: pcsgReplicaIndexInt})
 	}
 
 	pcsName, ok := pclqObjectMeta.Labels[apicommon.LabelPartOfKey]
@@ -59,6 +62,9 @@ func GetPodCliqueNameFromPodCliqueFQN(pclqObjectMeta metav1.ObjectMeta) (string,
 	if !ok {
 		return "", fmt.Errorf("missing label %s on PodClique: %v", apicommon.LabelPodCliqueSetReplicaIndex, pclqObjectKey)
 	}
-	pclqNamePrefix := fmt.Sprintf("%s-%s-", pcsName, pcsReplicaIndex)
-	return pclqObjectMeta.Name[len(pclqNamePrefix):], nil
+	pcsReplicaIndexInt, err := strconv.Atoi(pcsReplicaIndex)
+	if err != nil {
+		return "", fmt.Errorf("invalid label %s on PodClique: %v: %w", apicommon.LabelPodCliqueSetReplicaIndex, pclqObjectKey, err)
+	}
+	return apicommon.ExtractScalingGroupNameFromPCSGFQN(pclqObjectMeta.Name, apicommon.ResourceNameReplica{Name: pcsName, Replica: pcsReplicaIndexInt})
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api
-->
/kind bug
#### What this PR does / why we need it:

- prevent panic in ExtractScalingGroupNameFromPCSGFQN with input validation and resue
- simplify function signature and reuse in componentname.go

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #737


#### Special notes for your reviewer:

#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
