### PR TITLE
feat: improve PodGang status reporting with Scheduled and Ready conditions

### DIFF
--- a/docs/api-reference/operator-api.md
+++ b/docs/api-reference/operator-api.md
@@ -652,27 +652,6 @@ _Appears in:_
 | `readyPodsSelectedToUpdate` _[PodsSelectedToUpdate](#podsselectedtoupdate)_ | ReadyPodsSelectedToUpdate captures the pod names of ready Pods that are either currently being updated or have<br />been previously updated. This field is only set for auto update strategies where Grove orchestrates Pod deletions.<br />For the OnDelete strategy this field is not set, because Pod replacement is initiated by user-driven Pod deletions. |  |  |
 
 
-#### PodGangPhase
-
-_Underlying type:_ _string_
-
-PodGangPhase represents the phase of a PodGang.
-
-_Validation:_
-- Enum: [Pending Starting Running Failed Succeeded]
-
-_Appears in:_
-- [PodGangStatus](#podgangstatus)
-
-| Field | Description |
-| --- | --- |
-| `Pending` | PodGangPending indicates that the pods in a PodGang have not yet been taken up for scheduling.<br /> |
-| `Starting` | PodGangStarting indicates that the pods are bound to nodes by the scheduler and are starting.<br /> |
-| `Running` | PodGangRunning indicates that the all the pods in a PodGang are running.<br /> |
-| `Failed` | PodGangFailed indicates that one or more pods in a PodGang have failed.<br />This is a terminal state and is typically used for batch jobs.<br /> |
-| `Succeeded` | PodGangSucceeded indicates that all the pods in a PodGang have succeeded.<br />This is a terminal state and is typically used for batch jobs.<br /> |
-
-
 #### PodGangStatus
 
 
@@ -687,7 +666,6 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `name` _string_ | Name is the name of the PodGang. |  |  |
-| `phase` _[PodGangPhase](#podgangphase)_ | Phase is the current phase of the PodGang. |  | Enum: [Pending Starting Running Failed Succeeded] <br /> |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#condition-v1-meta) array_ | Conditions represents the latest available observations of the PodGang by its controller. |  |  |
 
 

--- a/docs/api-reference/scheduler-api.md
+++ b/docs/api-reference/scheduler-api.md
@@ -53,24 +53,6 @@ PodGang defines a specification of a group of pods that should be scheduled toge
 
 
 
-#### PodGangPhase
-
-_Underlying type:_ _string_
-
-PodGangPhase defines the current phase of a PodGang.
-
-
-
-_Appears in:_
-- [PodGangStatus](#podgangstatus)
-
-| Field | Description |
-| --- | --- |
-| `Pending` | PodGangPhasePending indicates that all the pods in a PodGang have been created and the PodGang is pending scheduling.<br /> |
-| `Starting` | PodGangPhaseStarting indicates that the scheduler has started binding pods in the PodGang to nodes.<br /> |
-| `Running` | PodGangPhaseRunning indicates that all the pods in the PodGang have been scheduled and are running.<br /> |
-
-
 #### PodGangSpec
 
 
@@ -104,7 +86,6 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `phase` _[PodGangPhase](#podgangphase)_ | Phase is the current phase of a PodGang. |  |  |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#condition-v1-meta) array_ | Conditions is a list of conditions that describe the current state of the PodGang. |  |  |
 | `placementScore` _float_ | PlacementScore is network optimality score for the PodGang. If the choice that the scheduler has made corresponds to the<br />best possible placement of the pods in the PodGang, then the score will be 1.0. Higher the score, better the placement. |  |  |
 

--- a/operator/api/core/v1alpha1/crds/grove.io_podcliquesets.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podcliquesets.yaml
@@ -11114,18 +11114,8 @@ spec:
                     name:
                       description: Name is the name of the PodGang.
                       type: string
-                    phase:
-                      description: Phase is the current phase of the PodGang.
-                      enum:
-                      - Pending
-                      - Starting
-                      - Running
-                      - Failed
-                      - Succeeded
-                      type: string
                   required:
                   - name
-                  - phase
                   type: object
                 type: array
               replicas:

--- a/operator/api/core/v1alpha1/podcliqueset.go
+++ b/operator/api/core/v1alpha1/podcliqueset.go
@@ -522,30 +522,9 @@ const (
 type PodGangStatus struct {
 	// Name is the name of the PodGang.
 	Name string `json:"name"`
-	// Phase is the current phase of the PodGang.
-	Phase PodGangPhase `json:"phase"`
 	// Conditions represents the latest available observations of the PodGang by its controller.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
-
-// PodGangPhase represents the phase of a PodGang.
-// +kubebuilder:validation:Enum={Pending,Starting,Running,Failed,Succeeded}
-type PodGangPhase string
-
-const (
-	// PodGangPending indicates that the pods in a PodGang have not yet been taken up for scheduling.
-	PodGangPending PodGangPhase = "Pending"
-	// PodGangStarting indicates that the pods are bound to nodes by the scheduler and are starting.
-	PodGangStarting PodGangPhase = "Starting"
-	// PodGangRunning indicates that the all the pods in a PodGang are running.
-	PodGangRunning PodGangPhase = "Running"
-	// PodGangFailed indicates that one or more pods in a PodGang have failed.
-	// This is a terminal state and is typically used for batch jobs.
-	PodGangFailed PodGangPhase = "Failed"
-	// PodGangSucceeded indicates that all the pods in a PodGang have succeeded.
-	// This is a terminal state and is typically used for batch jobs.
-	PodGangSucceeded PodGangPhase = "Succeeded"
-)
 
 // LastOperationType is a string alias for the type of the last operation.
 type LastOperationType string

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
@@ -516,11 +516,6 @@ func (r _resource) patchPodGangInitializedStatus(ctx context.Context, sc *syncCo
 		},
 	}
 	setOrUpdateInitializedCondition(statusPatch, status, reason, message)
-	// One could argue why not use Status.Phase to also denote Initialized condition. For now the argument is that
-	// current set of phases (Pending, Starting, Running) is influenced by the status of constituent Pods w.r.t their
-	// scheduling state, whereas initialized condition is denoting if a PodGang is ready to be scheduled
-	// (so it is pre-scheduling phase state). We can always revisit this in future if this reasoning changes.
-	statusPatch.Status.Phase = groveschedulerv1alpha1.PodGangPhasePending
 	if err := r.client.Status().Patch(ctx, statusPatch, client.Merge); err != nil {
 		return err
 	}
@@ -614,7 +609,7 @@ func (r _resource) createOrUpdatePodGang(ctx context.Context, sc *syncContext, p
 		)
 	}
 
-	// Update status with Initialized=False condition and Phase if not already set.
+	// Set Initialized=False if the condition is not already present.
 	// This needs to be done separately since CreateOrPatch doesn't handle updates/patches to status subresource.
 	if !k8sutils.HasCondition(pg.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeInitialized)) {
 		if err = r.patchPodGangInitializedStatus(ctx, sc, pg.Name, metav1.ConditionFalse, groveschedulerv1alpha1.ConditionReasonPodGangPodsCreationPending, "Not all constituent pods have been created yet"); err != nil {

--- a/operator/internal/controller/podgang/reconciler.go
+++ b/operator/internal/controller/podgang/reconciler.go
@@ -88,6 +88,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		logger.Error(err, "Failed to SyncPodGang on spec change")
 		return ctrl.Result{}, err
 	}
+	if err := r.reconcileStatus(ctx, podGang, backend); err != nil {
+		logger.Error(err, "Failed to reconcile PodGang status")
+		return ctrl.Result{}, err
+	}
 	logger.Info("Successfully synced PodGang")
 	return ctrl.Result{}, nil
 }

--- a/operator/internal/controller/podgang/register.go
+++ b/operator/internal/controller/podgang/register.go
@@ -44,7 +44,7 @@ func (r *Reconciler) RegisterWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(mapPodToPodGang),
-			builder.WithPredicates(podSchedulingStatusChangePredicate()),
+			builder.WithPredicates(podStatusChangePredicate()),
 		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: *r.config.ConcurrentSyncs,
@@ -87,7 +87,7 @@ func hasInitializedConditionChanged(updateEvent event.UpdateEvent) bool {
 		meta.IsStatusConditionTrue(newPodGang.Status.Conditions, conditionType)
 }
 
-func podSchedulingStatusChangePredicate() predicate.Predicate {
+func podStatusChangePredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(_ event.CreateEvent) bool { return true },
 		DeleteFunc: func(_ event.DeleteEvent) bool { return true },
@@ -99,7 +99,8 @@ func podSchedulingStatusChangePredicate() predicate.Predicate {
 			}
 			return oldPod.Labels[apicommon.LabelPodGang] != newPod.Labels[apicommon.LabelPodGang] ||
 				oldPod.DeletionTimestamp.IsZero() != newPod.DeletionTimestamp.IsZero() ||
-				isPodConditionTrue(oldPod, corev1.PodScheduled) != isPodConditionTrue(newPod, corev1.PodScheduled)
+				isPodConditionTrue(oldPod, corev1.PodScheduled) != isPodConditionTrue(newPod, corev1.PodScheduled) ||
+				isPodConditionTrue(oldPod, corev1.PodReady) != isPodConditionTrue(newPod, corev1.PodReady)
 		},
 		GenericFunc: func(_ event.GenericEvent) bool { return false },
 	}

--- a/operator/internal/controller/podgang/register.go
+++ b/operator/internal/controller/podgang/register.go
@@ -17,30 +17,48 @@
 package podgang
 
 import (
+	"context"
+
+	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	grovectrlutils "github.com/ai-dynamo/grove/operator/internal/controller/utils"
+	"github.com/ai-dynamo/grove/operator/internal/scheduler"
 
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // RegisterWithManager registers the backend controller with the manager
 func (r *Reconciler) RegisterWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&groveschedulerv1alpha1.PodGang{}, builder.WithPredicates(podGangSpecChangePredicate())).
+	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
+		For(&groveschedulerv1alpha1.PodGang{}, builder.WithPredicates(podGangChangePredicate())).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(mapPodToPodGang),
+			builder.WithPredicates(podSchedulingStatusChangePredicate()),
+		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: *r.config.ConcurrentSyncs,
 		}).
-		Named("podgang").
-		Complete(r)
+		Named("podgang")
+	for _, backend := range r.schedRegistry.All() {
+		if eventSource, ok := backend.(scheduler.PodGangStatusEventSource); ok {
+			controllerBuilder = eventSource.AddPodGangStatusWatches(controllerBuilder)
+		}
+	}
+	return controllerBuilder.Complete(r)
 }
 
