### PR TITLE
fix(operator): enable health probes by default

### DIFF
--- a/operator/charts/deployment_test.go
+++ b/operator/charts/deployment_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package charts_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/engine"
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func TestOperatorHealthProbes(t *testing.T) {
+	tests := []struct {
+		name       string
+		values     map[string]interface{}
+		wantProbes bool
+	}{
+		{
+			name:       "enabled by default",
+			values:     nil,
+			wantProbes: true,
+		},
+		{
+			name: "explicitly disabled",
+			values: map[string]interface{}{
+				"config": map[string]interface{}{
+					"server": map[string]interface{}{
+						"healthProbes": map[string]interface{}{
+							"enable": false,
+						},
+					},
+				},
+			},
+			wantProbes: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deployment := renderOperatorDeployment(t, tt.values)
+			require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+			container := deployment.Spec.Template.Spec.Containers[0]
+
+			if !tt.wantProbes {
+				assert.Nil(t, container.LivenessProbe)
+				assert.Nil(t, container.ReadinessProbe)
+				return
+			}
+
+			require.NotNil(t, container.LivenessProbe)
+			require.NotNil(t, container.LivenessProbe.HTTPGet)
+			assert.Equal(t, "/healthz", container.LivenessProbe.HTTPGet.Path)
+			assert.EqualValues(t, 9444, container.LivenessProbe.HTTPGet.Port.IntVal)
+
+			require.NotNil(t, container.ReadinessProbe)
+			require.NotNil(t, container.ReadinessProbe.HTTPGet)
+			assert.Equal(t, "/readyz", container.ReadinessProbe.HTTPGet.Path)
+			assert.EqualValues(t, 9444, container.ReadinessProbe.HTTPGet.Port.IntVal)
+		})
+	}
+}
+
+func renderOperatorDeployment(t *testing.T, values map[string]interface{}) *appsv1.Deployment {
+	t.Helper()
+
+	chart, err := loader.Load(".")
+	require.NoError(t, err)
+
+	renderValues, err := chartutil.ToRenderValues(
+		chart,
+		values,
+		chartutil.ReleaseOptions{Name: "grove", Namespace: "default", IsInstall: true},
+		chartutil.DefaultCapabilities,
+	)
+	require.NoError(t, err)
+
+	manifests, err := engine.Render(chart, renderValues)
+	require.NoError(t, err)
+
+	deploymentYAML, ok := manifests["grove-charts/templates/deployment.yaml"]
+	require.True(t, ok)
+
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, yaml.UnmarshalStrict([]byte(deploymentYAML), deployment))
+	return deployment
+}

--- a/operator/charts/values.yaml
+++ b/operator/charts/values.yaml
@@ -81,7 +81,9 @@ config:
       #     - Requires Secret to exist before operator starts
       certProvisionMode: auto
     healthProbes:
-      enable: false
+      # Enable liveness and readiness probes for the operator. The readiness
+      # endpoint gates on webhook certificate provisioning and listener startup.
+      enable: true
       port: 9444
     metrics:
       port: 9445

