### PR TITLE
fix: reconcile Grove resources from live API state

### DIFF
--- a/operator/internal/controller/podclique/reconciler.go
+++ b/operator/internal/controller/podclique/reconciler.go
@@ -37,8 +37,12 @@ import (
 
 // Reconciler reconciles PodClique objects.
 type Reconciler struct {
-	config                  configv1alpha1.PodCliqueControllerConfiguration
-	client                  ctrlclient.Client
+	config configv1alpha1.PodCliqueControllerConfiguration
+	client ctrlclient.Client
+	// apiReader reads straight from the apiserver, bypassing the informer cache. It is used only to
+	// fetch the PodClique being reconciled. See the Reconcile godoc for why that read cannot be
+	// served from the cache.
+	apiReader               ctrlclient.Reader
 	eventRecorder           record.EventRecorder
 	reconcileStatusRecorder ctrlcommon.ReconcileErrorRecorder
 	expectationsStore       *expect.ExpectationsStore
@@ -52,6 +56,7 @@ func NewReconciler(mgr ctrl.Manager, controllerCfg configv1alpha1.PodCliqueContr
 	return &Reconciler{
 		config:                  controllerCfg,
 		client:                  mgr.GetClient(),
+		apiReader:               mgr.GetAPIReader(),
 		eventRecorder:           eventRecorder,
 		reconcileStatusRecorder: ctrlcommon.NewReconcileErrorRecorder(mgr.GetClient()),
 		expectationsStore:       expectationsStore,
@@ -60,6 +65,19 @@ func NewReconciler(mgr ctrl.Manager, controllerCfg configv1alpha1.PodCliqueContr
 }
 
 // Reconcile reconciles the `PodClique` resource.
+//
+// The PodClique itself is read through apiReader rather than the informer cache. reconcileStatus
+// skips its write when the recomputed status equals the status this object was loaded with, treating
+// that as "already persisted". A cached read makes that claim unsound: the cache can still be serving
+// a copy from before a write this controller already made, so the recomputed status can match a stale
+// baseline and the skip drops a write the apiserver still needs. Nothing recovers from that - a status
+// write does not change the generation, so it is filtered by this controller's own
+// GenerationChangedPredicate and never re-enqueues, and once the Pods go quiet no other event arrives
+// either. Reading the object live makes the baseline authoritative by construction, which is what the
+// skip assumes.
+//
+// Child Pod reads and the parent PodCliqueSet lookup stay cache-backed; they are level-triggered by
+// their own watches and a stale read of them is corrected by the next event.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := ctrllogger.FromContext(ctx).WithName(controllerName)
 
@@ -70,7 +88,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	ctx = componentutils.WithPodCliqueSetCache(ctx)
 
 	pclq := &grovecorev1alpha1.PodClique{}
-	if result := ctrlutils.GetPodClique(ctx, r.client, logger, req.NamespacedName, pclq, true); ctrlcommon.ShortCircuitReconcileFlow(result) {
+	if result := ctrlutils.GetPodClique(ctx, r.apiReader, logger, req.NamespacedName, pclq, true); ctrlcommon.ShortCircuitReconcileFlow(result) {
 		return result.Result()
 	}
 

--- a/operator/internal/controller/podclique/reconciler_test.go
+++ b/operator/internal/controller/podclique/reconciler_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podclique
+
+import (
+	"context"
+	"testing"
+
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	testutils "github.com/ai-dynamo/grove/operator/test/utils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestReconcileReadsThePodCliqueFromTheAPIServer pins the same guarantee issue #711 required of the
+// PodCliqueSet controller, for the identically shaped skip in this controller's reconcileStatus.
+//
+// reconcileStatus treats the status the PodClique was loaded with as "already persisted" and skips
+// the write when the recomputed status matches it. That is only sound when the load is authoritative,
+// so the reconciled object must come from the apiserver rather than the informer cache, which can
+// still be serving a copy from before a write this controller already made.
+//
+// The two readers are given deliberately divergent contents. Only a reconcile that reads through
+// apiReader sees the PodClique as absent and stops before touching anything.
+func TestReconcileReadsThePodCliqueFromTheAPIServer(t *testing.T) {
+	ctx := context.Background()
+	pclq := testutils.NewPodCliqueBuilder(testPCSName, uuid.NewUUID(), "worker", testNamespace, 0).Build()
+	pclqObjectKey := client.ObjectKeyFromObject(pclq)
+
+	cachedReader := testutils.CreateDefaultFakeClient([]client.Object{pclq})
+	liveReader := testutils.CreateDefaultFakeClient(nil)
+	r := &Reconciler{client: cachedReader, apiReader: liveReader}
+
+	result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: pclqObjectKey})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// ensureFinalizer is the first thing a reconcile does once it has an object, so an untouched
+	// finalizer list is proof the cached copy was never used to drive the reconcile.
+	stored := &grovecorev1alpha1.PodClique{}
+	require.NoError(t, cachedReader.Get(ctx, pclqObjectKey, stored))
+	assert.Empty(t, stored.Finalizers, "reconcile must not proceed on the cached PodClique")
+}

--- a/operator/internal/controller/podcliquescalinggroup/reconciler.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconciler.go
@@ -35,8 +35,12 @@ import (
 
 // Reconciler reconciles PodCliqueScalingGroup objects.
 type Reconciler struct {
-	config                  groveconfigv1alpha1.PodCliqueScalingGroupControllerConfiguration
-	client                  ctrlclient.Client
+	config groveconfigv1alpha1.PodCliqueScalingGroupControllerConfiguration
+	client ctrlclient.Client
+	// apiReader reads straight from the apiserver, bypassing the informer cache. It is used only to
+	// fetch the PodCliqueScalingGroup being reconciled. See the Reconcile godoc for why that read
+	// cannot be served from the cache.
+	apiReader               ctrlclient.Reader
 	eventRecorder           record.EventRecorder
 	reconcileStatusRecorder ctrlcommon.ReconcileErrorRecorder
 	operatorRegistry        component.OperatorRegistry[grovecorev1alpha1.PodCliqueScalingGroup]
@@ -49,6 +53,7 @@ func NewReconciler(mgr ctrl.Manager, controllerCfg groveconfigv1alpha1.PodClique
 	return &Reconciler{
 		config:                  controllerCfg,
 		client:                  client,
+		apiReader:               mgr.GetAPIReader(),
 		eventRecorder:           eventRecorder,
 		reconcileStatusRecorder: ctrlcommon.NewReconcileErrorRecorder(client),
 		operatorRegistry:        pcsgcomponent.CreateOperatorRegistry(mgr, eventRecorder),
@@ -56,6 +61,19 @@ func NewReconciler(mgr ctrl.Manager, controllerCfg groveconfigv1alpha1.PodClique
 }
 
 // Reconcile reconciles a PodCliqueScalingGroup resource.
+//
+// The PodCliqueScalingGroup itself is read through apiReader rather than the informer cache.
+// reconcileStatus skips its write when the recomputed status equals the status this object was loaded
+// with, treating that as "already persisted". A cached read makes that claim unsound: the cache can
+// still be serving a copy from before a write this controller already made, so the recomputed status
+// can match a stale baseline and the skip drops a write the apiserver still needs. Nothing recovers
+// from that - a status write does not change the generation, so it is filtered by this controller's
+// own GenerationChangedPredicate and never re-enqueues, and once the PodCliques go quiet no other
+// event arrives either. Reading the object live makes the baseline authoritative by construction,
+// which is what the skip assumes.
+//
+// Child PodClique reads and the parent PodCliqueSet lookup stay cache-backed; they are level-triggered
+// by their own watches and a stale read of them is corrected by the next event.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := ctrllogger.FromContext(ctx).WithName(controllerName)
 
@@ -63,7 +81,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	ctx = componentutils.WithPodCliqueSetCache(ctx)
 
 	pcsg := &grovecorev1alpha1.PodCliqueScalingGroup{}
-	if result := ctrlutils.GetPodCliqueScalingGroup(ctx, r.client, logger, req.NamespacedName, pcsg); ctrlcommon.ShortCircuitReconcileFlow(result) {
+	if result := ctrlutils.GetPodCliqueScalingGroup(ctx, r.apiReader, logger, req.NamespacedName, pcsg); ctrlcommon.ShortCircuitReconcileFlow(result) {
 		return result.Result()
 	}
 

--- a/operator/internal/controller/podcliquescalinggroup/reconciler_test.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconciler_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podcliquescalinggroup
+
+import (
+	"context"
+	"testing"
+
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	testutils "github.com/ai-dynamo/grove/operator/test/utils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestReconcileReadsThePodCliqueScalingGroupFromTheAPIServer pins the same guarantee issue #711
+// required of the PodCliqueSet controller, for the identically shaped skip in this controller's
+// reconcileStatus.
+//
+// reconcileStatus treats the status the PodCliqueScalingGroup was loaded with as "already persisted"
+// and skips the write when the recomputed status matches it. That is only sound when the load is
+// authoritative, so the reconciled object must come from the apiserver rather than the informer
+// cache, which can still be serving a copy from before a write this controller already made.
+//
+// The two readers are given deliberately divergent contents. Only a reconcile that reads through
+// apiReader sees the PodCliqueScalingGroup as absent and stops before touching anything.
+func TestReconcileReadsThePodCliqueScalingGroupFromTheAPIServer(t *testing.T) {
+	ctx := context.Background()
+	pcsg := testutils.NewPodCliqueScalingGroupBuilder(testPCSGName, testNamespacePCSG, testPCSNamePCSG, 0).Build()
+	pcsgObjectKey := client.ObjectKeyFromObject(pcsg)
+
+	cachedReader := testutils.CreateDefaultFakeClient([]client.Object{pcsg})
+	liveReader := testutils.CreateDefaultFakeClient(nil)
+	r := &Reconciler{client: cachedReader, apiReader: liveReader}
+
+	result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: pcsgObjectKey})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// ensureFinalizer is the first thing a reconcile does once it has an object, so an untouched
+	// finalizer list is proof the cached copy was never used to drive the reconcile.
+	stored := &grovecorev1alpha1.PodCliqueScalingGroup{}
+	require.NoError(t, cachedReader.Get(ctx, pcsgObjectKey, stored))
+	assert.Empty(t, stored.Finalizers, "reconcile must not proceed on the cached PodCliqueScalingGroup")
+}

--- a/operator/internal/controller/podcliqueset/reconciler.go
+++ b/operator/internal/controller/podcliqueset/reconciler.go
@@ -16,7 +16,6 @@ package podcliqueset
 
 import (
 	"context"
-	"sync"
 
 	"github.com/ai-dynamo/grove/operator/api/common/constants"
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
@@ -36,12 +35,15 @@ import (
 
 // Reconciler reconciles PodCliqueSet resources.
 type Reconciler struct {
-	config                        configv1alpha1.PodCliqueSetControllerConfiguration
-	tasConfig                     configv1alpha1.TopologyAwareSchedulingConfiguration
-	client                        ctrlclient.Client
-	reconcileStatusRecorder       ctrlcommon.ReconcileErrorRecorder
-	operatorRegistry              component.OperatorRegistry[grovecorev1alpha1.PodCliqueSet]
-	pcsGenerationHashExpectations sync.Map
+	config    configv1alpha1.PodCliqueSetControllerConfiguration
+	tasConfig configv1alpha1.TopologyAwareSchedulingConfiguration
+	client    ctrlclient.Client
+	// apiReader reads straight from the apiserver, bypassing the informer cache. It is used only to
+	// fetch the PodCliqueSet being reconciled. See the Reconcile godoc for why that read cannot be
+	// served from the cache.
+	apiReader               ctrlclient.Reader
+	reconcileStatusRecorder ctrlcommon.ReconcileErrorRecorder
+	operatorRegistry        component.OperatorRegistry[grovecorev1alpha1.PodCliqueSet]
 }
 
 // NewReconciler creates a new reconciler for PodCliqueSet.
@@ -49,21 +51,33 @@ func NewReconciler(mgr ctrl.Manager, controllerCfg configv1alpha1.PodCliqueSetCo
 	eventRecorder := mgr.GetEventRecorderFor(controllerName)
 	client := mgr.GetClient()
 	return &Reconciler{
-		config:                        controllerCfg,
-		tasConfig:                     topologyAwareSchedulingConfig,
-		client:                        client,
-		reconcileStatusRecorder:       ctrlcommon.NewReconcileErrorRecorder(client),
-		operatorRegistry:              pcscomponent.CreateOperatorRegistry(mgr, eventRecorder, topologyAwareSchedulingConfig, networkConfig, schedRegistry),
-		pcsGenerationHashExpectations: sync.Map{},
+		config:                  controllerCfg,
+		tasConfig:               topologyAwareSchedulingConfig,
+		client:                  client,
+		apiReader:               mgr.GetAPIReader(),
+		reconcileStatusRecorder: ctrlcommon.NewReconcileErrorRecorder(client),
+		operatorRegistry:        pcscomponent.CreateOperatorRegistry(mgr, eventRecorder, topologyAwareSchedulingConfig, networkConfig, schedRegistry),
 	}
 }
 
 // Reconcile reconciles a PodCliqueSet resource.
+//
+// The PodCliqueSet itself is read through apiReader rather than the informer cache. reconcileStatus
+// skips its write when the recomputed status equals the status this object was loaded with, treating
+// that as "already persisted". A cached read makes that claim unsound: the cache can still be serving
+// a copy from before a write this controller already made, so the recomputed status can match a stale
+// baseline and the skip drops a write the apiserver still needs. Nothing recovers from that - a PCS
+// status write does not change the generation, so it does not pass podCliqueSetPredicate and never
+// re-enqueues, and once the children go quiet no other event arrives either. Reading the object live
+// makes the baseline authoritative by construction, which is what the skip assumes.
+//
+// Child PodClique, PodCliqueScalingGroup and Pod reads stay cache-backed; they are level-triggered by
+// their own watches and a stale child read is corrected by the next event.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := ctrllogger.FromContext(ctx).WithName(controllerName)
 
 	pcs := &grovecorev1alpha1.PodCliqueSet{}
-	if result := ctrlutils.GetPodCliqueSet(ctx, r.client, logger, req.NamespacedName, pcs); ctrlcommon.ShortCircuitReconcileFlow(result) {
+	if result := ctrlutils.GetPodCliqueSet(ctx, r.apiReader, logger, req.NamespacedName, pcs); ctrlcommon.ShortCircuitReconcileFlow(result) {
 		return result.Result()
 	}
 

--- a/operator/internal/controller/podcliqueset/reconciler_test.go
+++ b/operator/internal/controller/podcliqueset/reconciler_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podcliqueset
+
+import (
+	"context"
+	"testing"
+
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	testutils "github.com/ai-dynamo/grove/operator/test/utils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestReconcileReadsThePodCliqueSetFromTheAPIServer pins the fix for issue #711.
+//
+// reconcileStatus treats the status the PodCliqueSet was loaded with as "already persisted" and skips
+// the write when the recomputed status matches it. That is only sound when the load is authoritative,
+// so the reconciled object must come from the apiserver rather than the informer cache, which can
+// still be serving a copy from before a write this controller already made.
+//
+// The two readers are given deliberately divergent contents. Only a reconcile that reads through
+// apiReader sees the PodCliqueSet as absent and stops before touching anything.
+func TestReconcileReadsThePodCliqueSetFromTheAPIServer(t *testing.T) {
+	ctx := context.Background()
+	pcs := testutils.NewPodCliqueSetBuilder(testPCSName, testNamespace, uuid.NewUUID()).
+		WithReplicas(1).
+		WithStandaloneClique("worker").
+		Build()
+	pcsObjectKey := client.ObjectKeyFromObject(pcs)
+
+	cachedReader := testutils.CreateDefaultFakeClient([]client.Object{pcs})
+	liveReader := testutils.CreateDefaultFakeClient(nil)
+	r := &Reconciler{client: cachedReader, apiReader: liveReader}
+
+	result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: pcsObjectKey})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// ensureFinalizer is the first thing a reconcile does once it has an object, so an untouched
+	// finalizer list is proof the cached copy was never used to drive the reconcile.
+	stored := &grovecorev1alpha1.PodCliqueSet{}
+	require.NoError(t, cachedReader.Get(ctx, pcsObjectKey, stored))
+	assert.Empty(t, stored.Finalizers, "reconcile must not proceed on the cached PodCliqueSet")
+}

--- a/operator/internal/controller/podcliqueset/reconcilespec.go
+++ b/operator/internal/controller/podcliqueset/reconcilespec.go
@@ -32,7 +32,6 @@ import (
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -72,18 +71,11 @@ func (r *Reconciler) ensureFinalizer(ctx context.Context, logger logr.Logger, pc
 // changed from the previously persisted pcs.status.generationHash then it resets the pcs.status.updateProgress
 func (r *Reconciler) processGenerationHashChange(ctx context.Context, logger logr.Logger, pcs *grovecorev1alpha1.PodCliqueSet) ctrlcommon.ReconcileStepResult {
 	pcsObjectKey := client.ObjectKeyFromObject(pcs)
-	pcsObjectName := cache.NamespacedNameAsObjectName(pcsObjectKey).String()
-
-	// if the generationHash is not reflected correctly yet, requeue. Allow the informer cache to catch-up.
-	if !r.isGenerationHashExpectationSatisfied(pcsObjectName, pcs.Status.CurrentGenerationHash) {
-		return ctrlcommon.ReconcileAfter(constants.ComponentSyncRetryInterval, fmt.Sprintf("CurrentGenerationHash is not up-to-date for PodCliqueSet: %v", pcsObjectKey))
-	}
-	r.pcsGenerationHashExpectations.Delete(pcsObjectName)
 
 	newGenerationHash := computeGenerationHash(pcs)
 	if pcs.Status.CurrentGenerationHash == nil {
 		// update the generation hash and continue reconciliation. No rolling update is required.
-		if err := r.setGenerationHashAndUpdateStatus(ctx, pcs, pcsObjectName, newGenerationHash); err != nil {
+		if err := r.setGenerationHashAndUpdateStatus(ctx, pcs, newGenerationHash); err != nil {
 			logger.Error(err, "failed to set generation hash on PCS", "newGenerationHash", newGenerationHash)
 			return ctrlcommon.ReconcileWithErrors("error updating generation hash", err)
 		}
@@ -92,18 +84,12 @@ func (r *Reconciler) processGenerationHashChange(ctx context.Context, logger log
 
 	if newGenerationHash != *pcs.Status.CurrentGenerationHash {
 		// trigger rolling update by setting or overriding pcs.Status.UpdateProgress.
-		if err := r.initUpdateProgress(ctx, pcs, pcsObjectName, newGenerationHash); err != nil {
+		if err := r.initUpdateProgress(ctx, pcs, newGenerationHash); err != nil {
 			return ctrlcommon.ReconcileWithErrors(fmt.Sprintf("could not triggering rolling update for PCS: %v", pcsObjectKey), err)
 		}
 	}
 
 	return ctrlcommon.ContinueReconcile()
-}
-
-// isGenerationHashExpectationSatisfied checks if the current generation hash matches expectations.
-func (r *Reconciler) isGenerationHashExpectationSatisfied(pcsObjectName string, pcsGenerationHash *string) bool {
-	expectedGenerationHash, ok := r.pcsGenerationHashExpectations.Load(pcsObjectName)
-	return !ok || (pcsGenerationHash != nil && expectedGenerationHash.(string) == *pcsGenerationHash)
 }
 
 // computeGenerationHash calculates a hash of the PodCliqueSet pod template specifications.
@@ -122,18 +108,17 @@ func computeGenerationHash(pcs *grovecorev1alpha1.PodCliqueSet) string {
 	return k8sutils.ComputeHash(podTemplateSpecs...)
 }
 
-// setGenerationHashAndUpdateStatus updates the PodCliqueSet status with the new generation hash, stores the expectation, and updates the status subresource.
-func (r *Reconciler) setGenerationHashAndUpdateStatus(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet, pcsObjectName, generationHash string) error {
+// setGenerationHashAndUpdateStatus updates the PodCliqueSet status with the new generation hash and updates the status subresource.
+func (r *Reconciler) setGenerationHashAndUpdateStatus(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet, generationHash string) error {
 	pcs.Status.CurrentGenerationHash = &generationHash
 	if err := r.client.Status().Update(ctx, pcs); err != nil {
 		return fmt.Errorf("could not update CurrentGenerationHash for PodCliqueSet: %v: %w", client.ObjectKeyFromObject(pcs), err)
 	}
-	r.pcsGenerationHashExpectations.Store(pcsObjectName, generationHash)
 	return nil
 }
 
 // initUpdateProgress initializes a new rolling update by resetting progress tracking.
-func (r *Reconciler) initUpdateProgress(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet, pcsObjectName, newGenerationHash string) error {
+func (r *Reconciler) initUpdateProgress(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet, newGenerationHash string) error {
 	pcs.Status.UpdateProgress = &grovecorev1alpha1.PodCliqueSetUpdateProgress{
 		UpdateStartedAt: metav1.Now(),
 	}
@@ -143,7 +128,7 @@ func (r *Reconciler) initUpdateProgress(ctx context.Context, pcs *grovecorev1alp
 	}
 	pcs.Status.UpdatedReplicas = 0
 	pcs.Status.CurrentGenerationHash = &newGenerationHash
-	if err := r.setGenerationHashAndUpdateStatus(ctx, pcs, pcsObjectName, newGenerationHash); err != nil {
+	if err := r.setGenerationHashAndUpdateStatus(ctx, pcs, newGenerationHash); err != nil {
 		return fmt.Errorf("could not set UpdateProgress for PodCliqueSet: %v: %w", client.ObjectKeyFromObject(pcs), err)
 	}
 	return nil

--- a/operator/internal/controller/podcliqueset/reconcilespec_test.go
+++ b/operator/internal/controller/podcliqueset/reconcilespec_test.go
@@ -16,7 +16,6 @@ package podcliqueset
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
@@ -264,15 +263,11 @@ func TestInitUpdateProgress(t *testing.T) {
 			pcs := tt.setupPCS()
 
 			fakeClient := testutils.SetupFakeClient(pcs)
-			reconciler := &Reconciler{
-				client:                        fakeClient,
-				pcsGenerationHashExpectations: sync.Map{},
-			}
+			reconciler := &Reconciler{client: fakeClient}
 
 			newGenerationHash := "new-hash"
-			pcsObjectName := pcs.Namespace + "/" + pcs.Name
 
-			err := reconciler.initUpdateProgress(context.Background(), pcs, pcsObjectName, newGenerationHash)
+			err := reconciler.initUpdateProgress(context.Background(), pcs, newGenerationHash)
 			require.NoError(t, err, "initUpdateProgress should not return errors")
 
 			// Fetch the updated PCS from the fake client

--- a/operator/internal/controller/utils/reconciler.go
+++ b/operator/internal/controller/utils/reconciler.go
@@ -31,8 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GetPodCliqueSet gets the latest PodCliqueSet object. It will usually hit the informer cache. If the object is not found, it will log a message and return DoNotRequeue.
-func GetPodCliqueSet(ctx context.Context, cl client.Client, logger logr.Logger, objectKey client.ObjectKey, pcs *v1alpha1.PodCliqueSet) grovectrl.ReconcileStepResult {
+// GetPodCliqueSet gets the latest PodCliqueSet object from the given reader. If the object is not found, it will log a message and return DoNotRequeue.
+func GetPodCliqueSet(ctx context.Context, cl client.Reader, logger logr.Logger, objectKey client.ObjectKey, pcs *v1alpha1.PodCliqueSet) grovectrl.ReconcileStepResult {
 	if err := cl.Get(ctx, objectKey, pcs); err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("PodCliqueSet not found", "objectKey", objectKey)
@@ -43,8 +43,8 @@ func GetPodCliqueSet(ctx context.Context, cl client.Client, logger logr.Logger, 
 	return grovectrl.ContinueReconcile()
 }
 
-// GetPodClique gets the latest PodClique object. It will usually hit the informer cache. If the object is not found, it will log a message and return DoNotRequeue.
-func GetPodClique(ctx context.Context, cl client.Client, logger logr.Logger, objectKey client.ObjectKey, pclq *v1alpha1.PodClique, ignoreNotFound bool) grovectrl.ReconcileStepResult {
+// GetPodClique gets the latest PodClique object from the given reader. If the object is not found, it will log a message and return DoNotRequeue.
+func GetPodClique(ctx context.Context, cl client.Reader, logger logr.Logger, objectKey client.ObjectKey, pclq *v1alpha1.PodClique, ignoreNotFound bool) grovectrl.ReconcileStepResult {
 	if err := cl.Get(ctx, objectKey, pclq); err != nil {
 		if ignoreNotFound && apierrors.IsNotFound(err) {
 			logger.V(1).Info("PodClique not found", "objectKey", objectKey)
@@ -55,8 +55,8 @@ func GetPodClique(ctx context.Context, cl client.Client, logger logr.Logger, obj
 	return grovectrl.ContinueReconcile()
 }
 
-// GetPodCliqueScalingGroup gets the latest PodCliqueScalingGroup object. It will usually hit the informer cache. If the object is not found, it will log a message and return DoNotRequeue.
-func GetPodCliqueScalingGroup(ctx context.Context, cl client.Client, logger logr.Logger, objectKey client.ObjectKey, pcsg *v1alpha1.PodCliqueScalingGroup) grovectrl.ReconcileStepResult {
+// GetPodCliqueScalingGroup gets the latest PodCliqueScalingGroup object from the given reader. If the object is not found, it will log a message and return DoNotRequeue.
+func GetPodCliqueScalingGroup(ctx context.Context, cl client.Reader, logger logr.Logger, objectKey client.ObjectKey, pcsg *v1alpha1.PodCliqueScalingGroup) grovectrl.ReconcileStepResult {
 	if err := cl.Get(ctx, objectKey, pcsg); err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("PodCliqueScalingGroup not found")


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

`reconcileStatus` skips its status write when the recomputed status equals the status the reconciled object was loaded with, treating that as "already persisted". The object was loaded from the informer cache, which can still be serving a copy from before a write the controller already made — so the recomputed status could match a **stale baseline**, and the skip would drop a write the apiserver still needed.

Nothing recovered from that. A status write does not change the generation, so it never re-enqueued the controller, and once the children went quiet no other event arrived either. That is the wedge @yankay diagnosed in #711.

This PR reads the reconciled object through `mgr.GetAPIReader()`, so the baseline the skip relies on is authoritative by construction. Child PodClique / PodCliqueScalingGroup / Pod reads stay cache-backed — they are level-triggered by their own watches, and a stale child read is corrected by the next event.

**Applied to all three controllers.** The skip is identical in `podcliqueset/reconcilestatus.go`, `podclique/reconcilestatus.go` and `podcliquescalinggroup/reconcilestatus.go`, and so is the reasoning that makes a cached baseline unsound. PodCliqueSet is where it was caught, not where it is unique.

**Removes the PodCliqueSet generation-hash expectations.** That `sync.Map` and its requeue gate existed only to wait for the informer cache to catch up with a `CurrentGenerationHash` this controller had just written — exactly the staleness the live read now eliminates, so the gate can no longer fire. Removing it beats leaving compensation next to a live read telling future readers the cache still needs waiting on.

#### Why this approach:

The alternative is to keep the cached read and compensate: track what was persisted, or requeue after a skip. Both leave the unsound assumption in place and add controller-local state that has to be kept correct, bounded, and cleaned up. Reading the object live deletes the assumption instead, and it deletes code on net in the reconcile path.

Trade-off: one single-object GET per reconcile per controller. Child read paths, watches and public APIs are unchanged. If that GET turns out to matter at scale, `make run-scale-test` is the place to show it — I have not run it, so the cost is stated rather than measured.

#### Which issue(s) this PR fixes:

Fixes #711

#### Special notes for your reviewer:

Verified against the flake itself. RU-11 had been failing at the full 2-minute convergence timeout (148.38s and 148.40s on two consecutive attempts of an unrelated PR). With the fix it converges in ~43s, in line with its neighbours, and all ten rolling-update scenarios pass.

Each controller gets a regression test that gives `client` and `apiReader` deliberately divergent contents, so only a reconcile that reads through `apiReader` behaves correctly. All three were confirmed to fail when the read is reverted to `r.client`.

`E2E - auto_mnnvl` is red and unrelated — `Test_AutoMNNVL_UnsupportedButEnabled/operator_exits_when_CD_CRD_is_missing`, same 120.07s timeout signature on unrelated branches. It is #449, closed 2026-03-03 and evidently regressed; worth reopening separately.

`make lint` cannot run locally here (golangci-lint v2.6.1 is built with go1.24, repo targets 1.26.3), so CI covers it. `go build`, `go vet`, `gofmt`, the full unit suite and `-race` are green.

Supersedes the earlier approach on this branch, which compensated for the stale baseline instead of removing it. Note this overlaps with draft #716, which fixes the same bug for PodCliqueSet only — only one of the two should land.

#### Does this PR introduce a API change?
```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:
```docs
NONE
```
