### PR TITLE
fix #775: Prevent stuck MinAvailableBreached on PCLQ resources

### DIFF
--- a/operator/internal/constants/constants.go
+++ b/operator/internal/constants/constants.go
@@ -30,6 +30,7 @@ const (
 	// PodCliqueStatusResyncInterval is how often a PodClique is re-reconciled after a successful
 	// status reconcile even without a watch event. A status field left stale by a lost update is
 	// recomputed from a fresh cache and corrected within this interval.
+	// See https://github.com/ai-dynamo/grove/issues/775 for the analysis.
 	PodCliqueStatusResyncInterval = 3 * time.Minute
 	// EnvVarServiceAccountName is the name of the environment variable that stores the serviceAccountName of the operator pod.
 	EnvVarServiceAccountName = "GROVE_OPERATOR_SERVICE_ACCOUNT_NAME"

--- a/operator/internal/constants/constants.go
+++ b/operator/internal/constants/constants.go
@@ -27,6 +27,10 @@ const (
 	OperatorNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 	// ComponentSyncRetryInterval is a retry interval with which a reconcile request will be requeued.
 	ComponentSyncRetryInterval = 5 * time.Second
+	// PodCliqueStatusResyncInterval is how often a PodClique is re-reconciled after a successful
+	// status reconcile even without a watch event. A status field left stale by a lost update is
+	// recomputed from a fresh cache and corrected within this interval.
+	PodCliqueStatusResyncInterval = 3 * time.Minute
 	// EnvVarServiceAccountName is the name of the environment variable that stores the serviceAccountName of the operator pod.
 	EnvVarServiceAccountName = "GROVE_OPERATOR_SERVICE_ACCOUNT_NAME"
 )

--- a/operator/internal/controller/common/flow.go
+++ b/operator/internal/controller/common/flow.go
@@ -44,7 +44,7 @@ func (r ReconcileStepResult) Result() (ctrl.Result, error) {
 // NeedsRequeue returns true if the reconcile step needs to be requeued.
 // This will happen if there is an error or if the result is marked to be requeued.
 func (r ReconcileStepResult) NeedsRequeue() bool {
-	return len(r.errs) > 0 || r.result.Requeue || r.result.RequeueAfter > 0
+	return len(r.errs) > 0 || r.result.RequeueAfter > 0
 }
 
 // HasErrors returns true if there are errors from the reconcile step.
@@ -66,7 +66,7 @@ func (r ReconcileStepResult) GetDescription() string {
 func DoNotRequeue() ReconcileStepResult {
 	return ReconcileStepResult{
 		continueReconcile: false,
-		result:            ctrl.Result{Requeue: false},
+		result:            ctrl.Result{},
 	}
 }
 
@@ -74,7 +74,7 @@ func DoNotRequeue() ReconcileStepResult {
 func RecordErrorAndDoNotRequeue(description string, errs ...error) ReconcileStepResult {
 	return ReconcileStepResult{
 		continueReconcile: false,
-		result:            ctrl.Result{Requeue: false},
+		result:            ctrl.Result{},
 		errs:              errs,
 		description:       description,
 	}
@@ -110,4 +110,33 @@ func ReconcileAfter(duration time.Duration, description string) ReconcileStepRes
 // ShortCircuitReconcileFlow returns true if the reconcile flow should be short-circuited and not continue.
 func ShortCircuitReconcileFlow(result ReconcileStepResult) bool {
 	return !result.continueReconcile
+}
+
+// MergeStepResults unifies two reconcile step results into one, keeping the most urgent outcome.
+// Errors from either result are retained so the controller retries and no error is masked by a
+// requeue. When neither result has errors, the sooner of the two requeue delays is kept so a slower
+// periodic requeue never delays a faster pending one. The merged result continues the flow only
+// when both results continue.
+func MergeStepResults(first, second ReconcileStepResult) ReconcileStepResult {
+	allErrs := make([]error, 0, len(first.errs)+len(second.errs))
+	allErrs = append(allErrs, first.errs...)
+	allErrs = append(allErrs, second.errs...)
+	return ReconcileStepResult{
+		continueReconcile: first.continueReconcile && second.continueReconcile,
+		errs:              allErrs,
+		result:            ctrl.Result{RequeueAfter: earliestRequeueAfter(first.result.RequeueAfter, second.result.RequeueAfter)},
+	}
+}
+
+// earliestRequeueAfter returns the sooner of two requeue delays. A zero delay means no requeue was
+// requested, so it is ignored unless both are zero.
+func earliestRequeueAfter(a, b time.Duration) time.Duration {
+	switch {
+	case a == 0:
+		return b
+	case b == 0:
+		return a
+	default:
+		return min(a, b)
+	}
 }

--- a/operator/internal/controller/common/flow_test.go
+++ b/operator/internal/controller/common/flow_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -30,12 +31,12 @@ func TestReconcileStepResult(t *testing.T) {
 		err1 := errors.New("error 1")
 		err2 := errors.New("error 2")
 		result := ReconcileStepResult{
-			result: ctrl.Result{Requeue: true},
+			result: ctrl.Result{RequeueAfter: 5 * time.Second},
 			errs:   []error{err1, err2},
 		}
 
 		r, err := result.Result()
-		assert.True(t, r.Requeue)
+		assert.Equal(t, 5*time.Second, r.RequeueAfter)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "error 1")
 		assert.Contains(t, err.Error(), "error 2")
@@ -45,14 +46,6 @@ func TestReconcileStepResult(t *testing.T) {
 	t.Run("NeedsRequeue with errors", func(t *testing.T) {
 		result := ReconcileStepResult{
 			errs: []error{errors.New("some error")},
-		}
-		assert.True(t, result.NeedsRequeue())
-	})
-
-	// Test NeedsRequeue with Requeue flag
-	t.Run("NeedsRequeue with requeue flag", func(t *testing.T) {
-		result := ReconcileStepResult{
-			result: ctrl.Result{Requeue: true},
 		}
 		assert.True(t, result.NeedsRequeue())
 	})
@@ -68,7 +61,7 @@ func TestReconcileStepResult(t *testing.T) {
 	// Test NeedsRequeue returns false
 	t.Run("NeedsRequeue false", func(t *testing.T) {
 		result := ReconcileStepResult{
-			result: ctrl.Result{Requeue: false},
+			result: ctrl.Result{},
 		}
 		assert.False(t, result.NeedsRequeue())
 	})
@@ -114,7 +107,7 @@ func TestDoNotRequeue(t *testing.T) {
 	result := DoNotRequeue()
 
 	assert.False(t, result.continueReconcile)
-	assert.False(t, result.result.Requeue)
+	assert.Zero(t, result.result.RequeueAfter)
 	assert.False(t, result.NeedsRequeue())
 	assert.False(t, result.HasErrors())
 }
@@ -126,7 +119,7 @@ func TestRecordErrorAndDoNotRequeue(t *testing.T) {
 	result := RecordErrorAndDoNotRequeue("test description", err1, err2)
 
 	assert.False(t, result.continueReconcile)
-	assert.False(t, result.result.Requeue)
+	assert.Zero(t, result.result.RequeueAfter)
 	assert.True(t, result.HasErrors())
 	assert.Len(t, result.GetErrors(), 2)
 	assert.Equal(t, "test description", result.GetDescription())
@@ -193,4 +186,70 @@ func TestShortCircuitReconcileFlow(t *testing.T) {
 		result := ReconcileAfter(5*time.Second, "requeue")
 		assert.True(t, ShortCircuitReconcileFlow(result))
 	})
+}
+
+// TestMergeStepResults verifies that merging two step results keeps errors from either result,
+// keeps the sooner of the two requeues, and continues only when both results continue.
+func TestMergeStepResults(t *testing.T) {
+	errSpec := errors.New("spec failed")
+	errStatus := errors.New("status failed")
+
+	tests := []struct {
+		name             string
+		first            ReconcileStepResult
+		second           ReconcileStepResult
+		wantContinue     bool
+		wantErrContains  []string
+		wantRequeueAfter time.Duration
+	}{
+		{
+			name:         "both continue with no requeue",
+			first:        ContinueReconcile(),
+			second:       ContinueReconcile(),
+			wantContinue: true,
+		},
+		{
+			name:             "shorter requeue of the two wins",
+			first:            ReconcileAfter(5*time.Second, "spec"),
+			second:           ReconcileAfter(3*time.Minute, "status resync"),
+			wantRequeueAfter: 5 * time.Second,
+		},
+		{
+			name:             "requeue from one, continue from the other",
+			first:            ReconcileAfter(5*time.Second, "spec"),
+			second:           ContinueReconcile(),
+			wantRequeueAfter: 5 * time.Second,
+		},
+		{
+			name:            "errors from either result are kept",
+			first:           ReconcileWithErrors("spec", errSpec),
+			second:          ReconcileWithErrors("status", errStatus),
+			wantErrContains: []string{"spec failed", "status failed"},
+		},
+		{
+			name:             "spec error is kept even when status requeues",
+			first:            ReconcileWithErrors("spec", errSpec),
+			second:           ReconcileAfter(5*time.Second, "status conflict"),
+			wantErrContains:  []string{"spec failed"},
+			wantRequeueAfter: 5 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			merged := MergeStepResults(tt.first, tt.second)
+			res, err := merged.Result()
+
+			assert.Equal(t, tt.wantContinue, !ShortCircuitReconcileFlow(merged), "continue mismatch")
+			assert.Equal(t, tt.wantRequeueAfter, res.RequeueAfter, "RequeueAfter mismatch")
+			if len(tt.wantErrContains) == 0 {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				for _, want := range tt.wantErrContains {
+					assert.Contains(t, err.Error(), want)
+				}
+			}
+		})
+	}
 }

--- a/operator/internal/controller/podclique/reconciler.go
+++ b/operator/internal/controller/podclique/reconciler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ai-dynamo/grove/operator/api/common/constants"
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	internalconstants "github.com/ai-dynamo/grove/operator/internal/constants"
 	ctrlcommon "github.com/ai-dynamo/grove/operator/internal/controller/common"
 	"github.com/ai-dynamo/grove/operator/internal/controller/common/component"
 	componentutils "github.com/ai-dynamo/grove/operator/internal/controller/common/component/utils"
@@ -82,9 +83,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	reconcileSpecFlowResult := r.reconcileSpec(ctx, logger, pclq)
-	if statusReconcileResult := r.reconcileStatus(ctx, logger, pclq); ctrlcommon.ShortCircuitReconcileFlow(statusReconcileResult) {
-		return statusReconcileResult.Result()
-	}
+	statusReconcileResult := r.reconcileStatus(ctx, logger, pclq)
+	reconcileResult := ctrlcommon.MergeStepResults(reconcileSpecFlowResult, statusReconcileResult)
 
-	return reconcileSpecFlowResult.Result()
+	result, err := reconcileResult.Result()
+	// Neither flow requested a requeue, so schedule the periodic status resync as a backstop that
+	// recomputes a status left stale by a lost update. This is applied here rather than in
+	// reconcileStatus so it cannot mask a shorter requeue from the spec flow, which drives
+	// rolling-update progression. A longer resync overriding that shorter requeue would delay the
+	// update by a full interval.
+	// See https://github.com/ai-dynamo/grove/issues/775.
+	if err == nil && result.RequeueAfter == 0 {
+		result.RequeueAfter = internalconstants.PodCliqueStatusResyncInterval
+	}
+	return result, err
 }

--- a/operator/internal/controller/podclique/reconciler.go
+++ b/operator/internal/controller/podclique/reconciler.go
@@ -16,11 +16,12 @@ package podclique
 
 import (
 	"context"
+	"time"
 
-	"github.com/ai-dynamo/grove/operator/api/common/constants"
+	apicommonconstants "github.com/ai-dynamo/grove/operator/api/common/constants"
 	configv1alpha1 "github.com/ai-dynamo/grove/operator/api/config/v1alpha1"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
-	internalconstants "github.com/ai-dynamo/grove/operator/internal/constants"
+	"github.com/ai-dynamo/grove/operator/internal/constants"
 	ctrlcommon "github.com/ai-dynamo/grove/operator/internal/controller/common"
 	"github.com/ai-dynamo/grove/operator/internal/controller/common/component"
 	componentutils "github.com/ai-dynamo/grove/operator/internal/controller/common/component/utils"
@@ -76,7 +77,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	if !pclq.DeletionTimestamp.IsZero() {
-		if !controllerutil.ContainsFinalizer(pclq, constants.FinalizerPodClique) {
+		if !controllerutil.ContainsFinalizer(pclq, apicommonconstants.FinalizerPodClique) {
 			return ctrlcommon.DoNotRequeue().Result()
 		}
 		return r.triggerDeletionFlow(ctx, logger, pclq).Result()
@@ -87,14 +88,29 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	reconcileResult := ctrlcommon.MergeStepResults(reconcileSpecFlowResult, statusReconcileResult)
 
 	result, err := reconcileResult.Result()
-	// Neither flow requested a requeue, so schedule the periodic status resync as a backstop that
-	// recomputes a status left stale by a lost update. This is applied here rather than in
-	// reconcileStatus so it cannot mask a shorter requeue from the spec flow, which drives
-	// rolling-update progression. A longer resync overriding that shorter requeue would delay the
-	// update by a full interval.
+	// The spec and status reconciles both succeeded without asking for a requeue. Schedule a periodic
+	// status resync so a stale status is corrected even when no watch event arrives. A lost update can
+	// leave the status wrong with nothing left to trigger a recompute. This is applied here, not in
+	// reconcileStatus, so it cannot mask a shorter requeue from the spec flow that drives
+	// rolling-update progression.
 	// See https://github.com/ai-dynamo/grove/issues/775.
 	if err == nil && result.RequeueAfter == 0 {
-		result.RequeueAfter = internalconstants.PodCliqueStatusResyncInterval
+		result.RequeueAfter = r.getStatusResyncInterval(ctx, pclq)
 	}
 	return result, err
+}
+
+// getStatusResyncInterval returns the requeue interval for a successful reconcile. It is the periodic
+// status resync bounded by the owner PodCliqueSet's TerminationDelay. Gang termination is armed off
+// the MinAvailableBreached condition this reconciler writes. A stale condition must be recomputed
+// before the delay expires, else the breach goes undetected past its termination deadline. It falls
+// back to the plain resync interval when the owner PodCliqueSet cannot be read or sets no
+// TerminationDelay.
+func (r *Reconciler) getStatusResyncInterval(ctx context.Context, pclq *grovecorev1alpha1.PodClique) time.Duration {
+	defaultResyncInterval := constants.PodCliqueStatusResyncInterval
+	pcs, err := componentutils.GetPodCliqueSet(ctx, r.client, pclq.ObjectMeta)
+	if err != nil || pcs.Spec.Template.TerminationDelay == nil {
+		return defaultResyncInterval
+	}
+	return min(pcs.Spec.Template.TerminationDelay.Duration, defaultResyncInterval)
 }

--- a/operator/internal/controller/podclique/reconciler_test.go
+++ b/operator/internal/controller/podclique/reconciler_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podclique
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	testutils "github.com/ai-dynamo/grove/operator/test/utils"
+
+	"github.com/stretchr/testify/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestGetStatusResyncInterval(t *testing.T) {
+	const (
+		pcsName   = "pcs"
+		namespace = "default"
+	)
+	// expected values are literals, not constants.PodCliqueStatusResyncInterval, so the test does not
+	// pass by construction. A change to the resync interval must consciously update these.
+	tests := []struct {
+		name             string
+		terminationDelay *time.Duration
+		getPCSFails      bool
+		expected         time.Duration
+	}{
+		{
+			name:             "TerminationDelay shorter than the resync interval bounds the interval",
+			terminationDelay: ptr.To(2 * time.Minute),
+			expected:         2 * time.Minute,
+		},
+		{
+			name:             "TerminationDelay longer than the resync interval keeps the resync interval",
+			terminationDelay: ptr.To(4 * time.Hour),
+			expected:         3 * time.Minute,
+		},
+		{
+			name:             "no TerminationDelay falls back to the resync interval",
+			terminationDelay: nil,
+			expected:         3 * time.Minute,
+		},
+		{
+			name:        "PodCliqueSet fetch failure falls back to the resync interval",
+			getPCSFails: true,
+			expected:    3 * time.Minute,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pcsBuilder := testutils.NewPodCliqueSetBuilder(pcsName, namespace, "uid")
+			if tt.terminationDelay != nil {
+				pcsBuilder.WithTerminationDelay(*tt.terminationDelay)
+			}
+			pcs := pcsBuilder.Build()
+			pclq := testutils.NewPodCliqueBuilder(pcsName, "uid", "clq", namespace, 0).Build()
+
+			clientBuilder := testutils.NewTestClientBuilder().WithObjects(pcs, pclq)
+			if tt.getPCSFails {
+				clientBuilder.RecordErrorForObjects(testutils.ClientMethodGet,
+					apierrors.NewInternalError(errors.New("boom")),
+					client.ObjectKey{Name: pcsName, Namespace: namespace})
+			}
+			r := &Reconciler{client: clientBuilder.Build()}
+
+			actual := r.getStatusResyncInterval(context.Background(), pclq)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/operator/internal/controller/podclique/reconcilestatus.go
+++ b/operator/internal/controller/podclique/reconcilestatus.go
@@ -29,7 +29,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -40,11 +40,12 @@ import (
 func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pclq *grovecorev1alpha1.PodClique) ctrlcommon.ReconcileStepResult {
 	pcsName := componentutils.GetPodCliqueSetName(pclq.ObjectMeta)
 	pclqObjectKey := client.ObjectKeyFromObject(pclq)
-	// Snapshot status for both the merge-patch base AND a change check below. When the
-	// status is unchanged — common during steady-state reconciles — we skip the API call
-	// entirely.
+	// originalStatus captures the scheduled replica count before the mutators run so the
+	// scheduled to zero transition can be detected later. The patch uses an optimistic lock
+	// so a write built from a stale cached PodClique is rejected with a conflict instead of
+	// overwriting a newer status.
 	originalStatus := pclq.Status.DeepCopy()
-	patch := client.MergeFrom(pclq.DeepCopy())
+	patch := client.MergeFromWithOptions(pclq.DeepCopy(), client.MergeFromWithOptimisticLock{})
 
 	pcs, err := componentutils.GetPodCliqueSet(ctx, r.client, pclq.ObjectMeta)
 	if err != nil {
@@ -85,19 +86,11 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 		return ctrlcommon.ReconcileWithErrors("failed to set selector for PodClique", err)
 	}
 
-	// Skip the status patch when every mutate* above left status byte-identical to what the
-	// previous reconcile already persisted. The mutators above are the only code that writes
-	// pclq.Status in this path, so equality means there is nothing for the apiserver to
-	// store. Issuing the Patch anyway is not just wasted RPC; it bumps resourceVersion and
-	// fires a watch event that wakes every controller observing PodCliques, which on a quiet
-	// cluster cascades into N spurious reconciles. equality.Semantic is needed (not plain
-	// ==) because the status mixes counters, pointers, conditions, and a label-selector map.
-	if equality.Semantic.DeepEqual(*originalStatus, pclq.Status) {
-		return ctrlcommon.ContinueReconcile()
-	}
-
 	// update the PodClique status.
 	if err := r.client.Status().Patch(ctx, pclq, patch); err != nil {
+		if apierrors.IsConflict(err) {
+			return ctrlcommon.ReconcileAfter(internalconstants.ComponentSyncRetryInterval, fmt.Sprintf("409-conflict when updating PodClique status, re-queueing: %v", pclqObjectKey))
+		}
 		logger.Error(err, "failed to update PodClique status")
 		return ctrlcommon.ReconcileWithErrors("failed to update PodClique status", err)
 	}

--- a/operator/internal/controller/podclique/reconcilestatus.go
+++ b/operator/internal/controller/podclique/reconcilestatus.go
@@ -29,6 +29,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -86,6 +87,15 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 		return ctrlcommon.ReconcileWithErrors("failed to set selector for PodClique", err)
 	}
 
+	// Skip the patch when the mutators left the status byte-identical to what is already persisted.
+	// The API server no-ops an identical write, but it still receives, decodes and validates the
+	// request. Skipping avoids that cost, which matters at scale where pod events drive many
+	// reconciles. equality.Semantic is used because the status mixes counters, pointers, conditions
+	// and a label-selector map.
+	if equality.Semantic.DeepEqual(*originalStatus, pclq.Status) {
+		return ctrlcommon.ReconcileAfter(internalconstants.PodCliqueStatusResyncInterval, fmt.Sprintf("periodic status resync for PodClique: %v", pclqObjectKey))
+	}
+
 	// update the PodClique status.
 	if err := r.client.Status().Patch(ctx, pclq, patch); err != nil {
 		if apierrors.IsConflict(err) {
@@ -94,7 +104,7 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 		logger.Error(err, "failed to update PodClique status")
 		return ctrlcommon.ReconcileWithErrors("failed to update PodClique status", err)
 	}
-	return ctrlcommon.ContinueReconcile()
+	return ctrlcommon.ReconcileAfter(internalconstants.PodCliqueStatusResyncInterval, fmt.Sprintf("periodic status resync for PodClique: %v", pclqObjectKey))
 }
 
 // mutateCurrentHashes updates the PodClique's current template and generation hashes when updates are complete

--- a/operator/internal/controller/podclique/reconcilestatus.go
+++ b/operator/internal/controller/podclique/reconcilestatus.go
@@ -87,23 +87,21 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 		return ctrlcommon.ReconcileWithErrors("failed to set selector for PodClique", err)
 	}
 
-	// Skip the patch when the mutators left the status byte-identical to what is already persisted.
-	// The API server no-ops an identical write, but it still receives, decodes and validates the
-	// request. Skipping avoids that cost, which matters at scale where pod events drive many
-	// reconciles. equality.Semantic is used because the status mixes counters, pointers, conditions
-	// and a label-selector map.
-	if equality.Semantic.DeepEqual(*originalStatus, pclq.Status) {
-		return ctrlcommon.ReconcileAfter(internalconstants.PodCliqueStatusResyncInterval, fmt.Sprintf("periodic status resync for PodClique: %v", pclqObjectKey))
-	}
-
-	// update the PodClique status.
-	if err := r.client.Status().Patch(ctx, pclq, patch); err != nil {
-		if apierrors.IsConflict(err) {
-			return ctrlcommon.ReconcileAfter(internalconstants.ComponentSyncRetryInterval, fmt.Sprintf("409-conflict when updating PodClique status, re-queueing: %v", pclqObjectKey))
+	// Patch only when the mutators changed the status. The API server no-ops an identical write, but
+	// it still receives, decodes and validates the request. Skipping avoids that cost, which matters
+	// at scale where pod events drive many reconciles. equality.Semantic is used because the status
+	// mixes counters, pointers, conditions and a label-selector map.
+	if !equality.Semantic.DeepEqual(*originalStatus, pclq.Status) {
+		if err := r.client.Status().Patch(ctx, pclq, patch); err != nil {
+			if apierrors.IsConflict(err) {
+				return ctrlcommon.ReconcileAfter(internalconstants.ComponentSyncRetryInterval, fmt.Sprintf("409-conflict when updating PodClique status, re-queueing: %v", pclqObjectKey))
+			}
+			logger.Error(err, "failed to update PodClique status")
+			return ctrlcommon.ReconcileWithErrors("failed to update PodClique status", err)
 		}
-		logger.Error(err, "failed to update PodClique status")
-		return ctrlcommon.ReconcileWithErrors("failed to update PodClique status", err)
 	}
+	// Requeue after a fixed interval so a status left stale by a lost update is recomputed from a
+	// fresh cache and corrected even when no watch event fires.
 	return ctrlcommon.ReconcileAfter(internalconstants.PodCliqueStatusResyncInterval, fmt.Sprintf("periodic status resync for PodClique: %v", pclqObjectKey))
 }
 

--- a/operator/internal/controller/podclique/reconcilestatus.go
+++ b/operator/internal/controller/podclique/reconcilestatus.go
@@ -100,9 +100,8 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 			return ctrlcommon.ReconcileWithErrors("failed to update PodClique status", err)
 		}
 	}
-	// Requeue after a fixed interval so a status left stale by a lost update is recomputed from a
-	// fresh cache and corrected even when no watch event fires.
-	return ctrlcommon.ReconcileAfter(internalconstants.PodCliqueStatusResyncInterval, fmt.Sprintf("periodic status resync for PodClique: %v", pclqObjectKey))
+
+	return ctrlcommon.ContinueReconcile()
 }
 
 // mutateCurrentHashes updates the PodClique's current template and generation hashes when updates are complete

--- a/operator/internal/controller/podclique/reconcilestatus_test.go
+++ b/operator/internal/controller/podclique/reconcilestatus_test.go
@@ -244,13 +244,62 @@ func TestReconcileStatusConvergesWhenReadyPodMatchesDesiredHash(t *testing.T) {
 
 	result := r.reconcileStatus(context.Background(), logr.Discard(), pclq)
 
-	_, err := result.Result()
+	res, err := result.Result()
 	require.NoError(t, err)
+	assert.Equal(t, internalconstants.PodCliqueStatusResyncInterval, res.RequeueAfter,
+		"a successful status reconcile should requeue after PodCliqueStatusResyncInterval")
 	updatedPCLQ := &grovecorev1alpha1.PodClique{}
 	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: pclq.Name, Namespace: pclq.Namespace}, updatedPCLQ))
 	assert.Equal(t, int32(1), updatedPCLQ.Status.UpdatedReplicas)
 	assert.Equal(t, templateHash, *updatedPCLQ.Status.CurrentPodTemplateHash)
 	assert.Equal(t, *pcs.Status.CurrentGenerationHash, *updatedPCLQ.Status.CurrentPodCliqueSetGenerationHash)
+}
+
+// TestReconcileStatusRequeuesWithoutPatchWhenStatusUnchanged verifies that when a reconcile
+// recomputes a status identical to what is already persisted, reconcileStatus skips the patch but
+// still requeues after PodCliqueStatusResyncInterval. The periodic requeue lets a stale status left
+// by a lost update be recomputed from a fresh cache even when no watch event fires.
+func TestReconcileStatusRequeuesWithoutPatchWhenStatusUnchanged(t *testing.T) {
+	pcs, pclq, templateHash := newPodCliqueHashConvergenceFixture(t)
+	pclq.Generation = 1
+	pclq.Spec = grovecorev1alpha1.PodCliqueSpec{Replicas: 1, MinAvailable: ptr.To[int32](1)}
+	pclq.Status = grovecorev1alpha1.PodCliqueStatus{ObservedGeneration: ptr.To[int64](1)}
+	pod := createReadyOwnedPodWithHash("ready-pod", pclq, templateHash)
+
+	cl := testutils.NewTestClientBuilder().
+		WithObjects(pcs, pclq, pod).
+		WithStatusSubresource(pcs, pclq).
+		WithIndex(&corev1.Pod{}, ".metadata.controller.uid", func(obj client.Object) []string {
+			controllerRef := metav1.GetControllerOfNoCopy(obj)
+			if controllerRef == nil {
+				return nil
+			}
+			return []string{string(controllerRef.UID)}
+		}).
+		Build()
+	r := &Reconciler{client: cl, eventRecorder: record.NewFakeRecorder(1)}
+
+	// The first reconcile persists the computed status.
+	first := r.reconcileStatus(context.Background(), logr.Discard(), pclq)
+	require.False(t, first.HasErrors())
+
+	// Re-fetch so the in-memory object matches what is persisted, then reconcile again. The mutators
+	// recompute an identical status, so the equality guard skips the patch.
+	refetched := &grovecorev1alpha1.PodClique{}
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: pclq.Name, Namespace: pclq.Namespace}, refetched))
+	rvBefore := refetched.ResourceVersion
+
+	second := r.reconcileStatus(context.Background(), logr.Discard(), refetched)
+
+	res, err := second.Result()
+	require.NoError(t, err)
+	assert.Equal(t, internalconstants.PodCliqueStatusResyncInterval, res.RequeueAfter,
+		"an unchanged status reconcile should still requeue after PodCliqueStatusResyncInterval")
+
+	// No patch was issued, so the resourceVersion is unchanged.
+	after := &grovecorev1alpha1.PodClique{}
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: pclq.Name, Namespace: pclq.Namespace}, after))
+	assert.Equal(t, rvBefore, after.ResourceVersion, "no status patch should be issued when the status is unchanged")
 }
 
 // TestMutateCurrentHashesDoesNotAdvanceWhenTemplateHashIsStale verifies that