-// podGangSpecChangePredicate filters PodGang events to only process spec changes
-// Status-only updates (like Initialized condition) are ignored
-func podGangSpecChangePredicate() predicate.Predicate {
+func podGangChangePredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			return grovectrlutils.IsManagedPodGang(e.Object)
@@ -51,8 +69,60 @@ func podGangSpecChangePredicate() predicate.Predicate {
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return grovectrlutils.IsManagedPodGang(e.ObjectOld) &&
 				grovectrlutils.IsManagedPodGang(e.ObjectNew) &&
-				(e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration())
+				(e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() ||
+					hasInitializedConditionChanged(e))
 		},
 		GenericFunc: func(_ event.GenericEvent) bool { return false },
 	}
+}
+
+func hasInitializedConditionChanged(updateEvent event.UpdateEvent) bool {
+	oldPodGang, oldOK := updateEvent.ObjectOld.(*groveschedulerv1alpha1.PodGang)
+	newPodGang, newOK := updateEvent.ObjectNew.(*groveschedulerv1alpha1.PodGang)
+	if !oldOK || !newOK {
+		return false
+	}
+	conditionType := string(groveschedulerv1alpha1.PodGangConditionTypeInitialized)
+	return meta.IsStatusConditionTrue(oldPodGang.Status.Conditions, conditionType) !=
+		meta.IsStatusConditionTrue(newPodGang.Status.Conditions, conditionType)
+}
+
+func podSchedulingStatusChangePredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(_ event.CreateEvent) bool { return true },
+		DeleteFunc: func(_ event.DeleteEvent) bool { return true },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldPod, oldOK := e.ObjectOld.(*corev1.Pod)
+			newPod, newOK := e.ObjectNew.(*corev1.Pod)
+			if !oldOK || !newOK {
+				return false
+			}
+			return oldPod.Labels[apicommon.LabelPodGang] != newPod.Labels[apicommon.LabelPodGang] ||
+				oldPod.DeletionTimestamp.IsZero() != newPod.DeletionTimestamp.IsZero() ||
+				isPodConditionTrue(oldPod, corev1.PodScheduled) != isPodConditionTrue(newPod, corev1.PodScheduled)
+		},
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
+	}
+}
+
+func isPodConditionTrue(pod *corev1.Pod, conditionType corev1.PodConditionType) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == conditionType {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func mapPodToPodGang(_ context.Context, obj client.Object) []reconcile.Request {
+	podGangName := obj.GetLabels()[apicommon.LabelPodGang]
+	if podGangName == "" {
+		return nil
+	}
+	return []reconcile.Request{{
+		NamespacedName: types.NamespacedName{
+			Namespace: obj.GetNamespace(),
+			Name:      podGangName,
+		},
+	}}
 }

--- a/operator/internal/controller/podgang/register_test.go
+++ b/operator/internal/controller/podgang/register_test.go
@@ -156,8 +156,8 @@ func TestPodGangChangePredicateAllowsInitialization(t *testing.T) {
 	assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: oldPodGang, ObjectNew: newPodGang}))
 }
 
