### PR TITLE
operator/helm: support imagePullSecrets on the operator pod

### DIFF
--- a/operator/charts/deployment_test.go
+++ b/operator/charts/deployment_test.go
@@ -23,6 +23,7 @@ import (
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/engine"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 )
 
@@ -73,6 +74,36 @@ func TestOperatorHealthProbes(t *testing.T) {
 			require.NotNil(t, container.ReadinessProbe.HTTPGet)
 			assert.Equal(t, "/readyz", container.ReadinessProbe.HTTPGet.Path)
 			assert.EqualValues(t, 9444, container.ReadinessProbe.HTTPGet.Port.IntVal)
+		})
+	}
+}
+
+func TestOperatorImagePullSecrets(t *testing.T) {
+	tests := []struct {
+		name   string
+		values map[string]interface{}
+		want   []corev1.LocalObjectReference
+	}{
+		{
+			name:   "none by default",
+			values: nil,
+			want:   nil,
+		},
+		{
+			name: "set from values",
+			values: map[string]interface{}{
+				"imagePullSecrets": []interface{}{
+					map[string]interface{}{"name": "registry-creds"},
+				},
+			},
+			want: []corev1.LocalObjectReference{{Name: "registry-creds"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deployment := renderOperatorDeployment(t, tt.values)
+			assert.Equal(t, tt.want, deployment.Spec.Template.Spec.ImagePullSecrets)
 		})
 	}
 }

--- a/operator/charts/templates/deployment.yaml
+++ b/operator/charts/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Always
       {{- if .Values.priorityClass.enabled }}
       priorityClassName: {{ required ".Values.priorityClass.name is required" .Values.priorityClass.name }}

--- a/operator/charts/values.yaml
+++ b/operator/charts/values.yaml
@@ -12,6 +12,11 @@ image:
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
 
+# imagePullSecrets is an optional list of references to Secrets in the release
+# namespace used to pull the operator (and crd-installer init container) images.
+# Set this when the images are hosted in a private registry.
+imagePullSecrets: []
+
 resources:
   limits:
     memory: 1Gi


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Adds an optional `imagePullSecrets` list to the operator Helm chart, wired
into the deployment pod spec, so the operator (and crd-installer init
container) can be pulled from a private registry. Defaults to empty, so
public installs are unaffected.

#### Which issue(s) this PR fixes:
Fixes #746

#### Special notes for your reviewer:
Follows the existing `deployment_test.go` helm-unittest pattern; added
`TestOperatorImagePullSecrets` covering the empty default and a set value.

#### Does this PR introduce a API change?
```release-note
The operator Helm chart now supports `imagePullSecrets` for pulling the
operator image from a private registry.
```