### PR TITLE
fix: validate generated ResourceClaim DNS labels

### DIFF
--- a/docs/proposals/390-hierarchical-resource-sharing/README.md
+++ b/docs/proposals/390-hierarchical-resource-sharing/README.md
@@ -954,6 +954,10 @@ collision-free.
 
 The `rctName` is the name of the referenced `ResourceClaimTemplateConfig` or external `ResourceClaimTemplate`.
 
+Generated ResourceClaim names are also used in `pod.spec.resourceClaims[].name`, which must be a
+DNS label of at most 63 characters. Create and regular update validation checks this constraint
+using configured replicas and autoscaling maxima. Scale subresources are not covered.
+
 **Concrete example** — PCS `disagg` (replica 0), PCSG `sgx` (replicas: 2), cliques in PCSG:
 `pca` (replicas: 3), `pcb` (replicas: 2); standalone PCLQ: `metrics` (replicas: 2).
 PCS AllReplicas rctName=res1, PCS PerReplica rctName=res2, PCSG PerReplica rctName=gpu-pool,

--- a/docs/proposals/390-hierarchical-resource-sharing/README.md
+++ b/docs/proposals/390-hierarchical-resource-sharing/README.md
@@ -954,9 +954,10 @@ collision-free.
 
 The `rctName` is the name of the referenced `ResourceClaimTemplateConfig` or external `ResourceClaimTemplate`.
 
-Generated ResourceClaim names are also used in `pod.spec.resourceClaims[].name`, which must be a
-DNS label of at most 63 characters. Create and regular update validation checks this constraint
-using configured replicas and autoscaling maxima. Scale subresources are not covered.
+Generated ResourceClaim names used in `pod.spec.resourceClaims[].name` must be DNS labels of at most
+63 characters. This is validated on create; legacy PodCliqueSets remain updatable, but scaling one
+can make a generated name too long (for example, when a replica index grows from `9` to `10`) and
+block new Pods until it is scaled back or recreated with shorter names.
 
 **Concrete example** — PCS `disagg` (replica 0), PCSG `sgx` (replicas: 2), cliques in PCSG:
 `pca` (replicas: 3), `pcb` (replicas: 2); standalone PCLQ: `metrics` (replicas: 2).

--- a/operator/internal/controller/podclique/components/pod/task.go
+++ b/operator/internal/controller/podclique/components/pod/task.go
@@ -48,11 +48,11 @@ func (r _resource) createPodCreationTask(logger logr.Logger, pcs *grovecorev1alp
 			}
 			// create the Pod
 			if err := r.client.Create(ctx, pod); err != nil {
-				r.eventRecorder.Eventf(pclq, corev1.EventTypeWarning, constants.ReasonPodCreateFailed, "Error creating pod %v: %v", pod.Name, err)
+				r.eventRecorder.Eventf(pclq, corev1.EventTypeWarning, constants.ReasonPodCreateFailed, "Error creating Pod with generateName %q: %v", pod.GenerateName, err)
 				return groveerr.WrapError(err,
 					errCodeCreatePod,
 					component.OperationSync,
-					fmt.Sprintf("failed to create Pod: %s for PodClique %v", pod.Name, pclqObjKey),
+					fmt.Sprintf("failed to create Pod with generateName %q for PodClique %v", pod.GenerateName, pclqObjKey),
 				)
 			}
 			logger.Info("Created Pod for PodClique", "podName", pod.Name, "podUID", pod.GetUID())