-func TestPodSchedulingStatusChangePredicate(t *testing.T) {
-	pred := podSchedulingStatusChangePredicate()
+func TestPodStatusChangePredicate(t *testing.T) {
+	pred := podStatusChangePredicate()
 	oldPod := unscheduledPod("worker-0", "default", "test-podgang")
 	newPod := oldPod.DeepCopy()
 	newPod.Status.Conditions = []corev1.PodCondition{{
@@ -173,6 +173,13 @@ func TestPodSchedulingStatusChangePredicate(t *testing.T) {
 	unchangedPod := newPod.DeepCopy()
 	unchangedPod.Status.Conditions[0].Message = "diagnostic changed"
 	assert.False(t, pred.Update(event.UpdateEvent{ObjectOld: newPod, ObjectNew: unchangedPod}))
+
+	readyPod := newPod.DeepCopy()
+	readyPod.Status.Conditions = append(readyPod.Status.Conditions, corev1.PodCondition{
+		Type:   corev1.PodReady,
+		Status: corev1.ConditionTrue,
+	})
+	assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: newPod, ObjectNew: readyPod}))
 }
 
 func TestMapPodToPodGang(t *testing.T) {

--- a/operator/internal/controller/podgang/register_test.go
+++ b/operator/internal/controller/podgang/register_test.go
@@ -19,9 +19,15 @@ package podgang
 import (
 	"testing"
 
+	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
+	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
@@ -37,8 +43,8 @@ type predicateTestCase struct {
 	shouldAllowUpdateEvent  bool
 }
 
-func TestPodGangSpecChangePredicate(t *testing.T) {
-	pred := podGangSpecChangePredicate()
+func TestPodGangChangePredicate(t *testing.T) {
+	pred := podGangChangePredicate()
 
 	tests := []predicateTestCase{
 		{
@@ -132,4 +138,50 @@ func TestPodGangSpecChangePredicate(t *testing.T) {
 			assert.Equal(t, tc.shouldAllowUpdateEvent, pred.Update(event.UpdateEvent{ObjectOld: oldPG, ObjectNew: newPG}), "Update")
 		})
 	}
+}
+
+func TestPodGangChangePredicateAllowsInitialization(t *testing.T) {
+	pred := podGangChangePredicate()
+	oldPodGang := testutils.NewPodGangBuilder("test-pg", "default").
+		WithGeneration(1).
+		WithManaged(true).
+		Build()
+	oldPodGang.Status.Conditions = []metav1.Condition{{
+		Type:   string(groveschedulerv1alpha1.PodGangConditionTypeInitialized),
+		Status: metav1.ConditionFalse,
+	}}
+	newPodGang := oldPodGang.DeepCopy()
+	newPodGang.Status.Conditions[0].Status = metav1.ConditionTrue
+
+	assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: oldPodGang, ObjectNew: newPodGang}))
+}
+
+func TestPodSchedulingStatusChangePredicate(t *testing.T) {
+	pred := podSchedulingStatusChangePredicate()
+	oldPod := unscheduledPod("worker-0", "default", "test-podgang")
+	newPod := oldPod.DeepCopy()
+	newPod.Status.Conditions = []corev1.PodCondition{{
+		Type:   corev1.PodScheduled,
+		Status: corev1.ConditionTrue,
+	}}
+
+	assert.True(t, pred.Create(event.CreateEvent{Object: newPod}))
+	assert.True(t, pred.Delete(event.DeleteEvent{Object: newPod}))
+	assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: oldPod, ObjectNew: newPod}))
+	assert.False(t, pred.Generic(event.GenericEvent{Object: newPod}))
+
+	unchangedPod := newPod.DeepCopy()
+	unchangedPod.Status.Conditions[0].Message = "diagnostic changed"
+	assert.False(t, pred.Update(event.UpdateEvent{ObjectOld: newPod, ObjectNew: unchangedPod}))
+}
+
+func TestMapPodToPodGang(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "worker-0",
+		Namespace: "default",
+		Labels:    map[string]string{apicommon.LabelPodGang: "test-podgang"},
+	}}
+	requests := mapPodToPodGang(t.Context(), pod)
+	require.Len(t, requests, 1)
+	assert.Equal(t, types.NamespacedName{Namespace: "default", Name: "test-podgang"}, requests[0].NamespacedName)
 }

--- a/operator/internal/controller/podgang/status.go
+++ b/operator/internal/controller/podgang/status.go
@@ -41,6 +41,7 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, podGang *groveschedule
 		}
 	}
 	scheduledCondition := getScheduledCondition(podGang, pods)