--- a/operator/internal/controller/podclique/reconcilestatus_test.go
+++ b/operator/internal/controller/podclique/reconcilestatus_test.go
@@ -244,10 +244,8 @@ func TestReconcileStatusConvergesWhenReadyPodMatchesDesiredHash(t *testing.T) {
 
 	result := r.reconcileStatus(context.Background(), logr.Discard(), pclq)
 
-	res, err := result.Result()
+	_, err := result.Result()
 	require.NoError(t, err)
-	assert.Equal(t, internalconstants.PodCliqueStatusResyncInterval, res.RequeueAfter,
-		"a successful status reconcile should requeue after PodCliqueStatusResyncInterval")
 	updatedPCLQ := &grovecorev1alpha1.PodClique{}
 	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: pclq.Name, Namespace: pclq.Namespace}, updatedPCLQ))
 	assert.Equal(t, int32(1), updatedPCLQ.Status.UpdatedReplicas)
@@ -256,9 +254,9 @@ func TestReconcileStatusConvergesWhenReadyPodMatchesDesiredHash(t *testing.T) {
 }
 
 // TestReconcileStatusRequeuesWithoutPatchWhenStatusUnchanged verifies that when a reconcile
-// recomputes a status identical to what is already persisted, reconcileStatus skips the patch but
-// still requeues after PodCliqueStatusResyncInterval. The periodic requeue lets a stale status left
-// by a lost update be recomputed from a fresh cache even when no watch event fires.
+// recomputes a status identical to what is already persisted, reconcileStatus skips the patch and
+// returns without requesting a requeue. The periodic resync that recovers a stale status is applied
+// by the top-level Reconcile, not by reconcileStatus.
 func TestReconcileStatusRequeuesWithoutPatchWhenStatusUnchanged(t *testing.T) {
 	pcs, pclq, templateHash := newPodCliqueHashConvergenceFixture(t)
 	pclq.Generation = 1
@@ -291,10 +289,10 @@ func TestReconcileStatusRequeuesWithoutPatchWhenStatusUnchanged(t *testing.T) {
 
 	second := r.reconcileStatus(context.Background(), logr.Discard(), refetched)
 
+	require.False(t, second.HasErrors())
 	res, err := second.Result()
 	require.NoError(t, err)
-	assert.Equal(t, internalconstants.PodCliqueStatusResyncInterval, res.RequeueAfter,
-		"an unchanged status reconcile should still requeue after PodCliqueStatusResyncInterval")
+	assert.Zero(t, res.RequeueAfter, "an unchanged status reconcile should not requeue from reconcileStatus")
 
 	// No patch was issued, so the resourceVersion is unchanged.
 	after := &grovecorev1alpha1.PodClique{}

--- a/operator/internal/controller/podclique/reconcilestatus_test.go
+++ b/operator/internal/controller/podclique/reconcilestatus_test.go
@@ -16,6 +16,7 @@ package podclique
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -30,10 +31,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // TestMutateUpdatedReplica tests the mutateUpdatedReplica function across different PodClique states
@@ -491,6 +495,47 @@ func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testin
 			assert.Equal(t, tt.wantReason, condition.Reason, "MinAvailableBreached reason mismatch")
 		})
 	}
