### PR TITLE
fix(operator): allow deriving environment variables from Grove values

### DIFF
--- a/docs/user-guide/03_environment-variables-for-pod-discovery/02_env_var_reference.md
+++ b/docs/user-guide/03_environment-variables-for-pod-discovery/02_env_var_reference.md
@@ -9,6 +9,18 @@ Grove automatically injects environment variables into every container and init 
 - **Coordination**: Understanding your role in a distributed system
 - **Configuration**: Self-configuring based on your position in the hierarchy
 
+Grove places its injected variables before the environment variables from the PodClique template. Kubernetes [expands `$(VAR_NAME)` references in environment variable values in list order](https://kubernetes.io/docs/tasks/inject-data-application/define-interdependent-environment-variables/), so template variables can derive values from Grove variables. For example:
+
+```yaml
+env:
+  - name: CLUSTER_LEADER_ADDRESS
+    value: "$(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-leader-0.$(GROVE_HEADLESS_SERVICE)"
+args:
+  - "--leader-address=$(CLUSTER_LEADER_ADDRESS)"
+```
+
+The names of injected Grove variables are reserved. If a template defines a variable with the same name, Grove replaces the template value.
+
 However, before we get to the environment variables it is important to first make a distinction between a Pod's Name and its Hostname.
 
 ## Understanding Pod Names vs. Hostnames in Kubernetes
@@ -100,4 +112,3 @@ If a pod belongs to a PodClique that is part of a PodCliqueScalingGroup, these a
 ## Next Steps
 
 Continue to the [Hands-On Examples](./03_hands-on-examples.md) to deploy example PodCliqueSets and use environment variables to construct FQDNs and discover other pods. We strongly recommend working through these examples as they demonstrate the practical techniques you'll need to implement pod discovery in your own applications.
-

--- a/operator/internal/controller/common/component/utils/pod.go
+++ b/operator/internal/controller/common/component/utils/pod.go
@@ -109,10 +109,23 @@ func GetPCLQPods(ctx context.Context, cl client.Client, _ string, pclq *grovecor
 	return ownedPods, nil
 }
 
-// AddEnvVarsToContainers adds the given environment variables to the Pod containers.
-func AddEnvVarsToContainers(containers []corev1.Container, envVars []corev1.EnvVar) {
+// PrependEnvVarsToContainers prepends the given environment variables to the Pod containers.
+// Existing variables with the same names are replaced by the prepended values.
+func PrependEnvVarsToContainers(containers []corev1.Container, envVars []corev1.EnvVar) {
+	envVarNames := make(map[string]struct{}, len(envVars))
+	for _, envVar := range envVars {
+		envVarNames[envVar.Name] = struct{}{}
+	}
+
 	for i := range containers {
-		containers[i].Env = append(containers[i].Env, envVars...)
+		combinedEnvVars := make([]corev1.EnvVar, 0, len(envVars)+len(containers[i].Env))
+		combinedEnvVars = append(combinedEnvVars, envVars...)
+		for _, envVar := range containers[i].Env {
+			if _, isInjected := envVarNames[envVar.Name]; !isInjected {
+				combinedEnvVars = append(combinedEnvVars, envVar)
+			}
+		}
+		containers[i].Env = combinedEnvVars
 	}
 }
 

--- a/operator/internal/controller/common/component/utils/pod_test.go
+++ b/operator/internal/controller/common/component/utils/pod_test.go
@@ -231,8 +231,8 @@ func TestGetPCLQPods(t *testing.T) {
 	})
 }
 
