### PR TITLE
fix(podclique): exclude pods already being deleted from scale-in candidates

### DIFF
--- a/operator/internal/controller/podclique/components/pod/deletionsort.go
+++ b/operator/internal/controller/podclique/components/pod/deletionsort.go
@@ -44,6 +44,15 @@ var podPhaseToOrdinal = map[corev1.PodPhase]int{corev1.PodPending: 0, corev1.Pod
 // Code partially adapted from https://github.com/kubernetes/kubernetes/blob/5a450884b127f7b8e477d48cf3967a2a5eca9126/pkg/controller/controller_utils.go#L702
 // Only 4 conditions have been taken as is and used here.
 func (s DeletionSorter) Less(i, j int) bool {
+	// 0. Already terminating < not terminating
+	// A Pod that has been marked for deletion keeps reporting Running and Ready until its containers
+	// actually stop, so none of the criteria below can distinguish it from a healthy Pod. Sorting it
+	// first ensures that any surplus deletion budget is spent on Pods that are already on their way
+	// out rather than on Pods that are still serving.
+	if iTerminating, jTerminating := s.Pods[i].DeletionTimestamp != nil, s.Pods[j].DeletionTimestamp != nil; iTerminating != jTerminating {
+		return iTerminating
+	}
+
 	// 1. Unassigned < assigned
 	// If only one of the pods is unassigned, the unassigned one is smaller
 	if s.Pods[i].Spec.NodeName != s.Pods[j].Spec.NodeName && (len(s.Pods[i].Spec.NodeName) == 0 || len(s.Pods[j].Spec.NodeName) == 0) {

--- a/operator/internal/controller/podclique/components/pod/deletionsort.go
+++ b/operator/internal/controller/podclique/components/pod/deletionsort.go
@@ -16,6 +16,7 @@ package pod
 
 import (
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
+	k8sutils "github.com/ai-dynamo/grove/operator/internal/utils/kubernetes"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -49,8 +50,8 @@ func (s DeletionSorter) Less(i, j int) bool {
 	// actually stop, so none of the criteria below can distinguish it from a healthy Pod. Sorting it
 	// first ensures that any surplus deletion budget is spent on Pods that are already on their way
 	// out rather than on Pods that are still serving.
-	if iTerminating, jTerminating := s.Pods[i].DeletionTimestamp != nil, s.Pods[j].DeletionTimestamp != nil; iTerminating != jTerminating {
-		return iTerminating
+	if isPodTerminating(s.Pods[i]) != isPodTerminating(s.Pods[j]) {
+		return isPodTerminating(s.Pods[i])
 	}
 
 	// 1. Unassigned < assigned
@@ -80,6 +81,11 @@ func (s DeletionSorter) Less(i, j int) bool {
 		return s.Pods[i].CreationTimestamp.IsZero()
 	}
 	return s.Pods[i].CreationTimestamp.After(s.Pods[j].CreationTimestamp.Time)
+}
+
+// isPodTerminating checks if a pod has already been marked for deletion.
+func isPodTerminating(pod *corev1.Pod) bool {
+	return k8sutils.IsResourceTerminating(pod.ObjectMeta)
 }
 
 // isPodReady checks if a pod is ready by looking for the PodReady condition with status True

--- a/operator/internal/controller/podclique/components/pod/deletionsort.go
+++ b/operator/internal/controller/podclique/components/pod/deletionsort.go
@@ -46,10 +46,14 @@ var podPhaseToOrdinal = map[corev1.PodPhase]int{corev1.PodPending: 0, corev1.Pod
 // Only 4 conditions have been taken as is and used here.
 func (s DeletionSorter) Less(i, j int) bool {
 	// 0. Already terminating < not terminating
-	// A Pod that has been marked for deletion keeps reporting Running and Ready until its containers
-	// actually stop, so none of the criteria below can distinguish it from a healthy Pod. Sorting it
-	// first ensures that any surplus deletion budget is spent on Pods that are already on their way
-	// out rather than on Pods that are still serving.
+	//
+	// DEFENSIVE: the scale-in caller (selectExcessPodsToDelete) filters terminating Pods out
+	// before sorting, so in that path this criterion never fires. It is kept because
+	// DeletionSorter is exported along with its Pods field and a future caller may hand it an
+	// unfiltered list. A Pod that has been marked for deletion keeps reporting Running and Ready
+	// until its containers actually stop, so none of the criteria below can distinguish it from a
+	// healthy Pod — without this rule such a caller would spend its deletion budget on a Pod that
+	// is still serving.
 	if isPodTerminating(s.Pods[i]) != isPodTerminating(s.Pods[j]) {
 		return isPodTerminating(s.Pods[i])
 	}

--- a/operator/internal/controller/podclique/components/pod/deletionsort_test.go
+++ b/operator/internal/controller/podclique/components/pod/deletionsort_test.go
@@ -61,10 +61,13 @@ func podNames(pods []*corev1.Pod) []string {
 	return names
 }
 
-// TestDeletionSorterPrefersTerminatingPods asserts the criterion that keeps a surplus deletion budget
-// away from Pods that are still serving. A Pod inside its termination grace period keeps reporting
-// Running and Ready, so without an explicit deletionTimestamp criterion it ties with a healthy Pod on
-// every other rule and the resulting order is whatever the caller happened to pass in.
+// TestDeletionSorterPrefersTerminatingPods pins the defensive criterion 0.
+//
+// The scale-in caller (selectExcessPodsToDelete) filters terminating Pods out before sorting, so this
+// criterion does not fire on that path. It exists for callers that hand DeletionSorter an unfiltered
+// list — the type and its Pods field are both exported. A Pod inside its termination grace period
+// keeps reporting Running and Ready, so without an explicit deletionTimestamp rule it ties with a
+// healthy Pod on every other criterion and the resulting order is whatever the caller passed in.
 func TestDeletionSorterPrefersTerminatingPods(t *testing.T) {
 	createdAt := metav1.NewTime(time.Now())
 

--- a/operator/internal/controller/podclique/components/pod/deletionsort_test.go
+++ b/operator/internal/controller/podclique/components/pod/deletionsort_test.go
@@ -1,0 +1,111 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package pod
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/ai-dynamo/grove/operator/api/common"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// sortTestTemplateHash is the pod-template-hash shared by every Pod these tests build, so that
+// DeletionSorter criterion 4 always ties and the criteria under test decide the order.
+const sortTestTemplateHash = "abc123"
+
+// newSortablePod builds a Pod that is scheduled, Running and Ready, i.e. indistinguishable from a
+// healthy serving Pod on every DeletionSorter criterion except the ones the test varies.
+func newSortablePod(name string, createdAt metav1.Time, terminating bool) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			CreationTimestamp: createdAt,
+			Labels:            map[string]string{common.LabelPodTemplateHash: sortTestTemplateHash},
+		},
+		Spec: corev1.PodSpec{NodeName: "node-a"},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+	if terminating {
+		pod.DeletionTimestamp = &createdAt
+	}
+	return pod
+}
+
+func podNames(pods []*corev1.Pod) []string {
+	names := make([]string, 0, len(pods))
+	for _, pod := range pods {
+		names = append(names, pod.Name)
+	}
+	return names
+}
+
+// TestDeletionSorterPrefersTerminatingPods asserts the criterion that keeps a surplus deletion budget
+// away from Pods that are still serving. A Pod inside its termination grace period keeps reporting
+// Running and Ready, so without an explicit deletionTimestamp criterion it ties with a healthy Pod on
+// every other rule and the resulting order is whatever the caller happened to pass in.
+func TestDeletionSorterPrefersTerminatingPods(t *testing.T) {
+	createdAt := metav1.NewTime(time.Now())
+
+	tests := []struct {
+		name          string
+		pods          []*corev1.Pod
+		expectedFirst []string
+	}{
+		{
+			name: "terminating pod sorts ahead of a healthy pod regardless of input order",
+			pods: []*corev1.Pod{
+				newSortablePod("healthy", createdAt, false),
+				newSortablePod("terminating", createdAt, true),
+			},
+			expectedFirst: []string{"terminating", "healthy"},
+		},
+		{
+			name: "terminating pod sorts ahead even when it is passed last",
+			pods: []*corev1.Pod{
+				newSortablePod("healthy-1", createdAt, false),
+				newSortablePod("healthy-2", createdAt, false),
+				newSortablePod("terminating", createdAt, true),
+			},
+			expectedFirst: []string{"terminating"},
+		},
+		{
+			name: "all pods terminating leaves the remaining criteria in charge",
+			pods: []*corev1.Pod{
+				newSortablePod("older", metav1.NewTime(createdAt.Add(-time.Hour)), true),
+				newSortablePod("newer", createdAt, true),
+			},
+			// criterion 5 prefers the newer pod for deletion
+			expectedFirst: []string{"newer", "older"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sorter := DeletionSorter{Pods: tt.pods, ExpectedPodTemplateHash: sortTestTemplateHash}
+			sort.Sort(sorter)
+			assert.Equal(t, tt.expectedFirst, podNames(sorter.Pods)[:len(tt.expectedFirst)])
+		})
+	}
+}

--- a/operator/internal/controller/podclique/components/pod/syncflow.go
+++ b/operator/internal/controller/podclique/components/pod/syncflow.go
@@ -203,7 +203,7 @@ func getTerminatingAndNonTerminatingPodUIDs(existingPCLQPods []*corev1.Pod) (ter
 // The deletion of Pods are done in batches of increasing size. This is done to prevent burst of load
 // on the kube-apiserver. It will fail fast in case there is an
 func (r _resource) deleteExcessPods(sc *syncContext, logger logr.Logger, diff int) error {
-	candidatePodsToDelete := selectExcessPodsToDelete(sc, logger)
+	candidatePodsToDelete := r.selectExcessPodsToDelete(sc, logger)
 	numPodsToSelectForDeletion := min(diff, len(candidatePodsToDelete))
 	selectedPodsToDelete := candidatePodsToDelete[:numPodsToSelectForDeletion]
 
@@ -226,19 +226,36 @@ func (r _resource) deleteExcessPods(sc *syncContext, logger logr.Logger, diff in
 	return nil
 }
 
-// selectExcessPodsToDelete identifies excess pods for deletion using DeletionSorter for prioritization
-func selectExcessPodsToDelete(sc *syncContext, logger logr.Logger) []*corev1.Pod {
-	var candidatePodsToDelete []*corev1.Pod
-	if diff := len(sc.existingPCLQPods) - int(sc.pclq.Spec.Replicas); diff > 0 {
-		logger.Info("found excess pods for PodClique", "numExcessPods", diff)
-		sorter := DeletionSorter{
-			Pods: sc.existingPCLQPods,
+// selectExcessPodsToDelete identifies excess pods for deletion using DeletionSorter for prioritization.
+//
+// Pods whose deletion has already been triggered are excluded from the candidate set. GetPCLQPods
+// returns terminating Pods as well, and a Pod stays Running and Ready for the whole of its
+// terminationGracePeriodSeconds, so counting it as excess spends the deletion budget on a Pod that is
+// already on its way out - and, since DeletionSorter cannot tell it apart from a healthy Pod, can
+// select a Pod that is still serving instead. The rolling update path applies the same rule via
+// hasPodDeletionBeenTriggered (see computeUpdateWork in rollingupdate.go).
+//
+// Filtering into a fresh slice also keeps sort.Sort from reordering sc.existingPCLQPods in place,
+// which later steps of the same sync flow still read.
+func (r _resource) selectExcessPodsToDelete(sc *syncContext, logger logr.Logger) []*corev1.Pod {
+	livePods := make([]*corev1.Pod, 0, len(sc.existingPCLQPods))
+	for _, pod := range sc.existingPCLQPods {
+		if r.hasPodDeletionBeenTriggered(sc, pod) {
+			continue
 		}
-		sorter.ExpectedPodTemplateHash = sc.getExpectedPodTemplateHash()
-		sort.Sort(sorter)
-		candidatePodsToDelete = append(candidatePodsToDelete, sorter.Pods[:diff]...)
+		livePods = append(livePods, pod)
 	}
-	return candidatePodsToDelete
+	numExcessPods := len(livePods) - int(sc.pclq.Spec.Replicas)
+	if numExcessPods <= 0 {
+		return nil
+	}
+	logger.Info("found excess pods for PodClique", "numExcessPods", numExcessPods)
+	sorter := DeletionSorter{
+		Pods:                    livePods,
+		ExpectedPodTemplateHash: sc.getExpectedPodTemplateHash(),
+	}
+	sort.Sort(sorter)
+	return sorter.Pods[:numExcessPods]
 }
 
 func (sc *syncContext) getExpectedPodTemplateHash() string {

--- a/operator/internal/controller/podclique/components/pod/syncflow_test.go
+++ b/operator/internal/controller/podclique/components/pod/syncflow_test.go
@@ -19,9 +19,11 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ai-dynamo/grove/operator/api/common"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/ai-dynamo/grove/operator/internal/expect"
 
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	"github.com/go-logr/logr"
@@ -30,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -633,5 +636,121 @@ func createTestPodClique(name string, minAvailable, scheduledReplicas int32) *gr
 		Status: grovecorev1alpha1.PodCliqueStatus{
 			ScheduledReplicas: scheduledReplicas,
 		},
+	}
+}
+
+// TestSelectExcessPodsToDelete_ExcludesPodsAlreadyBeingDeleted covers the scale-in path when Pods
+// whose deletion was already triggered are still present in the informer cache. GetPCLQPods returns
+// them, and a Pod stays Running and Ready for the whole of its termination grace period, so without
+// an explicit filter they are counted as excess and can consume the deletion budget that should have
+// spared a Pod that is still serving.
+func TestSelectExcessPodsToDelete_ExcludesPodsAlreadyBeingDeleted(t *testing.T) {
+	createdAt := metav1.NewTime(time.Now())
+	const templateHash = "hash-1"
+
+	newPod := func(name string, terminating bool) *corev1.Pod {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				UID:               types.UID("uid-" + name),
+				CreationTimestamp: createdAt,
+				Labels:            map[string]string{common.LabelPodTemplateHash: templateHash},
+			},
+			Spec: corev1.PodSpec{NodeName: "node-a"},
+			Status: corev1.PodStatus{
+				Phase:      corev1.PodRunning,
+				Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+			},
+		}
+		if terminating {
+			pod.DeletionTimestamp = &createdAt
+		}
+		return pod
+	}
+
+	tests := []struct {
+		name string
+		// pods that already carry a deletionTimestamp
+		terminatingPods []string
+		// pods for which a delete expectation was recorded but the cache has not caught up yet
+		deleteExpected []string
+		healthyPods    []string
+		replicas       int32
+		expectedNames  []string
+	}{
+		{
+			name:          "no terminating pods - excess selected normally",
+			healthyPods:   []string{"a", "b", "c"},
+			replicas:      1,
+			expectedNames: []string{"a", "b"},
+		},
+		{
+			name:            "terminating pods are not counted as excess",
+			terminatingPods: []string{"a", "b"},
+			healthyPods:     []string{"c"},
+			replicas:        1,
+			expectedNames:   nil,
+		},
+		{
+			name:            "only the genuinely excess healthy pod is selected",
+			terminatingPods: []string{"a"},
+			healthyPods:     []string{"b", "c"},
+			replicas:        1,
+			expectedNames:   []string{"b"},
+		},
+		{
+			name:           "pods with a recorded delete expectation are not counted as excess",
+			deleteExpected: []string{"a", "b"},
+			healthyPods:    []string{"c"},
+			replicas:       1,
+			expectedNames:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := expect.NewExpectationsStore()
+			r := _resource{expectationsStore: store}
+
+			pclq := &grovecorev1alpha1.PodClique{
+				ObjectMeta: metav1.ObjectMeta{Name: "pclq-1", Namespace: "default"},
+				Spec:       grovecorev1alpha1.PodCliqueSpec{Replicas: tt.replicas},
+			}
+			key, err := getPodCliqueExpectationsStoreKey(logr.Discard(), "sync", pclq.ObjectMeta)
+			require.NoError(t, err)
+
+			var pods []*corev1.Pod
+			for _, name := range tt.terminatingPods {
+				pods = append(pods, newPod(name, true))
+			}
+			for _, name := range tt.deleteExpected {
+				pod := newPod(name, false)
+				require.NoError(t, store.ExpectDeletions(logr.Discard(), key, pod.GetUID()))
+				pods = append(pods, pod)
+			}
+			for _, name := range tt.healthyPods {
+				pods = append(pods, newPod(name, false))
+			}
+
+			sc := &syncContext{
+				pclq:                     pclq,
+				existingPCLQPods:         pods,
+				pclqExpectationsStoreKey: key,
+			}
+
+			selected := r.selectExcessPodsToDelete(sc, logr.Discard())
+
+			var gotNames []string
+			for _, pod := range selected {
+				gotNames = append(gotNames, pod.Name)
+			}
+			assert.ElementsMatch(t, tt.expectedNames, gotNames)
+
+			// no selected pod may be one that is already on its way out
+			for _, pod := range selected {
+				assert.Nil(t, pod.DeletionTimestamp, "pod %s is already terminating and must not be selected", pod.Name)
+				assert.False(t, store.HasDeleteExpectation(key, pod.GetUID()), "pod %s already has a delete expectation", pod.Name)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:

`componentutils.GetPCLQPods` returns terminating Pods, and a Pod keeps reporting `Running` and `Ready` for the whole of its `terminationGracePeriodSeconds`. Two things followed from that on the scale-in path:

- `selectExcessPodsToDelete` computed the excess as `len(sc.existingPCLQPods) - spec.Replicas`, counting Pods that were already on their way out.
- `DeletionSorter.Less` had no `deletionTimestamp` criterion, so for batch-created Pods **all five** existing criteria tie — same node assignment, same `Running` phase, same `Ready` status, same pod-template-hash, and identical `creationTimestamp` because `metav1.Time` is second-granular. `sort.Sort` then performs zero swaps and the resulting order is whatever the informer cache's Go-map `List()` happened to return.

The net effect is that whenever the deletion budget exceeds the true excess, it can be spent on a Pod that is still serving instead of on one that is already terminating.

The rolling update path in the same package already gets this right — `computeUpdateWork` skips Pods via `hasPodDeletionBeenTriggered` (`rollingupdate.go`). The scale-in path did not.

### Changes

- `selectExcessPodsToDelete` becomes a method on `_resource` and filters out Pods that are terminating or already carry a delete expectation, so the excess count is computed over live Pods only. Reusing `hasPodDeletionBeenTriggered` keeps both paths on one definition of "already being deleted".
- Filtering into a fresh slice also stops `sort.Sort` from reordering `sc.existingPCLQPods` in place. Later steps of the same sync flow (`checkAndRemovePodSchedulingGates`, `computeUpdateWork`) read that slice.
- `DeletionSorter.Less` gains a `deletionTimestamp` criterion ahead of the existing five, as defence in depth: a caller that does hand it terminating Pods now spends the budget on Pods that are already doomed.

### Tests

- `deletionsort_test.go` (new): the terminating Pod sorts first regardless of input position; when every Pod is terminating the remaining criteria still decide.
- `syncflow_test.go`: table test for `selectExcessPodsToDelete` covering no-terminating-Pods, all-excess-terminating, mixed, and the delete-expectation-recorded case, asserting that no selected Pod is one already being deleted.

`go test ./internal/controller/podclique/...` and `golangci-lint run` on the package are clean.

#### Which issue(s) this PR fixes:

Fixes #758

#### Special notes for your reviewer:

The behaviour change is confined to which Pods are *eligible* for deletion; the `diff` computation in `syncExpectationsAndComputeDifference` is untouched. On a healthy scale-in with no terminating Pods the selection is identical to before.

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
