### PR TITLE
fix(podclique): compare container Started status by value in pod predicate

### DIFF
--- a/operator/internal/controller/podclique/register.go
+++ b/operator/internal/controller/podclique/register.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -183,7 +184,7 @@ func hasStartedAndReadyChangedForAnyContainer(oldContainerStatuses []corev1.Cont
 			return true
 		}
 		if matchingNewContainerStatus.Ready != oldContainerStatus.Ready ||
-			matchingNewContainerStatus.Started != oldContainerStatus.Started {
+			!ptr.Equal(matchingNewContainerStatus.Started, oldContainerStatus.Started) {
 			return true
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The pod predicate in the PodClique controller compares `ContainerStatus.Started` (a `*bool`) with `!=`, which compares pointer addresses rather than values. Since the old and new Pod objects in an update event are independently deserialized, the two pointers are always distinct whenever both are non-nil, so the comparison is effectively always true.

As a result, `hasStartedAndReadyChangedForAnyContainer` returns true for virtually every Pod status update, defeating the event filter and triggering unnecessary PodClique reconciles on every Pod status change (e.g. periodic kubelet status updates).

This PR replaces the pointer-identity comparison with `ptr.Equal`, which compares the pointed-to values (treating two nils as equal), so the predicate only passes when the `Started` state actually transitions.

#### Which issue(s) this PR fixes:

Fixes #761

#### Special notes for your reviewer:

`Ready` is a plain `bool` and its comparison is unaffected; only the `Started` comparison was broken.

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
