### PR TITLE
Skip rolling update for PCLQs already at current generation hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,13 @@ scheduler/bin/*
 operator/charts/crds/*
 
 # scale-test result/profile output (per-run)
-operator/e2e/tests/scale/ScaleTest_*/
+operator/e2e/tests/scale/Scale*/
+
+# e2e diagnostic log files written to CWD when GROVE_E2E_DIAG_DIR is unset (local runs)
+e2e-diag-*.log
+
+# stress-test output directories
+operator/e2e-diagnostics/stress-run-*/
 
 # Python bytecode cache
 __pycache__/

--- a/operator/e2e/setup/shared_cluster.go
+++ b/operator/e2e/setup/shared_cluster.go
@@ -575,17 +575,19 @@ func SetupRegistryTestImages(registryPort string, images []string) error {
 	for _, imageName := range images {
 		registryImage := fmt.Sprintf("localhost:%s/%s", registryPort, imageName)
 
-		// Step 1: Pull the image
-		pullReader, err := cli.ImagePull(ctx, imageName, image.PullOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to pull %s: %w", imageName, err)
-		}
-
-		// Consume the pull output to avoid blocking
-		_, err = io.Copy(io.Discard, pullReader)
-		ioutil.CloseQuietly(pullReader)
-		if err != nil {
-			return fmt.Errorf("failed to read pull output for %s: %w", imageName, err)
+		// Step 1: Pull the image only if it is not already in the local Docker cache.
+		// Skipping the pull when the image is cached avoids Docker Hub rate limits
+		// (HTTP 429) during repeated local runs such as stress tests.
+		if _, _, err := cli.ImageInspectWithRaw(ctx, imageName); err != nil {
+			pullReader, err := cli.ImagePull(ctx, imageName, image.PullOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to pull %s: %w", imageName, err)
+			}
+			_, err = io.Copy(io.Discard, pullReader)
+			ioutil.CloseQuietly(pullReader)
+			if err != nil {
+				return fmt.Errorf("failed to read pull output for %s: %w", imageName, err)
+			}
 		}
 
 		// Step 2: Tag the image for the local registry

--- a/operator/e2e/tests/update/utils.go
+++ b/operator/e2e/tests/update/utils.go
@@ -352,17 +352,12 @@ func waitForRollingUpdateComplete(tc *testctx.TestContext, expectedReplicas int3
 	predicate := waiter.Predicate[*grovev1alpha1.PodCliqueSet](func(pcs *grovev1alpha1.PodCliqueSet) bool {
 		pollCount++
 
-		// Log status every few polls for debugging
-		if pollCount%3 == 1 {
-			tests.Logger.Debugf("[waitForRollingUpdateComplete] Poll #%d: UpdatedReplicas=%d, expectedReplicas=%d, UpdateProgress=%v",
-				pollCount, pcs.Status.UpdatedReplicas, expectedReplicas, pcs.Status.UpdateProgress != nil)
-			if pcs.Status.UpdateProgress != nil {
-				tests.Logger.Debugf("  UpdateStartedAt=%v, UpdateEndedAt=%v, CurrentlyUpdating=%v",
-					pcs.Status.UpdateProgress.UpdateStartedAt,
-					pcs.Status.UpdateProgress.UpdateEndedAt,
-					pcs.Status.UpdateProgress.CurrentlyUpdating)
-			}
+		endedAt := "<nil>"
+		if pcs.Status.UpdateProgress != nil && pcs.Status.UpdateProgress.UpdateEndedAt != nil {
+			endedAt = pcs.Status.UpdateProgress.UpdateEndedAt.UTC().Format("15:04:05Z")
 		}
+		tests.Logger.Infof("[waitForRollingUpdateComplete] Poll #%d: UpdatedReplicas=%d/%d UpdateEndedAt=%s",
+			pollCount, pcs.Status.UpdatedReplicas, expectedReplicas, endedAt)
 
 		// Check if rolling update is complete:
 		// - UpdatedReplicas should match expected

--- a/operator/internal/controller/podclique/reconcilespec.go
+++ b/operator/internal/controller/podclique/reconcilespec.go
@@ -146,6 +146,15 @@ func shouldResetOrTriggerUpdate(pcs *grovecorev1alpha1.PodCliqueSet, pclq *grove
 		return false
 	}
 
+	// PCLQ has no update history and its generation hash is already current.
+	// This happens for PCLQs scaled out after a rolling update: they are created
+	// from the already-updated template, so no rolling update pass is needed.
+	if pclq.Status.UpdateProgress == nil &&
+		pclq.Status.CurrentPodCliqueSetGenerationHash != nil &&
+		*pclq.Status.CurrentPodCliqueSetGenerationHash == *pcs.Status.CurrentGenerationHash {
+		return false
+	}
+
 	// PCLQ has never been updated yet and PCS has a new generation hash.
 	firstEverUpdateRequired := pclq.Status.UpdateProgress == nil && pclq.Status.CurrentPodCliqueSetGenerationHash != nil && *pcs.Status.CurrentGenerationHash != *pclq.Status.CurrentPodCliqueSetGenerationHash
 	if firstEverUpdateRequired {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`Test_RU11_RollingUpdateWithPCSScaleOut` was flaky because of a controller bug in `shouldResetOrTriggerUpdate`: when a PCS is scaled out during a rolling update, the new replica's standalone PCLQs are created from the already-updated template and have `CurrentPodCliqueSetGenerationHash` set correctly by `mutateCurrentHashes`. However, once the PCS rolling update ended and `UpdateEndedAt` was set, the PCLQ controller re-evaluated those
 PCLQs and — because `UpdateProgress` was nil and none of the "skip" guards matched — fell through to `return true`, triggering an unnecessary `initOrResetUpdate`. That call reset `UpdatedReplicas` to 0 on the PCLQ, causing `PCS.UpdatedReplicas` to read 2 instead of 3 for the remainder of the test timeout.

Fix: add an early-return guard in `shouldResetOrTriggerUpdate` — when `UpdateProgress` is nil and  `CurrentPodCliqueSetGenerationHash` already equals the current PCS generation hash, the PCLQ is up-to-date and no
rolling update is needed.

Supporting test improvements:
- Log `UpdatedReplicas` and `UpdateEndedAt` at every poll so timeout failures are self-diagnosing without needing the diag collector
- Log final PCS and per-PCLQ state on timeout
- Ignore scale-test output dirs (`Scale*/`) and local e2e diag log files in  `.gitignore`

#### Which issue(s) this PR fixes:

Fixes #711

#### Special notes for your reviewer:

The root cause is in `internal/controller/podclique/reconcilespec.go` (`shouldResetOrTriggerUpdate`). All other changes are test observability and local-dev cleanup.

#### Does this PR introduce a API change?

```release-note
NONE
```
Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```