+	readyCondition := getReadyCondition(podGang, pods)
 	schedulingBackendReadyCondition, backendStatusErr := getSchedulingBackendReadyCondition(ctx, podGang, backend)
 	if backendStatusErr != nil {
 		schedulingBackendReadyCondition = &metav1.Condition{
@@ -63,7 +64,8 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, podGang *groveschedule
 	} else {
 		schedulingBackendReadyChanged = meta.SetStatusCondition(&podGang.Status.Conditions, *schedulingBackendReadyCondition)
 	}
-	if !scheduledChanged && !schedulingBackendReadyChanged {
+	readyChanged := meta.SetStatusCondition(&podGang.Status.Conditions, readyCondition)
+	if !scheduledChanged && !schedulingBackendReadyChanged && !readyChanged {
 		return backendStatusErr
 	}
 	if err := r.Status().Patch(ctx, podGang, client.MergeFrom(original)); err != nil {
@@ -117,6 +119,35 @@ func getSchedulingBackendReadyCondition(ctx context.Context, podGang *grovesched
 		Message:            backendCondition.Message,
 		ObservedGeneration: podGang.Generation,
 	}, nil
+}
+
+func getReadyCondition(podGang *groveschedulerv1alpha1.PodGang, pods map[types.NamespacedName]*corev1.Pod) metav1.Condition {
+	condition := metav1.Condition{
+		Type:               string(groveschedulerv1alpha1.PodGangConditionTypeReady),
+		ObservedGeneration: podGang.Generation,
+	}
+	if !isPodGangInitialized(podGang) {
+		condition.Status = metav1.ConditionUnknown
+		condition.Reason = groveschedulerv1alpha1.ConditionReasonPodGangNotInitialized
+		condition.Message = "PodGang readiness cannot be determined before initialization completes"
+		return condition
+	}
+
+	for _, podGroup := range podGang.Spec.PodGroups {
+		ready := countPodsWithCondition(podGroup.PodReferences, pods, corev1.PodReady)
+		if ready >= podGroup.MinReplicas {
+			continue
+		}
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = groveschedulerv1alpha1.ConditionReasonInsufficientReadyPods
+		condition.Message = fmt.Sprintf("PodGroup %q has %d of %d required Pods ready", podGroup.Name, ready, podGroup.MinReplicas)
+		return condition
+	}
+
+	condition.Status = metav1.ConditionTrue
+	condition.Reason = groveschedulerv1alpha1.ConditionReasonSufficientReadyPods
+	condition.Message = "All PodGroups satisfy MinReplicas"
+	return condition
 }
 
 func isPodGangInitialized(podGang *groveschedulerv1alpha1.PodGang) bool {

--- a/operator/internal/controller/podgang/status.go
+++ b/operator/internal/controller/podgang/status.go
@@ -1,0 +1,168 @@
+// /*
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package podgang
+
+import (
+	"context"
+	"fmt"
+
+	apicommon "github.com/ai-dynamo/grove/operator/api/common"
+	"github.com/ai-dynamo/grove/operator/internal/scheduler"
+
+	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (r *Reconciler) reconcileStatus(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang, backend scheduler.Backend) error {
+	var pods map[types.NamespacedName]*corev1.Pod
+	if isPodGangInitialized(podGang) {
+		var err error
+		pods, err = r.listReferencedPods(ctx, podGang)
+		if err != nil {
+			return err
+		}
+	}
+	scheduledCondition := getScheduledCondition(podGang, pods)
+	schedulingBackendReadyCondition, backendStatusErr := getSchedulingBackendReadyCondition(ctx, podGang, backend)
+	if backendStatusErr != nil {
+		schedulingBackendReadyCondition = &metav1.Condition{
+			Type:               string(groveschedulerv1alpha1.PodGangConditionTypeSchedulingBackendReady),
+			Status:             metav1.ConditionUnknown,
+			Reason:             groveschedulerv1alpha1.ConditionReasonSchedulingBackendStatusUnavailable,
+			Message:            backendStatusErr.Error(),
+			ObservedGeneration: podGang.Generation,
+		}
+	}
+
+	original := podGang.DeepCopy()
+	scheduledChanged := meta.SetStatusCondition(&podGang.Status.Conditions, scheduledCondition)
+	var schedulingBackendReadyChanged bool
+	if schedulingBackendReadyCondition == nil {
+		schedulingBackendReadyChanged = meta.RemoveStatusCondition(
+			&podGang.Status.Conditions,
+			string(groveschedulerv1alpha1.PodGangConditionTypeSchedulingBackendReady),
+		)
+	} else {
+		schedulingBackendReadyChanged = meta.SetStatusCondition(&podGang.Status.Conditions, *schedulingBackendReadyCondition)
+	}
+	if !scheduledChanged && !schedulingBackendReadyChanged {
+		return backendStatusErr
+	}
+	if err := r.Status().Patch(ctx, podGang, client.MergeFrom(original)); err != nil {
+		return err
+	}
+	return backendStatusErr
+}
+
+func getScheduledCondition(podGang *groveschedulerv1alpha1.PodGang, pods map[types.NamespacedName]*corev1.Pod) metav1.Condition {
+	condition := metav1.Condition{
+		Type:               string(groveschedulerv1alpha1.PodGangConditionTypeScheduled),
+		ObservedGeneration: podGang.Generation,
+	}
+	if !isPodGangInitialized(podGang) {
+		condition.Status = metav1.ConditionUnknown
+		condition.Reason = groveschedulerv1alpha1.ConditionReasonPodGangNotInitialized
+		condition.Message = "PodGang scheduling cannot be determined before initialization completes"
+		return condition
+	}
+
+	for _, podGroup := range podGang.Spec.PodGroups {
+		scheduled := countPodsWithCondition(podGroup.PodReferences, pods, corev1.PodScheduled)
+		if scheduled >= podGroup.MinReplicas {
+			continue
+		}
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = groveschedulerv1alpha1.ConditionReasonInsufficientScheduledPods
+		condition.Message = fmt.Sprintf("PodGroup %q has %d of %d required Pods scheduled", podGroup.Name, scheduled, podGroup.MinReplicas)
+		return condition
+	}
+
+	condition.Status = metav1.ConditionTrue
+	condition.Reason = groveschedulerv1alpha1.ConditionReasonSufficientScheduledPods
+	condition.Message = "All PodGroups satisfy MinReplicas"
+	return condition
+}
+
+func getSchedulingBackendReadyCondition(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang, backend scheduler.Backend) (*metav1.Condition, error) {
+	provider, ok := backend.(scheduler.PodGangStatusProvider)
+	if !ok {
+		return nil, nil
+	}
+	backendCondition, err := provider.GetPodGangSchedulingBackendCondition(ctx, podGang)
+	if err != nil || backendCondition == nil {
+		return nil, err
+	}
+	return &metav1.Condition{
+		Type:               string(groveschedulerv1alpha1.PodGangConditionTypeSchedulingBackendReady),
+		Status:             backendCondition.Status,
+		Reason:             backendCondition.Reason,
+		Message:            backendCondition.Message,
+		ObservedGeneration: podGang.Generation,
+	}, nil
+}
+
+func isPodGangInitialized(podGang *groveschedulerv1alpha1.PodGang) bool {
+	return meta.IsStatusConditionTrue(podGang.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeInitialized))
+}
+
+func (r *Reconciler) listReferencedPods(ctx context.Context, podGang *groveschedulerv1alpha1.PodGang) (map[types.NamespacedName]*corev1.Pod, error) {
+	namespaces := make(map[string]struct{})
+	for _, podGroup := range podGang.Spec.PodGroups {
+		for _, ref := range podGroup.PodReferences {
+			namespaces[ref.Namespace] = struct{}{}
+		}
+	}
+
+	pods := make(map[types.NamespacedName]*corev1.Pod)
+	for namespace := range namespaces {
+		podList := &corev1.PodList{}
+		if err := r.List(
+			ctx,
+			podList,
+			client.InNamespace(namespace),
+			client.MatchingLabels{apicommon.LabelPodGang: podGang.Name},
+		); err != nil {
+			return nil, fmt.Errorf("failed to list Pods for PodGang %s/%s: %w", podGang.Namespace, podGang.Name, err)
+		}
+		for i := range podList.Items {
+			pod := &podList.Items[i]
+			pods[client.ObjectKeyFromObject(pod)] = pod
+		}
+	}
+	return pods, nil
+}
+
+func countPodsWithCondition(references []groveschedulerv1alpha1.NamespacedName, pods map[types.NamespacedName]*corev1.Pod, conditionType corev1.PodConditionType) int32 {
+	var count int32
+	for _, ref := range references {
+		pod := pods[types.NamespacedName{Namespace: ref.Namespace, Name: ref.Name}]
+		if pod == nil || !pod.DeletionTimestamp.IsZero() {
+			continue
+		}
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == conditionType && condition.Status == corev1.ConditionTrue {
+				count++
+				break
+			}
+		}
+	}
+	return count
+}

--- a/operator/internal/controller/podgang/status_test.go
+++ b/operator/internal/controller/podgang/status_test.go
@@ -1,0 +1,227 @@
+// /*
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package podgang
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	apicommon "github.com/ai-dynamo/grove/operator/api/common"
+	"github.com/ai-dynamo/grove/operator/internal/scheduler"
+	testutils "github.com/ai-dynamo/grove/operator/test/utils"
+
+	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type statusProviderBackend struct {
+	scheduler.Backend
+	condition *scheduler.PodGangSchedulingBackendCondition
+	err       error
+}
+
+func (b *statusProviderBackend) GetPodGangSchedulingBackendCondition(_ context.Context, _ *groveschedulerv1alpha1.PodGang) (*scheduler.PodGangSchedulingBackendCondition, error) {
+	return b.condition, b.err
+}
+
+func TestGetScheduledCondition(t *testing.T) {
+	const namespace = "default"
+	podGang := testutils.NewPodGangBuilder("test-podgang", namespace).
+		WithGeneration(2).
+		WithManaged(true).
+		Build()
+	podGang.Spec.PodGroups = []groveschedulerv1alpha1.PodGroup{{
+		Name:        "workers",
+		MinReplicas: 2,
+		PodReferences: []groveschedulerv1alpha1.NamespacedName{
+			{Namespace: namespace, Name: "worker-0"},
+			{Namespace: namespace, Name: "worker-1"},
+		},
+	}}
+	t.Run("unknown before initialization", func(t *testing.T) {
+		r := &Reconciler{Client: testutils.CreateDefaultFakeClient(nil)}
+		condition := scheduledConditionForTest(t, r, podGang.DeepCopy())
+		assert.Equal(t, metav1.ConditionUnknown, condition.Status)
+		assert.Equal(t, groveschedulerv1alpha1.ConditionReasonPodGangNotInitialized, condition.Reason)
+		assert.Equal(t, int64(2), condition.ObservedGeneration)
+	})
+
+	initializedPodGang := podGang.DeepCopy()
+	initializedPodGang.Status.Conditions = []metav1.Condition{{
+		Type:   string(groveschedulerv1alpha1.PodGangConditionTypeInitialized),
+		Status: metav1.ConditionTrue,
+	}}
+
+	t.Run("false when a PodGroup has insufficient scheduled Pods", func(t *testing.T) {
+		r := &Reconciler{Client: testutils.CreateDefaultFakeClient([]client.Object{
+			scheduledPod("worker-0", namespace, podGang.Name),
+			unscheduledPod("worker-1", namespace, podGang.Name),
+		})}
+		condition := scheduledConditionForTest(t, r, initializedPodGang.DeepCopy())
+		assert.Equal(t, metav1.ConditionFalse, condition.Status)
+		assert.Equal(t, groveschedulerv1alpha1.ConditionReasonInsufficientScheduledPods, condition.Reason)
+		assert.Equal(t, `PodGroup "workers" has 1 of 2 required Pods scheduled`, condition.Message)
+	})
+
+	t.Run("true when every PodGroup satisfies MinReplicas", func(t *testing.T) {
+		r := &Reconciler{Client: testutils.CreateDefaultFakeClient([]client.Object{
+			scheduledPod("worker-0", namespace, podGang.Name),
+			scheduledPod("worker-1", namespace, podGang.Name),
+		})}
+		condition := scheduledConditionForTest(t, r, initializedPodGang.DeepCopy())
+		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+		assert.Equal(t, groveschedulerv1alpha1.ConditionReasonSufficientScheduledPods, condition.Reason)
+	})
+}
+
+func TestGetSchedulingBackendReadyCondition(t *testing.T) {
+	podGang := testutils.NewPodGangBuilder("test-podgang", "default").
+		WithGeneration(4).
+		WithManaged(true).
+		Build()
+	backend := &statusProviderBackend{
+		Backend: testutils.NewFakeSchedulerBackend("test-scheduler"),
+		condition: &scheduler.PodGangSchedulingBackendCondition{
+			Status:  metav1.ConditionFalse,
+			Reason:  "QueueDoesNotExist",
+			Message: "queue is missing",
+		},
+	}
+
+	condition, err := getSchedulingBackendReadyCondition(t.Context(), podGang, backend)
+	require.NoError(t, err)
+	require.NotNil(t, condition)
+	assert.Equal(t, string(groveschedulerv1alpha1.PodGangConditionTypeSchedulingBackendReady), condition.Type)
+	assert.Equal(t, metav1.ConditionFalse, condition.Status)
+	assert.Equal(t, "QueueDoesNotExist", condition.Reason)
+	assert.Equal(t, "queue is missing", condition.Message)
+	assert.Equal(t, int64(4), condition.ObservedGeneration)
+
+	condition, err = getSchedulingBackendReadyCondition(t.Context(), podGang, testutils.NewFakeSchedulerBackend("test-scheduler"))
+	require.NoError(t, err)
+	assert.Nil(t, condition)
+}
+
+func TestReconcileStatus(t *testing.T) {
+	podGang, cl := createInitializedPodGangWithScheduledPod(t)
+	r := &Reconciler{Client: cl}
+	current := &groveschedulerv1alpha1.PodGang{}
+	require.NoError(t, cl.Get(t.Context(), client.ObjectKeyFromObject(podGang), current))
+	backend := &statusProviderBackend{
+		Backend: testutils.NewFakeSchedulerBackend("test-scheduler"),
+		condition: &scheduler.PodGangSchedulingBackendCondition{
+			Status:  metav1.ConditionFalse,
+			Reason:  "QueueDoesNotExist",
+			Message: "queue is missing",
+		},
+	}
+
+	require.NoError(t, r.reconcileStatus(t.Context(), current, backend))
+	updated := &groveschedulerv1alpha1.PodGang{}
+	require.NoError(t, cl.Get(t.Context(), client.ObjectKeyFromObject(podGang), updated))
+	scheduledCondition := apimeta.FindStatusCondition(updated.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeScheduled))
+	require.NotNil(t, scheduledCondition)
+	assert.Equal(t, metav1.ConditionTrue, scheduledCondition.Status)
+	schedulingBackendReadyCondition := apimeta.FindStatusCondition(updated.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeSchedulingBackendReady))
+	require.NotNil(t, schedulingBackendReadyCondition)
+	assert.Equal(t, metav1.ConditionFalse, schedulingBackendReadyCondition.Status)
+	assert.Equal(t, "QueueDoesNotExist", schedulingBackendReadyCondition.Reason)
+}
+
+func TestReconcileStatusPersistsGroveConditionOnBackendError(t *testing.T) {
+	podGang, cl := createInitializedPodGangWithScheduledPod(t)
+	r := &Reconciler{Client: cl}
+	current := &groveschedulerv1alpha1.PodGang{}
+	require.NoError(t, cl.Get(t.Context(), client.ObjectKeyFromObject(podGang), current))
+	backendErr := errors.New("backend status unavailable")
+	backend := &statusProviderBackend{
+		Backend: testutils.NewFakeSchedulerBackend("test-scheduler"),
+		err:     backendErr,
+	}
+
+	require.ErrorIs(t, r.reconcileStatus(t.Context(), current, backend), backendErr)
+	updated := &groveschedulerv1alpha1.PodGang{}
+	require.NoError(t, cl.Get(t.Context(), client.ObjectKeyFromObject(podGang), updated))
+	scheduledCondition := apimeta.FindStatusCondition(updated.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeScheduled))
+	require.NotNil(t, scheduledCondition)
+	assert.Equal(t, metav1.ConditionTrue, scheduledCondition.Status)
+	schedulingBackendReadyCondition := apimeta.FindStatusCondition(updated.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeSchedulingBackendReady))
+	require.NotNil(t, schedulingBackendReadyCondition)
+	assert.Equal(t, metav1.ConditionUnknown, schedulingBackendReadyCondition.Status)
+	assert.Equal(t, groveschedulerv1alpha1.ConditionReasonSchedulingBackendStatusUnavailable, schedulingBackendReadyCondition.Reason)
+}
+
+func scheduledConditionForTest(t *testing.T, r *Reconciler, podGang *groveschedulerv1alpha1.PodGang) metav1.Condition {
+	t.Helper()
+	var pods map[types.NamespacedName]*corev1.Pod
+	if isPodGangInitialized(podGang) {
+		var err error
+		pods, err = r.listReferencedPods(t.Context(), podGang)
+		require.NoError(t, err)
+	}
+	return getScheduledCondition(podGang, pods)
+}
+
+func createInitializedPodGangWithScheduledPod(t *testing.T) (*groveschedulerv1alpha1.PodGang, client.Client) {
+	t.Helper()
+	const namespace = "default"
+	podGang := testutils.NewPodGangBuilder("test-podgang", namespace).
+		WithGeneration(1).
+		WithManaged(true).
+		Build()
+	podGang.Spec.PodGroups = []groveschedulerv1alpha1.PodGroup{{
+		Name:        "workers",
+		MinReplicas: 1,
+		PodReferences: []groveschedulerv1alpha1.NamespacedName{{
+			Namespace: namespace,
+			Name:      "worker-0",
+		}},
+	}}
+	podGang.Status.Conditions = []metav1.Condition{{
+		Type:   string(groveschedulerv1alpha1.PodGangConditionTypeInitialized),
+		Status: metav1.ConditionTrue,
+	}}
+	return podGang, testutils.NewTestClientBuilder().
+		WithObjects(podGang, scheduledPod("worker-0", namespace, podGang.Name)).
+		WithStatusSubresource(&groveschedulerv1alpha1.PodGang{}).
+		Build()
+}
+
+func scheduledPod(name, namespace, podGangName string) *corev1.Pod {
+	pod := unscheduledPod(name, namespace, podGangName)
+	pod.Status.Conditions = []corev1.PodCondition{{
+		Type:   corev1.PodScheduled,
+		Status: corev1.ConditionTrue,
+	}}
+	return pod
+}
+
+func unscheduledPod(name, namespace, podGangName string) *corev1.Pod {
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      name,
+		Namespace: namespace,
+		Labels:    map[string]string{apicommon.LabelPodGang: podGangName},
+	}}
+}

