### PR TITLE
fix: suppress MinAvailableBreached churn during initial schedule grace

### DIFF
--- a/operator/api/common/constants/constants.go
+++ b/operator/api/common/constants/constants.go
@@ -145,6 +145,11 @@ const (
 	ConditionReasonSufficientScheduledPods = "SufficientScheduledPods"
 	// ConditionReasonScheduledReplicasBelowMinAvailable indicates that scheduledReplicas is below MinAvailable but greater than zero.
 	ConditionReasonScheduledReplicasBelowMinAvailable = "ScheduledReplicasBelowMinAvailable"
+	// ConditionReasonAwaitingInitialSchedule indicates that no pods have been scheduled yet for a
+	// PodClique still within its InitialScheduleGrace window since creation. Treated as not-breached
+	// even though scheduledReplicas (0) is below MinAvailable, since this is the expected transient
+	// state right after creation and not yet a real regression.
+	ConditionReasonAwaitingInitialSchedule = "AwaitingInitialSchedule"
 	// ConditionReasonInsufficientAvailablePCSGReplicas indicates that the number of ready replicas in the PodCliqueScalingGroup is below the PodCliqueScalingGroupSpec.MinAvailable.
 	ConditionReasonInsufficientAvailablePCSGReplicas = "InsufficientAvailablePodCliqueScalingGroupReplicas"
 	// ConditionReasonSufficientAvailablePCSGReplicas indicates that the number of ready replicas in the PodCliqueScalingGroup is greater than or equal to the PodCliqueScalingGroupSpec.MinAvailable.

--- a/operator/internal/controller/podclique/reconciler.go
+++ b/operator/internal/controller/podclique/reconciler.go
@@ -86,5 +86,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return statusReconcileResult.Result()
 	}
 
-	return reconcileSpecFlowResult.Result()
+	result, err := reconcileSpecFlowResult.Result()
+	// reconcileStatus mutates pclq.Status.Conditions in place even when it only continues the
+	// flow, so this reads the MinAvailableBreached condition as of the reconcile that just ran.
+	// See minAvailableBreachedGraceRemaining for why this explicit requeue is needed: without
+	// it, a PodClique whose pods never get scheduled would never be reconciled again once its
+	// InitialScheduleGrace window elapses. Only tightens the requeue (never loosens one
+	// reconcileSpec already asked for), so reconcileSpec's own retry cadence is preserved as-is.
+	// Skipped when err != nil: controller-runtime ignores Result in that case and applies its
+	// own error backoff, so result.RequeueAfter would be dead/misleading to set here.
+	if err == nil {
+		if graceRemaining, graceActive := minAvailableBreachedGraceRemaining(pclq); graceActive &&
+			(result.RequeueAfter <= 0 || graceRemaining < result.RequeueAfter) {
+			result.RequeueAfter = graceRemaining
+		}
+	}
+	return result, err
 }