-// TestAddEnvVarsToContainers tests adding environment variables to containers.
-func TestAddEnvVarsToContainers(t *testing.T) {
+// TestPrependEnvVarsToContainers tests prepending environment variables to containers.
+func TestPrependEnvVarsToContainers(t *testing.T) {
 	// Test adding to empty containers
 	t.Run("add to empty containers", func(t *testing.T) {
 		containers := []corev1.Container{
@@ -245,7 +245,7 @@ func TestAddEnvVarsToContainers(t *testing.T) {
 			{Name: "VAR2", Value: "value2"},
 		}
 
-		AddEnvVarsToContainers(containers, envVars)
+		PrependEnvVarsToContainers(containers, envVars)
 
 		assert.Len(t, containers[0].Env, 2)
 		assert.Len(t, containers[1].Env, 2)
@@ -253,13 +253,14 @@ func TestAddEnvVarsToContainers(t *testing.T) {
 		assert.Equal(t, "value1", containers[0].Env[0].Value)
 	})
 
-	// Test adding to containers with existing env vars
-	t.Run("add to containers with existing env", func(t *testing.T) {
+	// Test prepending to containers with existing env vars
+	t.Run("prepend to containers with existing env", func(t *testing.T) {
 		containers := []corev1.Container{
 			{
 				Name: "container1",
 				Env: []corev1.EnvVar{
 					{Name: "EXISTING", Value: "existing-value"},
+					{Name: "DERIVED", Value: "$(NEW_VAR)-derived"},
 				},
 			},
 		}
@@ -268,11 +269,34 @@ func TestAddEnvVarsToContainers(t *testing.T) {
 			{Name: "NEW_VAR", Value: "new-value"},
 		}
 
-		AddEnvVarsToContainers(containers, newEnvVars)
+		PrependEnvVarsToContainers(containers, newEnvVars)
 
-		assert.Len(t, containers[0].Env, 2)
-		assert.Equal(t, "EXISTING", containers[0].Env[0].Name)
-		assert.Equal(t, "NEW_VAR", containers[0].Env[1].Name)
+		assert.Equal(t, []corev1.EnvVar{
+			{Name: "NEW_VAR", Value: "new-value"},
+			{Name: "EXISTING", Value: "existing-value"},
+			{Name: "DERIVED", Value: "$(NEW_VAR)-derived"},
+		}, containers[0].Env)
+	})
+
+	// Test replacing existing variables with the same name
+	t.Run("replace existing variables", func(t *testing.T) {
+		containers := []corev1.Container{
+			{
+				Name: "container1",
+				Env: []corev1.EnvVar{
+					{Name: "INJECTED", Value: "stale-value"},
+					{Name: "EXISTING", Value: "existing-value"},
+				},
+			},
+		}
+		envVars := []corev1.EnvVar{{Name: "INJECTED", Value: "injected-value"}}
+
+		PrependEnvVarsToContainers(containers, envVars)
+
+		assert.Equal(t, []corev1.EnvVar{
+			{Name: "INJECTED", Value: "injected-value"},
+			{Name: "EXISTING", Value: "existing-value"},
+		}, containers[0].Env)
 	})
 
 	// Test with no env vars to add
@@ -281,7 +305,7 @@ func TestAddEnvVarsToContainers(t *testing.T) {
 			{Name: "container1"},
 		}
 
-		AddEnvVarsToContainers(containers, []corev1.EnvVar{})
+		PrependEnvVarsToContainers(containers, []corev1.EnvVar{})
 
 		assert.Empty(t, containers[0].Env)
 	})
@@ -294,7 +318,7 @@ func TestAddEnvVarsToContainers(t *testing.T) {
 		}
 
 		// Should not panic
-		AddEnvVarsToContainers(containers, envVars)
+		PrependEnvVarsToContainers(containers, envVars)
 	})
 }
 

--- a/operator/internal/controller/podclique/components/pod/pod.go
+++ b/operator/internal/controller/podclique/components/pod/pod.go
@@ -356,8 +356,8 @@ func addEnvironmentVariables(pod *corev1.Pod, pclq *grovecorev1alpha1.PodClique,
 			},
 		},
 	}
-	componentutils.AddEnvVarsToContainers(pod.Spec.Containers, groveEnvVars)
-	componentutils.AddEnvVarsToContainers(pod.Spec.InitContainers, groveEnvVars)
+	componentutils.PrependEnvVarsToContainers(pod.Spec.Containers, groveEnvVars)
+	componentutils.PrependEnvVarsToContainers(pod.Spec.InitContainers, groveEnvVars)
 }
 
 // configurePodHostname sets the pod hostname and subdomain for service discovery

--- a/operator/internal/controller/podclique/components/pod/pod_test.go
+++ b/operator/internal/controller/podclique/components/pod/pod_test.go
@@ -338,6 +338,15 @@ func TestAddGroveEnvironmentVariables_NoDuplicates(t *testing.T) {
 								},
 							},
 						},
+						InitContainers: []corev1.Container{
+							{
+								Name:  "test-init-container",
+								Image: "test-image",
+								Env: []corev1.EnvVar{
+									{Name: "GROVE_POD_INDEX", Value: "old-pod-index"},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -460,12 +469,29 @@ func TestAddGroveEnvironmentVariables_NoDuplicates(t *testing.T) {
 
 			addEnvironmentVariables(pod, tt.pclq, "test-pcs", 0)
 
-			// Check that all containers have the expected environment variables
-			for _, container := range pod.Spec.Containers {
+			expectedPrefix := []string{
+				constants.EnvVarPodCliqueSetName,
+				constants.EnvVarPodCliqueSetIndex,
+				constants.EnvVarPodCliqueName,
+				constants.EnvVarHeadlessService,
+				constants.EnvVarPodIndex,
+			}
+			assertContainer := func(container corev1.Container) {
 				assertExpectedEnvVars(t, container, tt.expectedEnvVars)
 				assertReplacedEnvVars(t, container, tt.shouldReplace)
 				assertPreservedEnvVars(t, container, tt.shouldPreserve)
 				assertNoDuplicateEnvVars(t, container)
+				require.GreaterOrEqual(t, len(container.Env), len(expectedPrefix))
+				for i, envVarName := range expectedPrefix {
+					assert.Equal(t, envVarName, container.Env[i].Name)
+				}
+				assertEnvVarUsesFieldRef(t, container, constants.EnvVarPodIndex, fmt.Sprintf("metadata.labels['%s']", common.LabelPodCliquePodIndex))
+			}
+			for _, container := range pod.Spec.Containers {
+				assertContainer(container)
+			}
+			for _, container := range pod.Spec.InitContainers {
+				assertContainer(container)
 			}
 		})
 	}

--- a/operator/internal/controller/podclique/components/pod/pod_test.go
+++ b/operator/internal/controller/podclique/components/pod/pod_test.go
@@ -465,6 +465,7 @@ func TestAddGroveEnvironmentVariables_NoDuplicates(t *testing.T) {
 				assertExpectedEnvVars(t, container, tt.expectedEnvVars)
 				assertReplacedEnvVars(t, container, tt.shouldReplace)
 				assertPreservedEnvVars(t, container, tt.shouldPreserve)
+				assertNoDuplicateEnvVars(t, container)
 			}
 		})
 	}

