### PR TITLE
ci: run Grove E2E from copied PR branches

### DIFF
--- a/.github/workflows/build-check-test.yaml
+++ b/.github/workflows/build-check-test.yaml
@@ -18,7 +18,6 @@ on:
   push:
     branches:
       - main
-      - "release/*"
       - "pull-request/[0-9]+"
   pull_request:
     types: [opened, synchronize, reopened, labeled, ready_for_review]

--- a/.github/workflows/build-check-test.yaml
+++ b/.github/workflows/build-check-test.yaml
@@ -18,6 +18,7 @@ on:
   push:
     branches:
       - main
+      - "release/*"
       - "pull-request/[0-9]+"
   pull_request:
     types: [opened, synchronize, reopened, labeled, ready_for_review]
@@ -26,21 +27,57 @@ on:
 # Cancel in-progress runs when a new run is triggered for the same PR
 # This prevents stale runs from consuming resources
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   # Detect which paths have changed to conditionally run E2E tests
   changes:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/pull-request/')
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
-      e2e-relevant: ${{ steps.filter.outputs.e2e-relevant }}
+      e2e-relevant: ${{ steps.filter-pr.outputs.e2e-relevant || steps.filter-copy.outputs.e2e-relevant }}
+      pr-draft: ${{ steps.copied-pr.outputs.draft }}
+      run-e2e: ${{ steps.copied-pr.outputs.run-e2e }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
+      - name: Read copied pull request metadata
+        id: copied-pr
+        if: startsWith(github.ref, 'refs/heads/pull-request/')
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
+          script: |
+            const pull_number = Number(context.ref.split('/').at(-1));
+            const { data: pull } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number,
+            });
+
+            core.setOutput('base-ref', pull.base.ref);
+            core.setOutput('draft', String(pull.draft));
+            core.setOutput(
+              'run-e2e',
+              String(pull.labels.some((label) => label.name === 'run-e2e')),
+            );
+      - uses: dorny/paths-filter@v3
+        id: filter-pr
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            e2e-relevant:
+              - 'operator/**'
+              - '.github/**'
+      - uses: dorny/paths-filter@v3
+        id: filter-copy
+        if: startsWith(github.ref, 'refs/heads/pull-request/')
+        with:
+          base: ${{ steps.copied-pr.outputs.base-ref }}
           filters: |
             e2e-relevant:
               - 'operator/**'
@@ -100,12 +137,12 @@ jobs:
   #   make_target   (optional) - Makefile target, defaults to run-e2e-full
   e2e:
     needs: [test, build, check, changes]
-    # Run on non-draft PRs (or draft PRs with 'run-e2e' label)
-    # AND only when operator or .github files are changed
+    # Run only from copy-pr-bot's trusted branch. Draft PRs require the
+    # 'run-e2e' label.
     if: |
-      github.event_name == 'pull_request' &&
+      startsWith(github.ref, 'refs/heads/pull-request/') &&
       needs.changes.outputs.e2e-relevant == 'true' &&