--- a/operator/internal/webhook/admission/pcs/validation/generatednames.go
+++ b/operator/internal/webhook/admission/pcs/validation/generatednames.go
@@ -1,0 +1,294 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"fmt"
+	"strings"
+
+	apicommon "github.com/ai-dynamo/grove/operator/api/common"
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/ai-dynamo/grove/operator/internal/resourceclaim"
+
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+type generatedResourceClaimNameCheck struct {
+	identity             string
+	fieldPath            *field.Path
+	referenceName        string
+	maxGeneratedName     string
+	ownerDescription     string
+	replicaLimits        []int32
+	nameValidationErrors []string
+}
+
+type generatedResourceClaimNameValidator struct {
+	pcs *grovecorev1alpha1.PodCliqueSet
+}
+
+func newGeneratedResourceClaimNameValidator(
+	pcs *grovecorev1alpha1.PodCliqueSet,
+) *generatedResourceClaimNameValidator {
+	return &generatedResourceClaimNameValidator{pcs: pcs}
+}
+
+func (v *generatedResourceClaimNameValidator) validate(fldPath *field.Path) field.ErrorList {
+	return generatedResourceClaimNameErrors(buildGeneratedResourceClaimNameChecks(v.pcs, fldPath))
+}
+
+func (v *generatedResourceClaimNameValidator) validateUpdate(
+	oldPCS *grovecorev1alpha1.PodCliqueSet,
+	fldPath *field.Path,
+) field.ErrorList {
+	oldChecks := indexGeneratedResourceClaimNameChecksByIdentity(
+		buildGeneratedResourceClaimNameChecks(oldPCS, fldPath),
+	)
+	newChecks := buildGeneratedResourceClaimNameChecks(v.pcs, fldPath)
+
+	var allErrs field.ErrorList
+	for _, check := range newChecks {
+		if len(check.nameValidationErrors) == 0 {
+			continue
+		}
+		oldCheck, exists := oldChecks[check.identity]
+		if exists && len(oldCheck.nameValidationErrors) > 0 &&
+			!replicaLimitsIncreased(oldCheck.replicaLimits, check.replicaLimits) {
+			continue
+		}
+		allErrs = append(allErrs, generatedResourceClaimNameError(check))
+	}
+	return allErrs
+}
+
+func buildGeneratedResourceClaimNameChecks(
+	pcs *grovecorev1alpha1.PodCliqueSet,
+	fldPath *field.Path,
+) []generatedResourceClaimNameCheck {
+	var checks []generatedResourceClaimNameCheck
+	pcsReplicas := pcs.Spec.Replicas
+	maxPCSReplicaIndex := maxReplicaIndex(pcsReplicas)
+
+	for i := range pcs.Spec.Template.ResourceSharing {
+		ref := &pcs.Spec.Template.ResourceSharing[i].ResourceSharingSpec
+		checks = appendGeneratedResourceClaimNameCheck(
+			checks,
+			fmt.Sprintf("pcs/%s/%s", ref.Name, ref.Scope),
+			fldPath.Child("resourceSharing").Index(i).Child("name"),
+			pcs.Name,
+			ref,
+			"PodCliqueSet",
+			nil,
+			pcsReplicas,
+		)
+	}
+
+	pcsgConfigIndexesByCliqueName := make(map[string][]int)
+	for i := range pcs.Spec.Template.PodCliqueScalingGroupConfigs {
+		cfg := &pcs.Spec.Template.PodCliqueScalingGroupConfigs[i]
+		pcsgName := apicommon.GeneratePodCliqueScalingGroupName(
+			apicommon.ResourceNameReplica{Name: pcs.Name, Replica: maxPCSReplicaIndex},
+			cfg.Name,
+		)
+		maxPCSGReplicas := maxPCSGConfiguredReplicas(cfg)
+		for j := range cfg.ResourceSharing {
+			ref := &cfg.ResourceSharing[j].ResourceSharingSpec
+			checks = appendGeneratedResourceClaimNameCheck(
+				checks,
+				fmt.Sprintf("pcsg/%s/%s/%s", cfg.Name, ref.Name, ref.Scope),
+				fldPath.Child("podCliqueScalingGroups").Index(i).Child("resourceSharing").Index(j).Child("name"),
+				pcsgName,
+				ref,
+				fmt.Sprintf("PodCliqueScalingGroup %q", cfg.Name),
+				[]int32{pcsReplicas},
+				maxPCSGReplicas,
+			)
+		}
+		for _, cliqueName := range cfg.CliqueNames {
+			pcsgConfigIndexesByCliqueName[cliqueName] = append(pcsgConfigIndexesByCliqueName[cliqueName], i)
+		}
+	}
+
+	for i, clique := range pcs.Spec.Template.Cliques {
+		if clique == nil {
+			continue
+		}
+		resourceSharingPath := fldPath.Child("cliques").Index(i).Child("resourceSharing")
+		maxPCLQReplicas := maxConfiguredReplicas(&clique.Spec.Replicas, clique.Spec.ScaleConfig)
+		pcsgConfigIndexes := pcsgConfigIndexesByCliqueName[clique.Name]
+		if len(pcsgConfigIndexes) == 0 {
+			pclqName := apicommon.GeneratePodCliqueName(
+				apicommon.ResourceNameReplica{Name: pcs.Name, Replica: maxPCSReplicaIndex},
+				clique.Name,
+			)
+			for j := range clique.ResourceSharing {
+				ref := &clique.ResourceSharing[j]
+				checks = appendGeneratedResourceClaimNameCheck(
+					checks,
+					fmt.Sprintf("pclq/%s/standalone/%s/%s", clique.Name, ref.Name, ref.Scope),
+					resourceSharingPath.Index(j).Child("name"),
+					pclqName,
+					ref,
+					fmt.Sprintf("standalone PodClique %q", clique.Name),
+					[]int32{pcsReplicas},
+					maxPCLQReplicas,
+				)
+			}
+			continue
+		}
+
+		for _, pcsgConfigIndex := range pcsgConfigIndexes {
+			cfg := &pcs.Spec.Template.PodCliqueScalingGroupConfigs[pcsgConfigIndex]
+			maxPCSGReplicas := maxPCSGConfiguredReplicas(cfg)
+			pcsgName := apicommon.GeneratePodCliqueScalingGroupName(
+				apicommon.ResourceNameReplica{Name: pcs.Name, Replica: maxPCSReplicaIndex},
+				cfg.Name,
+			)
+			pclqName := apicommon.GeneratePodCliqueName(
+				apicommon.ResourceNameReplica{
+					Name:    pcsgName,
+					Replica: maxReplicaIndex(maxPCSGReplicas),
+				},
+				clique.Name,
+			)
+			for j := range clique.ResourceSharing {
+				ref := &clique.ResourceSharing[j]
+				checks = appendGeneratedResourceClaimNameCheck(
+					checks,
+					fmt.Sprintf("pclq/%s/pcsg/%s/%s/%s", clique.Name, cfg.Name, ref.Name, ref.Scope),
+					resourceSharingPath.Index(j).Child("name"),
+					pclqName,
+					ref,
+					fmt.Sprintf("PodClique %q in PodCliqueScalingGroup %q", clique.Name, cfg.Name),
+					[]int32{pcsReplicas, maxPCSGReplicas},
+					maxPCLQReplicas,
+				)
+			}
+		}
+	}
+
+	return checks
+}
+
+func appendGeneratedResourceClaimNameCheck(
+	checks []generatedResourceClaimNameCheck,
+	identity string,
+	fldPath *field.Path,
+	ownerName string,
+	ref *grovecorev1alpha1.ResourceSharingSpec,
+	ownerDescription string,
+	parentReplicaLimits []int32,
+	replicaLimit int32,
+) []generatedResourceClaimNameCheck {
+	if ref.Name == "" {
+		return checks
+	}
+
+	var generatedName string
+	replicaLimits := append([]int32(nil), parentReplicaLimits...)
+	switch ref.Scope {
+	case grovecorev1alpha1.ResourceSharingScopeAllReplicas:
+		generatedName = resourceclaim.AllReplicasRCName(ownerName, ref.Name)
+	case grovecorev1alpha1.ResourceSharingScopePerReplica:
+		generatedName = resourceclaim.PerReplicaRCName(ownerName, maxReplicaIndex(replicaLimit), ref.Name)
+		replicaLimits = append(replicaLimits, replicaLimit)
+	default:
+		return checks
+	}
+
+	return append(checks, generatedResourceClaimNameCheck{
+		identity:             identity,
+		fieldPath:            fldPath,
+		referenceName:        ref.Name,
+		maxGeneratedName:     generatedName,
+		ownerDescription:     ownerDescription,
+		replicaLimits:        replicaLimits,
+		nameValidationErrors: k8svalidation.IsDNS1123Label(generatedName),
+	})
+}
+
+func generatedResourceClaimNameErrors(checks []generatedResourceClaimNameCheck) field.ErrorList {
+	var allErrs field.ErrorList
+	for _, check := range checks {
+		if len(check.nameValidationErrors) > 0 {
+			allErrs = append(allErrs, generatedResourceClaimNameError(check))
+		}
+	}
+	return allErrs
+}
+
+func generatedResourceClaimNameError(check generatedResourceClaimNameCheck) *field.Error {
+	return field.Invalid(
+		check.fieldPath,
+		check.referenceName,
+		fmt.Sprintf(
+			"generated ResourceClaim name %q for %s must be a valid DNS label because it is used as pod.spec.resourceClaims[].name: %s",
+			check.maxGeneratedName,
+			check.ownerDescription,
+			strings.Join(check.nameValidationErrors, "; "),
+		),
+	)
+}
+
+func indexGeneratedResourceClaimNameChecksByIdentity(
+	checks []generatedResourceClaimNameCheck,
+) map[string]generatedResourceClaimNameCheck {
+	result := make(map[string]generatedResourceClaimNameCheck, len(checks))
+	for _, check := range checks {
+		result[check.identity] = check
+	}
+	return result
+}
+
+func replicaLimitsIncreased(oldLimits, newLimits []int32) bool {
+	if len(oldLimits) != len(newLimits) {
+		return true
+	}
+	for i := range newLimits {
+		if newLimits[i] > oldLimits[i] {
+			return true
+		}
+	}
+	return false
+}
+
+func maxPCSGConfiguredReplicas(cfg *grovecorev1alpha1.PodCliqueScalingGroupConfig) int32 {
+	replicas := int32(1)
+	if cfg.Replicas != nil {
+		replicas = *cfg.Replicas
+	}
+	return maxConfiguredReplicas(&replicas, cfg.ScaleConfig)
+}
+
+// maxConfiguredReplicas returns the largest replica count visible from the PCS template.
+// It does not include direct child scale subresource updates, including those made by external autoscalers.
+func maxConfiguredReplicas(replicas *int32, scaleConfig *grovecorev1alpha1.AutoScalingConfig) int32 {
+	var maxReplicas int32
+	if replicas != nil {
+		maxReplicas = *replicas
+	}
+	if scaleConfig != nil && scaleConfig.MaxReplicas > maxReplicas {
+		maxReplicas = scaleConfig.MaxReplicas
+	}
+	return maxReplicas
+}
+
+func maxReplicaIndex(replicas int32) int {
+	if replicas <= 1 {
+		return 0
+	}
+	return int(replicas - 1)
+}

--- a/operator/internal/webhook/admission/pcs/validation/generatednames.go
+++ b/operator/internal/webhook/admission/pcs/validation/generatednames.go
@@ -27,12 +27,10 @@ import (
 )
 
 type generatedResourceClaimNameCheck struct {
-	identity             string
 	fieldPath            *field.Path
 	referenceName        string
 	maxGeneratedName     string
 	ownerDescription     string
-	replicaLimits        []int32
 	nameValidationErrors []string
 }
 
