### PR TITLE
fix: wait for updated pods before ending rollouts

### DIFF
--- a/operator/internal/controller/podclique/components/pod/rollingupdate.go
+++ b/operator/internal/controller/podclique/components/pod/rollingupdate.go
@@ -129,7 +129,22 @@ func (r _resource) processPendingUpdates(logger logr.Logger, sc *syncContext) er
 		)
 	}
 
-	// If the control comes here, then mark the end of update.
+	// Old non-ready pods are deleted eagerly and do not go through the
+	// ready-pod selection flow above. Wait for every desired replacement to
+	// become Ready before closing the update, otherwise UpdateEndedAt can be
+	// set while the new generation is still starting or crash-looping.
+	if int32(len(updateWork.newTemplateHashReadyPods)) < pclq.Spec.Replicas {
+		return groveerr.New(
+			groveerr.ErrCodeContinueReconcileAndRequeue,
+			component.OperationSync,
+			fmt.Sprintf(
+				"waiting for updated pods to become ready before marking update end: %d ready, need %d",
+				len(updateWork.newTemplateHashReadyPods),
+				pclq.Spec.Replicas,
+			),
+		)
+	}
+
 	return r.markRollingUpdateEnd(sc.ctx, logger, pclq)
 }
 

--- a/operator/internal/controller/podclique/components/pod/rollingupdate_test.go
+++ b/operator/internal/controller/podclique/components/pod/rollingupdate_test.go
@@ -17,16 +17,21 @@ limitations under the License.
 package pod
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/ai-dynamo/grove/operator/api/common"
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/ai-dynamo/grove/operator/internal/expect"
+	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 )
 
@@ -89,6 +94,82 @@ func TestComputeUpdateWork(t *testing.T) {
 					assert.Empty(t, pods, fmt.Sprintf("expected no pods in bucket %s", name))
 				}
 			}
+		})
+	}
+}
+
+func TestProcessPendingUpdatesWaitsForAllUpdatedPodsReady(t *testing.T) {
+	tests := []struct {
+		name            string
+		pods            []*corev1.Pod
+		wantRequeue     bool
+		wantReadyDetail string
+	}{
+		{
+			name: "one of two updated pods ready with minAvailable one",
+			pods: []*corev1.Pod{
+				newTestPod("new-ready", testNewHash, withPhase(corev1.PodRunning), withReadyCondition(), withContainerStatus(ptr.To(true), true)),
+				newTestPod("new-crash-looping", testNewHash, withPhase(corev1.PodRunning), withErroneousExit()),
+			},
+			wantRequeue:     true,
+			wantReadyDetail: "1 ready, need 2",
+		},
+		{
+			name: "all updated pods ready",
+			pods: []*corev1.Pod{
+				newTestPod("new-ready-0", testNewHash, withPhase(corev1.PodRunning), withReadyCondition(), withContainerStatus(ptr.To(true), true)),
+				newTestPod("new-ready-1", testNewHash, withPhase(corev1.PodRunning), withReadyCondition(), withContainerStatus(ptr.To(true), true)),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pclq := &grovecorev1alpha1.PodClique{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pclq",
+					Namespace: testNS,
+				},
+				Spec: grovecorev1alpha1.PodCliqueSpec{
+					Replicas:     2,
+					MinAvailable: ptr.To[int32](1),
+				},
+				Status: grovecorev1alpha1.PodCliqueStatus{
+					UpdateProgress: &grovecorev1alpha1.PodCliqueUpdateProgress{
+						UpdateStartedAt:            metav1.Now(),
+						PodCliqueSetGenerationHash: "new-generation-hash",
+						PodTemplateHash:            testNewHash,
+					},
+				},
+			}
+			cl := testutils.SetupFakeClient(pclq)
+			r := _resource{
+				client:            cl,
+				expectationsStore: expect.NewExpectationsStore(),
+			}
+			sc := &syncContext{
+				ctx:                      context.Background(),
+				pclq:                     pclq,
+				existingPCLQPods:         tt.pods,
+				expectedPodTemplateHash:  testNewHash,
+				pclqExpectationsStoreKey: "test-key",
+			}
+
+			err := r.processPendingUpdates(logr.Discard(), sc)
+			updatedPCLQ := &grovecorev1alpha1.PodClique{}
+			require.NoError(t, cl.Get(context.Background(), types.NamespacedName{
+				Name: pclq.Name, Namespace: pclq.Namespace,
+			}, updatedPCLQ))
+
+			if tt.wantRequeue {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantReadyDetail)
+				assert.Nil(t, updatedPCLQ.Status.UpdateProgress.UpdateEndedAt)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, updatedPCLQ.Status.UpdateProgress.UpdateEndedAt)
 		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`RollingRecreate` eagerly deletes old-template pods that are Pending, unhealthy, still starting, or otherwise not Ready. These pods bypass the normal ready-pod selection flow used for healthy old replicas.

After deleting those non-ready pods, `processPendingUpdates()` can currently find no remaining old-pod work and set `UpdateEndedAt` before all replacement pods with the target template hash are Ready. This makes the rollout appear complete while the new generation may still be starting or crash-looping.

This PR keeps `UpdateProgress` open until every desired target-template pod is Ready:

```text
ready target-template pods >= spec.replicas
```

The completion threshold intentionally uses `spec.replicas`, not `minAvailable`. `minAvailable` is the availability floor used to decide whether Grove may disrupt the next healthy old pod; it does not mean that a rollout with only a subset of its desired replicas Ready has completed.

This addresses the remaining premature-completion behavior described in #315.

The original `UpdatedReplicas`/current-hash self-lock from #315 has since been addressed by #671, which calculates target-hash `UpdatedReplicas` before advancing the current hashes.

Regression coverage includes a two-replica PodClique with `minAvailable: 1`, where one target-template pod is Ready and the other is crash-looping. The update remains open until both desired replicas are Ready.

#### Which issue(s) this PR fixes:

closes #786

#### Special notes for your reviewer:

The relevant failure sequence is:

```text
old non-ready pods are deleted eagerly
    → they do not enter ready-pod selection tracking
    → no old-pod update work remains
    → UpdateEndedAt is set before replacements are Ready
```

The new behavior is:

```text
old non-ready pods are deleted eagerly
    → wait for all desired target-template pods to become Ready
    → set UpdateEndedAt
```

This is intentionally stricter than the earlier proposed `newReady >= minAvailable` check. For example, with `replicas: 2` and `minAvailable: 1`, one Ready pod plus one crash-looping pod must not be considered a completed rollout.

Tests run:

```text
go test ./internal/controller/podclique/components/pod
go test ./internal/controller/podclique/...
```

Both passed.

AI assistance was used to investigate the production failure, review the relevant Grove history, and prepare the initial patch and tests. The submitter reviewed the resulting behavior and every changed line.

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```