--- a/operator/internal/controller/podgang/status_test.go
+++ b/operator/internal/controller/podgang/status_test.go
@@ -124,8 +124,51 @@ func TestGetSchedulingBackendReadyCondition(t *testing.T) {
 	assert.Nil(t, condition)
 }
 
+func TestGetReadyCondition(t *testing.T) {
+	const namespace = "default"
+	podGang := testutils.NewPodGangBuilder("test-podgang", namespace).
+		WithGeneration(3).
+		WithManaged(true).
+		Build()
+	podGang.Spec.PodGroups = []groveschedulerv1alpha1.PodGroup{{
+		Name:        "workers",
+		MinReplicas: 2,
+		PodReferences: []groveschedulerv1alpha1.NamespacedName{
+			{Namespace: namespace, Name: "worker-0"},
+			{Namespace: namespace, Name: "worker-1"},
+		},
+	}}
+
+	condition := getReadyCondition(podGang, nil)
+	assert.Equal(t, metav1.ConditionUnknown, condition.Status)
+	assert.Equal(t, groveschedulerv1alpha1.ConditionReasonPodGangNotInitialized, condition.Reason)
+
+	podGang.Status.Conditions = []metav1.Condition{{
+		Type:   string(groveschedulerv1alpha1.PodGangConditionTypeInitialized),
+		Status: metav1.ConditionTrue,
+	}}
+	terminatingPod := readyPod("worker-1", podGang.Name)
+	now := metav1.Now()
+	terminatingPod.DeletionTimestamp = &now
+	pods := map[types.NamespacedName]*corev1.Pod{
+		{Namespace: namespace, Name: "worker-0"}: readyPod("worker-0", podGang.Name),
+		{Namespace: namespace, Name: "worker-1"}: terminatingPod,
+	}
+
+	condition = getReadyCondition(podGang, pods)
+	assert.Equal(t, metav1.ConditionFalse, condition.Status)
+	assert.Equal(t, groveschedulerv1alpha1.ConditionReasonInsufficientReadyPods, condition.Reason)
+	assert.Equal(t, `PodGroup "workers" has 1 of 2 required Pods ready`, condition.Message)
+
+	pods[types.NamespacedName{Namespace: namespace, Name: "worker-1"}] = readyPod("worker-1", podGang.Name)
+	condition = getReadyCondition(podGang, pods)
+	assert.Equal(t, metav1.ConditionTrue, condition.Status)
+	assert.Equal(t, groveschedulerv1alpha1.ConditionReasonSufficientReadyPods, condition.Reason)
+	assert.Equal(t, int64(3), condition.ObservedGeneration)
+}
+
 func TestReconcileStatus(t *testing.T) {
-	podGang, cl := createInitializedPodGangWithScheduledPod(t)
+	podGang, cl := createInitializedPodGangWithScheduledAndReadyPod(t)
 	r := &Reconciler{Client: cl}
 	current := &groveschedulerv1alpha1.PodGang{}
 	require.NoError(t, cl.Get(t.Context(), client.ObjectKeyFromObject(podGang), current))
@@ -144,14 +187,17 @@ func TestReconcileStatus(t *testing.T) {
 	scheduledCondition := apimeta.FindStatusCondition(updated.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeScheduled))
 	require.NotNil(t, scheduledCondition)
 	assert.Equal(t, metav1.ConditionTrue, scheduledCondition.Status)
+	readyCondition := apimeta.FindStatusCondition(updated.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeReady))
+	require.NotNil(t, readyCondition)
+	assert.Equal(t, metav1.ConditionTrue, readyCondition.Status)
 	schedulingBackendReadyCondition := apimeta.FindStatusCondition(updated.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeSchedulingBackendReady))
 	require.NotNil(t, schedulingBackendReadyCondition)
 	assert.Equal(t, metav1.ConditionFalse, schedulingBackendReadyCondition.Status)
 	assert.Equal(t, "QueueDoesNotExist", schedulingBackendReadyCondition.Reason)
 }
 