@@ -50,28 +48,18 @@ func (v *generatedResourceClaimNameValidator) validate(fldPath *field.Path) fiel
 	return generatedResourceClaimNameErrors(buildGeneratedResourceClaimNameChecks(v.pcs, fldPath))
 }
 
-func (v *generatedResourceClaimNameValidator) validateUpdate(
-	oldPCS *grovecorev1alpha1.PodCliqueSet,
-	fldPath *field.Path,
-) field.ErrorList {
-	oldChecks := indexGeneratedResourceClaimNameChecksByIdentity(
-		buildGeneratedResourceClaimNameChecks(oldPCS, fldPath),
-	)
-	newChecks := buildGeneratedResourceClaimNameChecks(v.pcs, fldPath)
-
-	var allErrs field.ErrorList
-	for _, check := range newChecks {
+func (v *generatedResourceClaimNameValidator) updateWarnings(fldPath *field.Path) []string {
+	var warnings []string
+	for _, check := range buildGeneratedResourceClaimNameChecks(v.pcs, fldPath) {
 		if len(check.nameValidationErrors) == 0 {
 			continue
 		}
-		oldCheck, exists := oldChecks[check.identity]
-		if exists && len(oldCheck.nameValidationErrors) > 0 &&
-			!replicaLimitsIncreased(oldCheck.replicaLimits, check.replicaLimits) {
-			continue
-		}
-		allErrs = append(allErrs, generatedResourceClaimNameError(check))
+		warnings = append(warnings, fmt.Sprintf(
+			"%s generates an invalid ResourceClaim name for Pods; new Pods may fail admission",
+			check.fieldPath,
+		))
 	}
-	return allErrs
+	return warnings
 }
 
 func buildGeneratedResourceClaimNameChecks(
@@ -82,19 +70,14 @@ func buildGeneratedResourceClaimNameChecks(
 	pcsReplicas := pcs.Spec.Replicas
 	maxPCSReplicaIndex := maxReplicaIndex(pcsReplicas)
 
-	for i := range pcs.Spec.Template.ResourceSharing {
-		ref := &pcs.Spec.Template.ResourceSharing[i].ResourceSharingSpec
-		checks = appendGeneratedResourceClaimNameCheck(
-			checks,
-			fmt.Sprintf("pcs/%s/%s", ref.Name, ref.Scope),
-			fldPath.Child("resourceSharing").Index(i).Child("name"),
-			pcs.Name,
-			ref,
-			"PodCliqueSet",
-			nil,
-			pcsReplicas,
-		)
-	}
+	checks = appendGeneratedResourceClaimNameChecks(
+		checks,
+		resourceclaim.ResourceSharersFromPCS(pcs.Spec.Template.ResourceSharing),
+		fldPath.Child("resourceSharing"),
+		pcs.Name,
+		"PodCliqueSet",
+		pcsReplicas,
+	)
 
 	pcsgConfigIndexesByCliqueName := make(map[string][]int)
 	for i := range pcs.Spec.Template.PodCliqueScalingGroupConfigs {
@@ -104,19 +87,14 @@ func buildGeneratedResourceClaimNameChecks(
 			cfg.Name,
 		)
 		maxPCSGReplicas := maxPCSGConfiguredReplicas(cfg)
-		for j := range cfg.ResourceSharing {
-			ref := &cfg.ResourceSharing[j].ResourceSharingSpec
-			checks = appendGeneratedResourceClaimNameCheck(
-				checks,
-				fmt.Sprintf("pcsg/%s/%s/%s", cfg.Name, ref.Name, ref.Scope),
-				fldPath.Child("podCliqueScalingGroups").Index(i).Child("resourceSharing").Index(j).Child("name"),
-				pcsgName,
-				ref,
-				fmt.Sprintf("PodCliqueScalingGroup %q", cfg.Name),
-				[]int32{pcsReplicas},
-				maxPCSGReplicas,
-			)
-		}
+		checks = appendGeneratedResourceClaimNameChecks(
+			checks,
+			resourceclaim.ResourceSharersFromPCSG(cfg.ResourceSharing),
+			fldPath.Child("podCliqueScalingGroups").Index(i).Child("resourceSharing"),
+			pcsgName,
+			fmt.Sprintf("PodCliqueScalingGroup %q", cfg.Name),
+			maxPCSGReplicas,
+		)
 		for _, cliqueName := range cfg.CliqueNames {
 			pcsgConfigIndexesByCliqueName[cliqueName] = append(pcsgConfigIndexesByCliqueName[cliqueName], i)
 		}
@@ -134,19 +112,14 @@ func buildGeneratedResourceClaimNameChecks(
 				apicommon.ResourceNameReplica{Name: pcs.Name, Replica: maxPCSReplicaIndex},
 				clique.Name,
 			)
-			for j := range clique.ResourceSharing {
-				ref := &clique.ResourceSharing[j]
-				checks = appendGeneratedResourceClaimNameCheck(
-					checks,
-					fmt.Sprintf("pclq/%s/standalone/%s/%s", clique.Name, ref.Name, ref.Scope),
-					resourceSharingPath.Index(j).Child("name"),
-					pclqName,
-					ref,
-					fmt.Sprintf("standalone PodClique %q", clique.Name),
-					[]int32{pcsReplicas},
-					maxPCLQReplicas,
-				)
-			}
+			checks = appendGeneratedResourceClaimNameChecks(
+				checks,
+				resourceclaim.ResourceSharersFromPCLQ(clique.ResourceSharing),
+				resourceSharingPath,
+				pclqName,
+				fmt.Sprintf("standalone PodClique %q", clique.Name),
+				maxPCLQReplicas,
+			)
 			continue
 		}
 
@@ -164,60 +137,53 @@ func buildGeneratedResourceClaimNameChecks(
 				},
 				clique.Name,
 			)
-			for j := range clique.ResourceSharing {
-				ref := &clique.ResourceSharing[j]
-				checks = appendGeneratedResourceClaimNameCheck(
-					checks,
-					fmt.Sprintf("pclq/%s/pcsg/%s/%s/%s", clique.Name, cfg.Name, ref.Name, ref.Scope),
-					resourceSharingPath.Index(j).Child("name"),
-					pclqName,
-					ref,
-					fmt.Sprintf("PodClique %q in PodCliqueScalingGroup %q", clique.Name, cfg.Name),
-					[]int32{pcsReplicas, maxPCSGReplicas},
-					maxPCLQReplicas,
-				)
-			}
+			checks = appendGeneratedResourceClaimNameChecks(
+				checks,
+				resourceclaim.ResourceSharersFromPCLQ(clique.ResourceSharing),
+				resourceSharingPath,
+				pclqName,
+				fmt.Sprintf("PodClique %q in PodCliqueScalingGroup %q", clique.Name, cfg.Name),
+				maxPCLQReplicas,
+			)
 		}
 	}
 
 	return checks
 }
 
