### PR TITLE
feat: add scale dashboard overview filters

### DIFF
--- a/operator/hack/scale-dashboard/app.js
+++ b/operator/hack/scale-dashboard/app.js
@@ -49,6 +49,7 @@ const state = {
   testName: "",
   startDate: "",
   endDate: "",
+  hiddenOverviewTests: new Set(),
 };
 
 const els = {
@@ -186,24 +187,30 @@ function render() {
 }
 
 function drawOverviewChart(runs) {
-  const rows = runs
+  const allRows = runs
     .map((run) => ({ run, value: run.totalSeconds }))
     .filter((item) => Number.isFinite(item.value))
     .sort((a, b) => a.run.date - b.run.date);
-  const testNames = unique(rows.map((row) => row.run.testName)).sort();
-  const colors = testColorMap(testNames);
+  const testNames = unique(allRows.map((row) => row.run.testName)).sort();
+  const colors = testColorMap(unique(state.runs.map((run) => run.testName)).sort());
 
-  renderLegend(els.overviewLegend, testNames.map((name) => ({ name, color: colors.get(name) })));
+  renderOverviewLegend(testNames, colors);
 
   const svg = els.overviewChart;
   const dims = prepareChart(svg, { top: 20, right: 28, bottom: 42, left: 58 });
-  if (rows.length === 0) {
+  if (allRows.length === 0) {
     drawEmpty(svg, "No total runtime points");
     return;
   }
 
-  const minX = rows[0].run.date.getTime();
-  const maxX = rows[rows.length - 1].run.date.getTime();
+  const rows = allRows.filter((row) => !state.hiddenOverviewTests.has(row.run.testName));
+  if (rows.length === 0) {
+    drawEmpty(svg, "All test series hidden");
+    return;
+  }
+
+  const minX = allRows[0].run.date.getTime();
+  const maxX = allRows[allRows.length - 1].run.date.getTime();
   const maxY = Math.max(...rows.map((row) => row.value), 0.001);
   const yTop = maxY * 1.15;
   const xScale = (value) => {
@@ -214,7 +221,7 @@ function drawOverviewChart(runs) {
 
   drawGrid(svg, dims, yTop);
 
-  for (const testName of testNames) {
+  for (const testName of testNames.filter((name) => !state.hiddenOverviewTests.has(name))) {
     const seriesRows = rows.filter((row) => row.run.testName === testName);
     const color = colors.get(testName);
     const points = seriesRows.map((row) => [
@@ -260,7 +267,7 @@ function drawOverviewChart(runs) {
     }
   }
 
-  drawDateLabels(svg, dims, rows.map((row) => row.run));
+  drawDateLabels(svg, dims, allRows.map((row) => row.run));
 }
 
 function selectedRuns(runs) {
@@ -758,6 +765,32 @@ function renderLegend(target, items) {
       const swatch = document.createElement("i");
       swatch.style.background = item.color;
       entry.append(swatch, document.createTextNode(item.name));
+      return entry;
+    }),
+  );
+}
+
+function renderOverviewLegend(testNames, colors) {
+  els.overviewLegend.replaceChildren(
+    ...testNames.map((testName) => {
+      const visible = !state.hiddenOverviewTests.has(testName);
+      const entry = document.createElement("button");
+      entry.className = "legend-toggle";
+      entry.type = "button";
+      entry.setAttribute("aria-pressed", String(visible));
+      entry.setAttribute("aria-label", `${visible ? "Hide" : "Show"} ${testName} series`);
+
+      const swatch = document.createElement("i");
+      swatch.style.background = colors.get(testName);
+      entry.append(swatch, document.createTextNode(testName));
+      entry.addEventListener("click", () => {
+        if (visible) {
+          state.hiddenOverviewTests.add(testName);
+        } else {
+          state.hiddenOverviewTests.delete(testName);
+        }
+        render();
+      });
       return entry;
     }),
   );

--- a/operator/hack/scale-dashboard/app.js
+++ b/operator/hack/scale-dashboard/app.js
@@ -29,14 +29,36 @@ const STACK_COLORS = [
   "#53616f",
 ];
 
+const TEST_COLORS = [
+  "#0f766e",
+  "#dc2626",
+  "#2563eb",
+  "#d97706",
+  "#7c3aed",
+  "#16a34a",
+  "#db2777",
+  "#4b5563",
+  "#0891b2",
+  "#9333ea",
+  "#65a30d",
+  "#ea580c",
+];
+
 const state = {
   runs: [],
   testName: "",
+  startDate: "",
+  endDate: "",
 };
 
 const els = {
   status: document.getElementById("status"),
   testSelect: document.getElementById("test-select"),
+  startDate: document.getElementById("start-date"),
+  endDate: document.getElementById("end-date"),
+  clearDateRange: document.getElementById("clear-date-range"),
+  overviewChart: document.getElementById("overview-chart"),
+  overviewLegend: document.getElementById("overview-legend"),
   totalChart: document.getElementById("total-chart"),
   phaseChart: document.getElementById("phase-chart"),
   totalSummary: document.getElementById("total-summary"),
@@ -54,6 +76,7 @@ async function init() {
     state.runs = parseNdjson(text);
     if (state.runs.length === 0) {
       setStatus("No runs found.");
+      drawEmpty(els.overviewChart, "No runs found");
       drawEmpty(els.totalChart, "No runs found");
       return;
     }
@@ -63,10 +86,14 @@ async function init() {
       state.testName = els.testSelect.value;
       render();
     });
+    els.startDate.addEventListener("change", () => updateDateRange(els.startDate));
+    els.endDate.addEventListener("change", () => updateDateRange(els.endDate));
+    els.clearDateRange.addEventListener("click", resetDateRange);
     window.addEventListener("resize", render);
     render();
   } catch (err) {
     setStatus(`Failed to load ${RUNS_URL}: ${err.message}`);
+    drawEmpty(els.overviewChart, "Failed to load runs");
     drawEmpty(els.totalChart, "Failed to load runs");
   }
 }
@@ -129,6 +156,7 @@ function populateSelectors() {
   const tests = unique(state.runs.map((run) => run.testName)).sort();
   state.testName = tests[0] || "";
   setOptions(els.testSelect, tests);
+  resetDateRange(false);
 }
 
 function setOptions(select, values) {
@@ -144,21 +172,154 @@ function setOptions(select, values) {
 }
 
 function render() {
-  const runs = selectedRuns();
+  const rangedRuns = runsInDateRange();
+  const runs = selectedRuns(rangedRuns);
   const detail = selectedRunDetail(runs);
   const detailNote = detail.hideMilestoneCharts || detail.hideLatestMilestoneRows ? "; milestone details hidden" : "";
   setStatus(`${runs.length} ${state.testName} runs loaded${detailNote}`);
 
+  drawOverviewChart(rangedRuns);
   drawTotalChart(runs);
   drawPhaseChart(runs);
   renderMilestoneCharts(runs, detail);
   renderLatestTable(runs, detail);
 }
 
-function selectedRuns() {
-  return state.runs
+function drawOverviewChart(runs) {
+  const rows = runs
+    .map((run) => ({ run, value: run.totalSeconds }))
+    .filter((item) => Number.isFinite(item.value))
+    .sort((a, b) => a.run.date - b.run.date);
+  const testNames = unique(rows.map((row) => row.run.testName)).sort();
+  const colors = testColorMap(testNames);
+
+  renderLegend(els.overviewLegend, testNames.map((name) => ({ name, color: colors.get(name) })));
+
+  const svg = els.overviewChart;
+  const dims = prepareChart(svg, { top: 20, right: 28, bottom: 42, left: 58 });
+  if (rows.length === 0) {
+    drawEmpty(svg, "No total runtime points");
+    return;
+  }
+
+  const minX = rows[0].run.date.getTime();
+  const maxX = rows[rows.length - 1].run.date.getTime();
+  const maxY = Math.max(...rows.map((row) => row.value), 0.001);
+  const yTop = maxY * 1.15;
+  const xScale = (value) => {
+    if (minX === maxX) return dims.margin.left + dims.plotW / 2;
+    return dims.margin.left + ((value - minX) / (maxX - minX)) * dims.plotW;
+  };
+  const yScale = (value) => dims.margin.top + dims.plotH - (value / yTop) * dims.plotH;
+
+  drawGrid(svg, dims, yTop);
+
+  for (const testName of testNames) {
+    const seriesRows = rows.filter((row) => row.run.testName === testName);
+    const color = colors.get(testName);
+    const points = seriesRows.map((row) => [
+      xScale(row.run.date.getTime()),
+      yScale(row.value),
+      row,
+    ]);
+    const path = points
+      .map(([x, y], index) => `${index === 0 ? "M" : "L"} ${x.toFixed(2)} ${y.toFixed(2)}`)
+      .join(" ");
+    const line = addEl(svg, "path", { class: "series overview-series", d: path });
+    line.style.stroke = color;
+
+    for (const [x, y, row] of points) {
+      const marker = addEl(svg, "circle", {
+        class: "point overview-point",
+        cx: x,
+        cy: y,
+        r: 4,
+      });
+      marker.style.stroke = color;
+      const hit = addEl(svg, "circle", {
+        class: "point-hit",
+        cx: x,
+        cy: y,
+        r: 13,
+      });
+      const tooltip = () => tooltipRows(row.run, [
+        ["Test", testName],
+        ["Total", `${formatSeconds(row.value)}s`],
+      ]);
+      hit.addEventListener("mouseenter", (event) => {
+        marker.style.fill = color;
+        showTooltip(event, tooltip());
+      });
+      hit.addEventListener("mousemove", (event) => {
+        showTooltip(event, tooltip());
+      });
+      hit.addEventListener("mouseleave", () => {
+        marker.style.fill = "#ffffff";
+        hideTooltip();
+      });
+    }
+  }
+
+  drawDateLabels(svg, dims, rows.map((row) => row.run));
+}
+
+function selectedRuns(runs) {
+  return runs
     .filter((run) => run.testName === state.testName)
     .sort((a, b) => a.date - b.date);
+}
+
+function updateDateRange(changedInput) {
+  let startDate = els.startDate.value;
+  let endDate = els.endDate.value;
+
+  if (startDate && endDate && startDate > endDate) {
+    if (changedInput === els.startDate) {
+      endDate = startDate;
+      els.endDate.value = endDate;
+    } else {
+      startDate = endDate;
+      els.startDate.value = startDate;
+    }
+  }
+
+  state.startDate = startDate;
+  state.endDate = endDate;
+  updateDateRangeLimits();
+  render();
+}
+
+function resetDateRange(shouldRender = true) {
+  const { minDate, maxDate } = dateRangeBounds();
+  state.startDate = minDate;
+  state.endDate = maxDate;
+  els.startDate.value = minDate;
+  els.endDate.value = maxDate;
+  updateDateRangeLimits();
+  if (shouldRender) render();
+}
+
+function updateDateRangeLimits() {
+  const { minDate, maxDate } = dateRangeBounds();
+
+  els.startDate.min = minDate;
+  els.startDate.max = state.endDate || maxDate;
+  els.endDate.min = state.startDate || minDate;
+  els.endDate.max = maxDate;
+}
+
+function dateRangeBounds() {
+  const dates = state.runs.map((run) => dateKey(run.date)).sort();
+  const minDate = dates[0] || "";
+  return { minDate, maxDate: dateKey(new Date()) };
+}
+
+function runsInDateRange() {
+  return state.runs.filter((run) => {
+    const date = dateKey(run.date);
+    return (!state.startDate || date >= state.startDate)
+      && (!state.endDate || date <= state.endDate);
+  });
 }
 
 function drawTotalChart(runs) {
@@ -639,6 +800,40 @@ function colorMap(names) {
   return map;
 }
 
+function testColorMap(testNames) {
+  const colors = new Map();
+  const usedIndexes = new Set();
+
+  for (const testName of unique(testNames).sort()) {
+    if (usedIndexes.size < TEST_COLORS.length) {
+      let index = hashString(testName) % TEST_COLORS.length;
+      while (usedIndexes.has(index)) {
+        index = (index + 1) % TEST_COLORS.length;
+      }
+      usedIndexes.add(index);
+      colors.set(testName, TEST_COLORS[index]);
+      continue;
+    }
+
+    colors.set(testName, generatedTestColor(testName, colors.size));
+  }
+
+  return colors;
+}
+
+function hashString(value) {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = Math.imul(hash ^ value.charCodeAt(index), 16777619);
+  }
+  return hash >>> 0;
+}
+
+function generatedTestColor(testName, index) {
+  const hue = (hashString(`${testName}-${index}`) + index * 137) % 360;
+  return `hsl(${hue} 68% 38%)`;
+}
+
 function cell(text) {
   const td = document.createElement("td");
   td.textContent = text;
@@ -691,6 +886,13 @@ function formatSeconds(value) {
 function formatSignedPercent(value) {
   const sign = value > 0 ? "+" : "";
   return `${sign}${value.toFixed(1)}%`;
+}
+
+function dateKey(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 function formatDate(date) {

--- a/operator/hack/scale-dashboard/index.html
+++ b/operator/hack/scale-dashboard/index.html
@@ -22,23 +22,49 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Grove Scale Test</title>
-    <link rel="stylesheet" href="style.css?v=charts-v4">
+    <link rel="stylesheet" href="style.css?v=charts-v7">
   </head>
   <body>
     <main class="page">
       <header class="topbar">
-        <div>
+        <div class="title-area">
           <h1>Grove Scale Test</h1>
-          <p id="status">Loading runs...</p>
+          <fieldset class="date-range">
+            <legend>Date Range</legend>
+            <label>
+              From
+              <input id="start-date" type="date">
+            </label>
+            <label>
+              To
+              <input id="end-date" type="date">
+            </label>
+            <button id="clear-date-range" class="clear-filter" type="button">Clear filter</button>
+          </fieldset>
         </div>
         <a class="button" href="index/runs.ndjson" download>Download Runs as JSON</a>
       </header>
 
+      <section class="charts" aria-label="All scale-test runtime charts">
+        <article class="chart-panel">
+          <header class="chart-panel-header">
+            <h2>All Tests — Total Runtime</h2>
+            <div id="overview-legend" class="legend"></div>
+          </header>
+          <div class="chart-frame">
+            <svg id="overview-chart" class="chart" role="img" aria-label="Total scale-test runtime by test over time"></svg>
+          </div>
+        </article>
+      </section>
+
       <section class="controls" aria-label="Chart controls">
-        <label>
-          Test
-          <select id="test-select"></select>
-        </label>
+        <div class="control">
+          <label>
+            Test
+            <select id="test-select"></select>
+          </label>
+          <p id="status">Loading runs...</p>
+        </div>
       </section>
 
       <section class="charts" aria-label="Runtime charts">
@@ -80,6 +106,6 @@
       </section>
     </main>
     <div id="tooltip" class="tooltip" hidden></div>
-    <script src="app.js?v=charts-v4"></script>
+    <script src="app.js?v=charts-v7"></script>
   </body>
 </html>

--- a/operator/hack/scale-dashboard/index.html
+++ b/operator/hack/scale-dashboard/index.html
@@ -22,7 +22,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Grove Scale Test</title>
-    <link rel="stylesheet" href="style.css?v=charts-v7">
+    <link rel="stylesheet" href="style.css?v=charts-v8">
   </head>
   <body>
     <main class="page">
@@ -106,6 +106,6 @@
       </section>
     </main>
     <div id="tooltip" class="tooltip" hidden></div>
-    <script src="app.js?v=charts-v7"></script>
+    <script src="app.js?v=charts-v8"></script>
   </body>
 </html>

--- a/operator/hack/scale-dashboard/style.css
+++ b/operator/hack/scale-dashboard/style.css
@@ -50,6 +50,11 @@ body {
   margin-bottom: 18px;
 }
 
+.title-area {
+  display: grid;
+  gap: 10px;
+}
+
 h1,
 h2,
 p {
@@ -67,7 +72,7 @@ h2 {
 
 #status {
   color: var(--muted);
-  margin-top: 4px;
+  margin: 0;
 }
 
 .button {
@@ -103,6 +108,47 @@ h2 {
   padding: 14px;
 }
 
+.control {
+  display: grid;
+  gap: 4px;
+}
+
+.date-range {
+  border: 0;
+  display: grid;
+  gap: 8px 12px;
+  grid-template-columns: repeat(2, minmax(150px, 1fr)) auto;
+  margin: 0;
+  padding: 0;
+}
+
+.date-range legend {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  grid-column: 1 / -1;
+  padding: 0;
+  text-transform: uppercase;
+}
+
+.clear-filter {
+  align-self: end;
+  background: #ffffff;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--accent-dark);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  height: 38px;
+  padding: 0 12px;
+  white-space: nowrap;
+}
+
+.clear-filter:hover {
+  background: #edf7f6;
+}
+
 label {
   color: var(--muted);
   display: grid;
@@ -112,8 +158,8 @@ label {
   text-transform: uppercase;
 }
 
-select {
-  appearance: none;
+select,
+input[type="date"] {
   background: #ffffff;
   border: 1px solid var(--line);
   border-radius: 6px;
@@ -121,6 +167,10 @@ select {
   font: inherit;
   height: 38px;
   padding: 0 10px;
+}
+
+select {
+  appearance: none;
 }
 
 .charts {
@@ -347,6 +397,14 @@ th:nth-child(3) {
 
   .controls {
     grid-template-columns: 1fr;
+  }
+
+  .date-range {
+    grid-template-columns: 1fr;
+  }
+
+  .clear-filter {
+    justify-self: start;
   }
 
   .chart-frame {

--- a/operator/hack/scale-dashboard/style.css
+++ b/operator/hack/scale-dashboard/style.css
@@ -230,6 +230,34 @@ select {
   white-space: nowrap;
 }
 
+.legend-toggle {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  gap: 6px;
+  padding: 2px 0;
+  white-space: nowrap;
+}
+
+.legend-toggle[aria-pressed="false"] {
+  color: #9aa4b3;
+  text-decoration: line-through;
+}
+
+.legend-toggle[aria-pressed="false"] i {
+  opacity: 0.35;
+}
+
+.legend-toggle:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .legend i {
   border-radius: 2px;
   display: inline-block;


### PR DESCRIPTION
Refs #550 

## Summary
- add an all-tests total-runtime overview with per-test colored series
- add header date-range filtering with clear/reset behavior
- retain selected-test detailed charts below

## Validation
- `node --check operator/hack/scale-dashboard/app.js`
- `git diff --check`
- verified date filtering against the current 60-run scale-test-history dataset

Before:
<img width="1217" height="828" alt="image" src="https://github.com/user-attachments/assets/ac893119-449f-4aca-8244-cd2694d602d9" />

After:
<img width="981" height="988" alt="image" src="https://github.com/user-attachments/assets/fa2fa1c2-beff-4703-9d05-de8613044f30" />