--- a/operator/internal/controller/podclique/reconcilestatus.go
+++ b/operator/internal/controller/podclique/reconcilestatus.go
@@ -17,6 +17,7 @@ package podclique
 import (
 	"context"
 	"fmt"
+	"time"
 
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	"github.com/ai-dynamo/grove/operator/api/common/constants"
@@ -71,9 +72,10 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 
 	// mutate the conditions only if the PodClique has been successfully reconciled at least once.
 	// This prevents prematurely setting incorrect conditions.
+	var minAvailableBreachedCondition metav1.Condition
 	if pclq.Status.ObservedGeneration != nil {
 		mutatePodCliqueScheduledCondition(pclq)
-		mutateMinAvailableBreachedCondition(pclq,
+		minAvailableBreachedCondition = mutateMinAvailableBreachedCondition(pclq,
 			len(podCategories[k8sutils.PodHasAtleastOneContainerWithNonZeroExitCode]),
 			len(podCategories[k8sutils.PodStartedButNotReady]))
 		r.emitAllScheduledReplicasLostIfNeeded(pclq, originalStatus.ScheduledReplicas)
@@ -92,15 +94,30 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 	// fires a watch event that wakes every controller observing PodCliques, which on a quiet
 	// cluster cascades into N spurious reconciles. equality.Semantic is needed (not plain
 	// ==) because the status mixes counters, pointers, conditions, and a label-selector map.
-	if equality.Semantic.DeepEqual(*originalStatus, pclq.Status) {
-		return ctrlcommon.ContinueReconcile()
+	statusChanged := !equality.Semantic.DeepEqual(*originalStatus, pclq.Status)
+	if statusChanged {
+		// update the PodClique status.
+		if err := r.client.Status().Patch(ctx, pclq, patch); err != nil {
+			logger.Error(err, "failed to update PodClique status")
+			return ctrlcommon.ReconcileWithErrors("failed to update PodClique status", err)
+		}
 	}
 
-	// update the PodClique status.
-	if err := r.client.Status().Patch(ctx, pclq, patch); err != nil {
-		logger.Error(err, "failed to update PodClique status")
-		return ctrlcommon.ReconcileWithErrors("failed to update PodClique status", err)
+	// While MinAvailableBreached is being held False purely because scheduledReplicas == 0 is
+	// still within InitialScheduleGrace, nothing else guarantees a follow-up reconcile once the
+	// grace window elapses: if the pods never get scheduled (e.g. insufficient capacity, a
+	// cordoned node), there is no further pod watch event to wake this reconciler, and the
+	// suppression would otherwise persist forever — silently reintroducing the exact bug the
+	// always-breach rule was written to fix. Explicitly requeue for when the grace window ends
+	// so the condition is re-evaluated even with zero new events.
+	if minAvailableBreachedCondition.Reason == constants.ConditionReasonAwaitingInitialSchedule {
+		remaining := time.Until(pclq.CreationTimestamp.Add(componentutils.InitialScheduleGrace))
+		if remaining <= 0 {
+			remaining = time.Second
+		}
+		return ctrlcommon.ReconcileAfter(remaining, "requeue to re-evaluate MinAvailableBreached once InitialScheduleGrace elapses")
 	}
+
 	return ctrlcommon.ContinueReconcile()
 }
 
@@ -206,12 +223,15 @@ func (r *Reconciler) emitAllScheduledReplicasLostIfNeeded(pclq *grovecorev1alpha
 	}
 }
 
-// mutateMinAvailableBreachedCondition updates the MinAvailableBreached condition based on pod availability
-func mutateMinAvailableBreachedCondition(pclq *grovecorev1alpha1.PodClique, numNotReadyPodsWithContainersInError, numPodsStartedButNotReady int) {
+// mutateMinAvailableBreachedCondition updates the MinAvailableBreached condition based on pod
+// availability and returns the condition that was computed (regardless of whether it changed),
+// so the caller can react to its Reason (see the InitialScheduleGrace requeue in reconcileStatus).
+func mutateMinAvailableBreachedCondition(pclq *grovecorev1alpha1.PodClique, numNotReadyPodsWithContainersInError, numPodsStartedButNotReady int) metav1.Condition {
 	newCondition := computeMinAvailableBreachedCondition(pclq, numNotReadyPodsWithContainersInError, numPodsStartedButNotReady)
 	if k8sutils.HasConditionChanged(pclq.Status.Conditions, newCondition) {
 		meta.SetStatusCondition(&pclq.Status.Conditions, newCondition)
 	}
+	return newCondition
 }
 
 // computeMinAvailableBreachedCondition calculates the MinAvailableBreached condition status based on pod availability

--- a/operator/internal/controller/podclique/reconcilestatus.go
+++ b/operator/internal/controller/podclique/reconcilestatus.go
@@ -230,13 +230,35 @@ func computeMinAvailableBreachedCondition(pclq *grovecorev1alpha1.PodClique, num
 	scheduledReplicas := int(pclq.Status.ScheduledReplicas)
 	now := metav1.Now()
 
-	// scheduledReplicas < MinAvailable always breaches. TerminationDelay (default 4h) is
-	// the natural grace window: during a normal startup the breach flickers True briefly
-	// and resolves before TerminationDelay; a workload that stays below MinAvailable past
-	// TerminationDelay is genuinely stuck and gang-terminating gives the scheduler a fresh
-	// PodGang to retry against the current cluster state. This covers both the partial-
-	// regression case (0 < scheduled < MinAvailable) and the full-regression case
-	// (scheduled == 0 after the workload was once healthy).
+	// scheduledReplicas < MinAvailable always breaches, with one exception: a brand-new
+	// PodClique whose pods have not been scheduled yet (scheduledReplicas == 0) within
+	// InitialScheduleGrace of creation. Without this exception, every PodClique writes a
+	// MinAvailableBreached=True condition on its very first status reconcile (pods are
+	// created but the scheduler hasn't placed them yet), which is expected and not a
+	// regression — but the condition write still bumps resourceVersion and cascades into
+	// reconciles on every controller watching PodCliques. Under sustained churn (many
+	// PodCliques created in a burst, e.g. a scale-up) this adds significant reconcile
+	// overhead for a condition that resolves within seconds anyway. Once the grace window
+	// elapses, scheduledReplicas == 0 breaches normally like any other case — a workload
+	// that loses all its pods after being healthy must still breach so gang termination can
+	// eventually recycle it (this was the bug the always-breach rule fixed).
+	//
+	// TerminationDelay (default 4h) is the natural grace window for the breach->terminate
+	// action itself: during a normal startup the breach flickers True briefly and resolves
+	// before TerminationDelay; a workload that stays below MinAvailable past TerminationDelay
+	// is genuinely stuck and gang-terminating gives the scheduler a fresh PodGang to retry
+	// against the current cluster state. This covers both the partial-regression case
+	// (0 < scheduled < MinAvailable) and the full-regression case (scheduled == 0 after the
+	// workload was once healthy).
+	if scheduledReplicas == 0 && isWithinInitialScheduleGrace(pclq, now) {
+		return metav1.Condition{
+			Type:               constants.ConditionTypeMinAvailableBreached,
+			Status:             metav1.ConditionFalse,
+			Reason:             constants.ConditionReasonAwaitingInitialSchedule,
+			Message:            "No pods scheduled yet; within initial scheduling grace window",
+			LastTransitionTime: now,
+		}
+	}
 	if scheduledReplicas < minAvailable {
 		return metav1.Condition{
 			Type:               constants.ConditionTypeMinAvailableBreached,
@@ -268,6 +290,14 @@ func computeMinAvailableBreachedCondition(pclq *grovecorev1alpha1.PodClique, num
 		Message:            fmt.Sprintf("Either sufficient ready or starting pods found. expected at least: %d, found: %d", minAvailable, readyOrStartingPods),
 		LastTransitionTime: now,
 	}
+}
+
+// isWithinInitialScheduleGrace reports whether now is still within InitialScheduleGrace of the
+// PodClique's creation. Mirrors the grace window used by WasPCLQEverScheduled for the same
+// apiserver-timing reason: absorb the gap between CreationTimestamp and the first reconcile that
+// observes scheduled pods.
+func isWithinInitialScheduleGrace(pclq *grovecorev1alpha1.PodClique, now metav1.Time) bool {
+	return now.Time.Before(pclq.CreationTimestamp.Add(componentutils.InitialScheduleGrace))
 }
 
 // mutatePodCliqueScheduledCondition updates the PodCliqueScheduled condition based on scheduled pod counts

--- a/operator/internal/controller/podclique/reconcilestatus.go
+++ b/operator/internal/controller/podclique/reconcilestatus.go
@@ -72,10 +72,9 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 
 	// mutate the conditions only if the PodClique has been successfully reconciled at least once.
 	// This prevents prematurely setting incorrect conditions.
-	var minAvailableBreachedCondition metav1.Condition
 	if pclq.Status.ObservedGeneration != nil {
 		mutatePodCliqueScheduledCondition(pclq)
-		minAvailableBreachedCondition = mutateMinAvailableBreachedCondition(pclq,
+		mutateMinAvailableBreachedCondition(pclq,
 			len(podCategories[k8sutils.PodHasAtleastOneContainerWithNonZeroExitCode]),
 			len(podCategories[k8sutils.PodStartedButNotReady]))
 		r.emitAllScheduledReplicasLostIfNeeded(pclq, originalStatus.ScheduledReplicas)
@@ -94,31 +93,37 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 	// fires a watch event that wakes every controller observing PodCliques, which on a quiet
 	// cluster cascades into N spurious reconciles. equality.Semantic is needed (not plain
 	// ==) because the status mixes counters, pointers, conditions, and a label-selector map.
-	statusChanged := !equality.Semantic.DeepEqual(*originalStatus, pclq.Status)
-	if statusChanged {
-		// update the PodClique status.
-		if err := r.client.Status().Patch(ctx, pclq, patch); err != nil {
-			logger.Error(err, "failed to update PodClique status")
-			return ctrlcommon.ReconcileWithErrors("failed to update PodClique status", err)
-		}
+	if equality.Semantic.DeepEqual(*originalStatus, pclq.Status) {
+		return ctrlcommon.ContinueReconcile()
 	}
 
-	// While MinAvailableBreached is being held False purely because scheduledReplicas == 0 is
-	// still within InitialScheduleGrace, nothing else guarantees a follow-up reconcile once the
-	// grace window elapses: if the pods never get scheduled (e.g. insufficient capacity, a
-	// cordoned node), there is no further pod watch event to wake this reconciler, and the
-	// suppression would otherwise persist forever — silently reintroducing the exact bug the
-	// always-breach rule was written to fix. Explicitly requeue for when the grace window ends
-	// so the condition is re-evaluated even with zero new events.
-	if minAvailableBreachedCondition.Reason == constants.ConditionReasonAwaitingInitialSchedule {
-		remaining := time.Until(pclq.CreationTimestamp.Add(componentutils.InitialScheduleGrace))
-		if remaining <= 0 {
-			remaining = time.Second
-		}
-		return ctrlcommon.ReconcileAfter(remaining, "requeue to re-evaluate MinAvailableBreached once InitialScheduleGrace elapses")
+	// update the PodClique status.
+	if err := r.client.Status().Patch(ctx, pclq, patch); err != nil {
+		logger.Error(err, "failed to update PodClique status")
+		return ctrlcommon.ReconcileWithErrors("failed to update PodClique status", err)
 	}
-
 	return ctrlcommon.ContinueReconcile()
+}
+
+// minAvailableBreachedGraceRemaining reports how much longer the MinAvailableBreached condition
+// is being suppressed for scheduledReplicas == 0 within InitialScheduleGrace of pclq's creation
+// (see computeMinAvailableBreachedCondition). Reads pclq.Status.Conditions as already mutated by
+// reconcileStatus in this same reconcile pass, so it reflects the condition that was (or would
+// have been, if the status patch was skipped as a no-op) just computed. Callers use this to
+// schedule an explicit follow-up reconcile: without it, a PodClique whose pods never get
+// scheduled (e.g. a cordoned node) would never receive another pod watch event, and the
+// suppression would persist forever — silently reintroducing the bug the always-breach rule in
+// computeMinAvailableBreachedCondition was written to fix.
+func minAvailableBreachedGraceRemaining(pclq *grovecorev1alpha1.PodClique) (time.Duration, bool) {
+	cond := meta.FindStatusCondition(pclq.Status.Conditions, constants.ConditionTypeMinAvailableBreached)
+	if cond == nil || cond.Reason != constants.ConditionReasonAwaitingInitialSchedule {
+		return 0, false
+	}
+	remaining := time.Until(pclq.CreationTimestamp.Add(componentutils.InitialScheduleGrace))
+	if remaining <= 0 {
+		remaining = time.Second
+	}
+	return remaining, true
 }
 
 // mutateCurrentHashes updates the PodClique's current template and generation hashes when updates are complete

--- a/operator/internal/controller/podclique/reconcilestatus_test.go
+++ b/operator/internal/controller/podclique/reconcilestatus_test.go
@@ -479,6 +479,56 @@ func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testin
 			wantStatus: metav1.ConditionTrue,
 			wantReason: constants.ConditionReasonScheduledReplicasBelowMinAvailable,
 		},
+		{
+			// scheduled == 0 immediately after creation, still inside InitialScheduleGrace,
+			// must NOT breach — this is the churn-storm case: a burst of newly created
+			// PodCliques (e.g. a scale-up) would otherwise all write MinAvailableBreached=True
+			// on their very first status reconcile before the scheduler has had a chance to
+			// place any pod, cascading into extra reconciles across every PCLQ observer.
+			name: "fresh PCLQ within InitialScheduleGrace — not yet breached",
+			pclq: &grovecorev1alpha1.PodClique{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: grovecorev1alpha1.PodCliqueSpec{
+					Replicas:     3,
+					MinAvailable: ptr.To(int32(3)),
+				},
+				Status: grovecorev1alpha1.PodCliqueStatus{
+					ObservedGeneration: ptr.To(int64(1)),
+					Replicas:           3,
+					ScheduledReplicas:  0,
+					ReadyReplicas:      0,
+				},
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: constants.ConditionReasonAwaitingInitialSchedule,
+		},
+		{
+			// scheduled == 0 and InitialScheduleGrace has elapsed: the grace exception no
+			// longer applies and the always-breach rule from #614 takes over unchanged. This
+			// is the regression case #614 fixed — a workload that never manages to schedule
+			// (or loses all pods after being healthy) must still breach so TerminationDelay
+			// can eventually recycle it.
+			name: "PCLQ past InitialScheduleGrace still unscheduled — breaches",
+			pclq: &grovecorev1alpha1.PodClique{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: pastTransition,
+				},
+				Spec: grovecorev1alpha1.PodCliqueSpec{
+					Replicas:     3,
+					MinAvailable: ptr.To(int32(3)),
+				},
+				Status: grovecorev1alpha1.PodCliqueStatus{
+					ObservedGeneration: ptr.To(int64(1)),
+					Replicas:           3,
+					ScheduledReplicas:  0,
+					ReadyReplicas:      0,
+				},
+			},
+			wantStatus: metav1.ConditionTrue,
+			wantReason: constants.ConditionReasonScheduledReplicasBelowMinAvailable,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`SoakChurn` benchmark duration regressed ~35% (737.87s → 999.54s) over commits that changed `PodClique` breach detection so that `MinAvailableBreached` now flips to `True` on a `PodClique`'s very first status reconcile — before the scheduler has placed any of its pods (`scheduledReplicas == 0`). Previously this transient startup state produced no status write.

`SoakChurn` scales a `PodCliqueSet` between `SOAK_BASE` (25) and `SOAK_PEAK` (50) replicas over 10 cycles. Each scale-up burst creates ~25 brand-new `PodClique`s that all start at `scheduledReplicas=0`, so each now triggers an extra condition transition + status `Patch`, bumping `resourceVersion` and firing a watch event that cascades into extra reconciles on every controller observing `PodCliques` (`PodCliqueScalingGroup`, `PodCliqueSet`). Across 10 cycles × ~25 new replicas per cycle this adds significant reconcile/API-server overhead, consistent with the observed ~260s increase.

This PR reintroduces a suppression for that specific transient case, bounded to a short grace window after creation (`InitialScheduleGrace`, 5s — reusing the existing pattern from `componentutils`), rather than suppressing indefinitely:
- `scheduledReplicas == 0` **within** `InitialScheduleGrace` of creation → not breached.
- `scheduledReplicas == 0` **past** `InitialScheduleGrace`, or any `0 < scheduledReplicas < MinAvailable` → breaches as before, unchanged.

This keeps accurate breach detection for workloads that are genuinely stuck or that regress after being healthy (so gang-termination still eventually recycles them), while eliminating the burst of condition writes during ordinary scale-up.

The PCSG-level formula reads each PCLQ's already-computed `MinAvailableBreached` condition rather than re-deriving `scheduledReplicas == 0` itself, so it inherits this fix without a separate change.

#### Which issue(s) this PR fixes:

Fixes #781

#### Special notes for your reviewer:

- Could not reproduce the exact benchmark numbers locally in this environment (cluster bootstrap via `skaffold build` / `helm install kai-scheduler` did not complete in time), so this fix is validated at the unit level only:
  - `go build ./...`, `go vet ./...` clean.
  - `go test ./internal/controller/podclique/... ./internal/controller/podcliquescalinggroup/...` passes, including two new cases in `reconcilestatus_test.go`: within-grace/unscheduled → not breached, and past-grace/unscheduled → still breaches (regression coverage for both directions).
- Recommend validating against the live dashboard with a reduced run before merge: `make scale-cluster-up && make run-soak-test SOAK_BASE=5 SOAK_PEAK=10 SOAK_CYCLES=3`.

#### Does this PR introduce a API change?

```release-note
NONE
```
```Additional documentation e.g., enhancement proposals, usage docs, etc.:
```