-func appendGeneratedResourceClaimNameCheck(
+func appendGeneratedResourceClaimNameChecks(
 	checks []generatedResourceClaimNameCheck,
-	identity string,
+	sharers []resourceclaim.ResourceSharer,
 	fldPath *field.Path,
 	ownerName string,
-	ref *grovecorev1alpha1.ResourceSharingSpec,
 	ownerDescription string,
-	parentReplicaLimits []int32,
 	replicaLimit int32,
 ) []generatedResourceClaimNameCheck {
-	if ref.Name == "" {
-		return checks
-	}
+	for i, sharer := range sharers {
+		ref := sharer.GetBase()
+		if ref.Name == "" {
+			continue
+		}
 
-	var generatedName string
-	replicaLimits := append([]int32(nil), parentReplicaLimits...)
-	switch ref.Scope {
-	case grovecorev1alpha1.ResourceSharingScopeAllReplicas:
-		generatedName = resourceclaim.AllReplicasRCName(ownerName, ref.Name)
-	case grovecorev1alpha1.ResourceSharingScopePerReplica:
-		generatedName = resourceclaim.PerReplicaRCName(ownerName, maxReplicaIndex(replicaLimit), ref.Name)
-		replicaLimits = append(replicaLimits, replicaLimit)
-	default:
-		return checks
-	}
+		var generatedName string
+		switch ref.Scope {
+		case grovecorev1alpha1.ResourceSharingScopeAllReplicas:
+			generatedName = resourceclaim.AllReplicasRCName(ownerName, ref.Name)
+		case grovecorev1alpha1.ResourceSharingScopePerReplica:
+			generatedName = resourceclaim.PerReplicaRCName(ownerName, maxReplicaIndex(replicaLimit), ref.Name)
+		default:
+			continue
+		}
 
-	return append(checks, generatedResourceClaimNameCheck{
-		identity:             identity,
-		fieldPath:            fldPath,
-		referenceName:        ref.Name,
-		maxGeneratedName:     generatedName,
-		ownerDescription:     ownerDescription,
-		replicaLimits:        replicaLimits,
-		nameValidationErrors: k8svalidation.IsDNS1123Label(generatedName),
-	})
+		checks = append(checks, generatedResourceClaimNameCheck{
+			fieldPath:            fldPath.Index(i).Child("name"),
+			referenceName:        ref.Name,
+			maxGeneratedName:     generatedName,
+			ownerDescription:     ownerDescription,
+			nameValidationErrors: k8svalidation.IsDNS1123Label(generatedName),
+		})
+	}
+	return checks
 }
 
 func generatedResourceClaimNameErrors(checks []generatedResourceClaimNameCheck) field.ErrorList {
@@ -241,28 +207,6 @@ func generatedResourceClaimNameError(check generatedResourceClaimNameCheck) *fie
 			strings.Join(check.nameValidationErrors, "; "),
 		),
 	)
