### PR TITLE
fix(webhook): validate generated ComputeDomain label names

### DIFF
--- a/docs/proposals/417-auto-mnnvl/README.md
+++ b/docs/proposals/417-auto-mnnvl/README.md
@@ -348,6 +348,8 @@ CD names include the group name and use the form `{pcs-name}-{replica-index}-{gr
 
 Group names are scoped to the PCS — different PCS resources can use the same group names without conflict (the PCS name provides uniqueness).
 
+The generated ComputeDomain name is also stored in the `app.kubernetes.io/name` label, whose value is limited to 63 characters. The validating webhook checks the name generated for the highest configured PCS replica index on create and regular update requests. Direct updates through the PCS `/scale` subresource do not pass through this validation.
+
 #### Reconciliation Ordering
 
 ComputeDomain resources must be synced **before** creating PCLQs and PCSGs, ensuring the CD exists before pods that reference its RCT are created. If CD creation fails, the sync stops and requeues for retry.

--- a/operator/internal/mnnvl/computedomain/computedomain.go
+++ b/operator/internal/mnnvl/computedomain/computedomain.go
@@ -312,7 +312,10 @@ type cdNameInfo struct {
 }
 
 func (c cdNameInfo) fullName() string {
-	return generateComputeDomainName(c.pcsName, c.replicaIndex, c.groupName)
+	return mnnvl.GenerateComputeDomainName(
+		apicommon.ResourceNameReplica{Name: c.pcsName, Replica: c.replicaIndex},
+		c.groupName,
+	)
 }
 
 // triageCDs computes the set differences between required and existing ComputeDomains,
@@ -340,7 +343,7 @@ func triageCDs(requiredCDs []cdNameInfo, existingCDFQNs []string) (toCreate []cd
 // It collects MNNVL groups from all annotation layers (PCS, PCSG configs,
 // clique templates), deduplicates, and generates a cdNameInfo per group per replica.
 func getRequiredCDNames(pcs *grovecorev1alpha1.PodCliqueSet) []cdNameInfo {
-	groups := collectDistinctGroups(pcs)
+	groups := mnnvl.EffectiveMNNVLGroupNames(pcs)
 	if len(groups) == 0 {
 		return nil
 	}
@@ -356,49 +359,6 @@ func getRequiredCDNames(pcs *grovecorev1alpha1.PodCliqueSet) []cdNameInfo {
 		}
 	}
 	return result
-}
-
-// collectDistinctGroups determines which MNNVL groups need ComputeDomains by
-// resolving the effective group for each GPU clique using hierarchical
-// annotation resolution (clique → PCSG → PCS). Non-GPU cliques are skipped
-// so that a PCS-level annotation doesn't create orphaned CDs when no GPU
-// cliques exist.
-func collectDistinctGroups(pcs *grovecorev1alpha1.PodCliqueSet) map[string]struct{} {
-	groups := make(map[string]struct{})
-
-	pcsgByClique := buildPCSGLookup(pcs)
-
-	for _, clique := range pcs.Spec.Template.Cliques {
-		if clique == nil || !mnnvl.HasGPUInPodSpec(&clique.Spec.PodSpec) {
-			continue
-		}
-		var pcsgAnnotations map[string]string
-		if pcsgCfg, ok := pcsgByClique[clique.Name]; ok {
-			pcsgAnnotations = pcsgCfg.Annotations
-		}
-		if group, ok := mnnvl.ResolveGroupNameHierarchically(clique.Annotations, pcsgAnnotations, pcs.Annotations); ok {
-			groups[group] = struct{}{}
-		}
-	}
-
-	return groups
-}
-
-// buildPCSGLookup builds a map from clique name to the PCSG config that contains it.
-func buildPCSGLookup(pcs *grovecorev1alpha1.PodCliqueSet) map[string]grovecorev1alpha1.PodCliqueScalingGroupConfig {
-	lookup := make(map[string]grovecorev1alpha1.PodCliqueScalingGroupConfig)
-	for _, pcsg := range pcs.Spec.Template.PodCliqueScalingGroupConfigs {
-		for _, cliqueName := range pcsg.CliqueNames {
-			lookup[cliqueName] = pcsg
-		}
-	}
-	return lookup
-}
-
-// generateComputeDomainName creates the CD name for a replica.
-// Format: {pcs-name}-{replica-index}-{group-name} (e.g., "my-pcs-0-workers").
-func generateComputeDomainName(pcsName string, replicaIndex int, groupName string) string {
-	return fmt.Sprintf("%s-%d-%s", pcsName, replicaIndex, groupName)
 }
 
 // getSelectorLabels returns labels for selecting ComputeDomains of a PCS.

--- a/operator/internal/mnnvl/computedomain/computedomain_test.go
+++ b/operator/internal/mnnvl/computedomain/computedomain_test.go
@@ -77,40 +77,6 @@ func TestNew(t *testing.T) {
 // Helper Function Tests
 // ================================
 
-func Test_generateComputeDomainName(t *testing.T) {
-	testCases := []struct {
-		description  string
-		pcsName      string
-		replicaIndex int
-		groupName    string
-		expected     string
-	}{
-		{
-			description:  "default group",
-			pcsName:      "mypcs",
-			replicaIndex: 0,
-			groupName:    "default",
-			expected:     "mypcs-0-default",
-		},
-		{
-			description:  "named group with higher replica index",
-			pcsName:      "training",
-			replicaIndex: 5,
-			groupName:    "encoders",
-			expected:     "training-5-encoders",
-		},
-	}
-
-	t.Parallel()
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
-			result := generateComputeDomainName(tc.pcsName, tc.replicaIndex, tc.groupName)
-			assert.Equal(t, tc.expected, result)
-		})
-	}
-}
-
 func TestGetRequiredCDNames(t *testing.T) {
 	testCases := []struct {
 		description    string

--- a/operator/internal/mnnvl/helpers.go
+++ b/operator/internal/mnnvl/helpers.go
@@ -19,9 +19,11 @@ import (
 	"strings"
 
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/ai-dynamo/grove/operator/internal/constants"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
@@ -80,10 +82,47 @@ func ResolveGroupNameHierarchically(annotationLayers ...map[string]string) (stri
 	return "", false
 }
 
+// EffectiveMNNVLGroupNames returns the distinct MNNVL groups used by GPU PodCliques.
+func EffectiveMNNVLGroupNames(pcs *grovecorev1alpha1.PodCliqueSet) sets.Set[string] {
+	groups := sets.New[string]()
+	if pcs == nil {
+		return groups
+	}
+
+	pcsgAnnotationsByCliqueName := make(map[string]map[string]string)
+	for i := range pcs.Spec.Template.PodCliqueScalingGroupConfigs {
+		pcsg := &pcs.Spec.Template.PodCliqueScalingGroupConfigs[i]
+		for _, cliqueName := range pcsg.CliqueNames {
+			pcsgAnnotationsByCliqueName[cliqueName] = pcsg.Annotations
+		}
+	}
+
+	for _, clique := range pcs.Spec.Template.Cliques {
+		if clique == nil || !HasGPUInPodSpec(&clique.Spec.PodSpec) {
+			continue
+		}
+		groupName, enrolled := ResolveGroupNameHierarchically(
+			clique.Annotations,
+			pcsgAnnotationsByCliqueName[clique.Name],
+			pcs.Annotations,
+		)
+		if enrolled {
+			groups.Insert(groupName)
+		}
+	}
+	return groups
+}
+
+// GenerateComputeDomainName creates the ComputeDomain name for a PCS replica.
+// Format: {pcs-name}-{replica-index}-{group-name}.
+func GenerateComputeDomainName(pcsNameReplica apicommon.ResourceNameReplica, groupName string) string {
+	return fmt.Sprintf("%s-%d-%s", pcsNameReplica.Name, pcsNameReplica.Replica, groupName)
+}
+
 // GenerateRCTName creates the ResourceClaimTemplate name for a PCS replica.
 // Format: {pcs-name}-{replica-index}-{group-name}.
 func GenerateRCTName(pcsNameReplica apicommon.ResourceNameReplica, groupName string) string {
-	return fmt.Sprintf("%s-%d-%s", pcsNameReplica.Name, pcsNameReplica.Replica, groupName)
+	return GenerateComputeDomainName(pcsNameReplica, groupName)
 }
 
 // HasGPUInPodSpec checks if any container in the PodSpec requests GPU resources.

--- a/operator/internal/mnnvl/helpers_test.go
+++ b/operator/internal/mnnvl/helpers_test.go
@@ -190,6 +190,68 @@ func TestGenerateRCTName(t *testing.T) {
 	}
 }
 
+func TestGenerateComputeDomainName(t *testing.T) {
+	assert.Equal(
+		t,
+		"training-10-encoders",
+		GenerateComputeDomainName(
+			apicommon.ResourceNameReplica{Name: "training", Replica: 10},
+			"encoders",
+		),
+	)
+}
+
+func TestEffectiveMNNVLGroupNames(t *testing.T) {
+	tests := []struct {
+		description    string
+		pcs            *grovecorev1alpha1.PodCliqueSet
+		expectedGroups []string
+	}{
+		{
+			description:    "GPU clique inherits PCS group",
+			pcs:            createPCSWithGPU(map[string]string{AnnotationMNNVLGroup: "pcs-group"}),
+			expectedGroups: []string{"pcs-group"},
+		},
+		{
+			description: "clique group overrides PCS group",
+			pcs: func() *grovecorev1alpha1.PodCliqueSet {
+				pcs := createPCSWithGPU(map[string]string{AnnotationMNNVLGroup: "pcs-group"})
+				pcs.Spec.Template.Cliques[0].Annotations = map[string]string{AnnotationMNNVLGroup: "clique-group"}
+				return pcs
+			}(),
+			expectedGroups: []string{"clique-group"},
+		},
+		{
+			description: "PCSG group overrides PCS group",
+			pcs: func() *grovecorev1alpha1.PodCliqueSet {
+				pcs := createPCSWithPCSGConfigAnnotations(map[string]string{AnnotationMNNVLGroup: "pcsg-group"})
+				pcs.Annotations = map[string]string{AnnotationMNNVLGroup: "pcs-group"}
+				return pcs
+			}(),
+			expectedGroups: []string{"pcsg-group"},
+		},
+		{
+			description: "clique opt-out overrides inherited group",
+			pcs: func() *grovecorev1alpha1.PodCliqueSet {
+				pcs := createPCSWithGPU(map[string]string{AnnotationMNNVLGroup: "pcs-group"})
+				pcs.Spec.Template.Cliques[0].Annotations = map[string]string{AnnotationMNNVLGroup: AnnotationMNNVLGroupOptOut}
+				return pcs
+			}(),
+		},
+		{
+			description:    "non-GPU clique is ignored",
+			pcs:            createPCSWithNonGPUCliqueAnnotations(map[string]string{AnnotationMNNVLGroup: "cpu-group"}),
+			expectedGroups: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			assert.ElementsMatch(t, test.expectedGroups, EffectiveMNNVLGroupNames(test.pcs).UnsortedList())
+		})
+	}
+}
+
 func TestValidateMNNVLGroupName(t *testing.T) {
 	tests := []struct {
 		description string

--- a/operator/internal/mnnvl/webhook.go
+++ b/operator/internal/mnnvl/webhook.go
@@ -16,30 +16,41 @@ package mnnvl
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 
+	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	kubeutils "github.com/ai-dynamo/grove/operator/internal/utils/kubernetes"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 const mnnvlNotEnabledMsgFormat = "MNNVL is not enabled in the operator configuration. Either enable MNNVL globally or remove the %s annotation"
 
-// ValidatePCSOnCreate validates all MNNVL annotations on a PodCliqueSet during creation:
-// PCS-level metadata and each PodCliqueTemplateSpec in the spec.
+// ValidatePCSOnCreate validates MNNVL annotations and generated resource names
+// on a PodCliqueSet during creation.
 func ValidatePCSOnCreate(pcs *grovecorev1alpha1.PodCliqueSet, autoMNNVLEnabled bool) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, validateMetadataOnCreate(pcs, autoMNNVLEnabled)...)
 	allErrs = append(allErrs, validateSpecOnCreate(pcs, autoMNNVLEnabled)...)
+	if autoMNNVLEnabled {
+		allErrs = append(allErrs, validateGeneratedComputeDomainNames(pcs, field.NewPath("metadata", "name"))...)
+	}
 	return allErrs
 }
 
-// ValidatePCSOnUpdate validates MNNVL annotation immutability on a PodCliqueSet during update:
-// PCS-level metadata and each PodCliqueTemplateSpec in the spec.
-func ValidatePCSOnUpdate(oldPCS, newPCS *grovecorev1alpha1.PodCliqueSet) field.ErrorList {
+// ValidatePCSOnUpdate validates MNNVL annotation immutability and generated
+// resource names on a PodCliqueSet during update.
+func ValidatePCSOnUpdate(oldPCS, newPCS *grovecorev1alpha1.PodCliqueSet, autoMNNVLEnabled bool) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, validateMetadataOnUpdate(oldPCS, newPCS)...)
 	allErrs = append(allErrs, validateSpecOnUpdate(oldPCS, newPCS)...)
+	if autoMNNVLEnabled {
+		allErrs = append(allErrs, validateGeneratedComputeDomainNamesOnUpdate(oldPCS, newPCS)...)
+	}
 	return allErrs
 }
 
@@ -159,4 +170,97 @@ var mnnvlImmutableKeys = []string{AnnotationMNNVLGroup}
 
 func validateMNNVLAnnotationsImmutability(oldAnnotations, newAnnotations map[string]string, basePath *field.Path) field.ErrorList {
 	return kubeutils.ValidateAnnotationsImmutability(oldAnnotations, newAnnotations, mnnvlImmutableKeys, basePath)
+}
+
+type generatedComputeDomainNameCheck struct {
+	groupName        string
+	generatedName    string
+	validationErrors []string
+}
+
+func validateGeneratedComputeDomainNames(pcs *grovecorev1alpha1.PodCliqueSet, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	for _, check := range buildGeneratedComputeDomainNameChecks(pcs) {
+		if len(check.validationErrors) > 0 {
+			allErrs = append(allErrs, generatedComputeDomainNameError(check, fldPath, pcs.Name))
+		}
+	}
+	return allErrs
+}
+
+func validateGeneratedComputeDomainNamesOnUpdate(
+	oldPCS, newPCS *grovecorev1alpha1.PodCliqueSet,
+) field.ErrorList {
+	oldInvalidGroups := invalidGeneratedComputeDomainGroups(oldPCS)
+	oldEffectiveGroups := EffectiveMNNVLGroupNames(oldPCS)
+
+	var allErrs field.ErrorList
+	for _, check := range buildGeneratedComputeDomainNameChecks(newPCS) {
+		if len(check.validationErrors) == 0 {
+			continue
+		}
+		if oldInvalidGroups.Has(check.groupName) && newPCS.Spec.Replicas <= oldPCS.Spec.Replicas {
+			continue
+		}
+
+		fldPath := field.NewPath("metadata", "name")
+		badValue := any(newPCS.Name)
+		if oldEffectiveGroups.Has(check.groupName) && newPCS.Spec.Replicas > oldPCS.Spec.Replicas {
+			fldPath = field.NewPath("spec", "replicas")
+			badValue = newPCS.Spec.Replicas
+		}
+		allErrs = append(allErrs, generatedComputeDomainNameError(check, fldPath, badValue))
+	}
+	return allErrs
+}
+
+func buildGeneratedComputeDomainNameChecks(pcs *grovecorev1alpha1.PodCliqueSet) []generatedComputeDomainNameCheck {
+	groupNames := EffectiveMNNVLGroupNames(pcs).UnsortedList()
+	slices.Sort(groupNames)
+
+	maxReplicaIndex := 0
+	if pcs.Spec.Replicas > 1 {
+		maxReplicaIndex = int(pcs.Spec.Replicas - 1)
+	}
+
+	checks := make([]generatedComputeDomainNameCheck, 0, len(groupNames))
+	for _, groupName := range groupNames {
+		generatedName := GenerateComputeDomainName(
+			apicommon.ResourceNameReplica{Name: pcs.Name, Replica: maxReplicaIndex},
+			groupName,
+		)
+		checks = append(checks, generatedComputeDomainNameCheck{
+			groupName:        groupName,
+			generatedName:    generatedName,
+			validationErrors: k8svalidation.IsValidLabelValue(generatedName),
+		})
+	}
+	return checks
+}
+
+func invalidGeneratedComputeDomainGroups(pcs *grovecorev1alpha1.PodCliqueSet) sets.Set[string] {
+	groups := sets.New[string]()
+	for _, check := range buildGeneratedComputeDomainNameChecks(pcs) {
+		if len(check.validationErrors) > 0 {
+			groups.Insert(check.groupName)
+		}
+	}
+	return groups
+}
+
+func generatedComputeDomainNameError(
+	check generatedComputeDomainNameCheck,
+	fldPath *field.Path,
+	badValue any,
+) *field.Error {
+	return field.Invalid(
+		fldPath,
+		badValue,
+		fmt.Sprintf(
+			"generated ComputeDomain name %q for MNNVL group %q must be a valid label value because it is used as app.kubernetes.io/name: %s",
+			check.generatedName,
+			check.groupName,
+			strings.Join(check.validationErrors, "; "),
+		),
+	)
 }

--- a/operator/internal/mnnvl/webhook_test.go
+++ b/operator/internal/mnnvl/webhook_test.go
@@ -15,11 +15,13 @@
 package mnnvl
 
 import (
+	"strings"
 	"testing"
 
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestValidatePCSOnCreate_Metadata(t *testing.T) {
@@ -154,7 +156,7 @@ func TestValidatePCSOnUpdate_Metadata(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			errs := ValidatePCSOnUpdate(test.oldPCS, test.newPCS)
+			errs := ValidatePCSOnUpdate(test.oldPCS, test.newPCS, true)
 
 			if test.expectError {
 				assert.NotEmpty(t, errs, "expected validation errors")
@@ -361,7 +363,7 @@ func TestValidatePCSOnUpdate_PCSGConfig(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			errs := ValidatePCSOnUpdate(test.oldPCS, test.newPCS)
+			errs := ValidatePCSOnUpdate(test.oldPCS, test.newPCS, true)
 
 			if test.expectError {
 				assert.NotEmpty(t, errs, "expected validation errors")
@@ -463,7 +465,7 @@ func TestValidatePCSOnUpdate_Spec(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			errs := ValidatePCSOnUpdate(test.oldPCS, test.newPCS)
+			errs := ValidatePCSOnUpdate(test.oldPCS, test.newPCS, true)
 
 			if test.expectError {
 				assert.NotEmpty(t, errs, "expected validation errors")
@@ -511,4 +513,122 @@ func TestValidatePCSOnCreate_NonGPUCliqueWithMNNVL(t *testing.T) {
 			assert.Empty(t, errs, "MNNVL annotations on non-GPU cliques should be accepted")
 		})
 	}
+}
+
+func TestValidatePCSOnCreate_ComputeDomainName(t *testing.T) {
+	tests := []struct {
+		description        string
+		pcs                *grovecorev1alpha1.PodCliqueSet
+		expectedNameLength int
+		expectError        bool
+	}{
+		{
+			description:        "63-character generated label value is accepted",
+			pcs:                createPCSForComputeDomainNameValidation(strings.Repeat("p", 55), "group", 10, true),
+			expectedNameLength: 63,
+			expectError:        false,
+		},
+		{
+			description:        "64-character generated label value is rejected",
+			pcs:                createPCSForComputeDomainNameValidation(strings.Repeat("p", 55), "group", 11, true),
+			expectedNameLength: 64,
+			expectError:        true,
+		},
+		{
+			description: "non-GPU clique does not create a ComputeDomain",
+			pcs:         createPCSForComputeDomainNameValidation(strings.Repeat("p", 56), "group", 1, false),
+			expectError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			if test.expectedNameLength > 0 {
+				checks := buildGeneratedComputeDomainNameChecks(test.pcs)
+				assert.Len(t, checks, 1)
+				assert.Len(t, checks[0].generatedName, test.expectedNameLength)
+			}
+			errs := ValidatePCSOnCreate(test.pcs, true)
+
+			if test.expectError {
+				assert.Len(t, errs, 1)
+				assert.Equal(t, "metadata.name", errs[0].Field)
+				assert.Contains(t, errs[0].Detail, "generated ComputeDomain name")
+				assert.Contains(t, errs[0].Detail, "app.kubernetes.io/name")
+			} else {
+				assert.Empty(t, errs)
+			}
+		})
+	}
+}
+
+func TestValidatePCSOnUpdate_ComputeDomainName(t *testing.T) {
+	tests := []struct {
+		description      string
+		oldPCS           *grovecorev1alpha1.PodCliqueSet
+		newPCS           *grovecorev1alpha1.PodCliqueSet
+		autoMNNVLEnabled bool
+		expectedField    string
+	}{
+		{
+			description:      "scale-out crossing the label length boundary is rejected",
+			oldPCS:           createPCSForComputeDomainNameValidation(strings.Repeat("p", 55), "group", 10, true),
+			newPCS:           createPCSForComputeDomainNameValidation(strings.Repeat("p", 55), "group", 11, true),
+			autoMNNVLEnabled: true,
+			expectedField:    "spec.replicas",
+		},
+		{
+			description:      "unchanged legacy invalid name is accepted",
+			oldPCS:           createPCSForComputeDomainNameValidation(strings.Repeat("p", 56), "group", 1, true),
+			newPCS:           createPCSForComputeDomainNameValidation(strings.Repeat("p", 56), "group", 1, true),
+			autoMNNVLEnabled: true,
+		},
+		{
+			description:      "legacy invalid name can scale in",
+			oldPCS:           createPCSForComputeDomainNameValidation(strings.Repeat("p", 55), "group", 11, true),
+			newPCS:           createPCSForComputeDomainNameValidation(strings.Repeat("p", 55), "group", 10, true),
+			autoMNNVLEnabled: true,
+		},
+		{
+			description:      "newly effective invalid group is rejected",
+			oldPCS:           createPCSForComputeDomainNameValidation(strings.Repeat("p", 56), "group", 1, false),
+			newPCS:           createPCSForComputeDomainNameValidation(strings.Repeat("p", 56), "group", 1, true),
+			autoMNNVLEnabled: true,
+			expectedField:    "metadata.name",
+		},
+		{
+			description:      "generated name validation is skipped when Auto-MNNVL is disabled",
+			oldPCS:           createPCSForComputeDomainNameValidation(strings.Repeat("p", 55), "group", 10, true),
+			newPCS:           createPCSForComputeDomainNameValidation(strings.Repeat("p", 55), "group", 11, true),
+			autoMNNVLEnabled: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			errs := ValidatePCSOnUpdate(test.oldPCS, test.newPCS, test.autoMNNVLEnabled)
+
+			if test.expectedField == "" {
+				assert.Empty(t, errs)
+				return
+			}
+			assert.Len(t, errs, 1)
+			assert.Equal(t, test.expectedField, errs[0].Field)
+			assert.Contains(t, errs[0].Detail, "generated ComputeDomain name")
+		})
+	}
+}
+
+func createPCSForComputeDomainNameValidation(
+	name, groupName string,
+	replicas int32,
+	withGPU bool,
+) *grovecorev1alpha1.PodCliqueSet {
+	pcs := createPCSWithGPU(map[string]string{AnnotationMNNVLGroup: groupName})
+	pcs.Name = name
+	pcs.Spec.Replicas = replicas
+	if !withGPU {
+		pcs.Spec.Template.Cliques[0].Spec.PodSpec.Containers[0].Resources = corev1.ResourceRequirements{}
+	}
+	return pcs
 }

--- a/operator/internal/webhook/admission/pcs/validation/handler.go
+++ b/operator/internal/webhook/admission/pcs/validation/handler.go
@@ -107,7 +107,7 @@ func (h *Handler) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Obj
 	warnings, errs := v.validate()
 
 	// Validate MNNVL annotation immutability on PCS metadata and spec (clique templates)
-	errs = append(errs, mnnvl.ValidatePCSOnUpdate(oldPCS, newPCS)...)
+	errs = append(errs, mnnvl.ValidatePCSOnUpdate(oldPCS, newPCS, h.networkConfig.AutoMNNVLEnabled)...)
 
 	// Scheduler-backend-specific validation
 	if err := h.validatePodCliqueSetWithBackend(ctx, newPCS); err != nil {

--- a/operator/internal/webhook/admission/pcs/validation/handler_mnnvl_test.go
+++ b/operator/internal/webhook/admission/pcs/validation/handler_mnnvl_test.go
@@ -16,6 +16,7 @@ package validation
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -102,6 +103,15 @@ func TestValidateCreate_MNNVL(t *testing.T) {
 			expectError:      true,
 			errorContains:    "not a valid DNS-1123 label",
 		},
+		{
+			description: "generated ComputeDomain label value is too long -> error",
+			pcs: createValidPCSWithGPU(map[string]string{
+				mnnvl.AnnotationMNNVLGroup: strings.Repeat("g", 53),
+			}),
+			autoMNNVLEnabled: true,
+			expectError:      true,
+			errorContains:    "generated ComputeDomain name",
+		},
 	}
 
 	for _, tt := range tests {
@@ -146,11 +156,12 @@ func TestValidateCreate_MNNVL(t *testing.T) {
 // TestValidateUpdate_MNNVL tests the MNNVL annotation immutability on update.
 func TestValidateUpdate_MNNVL(t *testing.T) {
 	tests := []struct {
-		description   string
-		oldPCS        *grovecorev1alpha1.PodCliqueSet
-		newPCS        *grovecorev1alpha1.PodCliqueSet
-		expectError   bool
-		errorContains string
+		description      string
+		oldPCS           *grovecorev1alpha1.PodCliqueSet
+		newPCS           *grovecorev1alpha1.PodCliqueSet
+		autoMNNVLEnabled bool
+		expectError      bool
+		errorContains    string
 	}{
 		{
 			description: "no annotation on both -> no error",
@@ -220,6 +231,20 @@ func TestValidateUpdate_MNNVL(t *testing.T) {
 			expectError:   true,
 			errorContains: "cannot be added",
 		},
+		{
+			description: "scale-out makes generated ComputeDomain label value too long -> error",
+			oldPCS: createValidPCSWithGPUReplicas(
+				map[string]string{mnnvl.AnnotationMNNVLGroup: strings.Repeat("g", 52)},
+				10,
+			),
+			newPCS: createValidPCSWithGPUReplicas(
+				map[string]string{mnnvl.AnnotationMNNVLGroup: strings.Repeat("g", 52)},
+				11,
+			),
+			autoMNNVLEnabled: true,
+			expectError:      true,
+			errorContains:    "generated ComputeDomain name",
+		},
 	}
 
 	for _, tt := range tests {
@@ -231,11 +256,12 @@ func TestValidateUpdate_MNNVL(t *testing.T) {
 				Logger: logr.Discard(),
 			}
 
-			// MNNVL validation on update doesn't depend on feature flag
 			cfg := configv1alpha1.OperatorConfiguration{
 				TopologyAwareScheduling: getDefaultTASConfig(),
-				Network:                 getDefaultNetworkConfig(),
-				Scheduler:               configv1alpha1.SchedulerConfiguration{Profiles: []configv1alpha1.SchedulerProfile{{Name: configv1alpha1.SchedulerNameKube}}, DefaultProfileName: string(configv1alpha1.SchedulerNameKube)},
+				Network: configv1alpha1.NetworkAcceleration{
+					AutoMNNVLEnabled: tt.autoMNNVLEnabled,
+				},
+				Scheduler: configv1alpha1.SchedulerConfiguration{Profiles: []configv1alpha1.SchedulerProfile{{Name: configv1alpha1.SchedulerNameKube}}, DefaultProfileName: string(configv1alpha1.SchedulerNameKube)},
 			}
 			handler := NewHandler(mgr, &cfg, testutils.NewDefaultFakeRegistry())
 
@@ -320,6 +346,12 @@ func createValidPCSWithGPU(annotations map[string]string) *grovecorev1alpha1.Pod
 				Build(),
 		).
 		Build()
+}
+
+func createValidPCSWithGPUReplicas(annotations map[string]string, replicas int32) *grovecorev1alpha1.PodCliqueSet {
+	pcs := createValidPCSWithGPU(annotations)
+	pcs.Spec.Replicas = replicas
+	return pcs
 }
 
 // createValidPCSWithCliqueAnnotations creates a fully valid PCS with


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Validates generated Auto-MNNVL ComputeDomain names before they are copied into the `app.kubernetes.io/name` label, whose value is limited to 63 characters.

Validation covers effective MNNVL groups used by GPU PodCliques and the highest configured PCS replica index. Create and regular update requests reject new violations, while unchanged legacy violations and scale-in remain allowed.

This is intentionally separate from https://github.com/ai-dynamo/grove/pull/767, which validates generated ResourceClaim names.

#### Which issue(s) this PR fixes:

Related to #660

#### Special notes for your reviewer:

Direct PCS `/scale` subresource updates remain out of scope because those admission requests do not contain the full PodCliqueSet needed to resolve effective MNNVL groups.

#### Does this PR introduce a API change?

```release-note
PodCliqueSet admission now rejects Auto-MNNVL configurations whose generated ComputeDomain names cannot be used as Kubernetes label values.
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
GREP-417 documents the generated ComputeDomain label constraint and `/scale` limitation.
```