-      (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-e2e'))
+      (needs.changes.outputs.pr-draft == 'false' || needs.changes.outputs.run-e2e == 'true')
     # use NVIDIA self-hosted runner setting is on Velonix repository
     runs-on: prod-grove-e2e-v1
     timeout-minutes: 60
@@ -189,9 +226,12 @@ jobs:
   e2e-skip:
     needs: [changes]
     if: |
-      github.event_name == 'pull_request' &&
-      needs.changes.outputs.e2e-relevant != 'true' &&
-      !contains(github.event.pull_request.labels.*.name, 'run-e2e')
+      (github.event_name == 'pull_request' &&
+       needs.changes.outputs.e2e-relevant != 'true' &&
+       !contains(github.event.pull_request.labels.*.name, 'run-e2e')) ||
+      (startsWith(github.ref, 'refs/heads/pull-request/') &&
+       needs.changes.outputs.e2e-relevant != 'true' &&
+       needs.changes.outputs.run-e2e != 'true')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build-check-test.yaml
+++ b/.github/workflows/build-check-test.yaml
@@ -37,47 +37,15 @@ jobs:
   # Detect which paths have changed to conditionally run E2E tests
   changes:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/pull-request/')
-    permissions:
-      contents: read
-      pull-requests: read
+    if: startsWith(github.ref, 'refs/heads/pull-request/')
     outputs:
-      e2e-relevant: ${{ steps.filter-pr.outputs.e2e-relevant || steps.filter-copy.outputs.e2e-relevant }}
-      pr-draft: ${{ steps.copied-pr.outputs.draft }}
-      run-e2e: ${{ steps.copied-pr.outputs.run-e2e }}
+      e2e-relevant: ${{ steps.filter.outputs.e2e-relevant }}
     steps:
       - uses: actions/checkout@v4
-      - name: Read copied pull request metadata
-        id: copied-pr
-        if: startsWith(github.ref, 'refs/heads/pull-request/')
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          script: |
-            const pull_number = Number(context.ref.split('/').at(-1));
-            const { data: pull } = await github.rest.pulls.get({
-              ...context.repo,
-              pull_number,
-            });
-
-            core.setOutput('base-ref', pull.base.ref);
-            core.setOutput('draft', String(pull.draft));
-            core.setOutput(
-              'run-e2e',
-              String(pull.labels.some((label) => label.name === 'run-e2e')),
-            );
       - uses: dorny/paths-filter@v3
-        id: filter-pr
-        if: github.event_name == 'pull_request'
+        id: filter
         with:
-          filters: |
-            e2e-relevant:
-              - 'operator/**'
-              - '.github/**'
-      - uses: dorny/paths-filter@v3
-        id: filter-copy
-        if: startsWith(github.ref, 'refs/heads/pull-request/')
-        with:
-          base: ${{ steps.copied-pr.outputs.base-ref }}
+          base: main
           filters: |
             e2e-relevant:
               - 'operator/**'
@@ -137,12 +105,10 @@ jobs:
   #   make_target   (optional) - Makefile target, defaults to run-e2e-full
   e2e:
     needs: [test, build, check, changes]
-    # Run only from copy-pr-bot's trusted branch. Draft PRs require the
-    # 'run-e2e' label.
+    # Run only from copy-pr-bot's trusted branch.
     if: |
       startsWith(github.ref, 'refs/heads/pull-request/') &&
-      needs.changes.outputs.e2e-relevant == 'true' &&
-      (needs.changes.outputs.pr-draft == 'false' || needs.changes.outputs.run-e2e == 'true')
+      needs.changes.outputs.e2e-relevant == 'true'
     # use NVIDIA self-hosted runner setting is on Velonix repository
     runs-on: prod-grove-e2e-v1
     timeout-minutes: 60
@@ -220,18 +186,14 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
-  # This job runs with the same matrix as 'e2e' when E2E tests are skipped (no relevant
-  # file changes and no 'run-e2e' label). It reports a passing status so that required
-  # branch protection checks are satisfied even for documentation-only PRs.
+  # This job runs with the same matrix as 'e2e' when E2E tests are skipped because
+  # no relevant files changed. It reports a passing status so that required branch
+  # protection checks are satisfied even for documentation-only PRs.
   e2e-skip:
     needs: [changes]
     if: |
-      (github.event_name == 'pull_request' &&
-       needs.changes.outputs.e2e-relevant != 'true' &&
-       !contains(github.event.pull_request.labels.*.name, 'run-e2e')) ||
-      (startsWith(github.ref, 'refs/heads/pull-request/') &&
-       needs.changes.outputs.e2e-relevant != 'true' &&
-       needs.changes.outputs.run-e2e != 'true')
+      startsWith(github.ref, 'refs/heads/pull-request/') &&
+      needs.changes.outputs.e2e-relevant != 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -250,4 +212,4 @@ jobs:
     name: E2E - ${{ matrix.test_name }}
     steps:
       - name: Skip E2E (no relevant changes)
-        run: echo "E2E skipped — no changes to operator/ or .github/ and 'run-e2e' label not set"
+        run: echo "E2E skipped — no changes to operator/ or .github/"


### PR DESCRIPTION
## Summary

- keep the GitHub-hosted `pull_request` checks
- gate the Velonix `prod-grove-e2e-v1` matrix to copy-pr-bot's `pull-request/<id>` push
- evaluate the existing E2E path filter against `main` only on the copied branch
- allow trusted pushes to `main` and numeric copied-PR branches

## Why

The E2E matrix currently executes directly from the `pull_request` event on a Velonix runner. The copied branch is the approval boundary for external-contributor workloads.

## Validation

- verified Grove has no live `release/*` branches
- parsed the workflow as YAML
- asserted the copied-PR push filter and copied-branch-only Velonix E2E gate
- confirmed no PR metadata API lookup remains
- ran `git diff --check`
- verified all commits are signed

Closes OPS-8189
Fixes #770