+}
+
+// TestReconcileStatusRequeuesOnConflict verifies that when the optimistic-locked status patch is
+// rejected with a conflict, reconcileStatus requeues after ComponentSyncRetryInterval instead of
+// surfacing a hard error. A conflict means the PodClique was written by a concurrent reconcile
+// after this reconcile read it, so retrying against a fresher PodClique prevents a stale write
+// from silently winning. See https://github.com/ai-dynamo/grove/issues/775.
+func TestReconcileStatusRequeuesOnConflict(t *testing.T) {
+	pcs, pclq, templateHash := newPodCliqueHashConvergenceFixture(t)
+	pclq.Generation = 1
+	pclq.Spec = grovecorev1alpha1.PodCliqueSpec{
+		Replicas:     1,
+		MinAvailable: ptr.To[int32](1),
+	}
+	pclq.Status = grovecorev1alpha1.PodCliqueStatus{ObservedGeneration: ptr.To[int64](1)}
+	pod := createReadyOwnedPodWithHash("ready-pod", pclq, templateHash)
+
+	conflict := apierrors.NewConflict(
+		schema.GroupResource{Group: grovecorev1alpha1.SchemeGroupVersion.Group, Resource: "podcliques"},
+		pclq.Name, errors.New("object was modified"))
+	cl := testutils.NewTestClientBuilder().
+		WithObjects(pcs, pclq, pod).
+		WithStatusSubresource(pcs, pclq).
+		WithIndex(&corev1.Pod{}, ".metadata.controller.uid", func(obj client.Object) []string {
+			controllerRef := metav1.GetControllerOfNoCopy(obj)
+			if controllerRef == nil {
+				return nil
+			}
+			return []string{string(controllerRef.UID)}
+		}).
+		RecordErrorForObjects(testutils.ClientMethodStatusPatch, conflict, client.ObjectKeyFromObject(pclq)).
+		Build()
+	r := &Reconciler{client: cl, eventRecorder: record.NewFakeRecorder(1)}
+
+	result := r.reconcileStatus(context.Background(), logr.Discard(), pclq)
+
+	require.False(t, result.HasErrors(), "a conflicting status patch must not surface as a reconcile error")
+	res, err := result.Result()
+	require.NoError(t, err)
+	assert.Equal(t, internalconstants.ComponentSyncRetryInterval, res.RequeueAfter,
+		"a conflicting status patch should requeue after ComponentSyncRetryInterval")
 }
 
 // TestMutateSelector verifies the /scale selector is published for standalone PodCliques (with or

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
@@ -33,6 +33,7 @@ import (
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -52,7 +53,7 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 	}
 
 	originalStatus := pcsg.Status.DeepCopy()
