### PR TITLE
[Fix #782]: key generation-hash expectation by PCS UID

### DIFF
--- a/operator/internal/controller/podcliqueset/reconciledelete.go
+++ b/operator/internal/controller/podcliqueset/reconciledelete.go
@@ -52,6 +52,8 @@ func (r *Reconciler) triggerDeletionFlow(ctx context.Context, logger logr.Logger
 		}
 	}
 	logger.Info("PodCliqueSet finalizer removed; Kubernetes garbage collector will cascade-delete owned resources")
+	// Remove the in-memory generation-hash expectation so the map does not retain an entry for a deleted PodCliqueSet.
+	r.pcsGenerationHashExpectations.Delete(pcsGenerationHashKey(pcs))
 	return ctrlcommon.DoNotRequeue()
 }
 

--- a/operator/internal/controller/podcliqueset/reconcilespec.go
+++ b/operator/internal/controller/podcliqueset/reconcilespec.go
@@ -32,7 +32,6 @@ import (
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -72,18 +71,18 @@ func (r *Reconciler) ensureFinalizer(ctx context.Context, logger logr.Logger, pc
 // changed from the previously persisted pcs.status.generationHash then it resets the pcs.status.updateProgress
 func (r *Reconciler) processGenerationHashChange(ctx context.Context, logger logr.Logger, pcs *grovecorev1alpha1.PodCliqueSet) ctrlcommon.ReconcileStepResult {
 	pcsObjectKey := client.ObjectKeyFromObject(pcs)
-	pcsObjectName := cache.NamespacedNameAsObjectName(pcsObjectKey).String()
+	pcsGenHashKey := pcsGenerationHashKey(pcs)
 
 	// if the generationHash is not reflected correctly yet, requeue. Allow the informer cache to catch-up.
-	if !r.isGenerationHashExpectationSatisfied(pcsObjectName, pcs.Status.CurrentGenerationHash) {
+	if !r.isGenerationHashExpectationSatisfied(pcsGenHashKey, pcs.Status.CurrentGenerationHash) {
 		return ctrlcommon.ReconcileAfter(constants.ComponentSyncRetryInterval, fmt.Sprintf("CurrentGenerationHash is not up-to-date for PodCliqueSet: %v", pcsObjectKey))
 	}
-	r.pcsGenerationHashExpectations.Delete(pcsObjectName)
+	r.pcsGenerationHashExpectations.Delete(pcsGenHashKey)
 
 	newGenerationHash := computeGenerationHash(pcs)
 	if pcs.Status.CurrentGenerationHash == nil {
 		// update the generation hash and continue reconciliation. No rolling update is required.
-		if err := r.setGenerationHashAndUpdateStatus(ctx, pcs, pcsObjectName, newGenerationHash); err != nil {
+		if err := r.setGenerationHashAndUpdateStatus(ctx, pcs, pcsGenHashKey, newGenerationHash); err != nil {
 			logger.Error(err, "failed to set generation hash on PCS", "newGenerationHash", newGenerationHash)
 			return ctrlcommon.ReconcileWithErrors("error updating generation hash", err)
 		}
@@ -92,7 +91,7 @@ func (r *Reconciler) processGenerationHashChange(ctx context.Context, logger log
 
 	if newGenerationHash != *pcs.Status.CurrentGenerationHash {
 		// trigger rolling update by setting or overriding pcs.Status.UpdateProgress.
-		if err := r.initUpdateProgress(ctx, pcs, pcsObjectName, newGenerationHash); err != nil {
+		if err := r.initUpdateProgress(ctx, pcs, pcsGenHashKey, newGenerationHash); err != nil {
 			return ctrlcommon.ReconcileWithErrors(fmt.Sprintf("could not triggering rolling update for PCS: %v", pcsObjectKey), err)
 		}
 	}
@@ -100,9 +99,18 @@ func (r *Reconciler) processGenerationHashChange(ctx context.Context, logger log
 	return ctrlcommon.ContinueReconcile()
 }
 
+// pcsGenerationHashKey returns the key for the in-memory generation-hash expectation of a PCS.
+// The key scheme is <pcs-namespace>/<pcs-name>/<pcs-UID>. Suffixing a UID ensures that a stale
+// remnant expectation entry for the same <pcs-namespace>/<pcs-name> does not block reconciliation of
+// a new PCS (with a different UID).
+// See https://github.com/ai-dynamo/grove/issues/782 for context.
+func pcsGenerationHashKey(pcs *grovecorev1alpha1.PodCliqueSet) string {
+	return fmt.Sprintf("%s/%s", client.ObjectKeyFromObject(pcs), pcs.UID)
+}
+
 // isGenerationHashExpectationSatisfied checks if the current generation hash matches expectations.
-func (r *Reconciler) isGenerationHashExpectationSatisfied(pcsObjectName string, pcsGenerationHash *string) bool {
-	expectedGenerationHash, ok := r.pcsGenerationHashExpectations.Load(pcsObjectName)
+func (r *Reconciler) isGenerationHashExpectationSatisfied(pcsGenHashKey string, pcsGenerationHash *string) bool {
+	expectedGenerationHash, ok := r.pcsGenerationHashExpectations.Load(pcsGenHashKey)
 	return !ok || (pcsGenerationHash != nil && expectedGenerationHash.(string) == *pcsGenerationHash)
 }
 
@@ -123,17 +131,17 @@ func computeGenerationHash(pcs *grovecorev1alpha1.PodCliqueSet) string {
 }
 
 // setGenerationHashAndUpdateStatus updates the PodCliqueSet status with the new generation hash, stores the expectation, and updates the status subresource.
-func (r *Reconciler) setGenerationHashAndUpdateStatus(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet, pcsObjectName, generationHash string) error {
-	pcs.Status.CurrentGenerationHash = &generationHash
+func (r *Reconciler) setGenerationHashAndUpdateStatus(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet, pcsGenHashKey, newGenerationHash string) error {
+	pcs.Status.CurrentGenerationHash = &newGenerationHash
 	if err := r.client.Status().Update(ctx, pcs); err != nil {
 		return fmt.Errorf("could not update CurrentGenerationHash for PodCliqueSet: %v: %w", client.ObjectKeyFromObject(pcs), err)
 	}
-	r.pcsGenerationHashExpectations.Store(pcsObjectName, generationHash)
+	r.pcsGenerationHashExpectations.Store(pcsGenHashKey, newGenerationHash)
 	return nil
 }
 
 // initUpdateProgress initializes a new rolling update by resetting progress tracking.
-func (r *Reconciler) initUpdateProgress(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet, pcsObjectName, newGenerationHash string) error {
+func (r *Reconciler) initUpdateProgress(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet, pcsGenHashKey, newGenerationHash string) error {
 	pcs.Status.UpdateProgress = &grovecorev1alpha1.PodCliqueSetUpdateProgress{
 		UpdateStartedAt: metav1.Now(),
 	}
@@ -143,7 +151,7 @@ func (r *Reconciler) initUpdateProgress(ctx context.Context, pcs *grovecorev1alp
 	}
 	pcs.Status.UpdatedReplicas = 0
 	pcs.Status.CurrentGenerationHash = &newGenerationHash
-	if err := r.setGenerationHashAndUpdateStatus(ctx, pcs, pcsObjectName, newGenerationHash); err != nil {
+	if err := r.setGenerationHashAndUpdateStatus(ctx, pcs, pcsGenHashKey, newGenerationHash); err != nil {
 		return fmt.Errorf("could not set UpdateProgress for PodCliqueSet: %v: %w", client.ObjectKeyFromObject(pcs), err)
 	}
 	return nil

--- a/operator/internal/controller/podcliqueset/reconcilespec_test.go
+++ b/operator/internal/controller/podcliqueset/reconcilespec_test.go
@@ -20,7 +20,9 @@ import (
 	"testing"
 	"time"
 
+	apiconstants "github.com/ai-dynamo/grove/operator/api/common/constants"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	ctrlcommon "github.com/ai-dynamo/grove/operator/internal/controller/common"
 	"github.com/ai-dynamo/grove/operator/internal/controller/common/component"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
@@ -300,4 +302,60 @@ func TestInitUpdateProgress(t *testing.T) {
 			assert.Equal(t, newGenerationHash, *updatedPCS.Status.CurrentGenerationHash)
 		})
 	}
+}
+
+// TestPCSGenerationHashKey verifies the generation-hash expectation key includes the PCS UID so two
+// PodCliqueSets with the same namespace and name but different UIDs do not share a key.
+func TestPCSGenerationHashKey(t *testing.T) {
+	pcs1 := testutils.NewPodCliqueSetBuilder(testPCSName, testNamespace, "uid-1").Build()
+	pcs2 := testutils.NewPodCliqueSetBuilder(testPCSName, testNamespace, "uid-2").Build()
+
+	key1 := pcsGenerationHashKey(pcs1)
+
+	assert.Equal(t, testNamespace+"/"+testPCSName+"/uid-1", key1)
+	assert.NotEqual(t, key1, pcsGenerationHashKey(pcs2))
+}
+
+// TestProcessGenerationHashChangeNotBlockedByStaleSameNameExpectation verifies that an expectation
+// left by a previously deployed PodCliqueSet does not block a newly created
+// PodCliqueSet with a different UID but with the same name as the previously deployed PodCliqueSet.
+func TestProcessGenerationHashChangeNotBlockedByStaleSameNameExpectation(t *testing.T) {
+	newPCS := testutils.NewPodCliqueSetBuilder(testPCSName, testNamespace, "uid-new").
+		WithPodCliqueParameters("worker", 1, nil).
+		Build()
+
+	fakeClient := testutils.SetupFakeClient(newPCS)
+	r := &Reconciler{client: fakeClient, pcsGenerationHashExpectations: sync.Map{}}
+	// A previous incarnation with a different UID left a stale expectation in the map.
+	stalePCS := testutils.NewPodCliqueSetBuilder(testPCSName, testNamespace, "uid-old").Build()
+	r.pcsGenerationHashExpectations.Store(pcsGenerationHashKey(stalePCS), "stale-hash")
+
+	result := r.processGenerationHashChange(context.Background(), logr.Discard(), newPCS)
+
+	require.False(t, result.NeedsRequeue(), "a same-name recreate must not be blocked by a stale expectation")
+	updated := &grovecorev1alpha1.PodCliqueSet{}
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(newPCS), updated))
+	assert.NotNil(t, updated.Status.CurrentGenerationHash, "generation hash should be set on the new PCS")
+}
+
+// TestTriggerDeletionFlowClearsGenerationHashExpectation verifies the deletion flow removes the PCS
+// generation-hash expectation from the in-memory map.
+func TestTriggerDeletionFlowClearsGenerationHashExpectation(t *testing.T) {
+	pcs := testutils.NewPodCliqueSetBuilder(testPCSName, testNamespace, "uid-del").Build()
+	pcs.Finalizers = []string{apiconstants.FinalizerPodCliqueSet}
+
+	fakeClient := testutils.SetupFakeClient(pcs)
+	r := &Reconciler{
+		client:                        fakeClient,
+		operatorRegistry:              component.NewOperatorRegistry[grovecorev1alpha1.PodCliqueSet](),
+		reconcileStatusRecorder:       ctrlcommon.NewReconcileErrorRecorder(fakeClient),
+		pcsGenerationHashExpectations: sync.Map{},
+	}
+	key := pcsGenerationHashKey(pcs)
+	r.pcsGenerationHashExpectations.Store(key, "some-hash")
+
+	r.triggerDeletionFlow(context.Background(), logr.Discard(), pcs)
+
+	_, present := r.pcsGenerationHashExpectations.Load(key)
+	assert.False(t, present, "generation-hash expectation should be cleared when the PCS is deleted")
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api
-->
/kind bug

#### What this PR does / why we need it:

The in-memory generation-hash expectation was keyed by namespace/name and was never removed when a PodCliqueSet was deleted. A PodCliqueSet deleted while an expectation was still cached left a stale entry, and a new PodCliqueSet created with the same name (a different UID, an empty CurrentGenerationHash) matched that entry, so processGenerationHashChange requeued forever and never created its children.

Fix: In-memory expectation store for PCS generation now suffixes the PCS UID (`namespace/name/UID`)  so a recreated PodCliqueSet does not inherit an entry for the previously deployed PCS (with the same name + namespace). In addition in the deletion flow of the PCS, entry for the PCS is removed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #782 

#### Special notes for your reviewer:

#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix:  Stale in-memory generation-hash expectation that could block reconciliation of a same-named PodCliqueSet after delete-and-recreate
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