-func TestReconcileStatusPersistsGroveConditionOnBackendError(t *testing.T) {
-	podGang, cl := createInitializedPodGangWithScheduledPod(t)
+func TestReconcileStatusPersistsGroveConditionsOnBackendError(t *testing.T) {
+	podGang, cl := createInitializedPodGangWithScheduledAndReadyPod(t)
 	r := &Reconciler{Client: cl}
 	current := &groveschedulerv1alpha1.PodGang{}
 	require.NoError(t, cl.Get(t.Context(), client.ObjectKeyFromObject(podGang), current))
@@ -167,6 +213,9 @@ func TestReconcileStatusPersistsGroveConditionOnBackendError(t *testing.T) {
 	scheduledCondition := apimeta.FindStatusCondition(updated.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeScheduled))
 	require.NotNil(t, scheduledCondition)
 	assert.Equal(t, metav1.ConditionTrue, scheduledCondition.Status)
+	readyCondition := apimeta.FindStatusCondition(updated.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeReady))
+	require.NotNil(t, readyCondition)
+	assert.Equal(t, metav1.ConditionTrue, readyCondition.Status)
 	schedulingBackendReadyCondition := apimeta.FindStatusCondition(updated.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeSchedulingBackendReady))
 	require.NotNil(t, schedulingBackendReadyCondition)
 	assert.Equal(t, metav1.ConditionUnknown, schedulingBackendReadyCondition.Status)