-}
-
-func indexGeneratedResourceClaimNameChecksByIdentity(
-	checks []generatedResourceClaimNameCheck,
-) map[string]generatedResourceClaimNameCheck {
-	result := make(map[string]generatedResourceClaimNameCheck, len(checks))
-	for _, check := range checks {
-		result[check.identity] = check
-	}
-	return result
-}
-
-func replicaLimitsIncreased(oldLimits, newLimits []int32) bool {
-	if len(oldLimits) != len(newLimits) {
-		return true
-	}
-	for i := range newLimits {
-		if newLimits[i] > oldLimits[i] {
-			return true
-		}
-	}
-	return false
 }
 
 func maxPCSGConfiguredReplicas(cfg *grovecorev1alpha1.PodCliqueScalingGroupConfig) int32 {

--- a/operator/internal/webhook/admission/pcs/validation/generatednames_test.go
+++ b/operator/internal/webhook/admission/pcs/validation/generatednames_test.go
@@ -1,0 +1,388 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	apicommon "github.com/ai-dynamo/grove/operator/api/common"
+	groveconfigv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/ai-dynamo/grove/operator/internal/resourceclaim"
+	testutils "github.com/ai-dynamo/grove/operator/test/utils"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
+)
+
+func TestGeneratedResourceClaimNameChecksUseRuntimeGenerators(t *testing.T) {
+	fldPath := field.NewPath("spec", "template")
+	pcs := createTestPodCliqueSet("root")
+	pcs.Spec.Replicas = 2
+	pcs.Spec.Template.ResourceSharing = []grovecorev1alpha1.PCSResourceSharingSpec{
+		{ResourceSharingSpec: grovecorev1alpha1.ResourceSharingSpec{
+			Name:  "pcs-all",
+			Scope: grovecorev1alpha1.ResourceSharingScopeAllReplicas,
+		}},
+		{ResourceSharingSpec: grovecorev1alpha1.ResourceSharingSpec{
+			Name:  "pcs-per",
+			Scope: grovecorev1alpha1.ResourceSharingScopePerReplica,
+		}},
+	}
+
+	standalone := pcs.Spec.Template.Cliques[0]
+	standalone.Name = "solo"
+	standalone.Spec.Replicas = 4
+	standalone.ResourceSharing = []grovecorev1alpha1.ResourceSharingSpec{
+		{Name: "standalone-all", Scope: grovecorev1alpha1.ResourceSharingScopeAllReplicas},
+		{Name: "standalone-per", Scope: grovecorev1alpha1.ResourceSharingScopePerReplica},
+	}
+
+	grouped := createDummyPodCliqueTemplate("worker")
+	grouped.Spec.Replicas = 5
+	grouped.ResourceSharing = []grovecorev1alpha1.ResourceSharingSpec{
+		{Name: "grouped-all", Scope: grovecorev1alpha1.ResourceSharingScopeAllReplicas},
+		{Name: "grouped-per", Scope: grovecorev1alpha1.ResourceSharingScopePerReplica},
+	}
+	pcs.Spec.Template.Cliques = append(pcs.Spec.Template.Cliques, grouped)
+	pcs.Spec.Template.PodCliqueScalingGroupConfigs = []grovecorev1alpha1.PodCliqueScalingGroupConfig{{
+		Name:         "sg",
+		CliqueNames:  []string{"worker"},
+		Replicas:     ptr.To(int32(3)),
+		MinAvailable: ptr.To(int32(1)),
+		ResourceSharing: []grovecorev1alpha1.PCSGResourceSharingSpec{
+			{ResourceSharingSpec: grovecorev1alpha1.ResourceSharingSpec{
+				Name:  "pcsg-all",
+				Scope: grovecorev1alpha1.ResourceSharingScopeAllReplicas,
+			}},
+			{ResourceSharingSpec: grovecorev1alpha1.ResourceSharingSpec{
+				Name:  "pcsg-per",
+				Scope: grovecorev1alpha1.ResourceSharingScopePerReplica,
+			}},
+		},
+	}}
+
+	checks := indexGeneratedResourceClaimNameChecksByIdentity(
+		buildGeneratedResourceClaimNameChecks(pcs, fldPath),
+	)
+	require.Len(t, checks, 8)
+
+	pcsgName := apicommon.GeneratePodCliqueScalingGroupName(
+		apicommon.ResourceNameReplica{Name: pcs.Name, Replica: 1},
+		"sg",
+	)
+	standalonePCLQName := apicommon.GeneratePodCliqueName(
+		apicommon.ResourceNameReplica{Name: pcs.Name, Replica: 1},
+		"solo",
+	)
+	groupedPCLQName := apicommon.GeneratePodCliqueName(
+		apicommon.ResourceNameReplica{Name: pcsgName, Replica: 2},
+		"worker",
+	)
+
+	tests := []struct {
+		identity      string
+		generatedName string
+		replicaLimits []int32
+	}{
+		{"pcs/pcs-all/AllReplicas", resourceclaim.AllReplicasRCName(pcs.Name, "pcs-all"), nil},
+		{"pcs/pcs-per/PerReplica", resourceclaim.PerReplicaRCName(pcs.Name, 1, "pcs-per"), []int32{2}},
+		{"pcsg/sg/pcsg-all/AllReplicas", resourceclaim.AllReplicasRCName(pcsgName, "pcsg-all"), []int32{2}},
+		{"pcsg/sg/pcsg-per/PerReplica", resourceclaim.PerReplicaRCName(pcsgName, 2, "pcsg-per"), []int32{2, 3}},
+		{"pclq/solo/standalone/standalone-all/AllReplicas", resourceclaim.AllReplicasRCName(standalonePCLQName, "standalone-all"), []int32{2}},
+		{"pclq/solo/standalone/standalone-per/PerReplica", resourceclaim.PerReplicaRCName(standalonePCLQName, 3, "standalone-per"), []int32{2, 4}},
+		{"pclq/worker/pcsg/sg/grouped-all/AllReplicas", resourceclaim.AllReplicasRCName(groupedPCLQName, "grouped-all"), []int32{2, 3}},
+		{"pclq/worker/pcsg/sg/grouped-per/PerReplica", resourceclaim.PerReplicaRCName(groupedPCLQName, 4, "grouped-per"), []int32{2, 3, 5}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.identity, func(t *testing.T) {
+			check, exists := checks[tc.identity]
+			require.True(t, exists)
+			assert.Equal(t, tc.generatedName, check.maxGeneratedName)
+			assert.Equal(t, tc.replicaLimits, check.replicaLimits)
+		})
+	}
+}
+
+func TestValidateGeneratedResourceClaimNames(t *testing.T) {
+	fldPath := field.NewPath("spec", "template")
+	tests := []struct {
+		name           string
+		refName        string
+		expectedDetail string
+	}{
+		{
+			name:    "63-character generated name is valid",
+			refName: strings.Repeat("a", 57),
+		},
+		{
+			name:           "64-character generated name is rejected",
+			refName:        strings.Repeat("a", 58),
+			expectedDetail: "must be no more than 63 characters",
+		},
+		{
+			name:           "short generated name with a dot is rejected",
+			refName:        "shared.gpu",
+			expectedDetail: "must not contain dots",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pcs := createTestPodCliqueSet("p")
+			pcs.Spec.Template.ResourceSharing = []grovecorev1alpha1.PCSResourceSharingSpec{{
+				ResourceSharingSpec: grovecorev1alpha1.ResourceSharingSpec{
+					Name:  tc.refName,
+					Scope: grovecorev1alpha1.ResourceSharingScopeAllReplicas,
+				},
+			}}
+
+			errs := newGeneratedResourceClaimNameValidator(pcs).validate(fldPath)
+			if tc.expectedDetail == "" {
+				assert.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			assert.Equal(t, "spec.template.resourceSharing[0].name", errs[0].Field)
+			assert.Equal(t, field.ErrorTypeInvalid, errs[0].Type)
+			assert.Equal(t, tc.refName, errs[0].BadValue)
+			assert.Contains(t, errs[0].Detail, "pod.spec.resourceClaims[].name")
+			assert.Contains(t, errs[0].Detail, tc.expectedDetail)
+		})
+	}
+}
+
+func TestValidateGeneratedResourceClaimNamesRejectsOverlongPCLQScopedName(t *testing.T) {
+	fldPath := field.NewPath("spec", "template")
+	pcs := createTestPodCliqueSet(strings.Repeat("a", 40))
+	clique := pcs.Spec.Template.Cliques[0]
+	clique.Name = "workr"
+	clique.ResourceSharing = []grovecorev1alpha1.ResourceSharingSpec{{
+		Name:  "shared-gpus",
+		Scope: grovecorev1alpha1.ResourceSharingScopeAllReplicas,
+	}}
+
+	errs := newGeneratedResourceClaimNameValidator(pcs).validate(fldPath)
+	require.Len(t, errs, 1)
+	assert.Equal(t, "spec.template.cliques[0].resourceSharing[0].name", errs[0].Field)
+	assert.Equal(t, "shared-gpus", errs[0].BadValue)
+	assert.Contains(t, errs[0].Detail, strings.Repeat("a", 40)+"-0-workr-all-shared-gpus")
+}
+
+func TestValidateGeneratedResourceClaimNamesUsesPCLQAutoscalingMaximum(t *testing.T) {
+	fldPath := field.NewPath("spec", "template")
+	pcs := createTestPodCliqueSet(strings.Repeat("p", 30))
+	clique := pcs.Spec.Template.Cliques[0]
+	clique.Name = strings.Repeat("c", 10)
+	clique.ResourceSharing = []grovecorev1alpha1.ResourceSharingSpec{{
+		Name:  strings.Repeat("r", 17),
+		Scope: grovecorev1alpha1.ResourceSharingScopePerReplica,
+	}}
+	clique.Spec.ScaleConfig = &grovecorev1alpha1.AutoScalingConfig{
+		MinReplicas: ptr.To(int32(1)),
+		MaxReplicas: 10,
+	}
+
+	validator := newGeneratedResourceClaimNameValidator(pcs)
+	assert.Empty(t, validator.validate(fldPath))
+
+	clique.Spec.ScaleConfig.MaxReplicas = 11
+	errs := validator.validate(fldPath)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Detail, "-10-")
+}
+
+func TestValidateGeneratedResourceClaimNamesUsesPCSGAutoscalingMaximum(t *testing.T) {
+	fldPath := field.NewPath("spec", "template")
+	pcs := createTestPodCliqueSet(strings.Repeat("p", 30))
+	pcs.Spec.Template.PodCliqueScalingGroupConfigs = []grovecorev1alpha1.PodCliqueScalingGroupConfig{{
+		Name:         strings.Repeat("g", 10),
+		CliqueNames:  []string{pcs.Spec.Template.Cliques[0].Name},
+		Replicas:     ptr.To(int32(1)),
+		MinAvailable: ptr.To(int32(1)),
+		ScaleConfig: &grovecorev1alpha1.AutoScalingConfig{
+			MinReplicas: ptr.To(int32(1)),
+			MaxReplicas: 10,
+		},
+		ResourceSharing: []grovecorev1alpha1.PCSGResourceSharingSpec{{
+			ResourceSharingSpec: grovecorev1alpha1.ResourceSharingSpec{
+				Name:  strings.Repeat("r", 17),
+				Scope: grovecorev1alpha1.ResourceSharingScopePerReplica,
+			},
+		}},
+	}}
+
+	validator := newGeneratedResourceClaimNameValidator(pcs)
+	assert.Empty(t, validator.validate(fldPath))
+
+	pcs.Spec.Template.PodCliqueScalingGroupConfigs[0].ScaleConfig.MaxReplicas = 11
+	errs := validator.validate(fldPath)
+	require.Len(t, errs, 1)
+	assert.Equal(t, "spec.template.podCliqueScalingGroups[0].resourceSharing[0].name", errs[0].Field)
+	assert.Contains(t, errs[0].Detail, "-10-")
+}
+
+func TestValidateGeneratedResourceClaimNamesOnUpdate(t *testing.T) {
+	fldPath := field.NewPath("spec", "template")
+	validateUpdate := func(oldPCS, newPCS *grovecorev1alpha1.PodCliqueSet) field.ErrorList {
+		return newGeneratedResourceClaimNameValidator(newPCS).validateUpdate(oldPCS, fldPath)
+	}
+	oldPCS := createTestPodCliqueSet("p")
+	oldPCS.Spec.Template.ResourceSharing = []grovecorev1alpha1.PCSResourceSharingSpec{{
+		ResourceSharingSpec: grovecorev1alpha1.ResourceSharingSpec{
+			Name:  strings.Repeat("r", 58),
+			Scope: grovecorev1alpha1.ResourceSharingScopeAllReplicas,
+		},
+	}}
+
+	t.Run("unchanged legacy violation is allowed", func(t *testing.T) {
+		newPCS := oldPCS.DeepCopy()
+		assert.Empty(t, validateUpdate(oldPCS, newPCS))
+	})
+
+	t.Run("all-replicas violation allows scale out", func(t *testing.T) {
+		newPCS := oldPCS.DeepCopy()
+		newPCS.Spec.Replicas++
+		assert.Empty(t, validateUpdate(oldPCS, newPCS))
+	})
+
+	t.Run("per-replica violation allows scale in", func(t *testing.T) {
+		perReplicaOldPCS := oldPCS.DeepCopy()
+		perReplicaOldPCS.Spec.Replicas = 2
+		perReplicaOldPCS.Spec.Template.ResourceSharing[0].Scope = grovecorev1alpha1.ResourceSharingScopePerReplica
+		perReplicaOldPCS.Spec.Template.ResourceSharing[0].Name = strings.Repeat("r", 60)
+		newPCS := perReplicaOldPCS.DeepCopy()
+		newPCS.Spec.Replicas--
+
+		assert.Empty(t, validateUpdate(perReplicaOldPCS, newPCS))
+	})
+
+	t.Run("per-replica violation rejects scale out", func(t *testing.T) {
+		perReplicaOldPCS := oldPCS.DeepCopy()
+		perReplicaOldPCS.Spec.Template.ResourceSharing[0].Scope = grovecorev1alpha1.ResourceSharingScopePerReplica
+		perReplicaOldPCS.Spec.Template.ResourceSharing[0].Name = strings.Repeat("r", 60)
+		newPCS := perReplicaOldPCS.DeepCopy()
+		newPCS.Spec.Replicas++
+
+		errs := validateUpdate(perReplicaOldPCS, newPCS)
+		require.Len(t, errs, 1)
+		assert.Equal(t, "spec.template.resourceSharing[0].name", errs[0].Field)
+	})
+
+	t.Run("per-replica violation rejects autoscaling maximum increase", func(t *testing.T) {
+		scaledOldPCS := createTestPodCliqueSet(strings.Repeat("p", 30))
+		clique := scaledOldPCS.Spec.Template.Cliques[0]
+		clique.Name = strings.Repeat("c", 10)
+		clique.ResourceSharing = []grovecorev1alpha1.ResourceSharingSpec{{
+			Name:  strings.Repeat("r", 18),
+			Scope: grovecorev1alpha1.ResourceSharingScopePerReplica,
+		}}
+		clique.Spec.ScaleConfig = &grovecorev1alpha1.AutoScalingConfig{
+			MinReplicas: ptr.To(int32(1)),
+			MaxReplicas: 10,
+		}
+		newPCS := scaledOldPCS.DeepCopy()
+		newPCS.Spec.Template.Cliques[0].Spec.ScaleConfig.MaxReplicas = 11
+
+		errs := validateUpdate(scaledOldPCS, newPCS)
+		require.Len(t, errs, 1)
+		assert.Equal(t, "spec.template.cliques[0].resourceSharing[0].name", errs[0].Field)
+	})
+
+	t.Run("grouped PodClique violation rejects PCSG autoscaling maximum increase", func(t *testing.T) {
+		groupedOldPCS := createPCSWithOverlongGroupedPCLQClaimName(1, 10)
+		newPCS := groupedOldPCS.DeepCopy()
+		newPCS.Spec.Template.PodCliqueScalingGroupConfigs[0].ScaleConfig.MaxReplicas = 11
+
+		errs := validateUpdate(groupedOldPCS, newPCS)
+		require.Len(t, errs, 1)
+		assert.Equal(t, "spec.template.cliques[0].resourceSharing[0].name", errs[0].Field)
+	})
+
+	t.Run("grouped PodClique violation rejects PCS replica increase", func(t *testing.T) {
+		groupedOldPCS := createPCSWithOverlongGroupedPCLQClaimName(10, 1)
+		newPCS := groupedOldPCS.DeepCopy()
+		newPCS.Spec.Replicas = 11
+
+		errs := validateUpdate(groupedOldPCS, newPCS)
+		require.Len(t, errs, 1)
+		assert.Equal(t, "spec.template.cliques[0].resourceSharing[0].name", errs[0].Field)
+	})
+}
+
+func TestHandlerValidatesGeneratedResourceClaimNames(t *testing.T) {
+	handler := newGeneratedNameTestHandler()
+	pcs := createTestPodCliqueSet("p")
+	pcs.Spec.Template.ResourceSharing = []grovecorev1alpha1.PCSResourceSharingSpec{{
+		ResourceSharingSpec: grovecorev1alpha1.ResourceSharingSpec{
+			Name:  strings.Repeat("r", 58),
+			Scope: grovecorev1alpha1.ResourceSharingScopeAllReplicas,
+		},
+	}}
+
+	_, err := handler.ValidateCreate(context.Background(), pcs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pod.spec.resourceClaims[].name")
+
+	_, err = handler.ValidateUpdate(context.Background(), pcs, pcs.DeepCopy())
+	require.NoError(t, err)
+}
+
+func newGeneratedNameTestHandler() *Handler {
+	cl := testutils.NewTestClientBuilder().Build()
+	mgr := &testutils.FakeManager{
+		Client: cl,
+		Scheme: cl.Scheme(),
+		Logger: logr.Discard(),
+	}
+	cfg := groveconfigv1alpha1.OperatorConfiguration{
+		TopologyAwareScheduling: getDefaultTASConfig(),
+		Network:                 getDefaultNetworkConfig(),
+		Scheduler: groveconfigv1alpha1.SchedulerConfiguration{
+			Profiles:           []groveconfigv1alpha1.SchedulerProfile{{Name: groveconfigv1alpha1.SchedulerNameKube}},
+			DefaultProfileName: string(groveconfigv1alpha1.SchedulerNameKube),
+		},
+	}
+	return NewHandler(mgr, &cfg, testutils.NewDefaultFakeRegistry())
+}
+
+func createPCSWithOverlongGroupedPCLQClaimName(
+	pcsReplicas, pcsgMaxReplicas int32,
+) *grovecorev1alpha1.PodCliqueSet {
+	pcs := createTestPodCliqueSet(strings.Repeat("p", 30))
+	pcs.Spec.Replicas = pcsReplicas
+	clique := pcs.Spec.Template.Cliques[0]
+	clique.Name = strings.Repeat("c", 10)
+	clique.ResourceSharing = []grovecorev1alpha1.ResourceSharingSpec{{
+		Name:  "gpu",
+		Scope: grovecorev1alpha1.ResourceSharingScopeAllReplicas,
+	}}
+	pcs.Spec.Template.PodCliqueScalingGroupConfigs = []grovecorev1alpha1.PodCliqueScalingGroupConfig{{
+		Name:         strings.Repeat("g", 10),
+		CliqueNames:  []string{clique.Name},
+		Replicas:     ptr.To(int32(1)),
+		MinAvailable: ptr.To(int32(1)),
+		ScaleConfig: &grovecorev1alpha1.AutoScalingConfig{
+			MinReplicas: ptr.To(int32(1)),
+			MaxReplicas: pcsgMaxReplicas,
+		},
+	}}
+	return pcs
+}

--- a/operator/internal/webhook/admission/pcs/validation/generatednames_test.go
+++ b/operator/internal/webhook/admission/pcs/validation/generatednames_test.go
@@ -79,9 +79,7 @@ func TestGeneratedResourceClaimNameChecksUseRuntimeGenerators(t *testing.T) {
 		},
 	}}
 