--- a/operator/e2e/setup/constants.go
+++ b/operator/e2e/setup/constants.go
@@ -40,6 +40,10 @@ const (
 	// NOTE: If you change this, also update config.server.webhooks.port in operator/charts/values.yaml
 	DefaultWebhookPort = 9443
 
+	// DefaultHealthProbePort is the default port for health and readiness probes.
+	// NOTE: If you change this, also update config.server.healthProbes.port in operator/charts/values.yaml
+	DefaultHealthProbePort = 9444
+
 	// DefaultWebhookServerCertDir is the default directory for webhook certificates.
 	// NOTE: If you change this, also update config.server.webhooks.serverCertDir in operator/charts/values.yaml
 	DefaultWebhookServerCertDir = "/etc/grove-operator/webhook-certs"

--- a/operator/e2e/setup/grove.go
+++ b/operator/e2e/setup/grove.go
@@ -61,7 +61,7 @@ type WebhooksConfig struct {
 }
 
 // helmValues mirrors the Helm values.yaml structure, using configv1alpha1 types
-// for config.server to ensure JSON field names stay synchronized with the API.
+// where the chart configuration matches the operator API.
 type helmValues struct {
 	CRDInstaller helmCRDInstallerValues `json:"crdInstaller"`
 	Config       helmConfigValues       `json:"config"`
@@ -74,7 +74,19 @@ type helmCRDInstallerValues struct {
 }
 
 type helmConfigValues struct {
-	Server configv1alpha1.ServerConfiguration `json:"server"`
+	Server helmServerValues `json:"server"`
+}
+
+type helmServerValues struct {
+	Webhooks     configv1alpha1.WebhookServer `json:"webhooks"`
+	HealthProbes helmHealthProbeValues        `json:"healthProbes"`
+}
+
+// helmHealthProbeValues includes the chart-only enable switch in addition to
+// the operator's health probe server configuration.
+type helmHealthProbeValues struct {
+	Enable bool `json:"enable"`
+	Port   int  `json:"port"`
 }
 
 type helmWebhookValues struct {
@@ -97,7 +109,7 @@ func (c *GroveConfig) toHelmValues() (map[string]interface{}, error) {
 	hv := helmValues{
 		CRDInstaller: helmCRDInstallerValues{Enabled: c.InstallCRDs},
 		Config: helmConfigValues{
-			Server: configv1alpha1.ServerConfiguration{
+			Server: helmServerValues{
 				Webhooks: configv1alpha1.WebhookServer{
 					Server: configv1alpha1.Server{
 						Port: DefaultWebhookPort,
@@ -105,6 +117,10 @@ func (c *GroveConfig) toHelmValues() (map[string]interface{}, error) {
 					ServerCertDir:     DefaultWebhookServerCertDir,
 					CertProvisionMode: c.Webhooks.CertProvisionMode,
 					SecretName:        c.Webhooks.SecretName,
+				},
+				HealthProbes: helmHealthProbeValues{
+					Enable: true,
+					Port:   DefaultHealthProbePort,
 				},
 			},
 		},

--- a/operator/e2e/setup/grove_test.go
+++ b/operator/e2e/setup/grove_test.go
@@ -1,0 +1,40 @@
+//go:build e2e
+
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestGroveConfigToHelmValuesEnablesHealthProbes(t *testing.T) {
+	values, err := (&GroveConfig{}).toHelmValues()
+	require.NoError(t, err)
+
+	enabled, found, err := unstructured.NestedBool(values, "config", "server", "healthProbes", "enable")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.True(t, enabled)
+
+	port, found, err := unstructured.NestedFieldNoCopy(values, "config", "server", "healthProbes", "port")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.EqualValues(t, DefaultHealthProbePort, port)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Grove already exposes `/healthz` and `/readyz`, and `/readyz` does not succeed until webhook certificate provisioning and the HTTPS listener are ready. However, the Helm chart currently disables both probes by default. As a result, Kubernetes can mark the operator pod Ready while the admission webhook still refuses connections.

This change:

- enables the operator liveness and readiness probes by default;
- preserves `config.server.healthProbes.enable=false` as an explicit opt-out;
- makes the E2E Helm upgrade values include the same health-probe configuration; and
- adds Helm-rendering and E2E values tests for the default and opt-out behavior.

This deliberately does not set `publishNotReadyAddresses`. Normal Service endpoint publication should remain gated by the pod readiness probe, so callers only reach the webhook after its certificates and listener are ready.

#### Which issue(s) this PR fixes:

Fixes #742

#### Special notes for your reviewer:

The downstream Dynamo PR [ai-dynamo/dynamo#12387](https://github.com/ai-dynamo/dynamo/pull/12387) enables these probes for its pinned Grove chart and adds a server-side dry-run of a `PodCliqueSet` to its admission readiness loop.

The original failure was captured in [Dynamo CI job 90257708438](https://github.com/ai-dynamo/dynamo/actions/runs/30353383283/job/90257708438): the operator pod was Ready while the webhook endpoint was still refusing connections.

Validation:

```text
go test ./charts -count=1
go test -tags=e2e ./e2e/setup -count=1
```

#### Does this PR introduce a API change?

```release-note
Enable Grove operator liveness and webhook-aware readiness probes by default. Set config.server.healthProbes.enable=false to opt out.
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