@@ -184,7 +233,7 @@ func scheduledConditionForTest(t *testing.T, r *Reconciler, podGang *groveschedu
 	return getScheduledCondition(podGang, pods)
 }
 
-func createInitializedPodGangWithScheduledPod(t *testing.T) (*groveschedulerv1alpha1.PodGang, client.Client) {
+func createInitializedPodGangWithScheduledAndReadyPod(t *testing.T) (*groveschedulerv1alpha1.PodGang, client.Client) {
 	t.Helper()
 	const namespace = "default"
 	podGang := testutils.NewPodGangBuilder("test-podgang", namespace).
@@ -203,8 +252,13 @@ func createInitializedPodGangWithScheduledPod(t *testing.T) (*groveschedulerv1al
 		Type:   string(groveschedulerv1alpha1.PodGangConditionTypeInitialized),
 		Status: metav1.ConditionTrue,
 	}}
+	pod := readyPod("worker-0", podGang.Name)
+	pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
+		Type:   corev1.PodScheduled,
+		Status: corev1.ConditionTrue,
+	})
 	return podGang, testutils.NewTestClientBuilder().
-		WithObjects(podGang, scheduledPod("worker-0", namespace, podGang.Name)).
+		WithObjects(podGang, pod).
 		WithStatusSubresource(&groveschedulerv1alpha1.PodGang{}).
 		Build()
 }