--- a/operator/internal/controller/podcliquescalinggroup/components/podclique/podclique.go
+++ b/operator/internal/controller/podcliquescalinggroup/components/podclique/podclique.go
@@ -371,8 +371,8 @@ func (r _resource) addEnvironmentVariablesToPodContainerSpecs(pclq *grovecorev1a
 		},
 	}
 	pclqObjPodSpec := &pclq.Spec.PodSpec
-	componentutils.AddEnvVarsToContainers(pclqObjPodSpec.Containers, pcsgEnvVars)
-	componentutils.AddEnvVarsToContainers(pclqObjPodSpec.InitContainers, pcsgEnvVars)
+	componentutils.PrependEnvVarsToContainers(pclqObjPodSpec.Containers, pcsgEnvVars)
+	componentutils.PrependEnvVarsToContainers(pclqObjPodSpec.InitContainers, pcsgEnvVars)
 }
 
 // getPCSReplicaFromPCSG extracts the PodCliqueSet replica index from PodCliqueScalingGroup labels

--- a/operator/internal/controller/podcliquescalinggroup/components/podclique/podclique_test.go
+++ b/operator/internal/controller/podcliquescalinggroup/components/podclique/podclique_test.go
@@ -372,6 +372,47 @@ func TestAddEnvironmentVariablesToPodContainerSpecs(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "replace_colliding_pcsg_env_var",
+			pclq: &grovecorev1alpha1.PodClique{
+				Spec: grovecorev1alpha1.PodCliqueSpec{
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "container",
+								Env: []corev1.EnvVar{
+									{Name: apiconstants.EnvVarPodCliqueScalingGroupName, Value: "stale"},
+									{Name: "USER_VAR", Value: "user-value"},
+								},
+							},
+						},
+					},
+				},
+			},
+			numPods: 5,
+			validate: func(t *testing.T, pclq *grovecorev1alpha1.PodClique) {
+				assert.Equal(t, []corev1.EnvVar{
+					{
+						Name: apiconstants.EnvVarPodCliqueScalingGroupName,
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: fmt.Sprintf("metadata.labels['%s']", apicommon.LabelPodCliqueScalingGroup),
+							},
+						},
+					},
+					{Name: apiconstants.EnvVarPodCliqueScalingGroupTemplateNumPods, Value: "5"},
+					{
+						Name: apiconstants.EnvVarPodCliqueScalingGroupIndex,
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: fmt.Sprintf("metadata.labels['%s']", apicommon.LabelPodCliqueScalingGroupReplicaIndex),
+							},
+						},
+					},
+					{Name: "USER_VAR", Value: "user-value"},
+				}, pclq.Spec.PodSpec.Containers[0].Env)
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Grove currently appends its pod-discovery environment variables after the environment variables copied from PodClique templates. Kubernetes expands references in environment variable values in list order, so a template-defined variable cannot derive its value from a later `GROVE_*` variable.

This change prepends Grove's injected variables for containers and init containers at both injection stages. It also removes colliding template entries so Grove's reserved variables remain authoritative and duplicates are not passed to the kubelet.

The environment-variable reference documentation now describes the ordering contract and shows how to define a derived leader address.

#### Which issue(s) this PR fixes:

Fixes #752

#### Special notes for your reviewer:

The final order for PCSG-backed pods is the Pod-level Grove variables, the PCSG-level Grove variables, and then the remaining template variables. This makes all injected Grove variables available when Kubernetes expands template-defined environment variable values.

Validation:

- `make test-unit`
- `make lint`

#### Does this PR introduce a API change?

```release-note
Grove now injects pod-discovery environment variables before template-defined environment variables, allowing templates to derive values from Grove variables.
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
docs/user-guide/03_environment-variables-for-pod-discovery/02_env_var_reference.md
```
