### PR TITLE
ci: update GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/actions/e2e-setup/action.yaml
+++ b/.github/actions/e2e-setup/action.yaml
@@ -59,7 +59,7 @@ runs:
 
     - name: Set up Go (fallback)
       if: env.NEED_GO_SETUP == 'true'
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ inputs.go-version }}
         cache: true

--- a/.github/workflows/build-check-test.yaml
+++ b/.github/workflows/build-check-test.yaml
@@ -37,8 +37,8 @@ jobs:
     outputs:
       e2e-relevant: ${{ steps.filter.outputs.e2e-relevant }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -49,9 +49,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: "1.26.3"
           cache: true
@@ -67,9 +67,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: "1.26.3"
           cache: true
@@ -81,9 +81,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: "1.26.3"
           cache: true
@@ -146,7 +146,7 @@ jobs:
           echo "RAM: $(free -h | awk '/^Mem:/ {print $2}')"
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Pull registry image from GHCR to avoid Docker Hub rate limits
         run: |
@@ -176,7 +176,7 @@ jobs:
       # Uses 'warn' since this only runs on failure and missing files indicates a problem.
       - name: Upload test logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-test-logs-${{ matrix.test_name }}
           path: operator/e2e-diagnostics/

--- a/.github/workflows/push-artifacts.yaml
+++ b/.github/workflows/push-artifacts.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Set package version
         run: |
@@ -51,19 +51,19 @@ jobs:
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
           echo $PACKAGE_VERSION
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26.3'
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Set Docker Registry
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
     needs: push-artifacts
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Extract package version from tag
         run: |

--- a/.github/workflows/scale-test-ci.yaml
+++ b/.github/workflows/scale-test-ci.yaml
@@ -27,7 +27,7 @@ jobs:
           echo "RAM: $(free -h | awk '/^Mem:/ {print $2}')"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: E2E setup
         uses: ./.github/actions/e2e-setup

--- a/.github/workflows/validate-issue-references.yaml
+++ b/.github/workflows/validate-issue-references.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Validate PR references at least one open issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { owner, repo } = context.repo;


### PR DESCRIPTION
## Summary

- update 18 JavaScript action references across five workflows and one composite action
- move checkout, path filtering, Go setup, artifact upload, GitHub scripting, Docker login, and Buildx setup to releases that declare Node 24
- leave `actions/stale@v10` unchanged because it already declares Node 24

## Why

Grove CI logs warn that actions declaring Node 20 are deprecated and are currently being forced onto Node 24. The repository also contained older checkout and Go setup references declaring Node 12 and Node 16. Using the Node 24-native action releases removes those compatibility warnings before the override is retired.

## Dependency

Depends on #769. This PR remains a draft until the copied-branch E2E workflow lands, so Grove's current direct-PR E2E definition does not execute these workflow changes on Velonix.

## Validation

- verified each selected action major declares `node24`
- parsed all 7 workflow and composite-action YAML files
- confirmed no audited Node 12, Node 16, or Node 20 action references remain
- ran `git diff --check`
- verified the commit is SSH signed and DCO signed off

Fixes #771