@@ -213,6 +267,15 @@ func scheduledPod(name, namespace, podGangName string) *corev1.Pod {
 	pod := unscheduledPod(name, namespace, podGangName)
 	pod.Status.Conditions = []corev1.PodCondition{{
 		Type:   corev1.PodScheduled,
+		Status: corev1.ConditionTrue,
+	}}
+	return pod
+}
+
+func readyPod(name, podGangName string) *corev1.Pod {
+	pod := unscheduledPod(name, "default", podGangName)
+	pod.Status.Conditions = []corev1.PodCondition{{
+		Type:   corev1.PodReady,
 		Status: corev1.ConditionTrue,
 	}}
 	return pod

--- a/operator/internal/scheduler/types.go
+++ b/operator/internal/scheduler/types.go
@@ -23,7 +23,9 @@ import (
 
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -93,6 +95,26 @@ type TopologyAwareBackend interface {
 		ct *grovecorev1alpha1.ClusterTopologyBinding,
 		ref grovecorev1alpha1.SchedulerTopologyBinding,
 	) (bool, string, int64, error)
+}
+
+// PodGangSchedulingBackendCondition is a scheduler backend's readiness to schedule a PodGang.
+type PodGangSchedulingBackendCondition struct {
+	Status  metav1.ConditionStatus
+	Reason  string
+	Message string
+}
+
+// PodGangStatusProvider contributes scheduler-specific PodGang status.
+type PodGangStatusProvider interface {
+	GetPodGangSchedulingBackendCondition(
+		ctx context.Context,
+		podGang *groveschedulerv1alpha1.PodGang,
+	) (*PodGangSchedulingBackendCondition, error)
+}
+
+// PodGangStatusEventSource registers watches for backend resources that affect PodGang status.
+type PodGangStatusEventSource interface {
+	AddPodGangStatusWatches(builder *builder.Builder) *builder.Builder
 }
 
 // Registry provides access to initialized scheduler backends.

--- a/scheduler/api/core/v1alpha1/crds/scheduler.grove.io_podgangs.yaml
+++ b/scheduler/api/core/v1alpha1/crds/scheduler.grove.io_podgangs.yaml
@@ -279,16 +279,11 @@ spec:
                   - type
                   type: object
                 type: array
-              phase:
-                description: Phase is the current phase of a PodGang.
-                type: string
               placementScore:
                 description: |-
                   PlacementScore is network optimality score for the PodGang. If the choice that the scheduler has made corresponds to the
                   best possible placement of the pods in the PodGang, then the score will be 1.0. Higher the score, better the placement.
                 type: number
-            required:
-            - phase
             type: object
         required:
         - spec

--- a/scheduler/api/core/v1alpha1/podgang.go
+++ b/scheduler/api/core/v1alpha1/podgang.go
@@ -174,6 +174,10 @@ const (
 	ConditionReasonSufficientScheduledPods = "SufficientScheduledPods"
 	// ConditionReasonSchedulingBackendStatusUnavailable indicates that scheduler backend status could not be obtained.
 	ConditionReasonSchedulingBackendStatusUnavailable = "SchedulingBackendStatusUnavailable"
+	// ConditionReasonInsufficientReadyPods indicates that a PodGroup has fewer ready Pods than required.
+	ConditionReasonInsufficientReadyPods = "InsufficientReadyPods"
+	// ConditionReasonSufficientReadyPods indicates that every PodGroup has enough ready Pods.
+	ConditionReasonSufficientReadyPods = "SufficientReadyPods"
 )
 
 // PodGangStatus defines the status of a PodGang.

--- a/scheduler/api/core/v1alpha1/podgang.go
+++ b/scheduler/api/core/v1alpha1/podgang.go
@@ -137,18 +137,6 @@ type NamespacedName struct {
 	Name string `json:"name"`
 }
 
-// PodGangPhase defines the current phase of a PodGang.
-type PodGangPhase string
-
-const (
-	// PodGangPhasePending indicates that all the pods in a PodGang have been created and the PodGang is pending scheduling.
-	PodGangPhasePending PodGangPhase = "Pending"
-	// PodGangPhaseStarting indicates that the scheduler has started binding pods in the PodGang to nodes.
-	PodGangPhaseStarting PodGangPhase = "Starting"
-	// PodGangPhaseRunning indicates that all the pods in the PodGang have been scheduled and are running.
-	PodGangPhaseRunning PodGangPhase = "Running"
-)
-
 // PodGangConditionType defines the type of condition for a PodGang.
 type PodGangConditionType string
 
@@ -180,8 +168,6 @@ const (
 
 // PodGangStatus defines the status of a PodGang.
 type PodGangStatus struct {
-	// Phase is the current phase of a PodGang.
-	Phase PodGangPhase `json:"phase"`
 	// Conditions is a list of conditions that describe the current state of the PodGang.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 	// PlacementScore is network optimality score for the PodGang. If the choice that the scheduler has made corresponds to the

--- a/scheduler/api/core/v1alpha1/podgang.go
+++ b/scheduler/api/core/v1alpha1/podgang.go
@@ -143,6 +143,8 @@ type PodGangConditionType string
 const (
 	// PodGangConditionTypeScheduled indicates that the PodGang has been scheduled.
 	PodGangConditionTypeScheduled PodGangConditionType = "Scheduled"
+	// PodGangConditionTypeSchedulingBackendReady indicates whether the scheduler backend permits scheduling.
+	PodGangConditionTypeSchedulingBackendReady PodGangConditionType = "SchedulingBackendReady"
 	// PodGangConditionTypeReady indicates that all the constituent PodGroups are Ready.
 	PodGangConditionTypeReady PodGangConditionType = "Ready"
 	// PodGangConditionTypeInitialized indicates that all Pods have been created and PodGang has been populated with pod references.
@@ -164,6 +166,14 @@ const (
 	ConditionReasonPodGangPodsCreationPending = "PodGangPodsCreationPending"
 	// ConditionReasonPodGangPodsCreated indicates that all constituent Pods for a PodGang have been created.
 	ConditionReasonPodGangPodsCreated = "PodGangPodsCreated"
+	// ConditionReasonPodGangNotInitialized indicates that PodGang scheduling cannot be determined until initialization completes.
+	ConditionReasonPodGangNotInitialized = "PodGangNotInitialized"
+	// ConditionReasonInsufficientScheduledPods indicates that a PodGroup has fewer scheduled Pods than required.
+	ConditionReasonInsufficientScheduledPods = "InsufficientScheduledPods"
+	// ConditionReasonSufficientScheduledPods indicates that every PodGroup has enough scheduled Pods.
+	ConditionReasonSufficientScheduledPods = "SufficientScheduledPods"
+	// ConditionReasonSchedulingBackendStatusUnavailable indicates that scheduler backend status could not be obtained.
+	ConditionReasonSchedulingBackendStatusUnavailable = "SchedulingBackendStatusUnavailable"
 )
 
 // PodGangStatus defines the status of a PodGang.


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api
-->
/kind feature
/kind api

#### What this PR does / why we need it:
Improves PodGang status reporting by:
- Removing the deprecated `status.phase` field. https://github.com/kubernetes/community/blob/main/contributors/devel/sig-architecture/api-conventions.md 
- Reconciling `Scheduled` and `Ready` conditions from referenced Pods.
- Allowing scheduler backends to optionally contribute scheduling 
   diagnostics and event sources.
This prevents PodGang status from remaining indefinitely pending after its Pods have been scheduled or become ready.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #762 

#### Special notes for your reviewer:


#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
Yes. The deprecated `phase` field is removed from PodGang status and the mirrored PodCliqueSet PodGang status.

```release-note
removed podgang.status.phase and add API conditions to accurately represent podgang state
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs

```