-	checks := indexGeneratedResourceClaimNameChecksByIdentity(
-		buildGeneratedResourceClaimNameChecks(pcs, fldPath),
-	)
+	checks := buildGeneratedResourceClaimNameChecks(pcs, fldPath)
 	require.Len(t, checks, 8)
 
 	pcsgName := apicommon.GeneratePodCliqueScalingGroupName(
@@ -97,27 +95,18 @@ func TestGeneratedResourceClaimNameChecksUseRuntimeGenerators(t *testing.T) {
 		"worker",
 	)
 
-	tests := []struct {
-		identity      string
-		generatedName string
-		replicaLimits []int32
-	}{
-		{"pcs/pcs-all/AllReplicas", resourceclaim.AllReplicasRCName(pcs.Name, "pcs-all"), nil},
-		{"pcs/pcs-per/PerReplica", resourceclaim.PerReplicaRCName(pcs.Name, 1, "pcs-per"), []int32{2}},
-		{"pcsg/sg/pcsg-all/AllReplicas", resourceclaim.AllReplicasRCName(pcsgName, "pcsg-all"), []int32{2}},
-		{"pcsg/sg/pcsg-per/PerReplica", resourceclaim.PerReplicaRCName(pcsgName, 2, "pcsg-per"), []int32{2, 3}},
-		{"pclq/solo/standalone/standalone-all/AllReplicas", resourceclaim.AllReplicasRCName(standalonePCLQName, "standalone-all"), []int32{2}},
-		{"pclq/solo/standalone/standalone-per/PerReplica", resourceclaim.PerReplicaRCName(standalonePCLQName, 3, "standalone-per"), []int32{2, 4}},
-		{"pclq/worker/pcsg/sg/grouped-all/AllReplicas", resourceclaim.AllReplicasRCName(groupedPCLQName, "grouped-all"), []int32{2, 3}},
-		{"pclq/worker/pcsg/sg/grouped-per/PerReplica", resourceclaim.PerReplicaRCName(groupedPCLQName, 4, "grouped-per"), []int32{2, 3, 5}},
+	expectedNames := []string{
+		resourceclaim.AllReplicasRCName(pcs.Name, "pcs-all"),
+		resourceclaim.PerReplicaRCName(pcs.Name, 1, "pcs-per"),
+		resourceclaim.AllReplicasRCName(pcsgName, "pcsg-all"),
+		resourceclaim.PerReplicaRCName(pcsgName, 2, "pcsg-per"),
+		resourceclaim.AllReplicasRCName(standalonePCLQName, "standalone-all"),
+		resourceclaim.PerReplicaRCName(standalonePCLQName, 3, "standalone-per"),
+		resourceclaim.AllReplicasRCName(groupedPCLQName, "grouped-all"),
+		resourceclaim.PerReplicaRCName(groupedPCLQName, 4, "grouped-per"),
 	}
-	for _, tc := range tests {
-		t.Run(tc.identity, func(t *testing.T) {
-			check, exists := checks[tc.identity]
-			require.True(t, exists)
-			assert.Equal(t, tc.generatedName, check.maxGeneratedName)
-			assert.Equal(t, tc.replicaLimits, check.replicaLimits)
-		})
+	for i, expectedName := range expectedNames {
+		assert.Equal(t, expectedName, checks[i].maxGeneratedName)
 	}
 }
 
@@ -239,95 +228,7 @@ func TestValidateGeneratedResourceClaimNamesUsesPCSGAutoscalingMaximum(t *testin
 	assert.Contains(t, errs[0].Detail, "-10-")
 }
 
-func TestValidateGeneratedResourceClaimNamesOnUpdate(t *testing.T) {
-	fldPath := field.NewPath("spec", "template")
-	validateUpdate := func(oldPCS, newPCS *grovecorev1alpha1.PodCliqueSet) field.ErrorList {
-		return newGeneratedResourceClaimNameValidator(newPCS).validateUpdate(oldPCS, fldPath)
-	}
-	oldPCS := createTestPodCliqueSet("p")
-	oldPCS.Spec.Template.ResourceSharing = []grovecorev1alpha1.PCSResourceSharingSpec{{
-		ResourceSharingSpec: grovecorev1alpha1.ResourceSharingSpec{
-			Name:  strings.Repeat("r", 58),
-			Scope: grovecorev1alpha1.ResourceSharingScopeAllReplicas,
-		},
-	}}
-
-	t.Run("unchanged legacy violation is allowed", func(t *testing.T) {
-		newPCS := oldPCS.DeepCopy()
-		assert.Empty(t, validateUpdate(oldPCS, newPCS))
-	})
-
-	t.Run("all-replicas violation allows scale out", func(t *testing.T) {
-		newPCS := oldPCS.DeepCopy()
-		newPCS.Spec.Replicas++
-		assert.Empty(t, validateUpdate(oldPCS, newPCS))
-	})
-
-	t.Run("per-replica violation allows scale in", func(t *testing.T) {
-		perReplicaOldPCS := oldPCS.DeepCopy()
-		perReplicaOldPCS.Spec.Replicas = 2
-		perReplicaOldPCS.Spec.Template.ResourceSharing[0].Scope = grovecorev1alpha1.ResourceSharingScopePerReplica
-		perReplicaOldPCS.Spec.Template.ResourceSharing[0].Name = strings.Repeat("r", 60)
-		newPCS := perReplicaOldPCS.DeepCopy()
-		newPCS.Spec.Replicas--
-
-		assert.Empty(t, validateUpdate(perReplicaOldPCS, newPCS))
-	})
-
-	t.Run("per-replica violation rejects scale out", func(t *testing.T) {
-		perReplicaOldPCS := oldPCS.DeepCopy()
-		perReplicaOldPCS.Spec.Template.ResourceSharing[0].Scope = grovecorev1alpha1.ResourceSharingScopePerReplica
-		perReplicaOldPCS.Spec.Template.ResourceSharing[0].Name = strings.Repeat("r", 60)
-		newPCS := perReplicaOldPCS.DeepCopy()
-		newPCS.Spec.Replicas++
-
-		errs := validateUpdate(perReplicaOldPCS, newPCS)
-		require.Len(t, errs, 1)
-		assert.Equal(t, "spec.template.resourceSharing[0].name", errs[0].Field)
-	})
-
-	t.Run("per-replica violation rejects autoscaling maximum increase", func(t *testing.T) {
-		scaledOldPCS := createTestPodCliqueSet(strings.Repeat("p", 30))
-		clique := scaledOldPCS.Spec.Template.Cliques[0]
-		clique.Name = strings.Repeat("c", 10)
-		clique.ResourceSharing = []grovecorev1alpha1.ResourceSharingSpec{{
-			Name:  strings.Repeat("r", 18),
-			Scope: grovecorev1alpha1.ResourceSharingScopePerReplica,
-		}}
-		clique.Spec.ScaleConfig = &grovecorev1alpha1.AutoScalingConfig{
-			MinReplicas: ptr.To(int32(1)),
-			MaxReplicas: 10,
-		}
-		newPCS := scaledOldPCS.DeepCopy()
-		newPCS.Spec.Template.Cliques[0].Spec.ScaleConfig.MaxReplicas = 11
-
-		errs := validateUpdate(scaledOldPCS, newPCS)
-		require.Len(t, errs, 1)
-		assert.Equal(t, "spec.template.cliques[0].resourceSharing[0].name", errs[0].Field)
-	})
-
-	t.Run("grouped PodClique violation rejects PCSG autoscaling maximum increase", func(t *testing.T) {
-		groupedOldPCS := createPCSWithOverlongGroupedPCLQClaimName(1, 10)
-		newPCS := groupedOldPCS.DeepCopy()
-		newPCS.Spec.Template.PodCliqueScalingGroupConfigs[0].ScaleConfig.MaxReplicas = 11
-
-		errs := validateUpdate(groupedOldPCS, newPCS)
-		require.Len(t, errs, 1)
-		assert.Equal(t, "spec.template.cliques[0].resourceSharing[0].name", errs[0].Field)
-	})
-
-	t.Run("grouped PodClique violation rejects PCS replica increase", func(t *testing.T) {
-		groupedOldPCS := createPCSWithOverlongGroupedPCLQClaimName(10, 1)
-		newPCS := groupedOldPCS.DeepCopy()
-		newPCS.Spec.Replicas = 11
-
-		errs := validateUpdate(groupedOldPCS, newPCS)
-		require.Len(t, errs, 1)
-		assert.Equal(t, "spec.template.cliques[0].resourceSharing[0].name", errs[0].Field)
-	})
-}
-
-func TestHandlerValidatesGeneratedResourceClaimNames(t *testing.T) {
+func TestHandlerValidatesGeneratedResourceClaimNamesOnCreate(t *testing.T) {
 	handler := newGeneratedNameTestHandler()
 	pcs := createTestPodCliqueSet("p")
 	pcs.Spec.Template.ResourceSharing = []grovecorev1alpha1.PCSResourceSharingSpec{{
@@ -340,9 +241,26 @@ func TestHandlerValidatesGeneratedResourceClaimNames(t *testing.T) {
 	_, err := handler.ValidateCreate(context.Background(), pcs)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pod.spec.resourceClaims[].name")
+}
 
-	_, err = handler.ValidateUpdate(context.Background(), pcs, pcs.DeepCopy())
+func TestHandlerGrandfathersGeneratedResourceClaimNamesOnUpdate(t *testing.T) {
+	handler := newGeneratedNameTestHandler()
+	oldPCS := createTestPodCliqueSet("p")
+	oldPCS.Spec.Template.ResourceSharing = []grovecorev1alpha1.PCSResourceSharingSpec{{
+		ResourceSharingSpec: grovecorev1alpha1.ResourceSharingSpec{
+			Name:  strings.Repeat("r", 60),
+			Scope: grovecorev1alpha1.ResourceSharingScopePerReplica,
+		},
+	}}
+	newPCS := oldPCS.DeepCopy()
+	newPCS.Spec.Replicas++
+
+	warnings, err := handler.ValidateUpdate(context.Background(), oldPCS, newPCS)
 	require.NoError(t, err)
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "spec.template.resourceSharing[0].name")
+	assert.Contains(t, warnings[0], "invalid ResourceClaim name")
+	assert.Contains(t, warnings[0], "new Pods may fail admission")
 }
 
 func newGeneratedNameTestHandler() *Handler {
@@ -361,28 +279,4 @@ func newGeneratedNameTestHandler() *Handler {
 		},
 	}
 	return NewHandler(mgr, &cfg, testutils.NewDefaultFakeRegistry())
-}
-
-func createPCSWithOverlongGroupedPCLQClaimName(
-	pcsReplicas, pcsgMaxReplicas int32,
-) *grovecorev1alpha1.PodCliqueSet {
-	pcs := createTestPodCliqueSet(strings.Repeat("p", 30))
-	pcs.Spec.Replicas = pcsReplicas
-	clique := pcs.Spec.Template.Cliques[0]
-	clique.Name = strings.Repeat("c", 10)
-	clique.ResourceSharing = []grovecorev1alpha1.ResourceSharingSpec{{
-		Name:  "gpu",
-		Scope: grovecorev1alpha1.ResourceSharingScopeAllReplicas,
-	}}
-	pcs.Spec.Template.PodCliqueScalingGroupConfigs = []grovecorev1alpha1.PodCliqueScalingGroupConfig{{
-		Name:         strings.Repeat("g", 10),
-		CliqueNames:  []string{clique.Name},
-		Replicas:     ptr.To(int32(1)),
-		MinAvailable: ptr.To(int32(1)),
-		ScaleConfig: &grovecorev1alpha1.AutoScalingConfig{
-			MinReplicas: ptr.To(int32(1)),
-			MaxReplicas: pcsgMaxReplicas,
-		},
-	}}
-	return pcs
 }

--- a/operator/internal/webhook/admission/pcs/validation/handler.go
+++ b/operator/internal/webhook/admission/pcs/validation/handler.go
@@ -79,6 +79,8 @@ func (h *Handler) ValidateCreate(ctx context.Context, obj runtime.Object) (admis
 	warnings, errs := v.validate()
 	warnings = append(warnings, topologyWarnings...)
 	allErrs = append(allErrs, errs...)
+	resourceClaimNameValidator := newGeneratedResourceClaimNameValidator(pcs)
+	allErrs = append(allErrs, resourceClaimNameValidator.validate(field.NewPath("spec", "template"))...)
 
 	// Validate MNNVL annotations on PCS metadata and spec (clique templates)
 	allErrs = append(allErrs, mnnvl.ValidatePCSOnCreate(pcs, h.networkConfig.AutoMNNVLEnabled)...)
@@ -105,6 +107,8 @@ func (h *Handler) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Obj
 
 	v := newPCSValidator(newPCS, admissionv1.Update, h.tasConfig, h.schedulerConfig, h.client, h.schedRegistry)
 	warnings, errs := v.validate()
+	resourceClaimNameValidator := newGeneratedResourceClaimNameValidator(newPCS)
+	errs = append(errs, resourceClaimNameValidator.validateUpdate(oldPCS, field.NewPath("spec", "template"))...)
 
 	// Validate MNNVL annotation immutability on PCS metadata and spec (clique templates)
 	errs = append(errs, mnnvl.ValidatePCSOnUpdate(oldPCS, newPCS)...)

--- a/operator/internal/webhook/admission/pcs/validation/handler.go
+++ b/operator/internal/webhook/admission/pcs/validation/handler.go
@@ -107,8 +107,6 @@ func (h *Handler) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Obj
 
 	v := newPCSValidator(newPCS, admissionv1.Update, h.tasConfig, h.schedulerConfig, h.client, h.schedRegistry)
 	warnings, errs := v.validate()
-	resourceClaimNameValidator := newGeneratedResourceClaimNameValidator(newPCS)
-	errs = append(errs, resourceClaimNameValidator.validateUpdate(oldPCS, field.NewPath("spec", "template"))...)
 
 	// Validate MNNVL annotation immutability on PCS metadata and spec (clique templates)
 	errs = append(errs, mnnvl.ValidatePCSOnUpdate(oldPCS, newPCS)...)
@@ -123,6 +121,8 @@ func (h *Handler) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Obj
 	}
 	updateWarnings := newTopologyConstraintsValidator(newPCS, h.tasConfig.Enabled, nil).updateWarnings()
 	warnings = append(warnings, updateWarnings...)
+	resourceClaimNameWarnings := newGeneratedResourceClaimNameValidator(newPCS).updateWarnings(field.NewPath("spec", "template"))
+	warnings = append(warnings, resourceClaimNameWarnings...)
 	return warnings, v.validateUpdate(oldPCS)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Validates generated ResourceClaim names as DNS labels during PodCliqueSet creation, before they are copied into `pod.spec.resourceClaims[].name`.

Validation covers PCS, PCSG, standalone PCLQ, and grouped PCLQ scopes using configured replicas and autoscaling maxima. Existing PodCliqueSet updates are grandfathered and return an admission warning when generated names remain invalid.

Pod creation errors also report the Pod `generateName` for easier diagnosis.

#### Which issue(s) this PR fixes:

Fixes #660 ([issue link](https://github.com/ai-dynamo/grove/issues/660))

#### Special notes for your reviewer:

Generated-name validation is create-only so legacy PodCliqueSets remain updatable. Scaling one can still cross the 63-character limit, for example when a replica index grows from `9` to `10`; affected Pods then fail admission until the workload is scaled back or recreated with shorter names.

#### Does this PR introduce a API change?

```release-note
PodCliqueSet creation now rejects resourceSharing configurations whose generated ResourceClaim names are not valid DNS labels. Existing PodCliqueSet updates remain allowed and warn when invalid generated names are detected.
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
GREP-390 documents the generated ResourceClaim DNS label constraint and the legacy scaling risk.
```