-	patchObj := client.MergeFrom(pcsg.DeepCopy())
+	patchObj := client.MergeFromWithOptions(pcsg.DeepCopy(), client.MergeFromWithOptimisticLock{})
 
 	pcs, err := componentutils.GetPodCliqueSet(ctx, r.client, pcsg.ObjectMeta)
 	if err != nil {
@@ -83,18 +84,18 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 
 	mutateCurrentPodCliqueSetGenerationHash(logger, pcs, pcsg, lo.Flatten(lo.Values(pclqsPerPCSGReplica)))
 
-	// Skip the status patch when every mutate* above left status byte-identical to what the
-	// previous reconcile already persisted. The mutators are the only code writing
-	// pcsg.Status here, so equality means there is nothing for the apiserver to store.
-	// Issuing the Patch anyway bumps resourceVersion and fires a watch event that wakes the
-	// parent PCS reconciler and any other PCSG observers, cascading into spurious
-	// reconciles. equality.Semantic is required because the status mixes counters,
-	// pointers, conditions, and a label-selector map.
+	// Skip the patch when the mutators left the status byte-identical to what is already persisted.
+	// The API server no-ops an identical write, but it still receives, decodes and validates the
+	// request. Skipping avoids that cost. equality.Semantic is used because the status mixes counters,
+	// pointers, conditions and a label-selector map.
 	if equality.Semantic.DeepEqual(*originalStatus, pcsg.Status) {
 		return ctrlcommon.ContinueReconcile()
 	}
 
 	if err = r.client.Status().Patch(ctx, pcsg, patchObj); err != nil {
+		if apierrors.IsConflict(err) {
+			return ctrlcommon.ReconcileAfter(internalconstants.ComponentSyncRetryInterval, fmt.Sprintf("409-conflict when updating PodCliqueScalingGroup status, re-queueing: %v", pcsgObjectKey))
+		}
 		logger.Error(err, "failed to update PodCliqueScalingGroup status")
 		return ctrlcommon.ReconcileWithErrors("failed to update the status with label selector and replicas", err)
 	}

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
@@ -84,20 +84,17 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 
 	mutateCurrentPodCliqueSetGenerationHash(logger, pcs, pcsg, lo.Flatten(lo.Values(pclqsPerPCSGReplica)))
 
-	// Skip the patch when the mutators left the status byte-identical to what is already persisted.
-	// The API server no-ops an identical write, but it still receives, decodes and validates the
-	// request. Skipping avoids that cost. equality.Semantic is used because the status mixes counters,
-	// pointers, conditions and a label-selector map.
-	if equality.Semantic.DeepEqual(*originalStatus, pcsg.Status) {
-		return ctrlcommon.ContinueReconcile()
-	}
-
-	if err = r.client.Status().Patch(ctx, pcsg, patchObj); err != nil {
-		if apierrors.IsConflict(err) {
-			return ctrlcommon.ReconcileAfter(internalconstants.ComponentSyncRetryInterval, fmt.Sprintf("409-conflict when updating PodCliqueScalingGroup status, re-queueing: %v", pcsgObjectKey))
+	// Patch only when the mutators changed the status. The API server no-ops an identical write, but
+	// it still receives, decodes and validates the request. Skipping avoids that cost. equality.Semantic
+	// is used because the status mixes counters, pointers, conditions and a label-selector map.
+	if !equality.Semantic.DeepEqual(*originalStatus, pcsg.Status) {
+		if err = r.client.Status().Patch(ctx, pcsg, patchObj); err != nil {
+			if apierrors.IsConflict(err) {
+				return ctrlcommon.ReconcileAfter(internalconstants.ComponentSyncRetryInterval, fmt.Sprintf("409-conflict when updating PodCliqueScalingGroup status, re-queueing: %v", pcsgObjectKey))
+			}
+			logger.Error(err, "failed to update PodCliqueScalingGroup status")
+			return ctrlcommon.ReconcileWithErrors("failed to update the status with label selector and replicas", err)
 		}
-		logger.Error(err, "failed to update PodCliqueScalingGroup status")
-		return ctrlcommon.ReconcileWithErrors("failed to update the status with label selector and replicas", err)
 	}
 
 	return ctrlcommon.ContinueReconcile()

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus_test.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus_test.go
@@ -16,6 +16,7 @@ package podcliquescalinggroup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -30,7 +31,9 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
@@ -960,6 +963,38 @@ func TestReconcileStatusBoundedDuringScaleDown(t *testing.T) {
 	assert.LessOrEqual(t, pcsg.Status.UpdateProgress.UpdatedPodCliquesCount,
 		pcsg.Status.UpdateProgress.TotalPodCliquesCount,
 		"UpdatedPodCliquesCount must never exceed TotalPodCliquesCount")
+}
+
+// TestReconcileStatusRequeuesOnConflict verifies that when the optimistic-locked status patch is
+// rejected with a conflict, reconcileStatus requeues after ComponentSyncRetryInterval instead of
+// surfacing a hard error. A conflict means the PodCliqueScalingGroup was written by a concurrent
+// reconcile after this reconcile read it, so retrying against a fresher object prevents a stale
+// write from silently winning. See https://github.com/ai-dynamo/grove/issues/775.
+func TestReconcileStatusRequeuesOnConflict(t *testing.T) {
+	ctx := context.Background()
+	pcsg := testutils.NewPodCliqueScalingGroupBuilder("test-pcsg", "test-ns", "test-pcs", 0).
+		WithReplicas(1).
+		Build()
+	pcsg.Status.ObservedGeneration = ptr.To[int64](1)
+	pcs := testutils.NewPodCliqueSetBuilder("test-pcs", "test-ns", uuid.NewUUID()).Build()
+
+	conflict := apierrors.NewConflict(
+		schema.GroupResource{Group: grovecorev1alpha1.SchemeGroupVersion.Group, Resource: "podcliquescalinggroups"},
+		pcsg.Name, errors.New("object was modified"))
+	cl := testutils.NewTestClientBuilder().
+		WithObjects(pcsg, pcs).
+		WithStatusSubresource(&grovecorev1alpha1.PodCliqueScalingGroup{}).
+		RecordErrorForObjects(testutils.ClientMethodStatusPatch, conflict, client.ObjectKeyFromObject(pcsg)).
+		Build()
+	reconciler := &Reconciler{client: cl, eventRecorder: record.NewFakeRecorder(1)}
+
+	result := reconciler.reconcileStatus(ctx, logr.Discard(), client.ObjectKeyFromObject(pcsg))
+
+	require.False(t, result.HasErrors(), "a conflicting status patch must not surface as a reconcile error")
+	res, err := result.Result()
+	require.NoError(t, err)
+	assert.Equal(t, internalconstants.ComponentSyncRetryInterval, res.RequeueAfter,
+		"a conflicting status patch should requeue after ComponentSyncRetryInterval")
 }
 
 func pcsgChildName(pcsgName string, replicaIndex int, cliqueName string) string {

--- a/operator/test/utils/client.go
+++ b/operator/test/utils/client.go
@@ -48,10 +48,10 @@ const (
 	ClientMethodPatch ClientMethod = "Patch"
 	// ClientMethodUpdate is the name of the Update method on client.Client.
 	ClientMethodUpdate ClientMethod = "Update"
-	// ClientMethodStatus is the name of the Status method on client.Client.StatusClient.
-	ClientMethodStatus ClientMethod = "Status"
-	// ClientMethodApply is the name of the Apply method on client.Client.
-	ClientMethodApply ClientMethod = "Apply"
+	// ClientMethodStatusPatch is the name of the Patch method on the status subresource writer.
+	ClientMethodStatusPatch ClientMethod = "StatusPatch"
+	// ClientMethodStatusUpdate is the name of the Update method on the status subresource writer.
+	ClientMethodStatusUpdate ClientMethod = "StatusUpdate"
 )
 
 // TestClientBuilder is a builder for creating a test client.Client which is capable of recording and replaying errors.
@@ -149,6 +149,13 @@ func (b *TestClientBuilder) WithStatusSubresource(objs ...client.Object) *TestCl
 	if len(objs) > 0 {
 		b.delegatingClientBuilder.WithStatusSubresource(objs...)
 	}
+	return b
+}
+
+// WithIndex registers a field index on the delegating fake client so that List calls using a
+// field selector on that field are served.
+func (b *TestClientBuilder) WithIndex(obj client.Object, field string, extractValue client.IndexerFunc) *TestClientBuilder {
+	b.delegatingClientBuilder.WithIndex(obj, field, extractValue)
 	return b
 }
 
@@ -274,7 +281,7 @@ func (c *testClient) Apply(ctx context.Context, applyConfig runtime.ApplyConfigu
 }
 
 func (c *testClient) Status() client.StatusWriter {
-	return c.delegate.Status()
+	return &testStatusWriter{testClient: c, delegate: c.delegate.Status()}
 }
 
 func (c *testClient) SubResource(subResource string) client.SubResourceClient {
@@ -295,6 +302,35 @@ func (c *testClient) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersio
 
 func (c *testClient) IsObjectNamespaced(obj runtime.Object) (bool, error) {
 	return c.delegate.IsObjectNamespaced(obj)
+}
+
+// testStatusWriter wraps the delegate status writer and reacts to errors recorded for the
+// StatusPatch and StatusUpdate methods before delegating to the underlying fake client.
+type testStatusWriter struct {
+	testClient *testClient
+	delegate   client.SubResourceWriter
+}
+
+func (w *testStatusWriter) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	return w.delegate.Create(ctx, obj, subResource, opts...)
+}
+
+func (w *testStatusWriter) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+	return w.delegate.Apply(ctx, obj, opts...)
+}
+
+func (w *testStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	if err := w.testClient.getRecordedObjectError(ClientMethodStatusUpdate, client.ObjectKeyFromObject(obj)); err != nil {
+		return err
+	}
+	return w.delegate.Update(ctx, obj, opts...)
+}
+
+func (w *testStatusWriter) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	if err := w.testClient.getRecordedObjectError(ClientMethodStatusPatch, client.ObjectKeyFromObject(obj)); err != nil {
+		return err
+	}
+	return w.delegate.Patch(ctx, obj, patch, opts...)
 }
 
 // ---------------------------------- Helper methods ----------------------------------


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api
-->
/kind bug

#### What this PR does / why we need it:
Issue description: https://github.com/ai-dynamo/grove/issues/775#issuecomment-5344927136
In this PR we implemented `change-2` and `change-3` as describe at https://github.com/ai-dynamo/grove/issues/775#issuecomment-5351694208

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #775 

#### Special notes for your reviewer:

#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a bug where a PodClique could remain stuck with MinAvailableBreached=True after its pods became Ready, causing unnecessary gang termination. Status updates now use optimistic locking so a write based on a stale cache is retried against current state instead of silently persisting or being skipped. (#775)
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
