### PR TITLE
fix: avoid redundant secret create request when secret already exists

### DIFF
--- a/operator/internal/controller/cert/cert.go
+++ b/operator/internal/controller/cert/cert.go
@@ -148,6 +148,12 @@ func getWebhooks(authorizerEnabled bool) []cert.WebhookInfo {
 func createPlaceholderSecretIfNotExists(ctx context.Context, cl client.Client, namespace, secretName string) error {
 	secret := &corev1.Secret{}
 	err := cl.Get(ctx, types.NamespacedName{Namespace: namespace, Name: secretName}, secret)
+	if err == nil {
+		// In HA deployments (replicaCount > 1) or restarts, two replicas can race between
+		// Get (not found) and Create. If the secret already exists,
+		// we treat it as success and do not attempt to create it again.
+		return nil
+	}
 	if !apierrors.IsNotFound(err) {
 		return err
 	}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api
-->
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #739

#### Special notes for your reviewer:

#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
