### PR TITLE
GREP-0677 prototype: scale-to-zero component hibernation

### DIFF
--- a/docs/api-reference/operator-api.md
+++ b/docs/api-reference/operator-api.md
@@ -357,6 +357,8 @@ _Appears in:_
 
 
 PodCliqueScalingGroupSpec is the specification of the PodCliqueScalingGroup.
+GREP-0677: replicas must be 0 (intentional idle state) or at least minAvailable; positive
+below-quorum values are rejected. This runs on create, update, and the scale subresource.
 
 
 
@@ -568,6 +570,8 @@ _Appears in:_
 
 
 PodCliqueSpec defines the specification of a PodClique.
+GREP-0677: replicas must be 0 (intentional idle state) or at least minAvailable; positive
+below-quorum values are rejected. This runs on create, update, and the scale subresource.
 
 
 
@@ -579,7 +583,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `roleName` _string_ | RoleName is the name of the role that this PodClique will assume. |  |  |
 | `podSpec` _[PodSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#podspec-v1-core)_ | Spec is the spec of the pods in the clique. |  |  |
-| `replicas` _integer_ | Replicas is the number of replicas of the pods in the clique. It cannot be less than 1. |  |  |
+| `replicas` _integer_ | Replicas is the number of replicas of the pods in the clique. GREP-0677: it is either 0<br />(an intentional idle state) or at least MinAvailable. When omitted it defaults to 1; an<br />explicit 0 is preserved. | 1 | Minimum: 0 <br /> |
 | `minAvailable` _integer_ | MinAvailable serves two purposes:<br />1. It defines the minimum number of pods that are guaranteed to be gang scheduled.<br />2. It defines the minimum requirement of available pods in a PodClique. Violation of this threshold will result<br />in termination of the PodGang that it belongs to. If MinAvailable is not set, then it will default to the template<br />Replicas. |  |  |
 | `startsAfter` _string array_ | StartsAfter provides you a way to explicitly define the startup dependencies amongst cliques.<br />If CliqueStartupType in PodGang has been set to 'CliqueStartupTypeExplicit', then to create an ordered start<br />amongst PodClique's StartsAfter can be used. A forest of DAG's can be defined to model any start order dependencies.<br />If there are more than one PodClique's defined and StartsAfter is not set for any of them, then their startup order<br />is random at best and must not be relied upon.<br />Validations:<br />1. If a StartsAfter has been defined and one or more cycles are detected in DAG's then it will be flagged as validation error.<br />2. If StartsAfter is defined and does not identify any PodClique then it will be flagged as a validation error. |  |  |
 | `autoScalingConfig` _[AutoScalingConfig](#autoscalingconfig)_ | ScaleConfig is the horizontal pod autoscaler configuration for a PodClique. |  |  |

--- a/operator/api/common/constants/constants.go
+++ b/operator/api/common/constants/constants.go
@@ -123,16 +123,6 @@ const (
 	// ConditionTypePodCliqueScheduled indicates that the PodClique has been successfully scheduled.
 	// This condition is set to true when number of scheduled pods in the PodClique is greater than or equal to PodCliqueSpec.MinAvailable.
 	ConditionTypePodCliqueScheduled = "PodCliqueScheduled"
-	// ConditionTypeGangTerminationInProgress indicates that PCS-level gang termination has fired for this
-	// PodCliqueScalingGroup and is still in flight. It is set on the PCSG when the PCS-level handler deletes
-	// the PodCliques of the whole PCS replica, and is cleared when the PCSG's MinAvailableBreached transitions
-	// back to False (recovered). While it is True, further PCS-level gang termination for the PCS replica is
-	// suppressed — at most one fire per breach episode, regardless of how long the workload stays below
-	// MinAvailable. This is a PCS-level-only mechanism: the PCSG-replica-scoped recycle path does not use this
-	// flag and instead breaks its own re-fire loop via WasPCLQEverScheduled, since a freshly recreated
-	// PodClique has never been scheduled and is therefore excluded from the breached set.
-	// Its only Reason is ConditionReasonGangTerminationActive.
-	ConditionTypeGangTerminationInProgress = "GangTerminationInProgress"
 	// ConditionTopologyLevelsUnavailable indicates that the required topology levels defined on a PodCliqueSet for topology-aware scheduling are no longer available.
 	// This can happen when the ClusterTopologyBinding resource is modified which removes one or more levels required by the PodCliqueSet.
 	ConditionTopologyLevelsUnavailable = "TopologyLevelsUnavailable"
@@ -162,12 +152,13 @@ const (
 	ConditionReasonSufficientAvailablePCSGReplicas = "SufficientAvailablePodCliqueScalingGroupReplicas"
 	// ConditionReasonUpdateInProgress indicates that the resource is undergoing rolling update.
 	ConditionReasonUpdateInProgress = "UpdateInProgress"
-	// ConditionReasonGangTerminationActive is the (only) Reason paired with
-	// ConditionTypeGangTerminationInProgress=True. The Kubernetes condition API requires a
-	// non-empty Reason, and the flag has exactly one cause, so this Reason simply restates the
-	// Type in the CamelCase token form callers branch on. If a second cause for the flag is ever
-	// introduced, add a distinct Reason then.
-	ConditionReasonGangTerminationActive = "GangTerminationActive"
+	// ConditionReasonInitialScheduling indicates that the component has not reached MinAvailable
+	// Ready replicas since creation, wake, update, or gang termination.
+	ConditionReasonInitialScheduling = "InitialScheduling"
+	// ConditionReasonIdle indicates that the component is intentionally idle (spec.replicas == 0)
+	// and therefore does not participate in gang membership. It contributes no required gang
+	// members and never breaches MinAvailable. See GREP-0677.
+	ConditionReasonIdle = "Idle"
 	// ConditionReasonClusterTopologyNotFound indicates that the ClusterTopologyBinding resource required for topology-aware scheduling was not found.
 	ConditionReasonClusterTopologyNotFound = "ClusterTopologyNotFound"
 	// ConditionReasonTopologyLevelsUnavailable indicates that the one or more required topology levels defined on a

--- a/operator/api/core/v1alpha1/crds/grove.io_podcliques.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podcliques.yaml
@@ -8994,9 +8994,13 @@ spec:
                 - containers
                 type: object
               replicas:
-                description: Replicas is the number of replicas of the pods in the
-                  clique. It cannot be less than 1.
+                default: 1
+                description: |-
+                  Replicas is the number of replicas of the pods in the clique. GREP-0677: it is either 0
+                  (an intentional idle state) or at least MinAvailable. When omitted it defaults to 1; an
+                  explicit 0 is preserved.
                 format: int32
+                minimum: 0
                 type: integer
               roleName:
                 description: RoleName is the name of the role that this PodClique
@@ -9020,6 +9024,11 @@ spec:
             - replicas
             - roleName
             type: object
+            x-kubernetes-validations:
+            - message: spec.replicas must be 0 (idle) or greater than or equal to
+                spec.minAvailable
+              rule: self.replicas == 0 || !has(self.minAvailable) || self.replicas
+                >= self.minAvailable
           status:
             description: Status defines the status of a PodClique.
             properties:

--- a/operator/api/core/v1alpha1/crds/grove.io_podcliquescalinggroups.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podcliquescalinggroups.yaml
@@ -104,6 +104,11 @@ spec:
             - cliqueNames
             - replicas
             type: object
+            x-kubernetes-validations:
+            - message: spec.replicas must be 0 (idle) or greater than or equal to
+                spec.minAvailable
+              rule: self.replicas == 0 || !has(self.minAvailable) || self.replicas
+                >= self.minAvailable
           status:
             description: Status is the status of the PodCliqueScalingGroup.
             properties:

--- a/operator/api/core/v1alpha1/crds/grove.io_podcliquesets.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podcliquesets.yaml
@@ -9342,9 +9342,13 @@ spec:
                               - containers
                               type: object
                             replicas:
-                              description: Replicas is the number of replicas of the
-                                pods in the clique. It cannot be less than 1.
+                              default: 1
+                              description: |-
+                                Replicas is the number of replicas of the pods in the clique. GREP-0677: it is either 0
+                                (an intentional idle state) or at least MinAvailable. When omitted it defaults to 1; an
+                                explicit 0 is preserved.
                               format: int32
+                              minimum: 0
                               type: integer
                             roleName:
                               description: RoleName is the name of the role that this
@@ -9368,6 +9372,11 @@ spec:
                           - replicas
                           - roleName
                           type: object
+                          x-kubernetes-validations:
+                          - message: spec.replicas must be 0 (idle) or greater than
+                              or equal to spec.minAvailable
+                            rule: self.replicas == 0 || !has(self.minAvailable) ||
+                              self.replicas >= self.minAvailable
                         topologyConstraint:
                           description: |-
                             TopologyConstraint defines topology placement requirements for PodClique.

--- a/operator/api/core/v1alpha1/podclique.go
+++ b/operator/api/core/v1alpha1/podclique.go
@@ -57,12 +57,19 @@ type PodCliqueList struct {
 }
 
 // PodCliqueSpec defines the specification of a PodClique.
+// GREP-0677: replicas must be 0 (intentional idle state) or at least minAvailable; positive
+// below-quorum values are rejected. This runs on create, update, and the scale subresource.
+// +kubebuilder:validation:XValidation:rule="self.replicas == 0 || !has(self.minAvailable) || self.replicas >= self.minAvailable",message="spec.replicas must be 0 (idle) or greater than or equal to spec.minAvailable"
 type PodCliqueSpec struct {
 	// RoleName is the name of the role that this PodClique will assume.
 	RoleName string `json:"roleName"`
 	// Spec is the spec of the pods in the clique.
 	PodSpec corev1.PodSpec `json:"podSpec"`
-	// Replicas is the number of replicas of the pods in the clique. It cannot be less than 1.
+	// Replicas is the number of replicas of the pods in the clique. GREP-0677: it is either 0
+	// (an intentional idle state) or at least MinAvailable. When omitted it defaults to 1; an
+	// explicit 0 is preserved.
+	// +kubebuilder:default=1
+	// +kubebuilder:validation:Minimum=0
 	Replicas int32 `json:"replicas"`
 	// MinAvailable serves two purposes:
 	// 1. It defines the minimum number of pods that are guaranteed to be gang scheduled.

--- a/operator/api/core/v1alpha1/scalinggroup.go
+++ b/operator/api/core/v1alpha1/scalinggroup.go
@@ -55,6 +55,9 @@ type PodCliqueScalingGroupList struct {
 }
 
 // PodCliqueScalingGroupSpec is the specification of the PodCliqueScalingGroup.
+// GREP-0677: replicas must be 0 (intentional idle state) or at least minAvailable; positive
+// below-quorum values are rejected. This runs on create, update, and the scale subresource.
+// +kubebuilder:validation:XValidation:rule="self.replicas == 0 || !has(self.minAvailable) || self.replicas >= self.minAvailable",message="spec.replicas must be 0 (idle) or greater than or equal to spec.minAvailable"
 type PodCliqueScalingGroupSpec struct {
 	// Replicas is the desired number of replicas for the PodCliqueScalingGroup.
 	// If not specified, it defaults to 1.

--- a/operator/charts/templates/pcs-validating-webhook-config.yaml
+++ b/operator/charts/templates/pcs-validating-webhook-config.yaml
@@ -39,3 +39,31 @@ webhooks:
         scope: "Namespaced"
     sideEffects: None
     timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      {{- if .Values.webhooks.caBundle }}
+      caBundle: {{ .Values.webhooks.caBundle }}
+      {{- end }}
+      service:
+        name: {{ required ".Values.service.name is required" .Values.service.name }}
+        namespace: {{ .Release.Namespace }}
+        path: /webhooks/validate-podclique
+        port: {{ required ".Values.config.server.webhooks.port" .Values.config.server.webhooks.port }}
+    failurePolicy: Fail
+    matchPolicy: Exact
+    name: pclq.validating.webhooks.grove.io
+    namespaceSelector: { }
+    rules:
+      - apiGroups:
+          - "grove.io"
+        apiVersions:
+          - "v1alpha1"
+        operations:
+          - UPDATE
+        resources:
+          - podcliques
+          - podcliques/scale
+        scope: "Namespaced"
+    sideEffects: None
+    timeoutSeconds: 10

--- a/operator/charts/webhook_test.go
+++ b/operator/charts/webhook_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package charts_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/engine"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func TestPodCliqueValidationWebhook(t *testing.T) {
+	chart, err := loader.Load(".")
+	require.NoError(t, err)
+	values, err := chartutil.ToRenderValues(
+		chart,
+		nil,
+		chartutil.ReleaseOptions{Name: "grove", Namespace: "default", IsInstall: true},
+		chartutil.DefaultCapabilities,
+	)
+	require.NoError(t, err)
+	manifests, err := engine.Render(chart, values)
+	require.NoError(t, err)
+
+	rendered, ok := manifests["grove-charts/templates/pcs-validating-webhook-config.yaml"]
+	require.True(t, ok)
+	config := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+	require.NoError(t, yaml.UnmarshalStrict([]byte(rendered), config))
+
+	require.Len(t, config.Webhooks, 2)
+	webhook := config.Webhooks[1]
+	assert.Equal(t, "pclq.validating.webhooks.grove.io", webhook.Name)
+	require.NotNil(t, webhook.ClientConfig.Service)
+	require.NotNil(t, webhook.ClientConfig.Service.Path)
+	assert.Equal(t, "/webhooks/validate-podclique", *webhook.ClientConfig.Service.Path)
+	require.Len(t, webhook.Rules, 1)
+	assert.Equal(t, []string{"podcliques", "podcliques/scale"}, webhook.Rules[0].Resources)
+	assert.Equal(t, []admissionregistrationv1.OperationType{admissionregistrationv1.Update}, webhook.Rules[0].Operations)
+}

--- a/operator/e2e/tests/gang_scheduling_test.go
+++ b/operator/e2e/tests/gang_scheduling_test.go
@@ -18,13 +18,25 @@ package tests
 
 import (
 	"context"
+	"fmt"
+	"slices"
+	"strconv"
 	"testing"
+	"time"
 
+	apicommon "github.com/ai-dynamo/grove/operator/api/common"
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/ai-dynamo/grove/operator/e2e/grove/podgang"
+	"github.com/ai-dynamo/grove/operator/e2e/grove/workload"
 	"github.com/ai-dynamo/grove/operator/e2e/testctx"
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Test_GS1_GangSchedulingWithFullReplicas tests gang-scheduling behavior with insufficient resources
@@ -98,6 +110,508 @@ func Test_GS1_GangSchedulingWithFullReplicas(t *testing.T) {
 	}
 
 	Logger.Info("🎉 Gang-scheduling With Full Replicas test completed successfully!")
+}
+
+// Test_GS13_SimultaneousWakeWithMixedIdle verifies concurrent standalone and PCSG wake while another
+// standalone clique remains idle. Depending on reconcile timing, the woken components may share the
+// retained base anchor or receive distinct anchors; both paths must preserve membership and ordering.
+func Test_GS13_SimultaneousWakeWithMixedIdle(t *testing.T) {
+	const (
+		pcsName       = "workload-idle-wake"
+		idlePCLQName  = pcsName + "-0-idle"
+		guardedName   = pcsName + "-0-guarded"
+		workerName    = pcsName + "-0-worker"
+		pcsgName      = pcsName + "-0-workers"
+		prefillName   = pcsgName + "-0-prefill"
+		decodeName    = pcsgName + "-0-decode"
+		barrierWindow = 5 * time.Second
+	)
+	ctx := context.Background()
+	tc, cleanup := testctx.PrepareTest(ctx, t, 3,
+		testctx.WithWorkload(&testctx.WorkloadConfig{
+			Name:         pcsName,
+			YAMLPath:     "../yaml/workload-idle-wake.yaml",
+			Namespace:    "default",
+			ExpectedPods: 0,
+		}),
+	)
+	defer cleanup()
+
+	Logger.Info("1. Deploy a PodCliqueSet whose standalone and scaling-group components are idle")
+	if _, err := tc.DeployAndVerifyWorkload(); err != nil {
+		t.Fatalf("Failed to deploy workload: %v", err)
+	}
+	wm := workload.NewWorkloadManager(tc.Client, Logger)
+	if _, err := wm.WaitForPodClique(ctx, tc.Namespace, workerName, tc.Timeout, tc.Interval); err != nil {
+		t.Fatalf("Failed to wait for idle PodClique: %v", err)
+	}
+	if _, err := wm.WaitForPCSG(ctx, tc.Namespace, pcsgName, tc.Timeout, tc.Interval); err != nil {
+		t.Fatalf("Failed to wait for idle PodCliqueScalingGroup: %v", err)
+	}
+	if _, err := wm.WaitForPodClique(ctx, tc.Namespace, guardedName, tc.Timeout, tc.Interval); err != nil {
+		t.Fatalf("Failed to wait for guarded PodClique: %v", err)
+	}
+	waitForNoPodGangs(t, ctx, tc, pcsName)
+	waitForAllIdleBootstrap(t, ctx, tc, pcsName)
+
+	Logger.Info("2. Verify main-resource and scale-subresource below-quorum updates are rejected")
+	assertBelowQuorumRejected(t, ctx, tc, guardedName)
+
+	Logger.Info("3. Wake the standalone PodClique and PodCliqueScalingGroup concurrently")
+	scaleIdleComponents(t, ctx, tc, workerName, pcsgName, 1)
+	if err := tc.WaitForReadyPods(3); err != nil {
+		t.Fatalf("Failed to wait for woken pods: %v", err)
+	}
+	firstWake := waitForWakeState(t, ctx, tc, pcsName, idlePCLQName, workerName, prefillName, decodeName)
+
+	Logger.Info("4. Verify PCSG ownership remains enforced after removing the compatibility label")
+	assertOwnerReferenceBlocksIndependentScale(t, ctx, tc, prefillName)
+
+	Logger.Info("5. Hold old PodGangs and scale both components to zero")
+	heldPodGangs := addPodGangFinalizers(t, ctx, tc, pcsName)
+	pods, err := tc.ListPods()
+	if err != nil {
+		t.Fatalf("Failed to list pods before scale-to-zero: %v", err)
+	}
+	originalUIDs := capturePodUIDs(pods)
+	scaleIdleComponents(t, ctx, tc, workerName, pcsgName, 0)
+	waitForRemovedMembershipAndTerminatingPodGangs(t, ctx, tc, pcsName, heldPodGangs)
+	restartOperator(t, ctx, tc)
+	assertBarrierRetainsWorkload(t, ctx, tc, originalUIDs, []string{workerName, prefillName, decodeName}, barrierWindow)
+
+	Logger.Info("6. Release PodGang finalizers and verify the all-idle state converges")
+	removePodGangFinalizers(t, ctx, tc, heldPodGangs)
+	waitForAllIdle(t, ctx, tc, pcsName, prefillName, decodeName)
+
+	Logger.Info("7. Wake both components again and verify epochs and PodGang names are fresh")
+	scaleIdleComponents(t, ctx, tc, workerName, pcsgName, 1)
+	if err := tc.WaitForReadyPods(3); err != nil {
+		t.Fatalf("Failed to wait for second wake: %v", err)
+	}
+	secondWake := waitForWakeState(t, ctx, tc, pcsName, idlePCLQName, workerName, prefillName, decodeName)
+	for name := range secondWake.podGangNames {
+		if firstWake.podGangNames.Has(name) {
+			t.Fatalf("second wake reused old PodGang name %s", name)
+		}
+	}
+}
+
+type observedWakeState struct {
+	podGangNames stringSet
+}
+
+type stringSet map[string]struct{}
+
+func (s stringSet) Has(value string) bool {
+	_, ok := s[value]
+	return ok
+}
+
+func waitForWakeState(t *testing.T, ctx context.Context, tc *testctx.TestContext, pcsName, idlePCLQName, workerName, prefillName, decodeName string) observedWakeState {
+	t.Helper()
+	var observed observedWakeState
+	if err := wait.PollUntilContextTimeout(ctx, tc.Interval, tc.Timeout, true, func(ctx context.Context) (bool, error) {
+		pgm := &grovecorev1alpha1.PodGangMap{}
+		if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: pcsName + "-0"}, pgm); err != nil {
+			return false, client.IgnoreNotFound(err)
+		}
+		var workerAnchor, pcsgAnchor *grovecorev1alpha1.PodGangEntry
+		epochs := stringSet{}
+		for i := range pgm.Spec.Entries {
+			entry := &pgm.Spec.Entries[i]
+			if epochs.Has(entry.Epoch) {
+				return false, nil
+			}
+			epochs[entry.Epoch] = struct{}{}
+			if entry.Role != grovecorev1alpha1.PodGangEntryRoleAnchor {
+				continue
+			}
+			if _, carriesIdle := entry.PodCliques["idle"]; carriesIdle {
+				return false, nil
+			}
+			if entry.PodCliques["worker"] == 1 {
+				workerAnchor = entry
+			}
+			if indices := entry.PCSGReplicaIndices["workers"]; len(indices) == 1 && indices[0] == 0 {
+				pcsgAnchor = entry
+			}
+		}
+		if workerAnchor == nil || pcsgAnchor == nil {
+			return false, nil
+		}
+		if workerAnchor != pcsgAnchor && workerAnchor.Epoch == pcsgAnchor.Epoch {
+			return false, nil
+		}
+		if workerAnchor == pcsgAnchor {
+			if len(workerAnchor.DependsOn) != 0 {
+				return false, nil
+			}
+		} else {
+			first, second := workerAnchor, pcsgAnchor
+			firstEpoch, firstErr := strconv.ParseInt(first.Epoch, 10, 64)
+			secondEpoch, secondErr := strconv.ParseInt(second.Epoch, 10, 64)
+			if firstErr != nil || secondErr != nil {
+				return false, nil
+			}
+			if firstEpoch > secondEpoch {
+				first, second = second, first
+			}
+			if len(first.DependsOn) != 0 || !slices.Equal(second.DependsOn, []string{first.Epoch}) {
+				return false, nil
+			}
+		}
+		rnr := apicommon.ResourceNameReplica{Name: pcsName, Replica: 0}
+		workerPodGangName := apicommon.GenerateAnchorPodGangName(rnr, workerAnchor.Epoch)
+		pcsgPodGangName := apicommon.GenerateAnchorPodGangName(rnr, pcsgAnchor.Epoch)
+		prefillDependencies := []string(nil)
+		if workerAnchor == pcsgAnchor {
+			prefillDependencies = []string{workerName}
+		}
+		expectedPodGangs := map[string]string{
+			workerName:  workerPodGangName,
+			prefillName: pcsgPodGangName,
+			decodeName:  pcsgPodGangName,
+		}
+		expectedDependencies := map[string][]string{
+			workerName:  nil,
+			prefillName: prefillDependencies,
+			decodeName:  {prefillName},
+		}
+		for name, dependencies := range expectedDependencies {
+			pclq := &grovecorev1alpha1.PodClique{}
+			if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: name}, pclq); err != nil {
+				return false, client.IgnoreNotFound(err)
+			}
+			if pclq.Labels[apicommon.LabelPodGang] != expectedPodGangs[name] ||
+				!slices.Equal(pclq.Spec.StartsAfter, dependencies) {
+				return false, nil
+			}
+		}
+		idle := &grovecorev1alpha1.PodClique{}
+		if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: idlePCLQName}, idle); err != nil {
+			return false, client.IgnoreNotFound(err)
+		}
+		if idle.Spec.Replicas != 0 || len(idle.Spec.StartsAfter) != 0 {
+			return false, nil
+		}
+		podGangs := &groveschedulerv1alpha1.PodGangList{}
+		if err := tc.Client.List(ctx, podGangs,
+			client.InNamespace(tc.Namespace),
+			client.MatchingLabels{apicommon.LabelPartOfKey: pcsName},
+		); err != nil {
+			return false, err
+		}
+		expectedNames := map[string]struct{}{workerPodGangName: {}, pcsgPodGangName: {}}
+		if len(podGangs.Items) != len(expectedNames) {
+			return false, nil
+		}
+		expectedGroups := map[string]int{
+			workerName:  1,
+			prefillName: 1,
+			decodeName:  1,
+		}
+		for i := range podGangs.Items {
+			if _, ok := expectedNames[podGangs.Items[i].Name]; !ok {
+				return false, nil
+			}
+			for _, group := range podGangs.Items[i].Spec.PodGroups {
+				wantRefs, ok := expectedGroups[group.Name]
+				if !ok || len(group.PodReferences) != wantRefs {
+					return false, nil
+				}
+				delete(expectedGroups, group.Name)
+			}
+		}
+		if len(expectedGroups) != 0 {
+			return false, nil
+		}
+		observed.podGangNames = expectedNames
+		return true, nil
+	}); err != nil {
+		t.Fatalf("Wake state did not converge: %v", err)
+	}
+	return observed
+}
+
+func assertBelowQuorumRejected(t *testing.T, ctx context.Context, tc *testctx.TestContext, pclqName string) {
+	t.Helper()
+	pclq := &grovecorev1alpha1.PodClique{ObjectMeta: metav1.ObjectMeta{Name: pclqName, Namespace: tc.Namespace}}
+	err := tc.Client.Patch(ctx, pclq, client.RawPatch(types.MergePatchType, []byte(`{"spec":{"replicas":1}}`)))
+	if !apierrors.IsInvalid(err) {
+		t.Fatalf("main-resource below-quorum update error = %v, want Invalid", err)
+	}
+	assertPCLQReplicas(t, ctx, tc, pclqName, 0)
+
+	scale := &autoscalingv1.Scale{
+		ObjectMeta: metav1.ObjectMeta{Name: pclqName, Namespace: tc.Namespace},
+		Spec:       autoscalingv1.ScaleSpec{Replicas: 1},
+	}
+	err = tc.Client.SubResource("scale").Update(ctx, pclq, client.WithSubResourceBody(scale))
+	if !apierrors.IsInvalid(err) {
+		t.Fatalf("scale-subresource below-quorum update error = %v, want Invalid", err)
+	}
+	assertPCLQReplicas(t, ctx, tc, pclqName, 0)
+}
+
+func assertOwnerReferenceBlocksIndependentScale(t *testing.T, ctx context.Context, tc *testctx.TestContext, pclqName string) {
+	t.Helper()
+	pclq := &grovecorev1alpha1.PodClique{}
+	key := client.ObjectKey{Namespace: tc.Namespace, Name: pclqName}
+	if err := tc.Client.Get(ctx, key, pclq); err != nil {
+		t.Fatalf("Failed to get PCSG-owned PodClique: %v", err)
+	}
+	ownerLabel := pclq.Labels[apicommon.LabelPodCliqueScalingGroup]
+	delete(pclq.Labels, apicommon.LabelPodCliqueScalingGroup)
+	if err := tc.Client.Update(ctx, pclq); err != nil {
+		t.Fatalf("Failed to remove PCSG owner label: %v", err)
+	}
+
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current := &grovecorev1alpha1.PodClique{}
+		if err := tc.Client.Get(ctx, key, current); err != nil {
+			return err
+		}
+		if current.Annotations == nil {
+			current.Annotations = map[string]string{}
+		}
+		current.Annotations["e2e.grove.io/metadata-update"] = "allowed"
+		current.Finalizers = append(current.Finalizers, "e2e.grove.io/metadata-update")
+		return tc.Client.Update(ctx, current)
+	}); err != nil {
+		t.Fatalf("Metadata-only update on PCSG-owned PodClique was rejected: %v", err)
+	}
+	defer func() {
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			current := &grovecorev1alpha1.PodClique{}
+			if err := tc.Client.Get(ctx, key, current); err != nil {
+				return client.IgnoreNotFound(err)
+			}
+			current.Finalizers = slices.DeleteFunc(current.Finalizers, func(value string) bool {
+				return value == "e2e.grove.io/metadata-update"
+			})
+			current.Labels[apicommon.LabelPodCliqueScalingGroup] = ownerLabel
+			return tc.Client.Update(ctx, current)
+		}); err != nil {
+			t.Errorf("Failed to restore PCSG-owned PodClique metadata: %v", err)
+		}
+	}()
+
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current := &grovecorev1alpha1.PodClique{}
+		if err := tc.Client.Get(ctx, key, current); err != nil {
+			return err
+		}
+		return tc.Client.Update(ctx, current)
+	}); err != nil {
+		t.Fatalf("Replicas no-op update on PCSG-owned PodClique was rejected: %v", err)
+	}
+	if err := tc.Client.Get(ctx, key, pclq); err != nil {
+		t.Fatalf("Failed to refresh PCSG-owned PodClique: %v", err)
+	}
+	noOpScale := &autoscalingv1.Scale{
+		ObjectMeta: metav1.ObjectMeta{Name: pclqName, Namespace: tc.Namespace},
+		Spec:       autoscalingv1.ScaleSpec{Replicas: pclq.Spec.Replicas},
+	}
+	if err := tc.Client.SubResource("scale").Update(ctx, pclq, client.WithSubResourceBody(noOpScale)); err != nil {
+		t.Fatalf("Replicas no-op scale on PCSG-owned PodClique was rejected: %v", err)
+	}
+	currentScale := &autoscalingv1.Scale{}
+	if err := tc.Client.SubResource("scale").Get(ctx, pclq, currentScale); err != nil {
+		t.Fatalf("Failed to get scale for PCSG-owned PodClique: %v", err)
+	}
+	if currentScale.Status.Selector != "" {
+		t.Fatalf("PCSG-owned PodClique published autoscaler selector %q", currentScale.Status.Selector)
+	}
+
+	err := retry.OnError(retry.DefaultRetry, apierrors.IsConflict, func() error {
+		current := &grovecorev1alpha1.PodClique{}
+		if err := tc.Client.Get(ctx, key, current); err != nil {
+			return err
+		}
+		current.Spec.Replicas = 0
+		return tc.Client.Update(ctx, current)
+	})
+	if !apierrors.IsForbidden(err) {
+		t.Fatalf("PCSG-owned PodClique main update error = %v, want Forbidden", err)
+	}
+	scale := &autoscalingv1.Scale{
+		ObjectMeta: metav1.ObjectMeta{Name: pclqName, Namespace: tc.Namespace},
+		Spec:       autoscalingv1.ScaleSpec{Replicas: 0},
+	}
+	err = tc.Client.SubResource("scale").Update(ctx, pclq, client.WithSubResourceBody(scale))
+	if !apierrors.IsForbidden(err) {
+		t.Fatalf("PCSG-owned PodClique scale error = %v, want Forbidden", err)
+	}
+	assertPCLQReplicas(t, ctx, tc, pclqName, 1)
+}
+
+func assertPCLQReplicas(t *testing.T, ctx context.Context, tc *testctx.TestContext, name string, expected int32) {
+	t.Helper()
+	pclq := &grovecorev1alpha1.PodClique{}
+	if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: name}, pclq); err != nil {
+		t.Fatalf("Failed to get PodClique %s: %v", name, err)
+	}
+	if pclq.Spec.Replicas != expected {
+		t.Fatalf("PodClique %s replicas = %d, want %d", name, pclq.Spec.Replicas, expected)
+	}
+}
+
+func scaleIdleComponents(t *testing.T, ctx context.Context, tc *testctx.TestContext, workerName, pcsgName string, replicas int32) {
+	t.Helper()
+	errCh := make(chan error, 2)
+	go func() {
+		errCh <- tc.Client.Patch(ctx,
+			&grovecorev1alpha1.PodClique{ObjectMeta: metav1.ObjectMeta{Name: workerName, Namespace: tc.Namespace}},
+			client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf(`{"spec":{"replicas":%d}}`, replicas))))
+	}()
+	go func() {
+		errCh <- tc.Client.Patch(ctx,
+			&grovecorev1alpha1.PodCliqueScalingGroup{ObjectMeta: metav1.ObjectMeta{Name: pcsgName, Namespace: tc.Namespace}},
+			client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf(`{"spec":{"replicas":%d}}`, replicas))))
+	}()
+	for range 2 {
+		if err := <-errCh; err != nil {
+			t.Fatalf("Failed to scale idle component to %d: %v", replicas, err)
+		}
+	}
+}
+
+func addPodGangFinalizers(t *testing.T, ctx context.Context, tc *testctx.TestContext, pcsName string) []client.ObjectKey {
+	t.Helper()
+	podGangs := listPodGangs(t, ctx, tc, pcsName)
+	if len(podGangs.Items) == 0 {
+		t.Fatal("no PodGangs available for deletion barrier")
+	}
+	keys := make([]client.ObjectKey, 0, len(podGangs.Items))
+	for i := range podGangs.Items {
+		podGang := &podGangs.Items[i]
+		podGang.Finalizers = append(podGang.Finalizers, "e2e.grove.io/hold")
+		if err := tc.Client.Update(ctx, podGang); err != nil {
+			t.Fatalf("Failed to add finalizer to PodGang %s: %v", podGang.Name, err)
+		}
+		keys = append(keys, client.ObjectKeyFromObject(podGang))
+	}
+	return keys
+}
+
+func waitForRemovedMembershipAndTerminatingPodGangs(t *testing.T, ctx context.Context, tc *testctx.TestContext, pcsName string, podGangKeys []client.ObjectKey) {
+	t.Helper()
+	if err := wait.PollUntilContextTimeout(ctx, tc.Interval, tc.Timeout, true, func(ctx context.Context) (bool, error) {
+		pgm := &grovecorev1alpha1.PodGangMap{}
+		if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: pcsName + "-0"}, pgm); err != nil {
+			return false, err
+		}
+		for i := range pgm.Spec.Entries {
+			if pgm.Spec.Entries[i].PodCliques["worker"] > 0 ||
+				len(pgm.Spec.Entries[i].PCSGReplicaIndices["workers"]) > 0 {
+				return false, nil
+			}
+		}
+		for _, key := range podGangKeys {
+			podGang := &groveschedulerv1alpha1.PodGang{}
+			if err := tc.Client.Get(ctx, key, podGang); err != nil {
+				return false, err
+			}
+			if podGang.DeletionTimestamp == nil {
+				return false, nil
+			}
+		}
+		return true, nil
+	}); err != nil {
+		t.Fatalf("Scale-to-zero did not reach deletion barrier: %v", err)
+	}
+}
+
+func assertBarrierRetainsWorkload(t *testing.T, ctx context.Context, tc *testctx.TestContext, originalUIDs map[types.UID]struct{}, pclqNames []string, duration time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(duration)
+	for {
+		pods, err := tc.ListPods()
+		if err != nil {
+			t.Fatalf("Failed to list pods during barrier observation: %v", err)
+		}
+		currentUIDs := capturePodUIDs(pods)
+		for uid := range originalUIDs {
+			if !currentUIDsHas(currentUIDs, uid) {
+				t.Fatalf("Pod UID %s was deleted before old PodGang removal", uid)
+			}
+		}
+		for _, name := range pclqNames {
+			if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: name}, &grovecorev1alpha1.PodClique{}); err != nil {
+				t.Fatalf("PodClique %s was deleted before old PodGang removal: %v", name, err)
+			}
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+func currentUIDsHas(uids map[types.UID]struct{}, uid types.UID) bool {
+	_, ok := uids[uid]
+	return ok
+}
+
+func removePodGangFinalizers(t *testing.T, ctx context.Context, tc *testctx.TestContext, keys []client.ObjectKey) {
+	t.Helper()
+	for _, key := range keys {
+		podGang := &groveschedulerv1alpha1.PodGang{}
+		if err := tc.Client.Get(ctx, key, podGang); err != nil {
+			t.Fatalf("Failed to get held PodGang %s: %v", key.Name, err)
+		}
+		podGang.Finalizers = nil
+		if err := tc.Client.Update(ctx, podGang); err != nil {
+			t.Fatalf("Failed to release PodGang %s: %v", key.Name, err)
+		}
+	}
+}
+
+func waitForAllIdle(t *testing.T, ctx context.Context, tc *testctx.TestContext, pcsName, prefillName, decodeName string) {
+	t.Helper()
+	if err := wait.PollUntilContextTimeout(ctx, tc.Interval, tc.Timeout, true, func(ctx context.Context) (bool, error) {
+		pods, err := tc.ListPods()
+		if err != nil || len(pods.Items) != 0 {
+			return false, err
+		}
+		if len(listPodGangs(t, ctx, tc, pcsName).Items) != 0 {
+			return false, nil
+		}
+		for _, name := range []string{prefillName, decodeName} {
+			err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: name}, &grovecorev1alpha1.PodClique{})
+			if err == nil || !apierrors.IsNotFound(err) {
+				return false, err
+			}
+		}
+		return true, nil
+	}); err != nil {
+		t.Fatalf("All-idle state did not converge: %v", err)
+	}
+}
+
+func waitForNoPodGangs(t *testing.T, ctx context.Context, tc *testctx.TestContext, pcsName string) {
+	t.Helper()
+	if err := wait.PollUntilContextTimeout(ctx, tc.Interval, tc.Timeout, true, func(ctx context.Context) (bool, error) {
+		return len(listPodGangs(t, ctx, tc, pcsName).Items) == 0, nil
+	}); err != nil {
+		t.Fatalf("PodGangs remained for all-idle workload: %v", err)
+	}
+}
+
+func listPodGangs(t *testing.T, ctx context.Context, tc *testctx.TestContext, pcsName string) *groveschedulerv1alpha1.PodGangList {
+	t.Helper()
+	podGangs := &groveschedulerv1alpha1.PodGangList{}
+	if err := tc.Client.List(ctx, podGangs,
+		client.InNamespace(tc.Namespace),
+		client.MatchingLabels{apicommon.LabelPartOfKey: pcsName},
+	); err != nil {
+		t.Fatalf("Failed to list PodGangs: %v", err)
+	}
+	return podGangs
 }
 
 // Test_GS2_GangSchedulingWithScalingFullReplicas verifies gang-scheduling behavior when scaling a PodCliqueScalingGroup

--- a/operator/e2e/tests/gang_scheduling_test.go
+++ b/operator/e2e/tests/gang_scheduling_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strconv"
 	"testing"
 	"time"
 
@@ -113,8 +112,8 @@ func Test_GS1_GangSchedulingWithFullReplicas(t *testing.T) {
 }
 
 // Test_GS13_SimultaneousWakeWithMixedIdle verifies concurrent standalone and PCSG wake while another
-// standalone clique remains idle. Depending on reconcile timing, the woken components may share the
-// retained base anchor or receive distinct anchors; both paths must preserve membership and ordering.
+// standalone clique remains idle. The standalone returns to the retained anchor, while each PCSG
+// replica wakes in its own scaled PodGang.
 func Test_GS13_SimultaneousWakeWithMixedIdle(t *testing.T) {
 	const (
 		pcsName       = "workload-idle-wake"
@@ -183,21 +182,23 @@ func Test_GS13_SimultaneousWakeWithMixedIdle(t *testing.T) {
 	removePodGangFinalizers(t, ctx, tc, heldPodGangs)
 	waitForAllIdle(t, ctx, tc, pcsName, prefillName, decodeName)
 
-	Logger.Info("7. Wake both components again and verify epochs and PodGang names are fresh")
+	Logger.Info("7. Wake both components again and verify the anchor is reused and the SPG is fresh")
 	scaleIdleComponents(t, ctx, tc, workerName, pcsgName, 1)
 	if err := tc.WaitForReadyPods(3); err != nil {
 		t.Fatalf("Failed to wait for second wake: %v", err)
 	}
 	secondWake := waitForWakeState(t, ctx, tc, pcsName, idlePCLQName, workerName, prefillName, decodeName)
-	for name := range secondWake.podGangNames {
-		if firstWake.podGangNames.Has(name) {
-			t.Fatalf("second wake reused old PodGang name %s", name)
-		}
+	if secondWake.anchorName != firstWake.anchorName {
+		t.Fatalf("second wake changed anchor name: %s -> %s", firstWake.anchorName, secondWake.anchorName)
+	}
+	if secondWake.scaleOutName == firstWake.scaleOutName {
+		t.Fatalf("second wake reused scaled PodGang %s", secondWake.scaleOutName)
 	}
 }
 
 type observedWakeState struct {
-	podGangNames stringSet
+	anchorName   string
+	scaleOutName string
 }
 
 type stringSet map[string]struct{}
@@ -215,7 +216,8 @@ func waitForWakeState(t *testing.T, ctx context.Context, tc *testctx.TestContext
 		if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: pcsName + "-0"}, pgm); err != nil {
 			return false, client.IgnoreNotFound(err)
 		}
-		var workerAnchor, pcsgAnchor *grovecorev1alpha1.PodGangEntry
+		var workerAnchor, scaleOut *grovecorev1alpha1.PodGangEntry
+		anchorCount := 0
 		epochs := stringSet{}
 		for i := range pgm.Spec.Entries {
 			entry := &pgm.Spec.Entries[i]
@@ -223,50 +225,37 @@ func waitForWakeState(t *testing.T, ctx context.Context, tc *testctx.TestContext
 				return false, nil
 			}
 			epochs[entry.Epoch] = struct{}{}
-			if entry.Role != grovecorev1alpha1.PodGangEntryRoleAnchor {
-				continue
-			}
 			if _, carriesIdle := entry.PodCliques["idle"]; carriesIdle {
 				return false, nil
 			}
-			if entry.PodCliques["worker"] == 1 {
-				workerAnchor = entry
-			}
-			if indices := entry.PCSGReplicaIndices["workers"]; len(indices) == 1 && indices[0] == 0 {
-				pcsgAnchor = entry
+			switch entry.Role {
+			case grovecorev1alpha1.PodGangEntryRoleAnchor:
+				anchorCount++
+				if len(entry.PCSGReplicaIndices) != 0 {
+					return false, nil
+				}
+				if entry.PodCliques["worker"] == 1 {
+					workerAnchor = entry
+				}
+			case grovecorev1alpha1.PodGangEntryRoleScaleOut:
+				if slices.Equal(entry.PCSGReplicaIndices["workers"], []int32{0}) {
+					scaleOut = entry
+				}
 			}
 		}
-		if workerAnchor == nil || pcsgAnchor == nil {
+		if anchorCount != 1 || workerAnchor == nil || scaleOut == nil {
 			return false, nil
 		}
-		if workerAnchor != pcsgAnchor && workerAnchor.Epoch == pcsgAnchor.Epoch {
+		if len(workerAnchor.DependsOn) != 0 {
 			return false, nil
 		}
-		if workerAnchor == pcsgAnchor {
-			if len(workerAnchor.DependsOn) != 0 {
-				return false, nil
-			}
-		} else {
-			first, second := workerAnchor, pcsgAnchor
-			firstEpoch, firstErr := strconv.ParseInt(first.Epoch, 10, 64)
-			secondEpoch, secondErr := strconv.ParseInt(second.Epoch, 10, 64)
-			if firstErr != nil || secondErr != nil {
-				return false, nil
-			}
-			if firstEpoch > secondEpoch {
-				first, second = second, first
-			}
-			if len(first.DependsOn) != 0 || !slices.Equal(second.DependsOn, []string{first.Epoch}) {
-				return false, nil
-			}
+		// A PCSG that wakes first has no anchor dependency; active entries retain that choice.
+		if len(scaleOut.DependsOn) != 0 && !slices.Equal(scaleOut.DependsOn, []string{workerAnchor.Epoch}) {
+			return false, nil
 		}
 		rnr := apicommon.ResourceNameReplica{Name: pcsName, Replica: 0}
 		workerPodGangName := apicommon.GenerateAnchorPodGangName(rnr, workerAnchor.Epoch)
-		pcsgPodGangName := apicommon.GenerateAnchorPodGangName(rnr, pcsgAnchor.Epoch)
-		prefillDependencies := []string(nil)
-		if workerAnchor == pcsgAnchor {
-			prefillDependencies = []string{workerName}
-		}
+		pcsgPodGangName := apicommon.GenerateNonAnchorPodGangName(rnr, scaleOut.Epoch, "workers", 0)
 		expectedPodGangs := map[string]string{
 			workerName:  workerPodGangName,
 			prefillName: pcsgPodGangName,
@@ -274,7 +263,7 @@ func waitForWakeState(t *testing.T, ctx context.Context, tc *testctx.TestContext
 		}
 		expectedDependencies := map[string][]string{
 			workerName:  nil,
-			prefillName: prefillDependencies,
+			prefillName: nil,
 			decodeName:  {prefillName},
 		}
 		for name, dependencies := range expectedDependencies {
@@ -325,7 +314,8 @@ func waitForWakeState(t *testing.T, ctx context.Context, tc *testctx.TestContext
 		if len(expectedGroups) != 0 {
 			return false, nil
 		}
-		observed.podGangNames = expectedNames
+		observed.anchorName = workerPodGangName
+		observed.scaleOutName = pcsgPodGangName
 		return true, nil
 	}); err != nil {
 		t.Fatalf("Wake state did not converge: %v", err)

--- a/operator/e2e/tests/gang_termination_test.go
+++ b/operator/e2e/tests/gang_termination_test.go
@@ -23,11 +23,16 @@ import (
 	"time"
 
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
+	apiconstants "github.com/ai-dynamo/grove/operator/api/common/constants"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/ai-dynamo/grove/operator/e2e/testctx"
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -219,10 +224,9 @@ func Test_GT4_GangTerminationMinReplicasPCSGOwned(t *testing.T) {
 	Logger.Info("5. Kill 1 ready pod from sg-x-1-pc-c — expect NO PCS-level gang termination (pc-a must survive)")
 	// We assert on pc-a (the standalone PCLQ) rather than on PCSG-0's UIDs: PCSG-0 was already
 	// recycled once by the PCSG-replica-scoped restart in step 4, so its pods no longer carry
-	// their original UIDs. That path does not keep re-firing — WasPCLQEverScheduled excludes the
-	// freshly recreated, never-scheduled PodCliques from the breached set — but the UIDs still
-	// reflect the step-4 recycle, so they are not a useful signal here. pc-a's UIDs change only
-	// under PCS-level gang termination, so pc-a surviving proves no PCS-level termination fired.
+	// their original UIDs. That path does not keep re-firing because initial scheduling is unarmed.
+	// pc-a's UIDs change only under PCS-level gang termination, so pc-a surviving proves no
+	// PCS-level termination fired.
 	pods, err = tc.ListPods()
 	if err != nil {
 		t.Fatalf("Failed to list pods: %v", err)
@@ -366,7 +370,134 @@ func Test_GT6_ScaledPodGangPodDeletion(t *testing.T) {
 	uncordonAndVerifyRecovery(t, tc, []string{scaled.Spec.NodeName}, totalWLPods)
 }
 
+// Test_GT7_FirstWakeArmsTerminationOnlyAfterHealthy verifies that an unschedulable first wake is
+// not treated as a regression. Once the clique reaches MinAvailable, the same loss must recycle it.
+func Test_GT7_FirstWakeArmsTerminationOnlyAfterHealthy(t *testing.T) {
+	const (
+		workloadName = "workload-idle-wake"
+		workerName   = workloadName + "-0-worker"
+	)
+	ctx := context.Background()
+	tc, cleanup := testctx.PrepareTest(ctx, t, 1,
+		testctx.WithWorkload(&testctx.WorkloadConfig{
+			Name:         workloadName,
+			YAMLPath:     "../yaml/workload-idle-wake.yaml",
+			Namespace:    "default",
+			ExpectedPods: 0,
+		}),
+	)
+	defer cleanup()
+
+	cordoned := tc.SetupAndCordonNodes(1)
+	defer tc.UncordonNodes(cordoned)
+	if _, err := tc.DeployAndVerifyWorkload(); err != nil {
+		t.Fatalf("Failed to deploy idle workload: %v", err)
+	}
+
+	worker := waitForPCLQ(t, ctx, tc, workerName)
+	initialUID := worker.UID
+	if err := tc.Client.Patch(ctx,
+		&grovecorev1alpha1.PodClique{ObjectMeta: metav1.ObjectMeta{Name: workerName, Namespace: tc.Namespace}},
+		client.RawPatch(types.MergePatchType, []byte(`{"spec":{"replicas":1}}`))); err != nil {
+		t.Fatalf("Failed to wake PodClique: %v", err)
+	}
+	waitForPCLQConditionReason(t, ctx, tc, workerName, apiconstants.ConditionReasonInitialScheduling)
+	assertPCLQUIDStableFor(t, ctx, tc, workerName, initialUID, terminationDelayInWorkloadYAML+gangTerminationGrace)
+
+	tc.UncordonNodes(cordoned)
+	if err := tc.WaitForReadyPods(1); err != nil {
+		t.Fatalf("First wake did not become ready: %v", err)
+	}
+	waitForPCLQConditionReason(t, ctx, tc, workerName, apiconstants.ConditionReasonSufficientReadyPods)
+
+	pods, err := tc.ListPods()
+	if err != nil {
+		t.Fatalf("Failed to list healthy wake pods: %v", err)
+	}
+	target := findReadyPodFromPodClique(pods, workerName)
+	if target == nil {
+		t.Fatalf("No ready pod found for %s", workerName)
+	}
+	if err := tc.CordonNode(target.Spec.NodeName); err != nil {
+		t.Fatalf("Failed to cordon node %s: %v", target.Spec.NodeName, err)
+	}
+	if err := tc.Client.Delete(ctx, target); err != nil {
+		t.Fatalf("Failed to delete worker pod: %v", err)
+	}
+	waitForPCLQUIDChange(t, ctx, tc, workerName, initialUID)
+	assertPCLQReplicas(t, ctx, tc, workerName, 0)
+}
+
 // ---------- helpers ----------
+
+func waitForPCLQ(t *testing.T, ctx context.Context, tc *testctx.TestContext, name string) *grovecorev1alpha1.PodClique {
+	t.Helper()
+	var result *grovecorev1alpha1.PodClique
+	if err := wait.PollUntilContextTimeout(ctx, tc.Interval, tc.Timeout, true, func(ctx context.Context) (bool, error) {
+		pclq := &grovecorev1alpha1.PodClique{}
+		if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: name}, pclq); err != nil {
+			return false, client.IgnoreNotFound(err)
+		}
+		result = pclq
+		return true, nil
+	}); err != nil {
+		t.Fatalf("PodClique %s did not appear: %v", name, err)
+	}
+	return result
+}
+
+func waitForPCLQConditionReason(t *testing.T, ctx context.Context, tc *testctx.TestContext, name, reason string) {
+	t.Helper()
+	if err := wait.PollUntilContextTimeout(ctx, tc.Interval, tc.Timeout, true, func(ctx context.Context) (bool, error) {
+		pclq := &grovecorev1alpha1.PodClique{}
+		if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: name}, pclq); err != nil {
+			return false, client.IgnoreNotFound(err)
+		}
+		condition := meta.FindStatusCondition(pclq.Status.Conditions, apiconstants.ConditionTypeMinAvailableBreached)
+		return condition != nil && condition.Reason == reason && condition.ObservedGeneration == pclq.Generation, nil
+	}); err != nil {
+		t.Fatalf("PodClique %s condition did not reach reason %s: %v", name, reason, err)
+	}
+}
+
+func assertPCLQUIDStableFor(t *testing.T, ctx context.Context, tc *testctx.TestContext, name string, uid types.UID, duration time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(duration)
+	for {
+		pclq := &grovecorev1alpha1.PodClique{}
+		if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: name}, pclq); err != nil {
+			t.Fatalf("PodClique %s disappeared before gang termination was armed: %v", name, err)
+		}
+		if pclq.UID != uid {
+			t.Fatalf("PodClique %s UID changed before gang termination was armed: %s -> %s", name, uid, pclq.UID)
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+func waitForPCLQUIDChange(t *testing.T, ctx context.Context, tc *testctx.TestContext, name string, oldUID types.UID) {
+	t.Helper()
+	if err := wait.PollUntilContextTimeout(ctx, tc.Interval, tc.Timeout, true, func(ctx context.Context) (bool, error) {
+		pclq := &grovecorev1alpha1.PodClique{}
+		err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: name}, pclq)
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return pclq.UID != oldUID, nil
+	}); err != nil {
+		t.Fatalf("PodClique %s was not recycled after armed availability loss: %v", name, err)
+	}
+}
 
 // findReadyPodFromPodClique returns the first ready pod whose grove.io/podclique
 // label equals cliqueFQN, or nil if none found.

--- a/operator/e2e/tests/startup_ordering_test.go
+++ b/operator/e2e/tests/startup_ordering_test.go
@@ -41,9 +41,11 @@ import (
 	"testing"
 	"time"
 
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/ai-dynamo/grove/operator/e2e/testctx"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -269,6 +271,37 @@ func Test_SO4_ExplicitStartupOrderWithMinReplicas(t *testing.T) {
 	})
 
 	Logger.Info("Explicit startup order with min replicas test completed successfully!")
+}
+
+func Test_SO5_ExplicitStartupSkipsIdleDependencies(t *testing.T) {
+	const pcsName = "startup-idle-explicit"
+	ctx := context.Background()
+	tc, cleanup := prepareIdleWorkload(t, ctx, 3, pcsName, 1, func(pcs *grovecorev1alpha1.PodCliqueSet) {
+		startupType := grovecorev1alpha1.CliqueStartupTypeExplicit
+		pcs.Spec.Template.StartupType = &startupType
+		idlePCSGConfig(t, pcs).Replicas = ptr.To(int32(1))
+		idleClique(t, pcs, "prefill").Spec.StartsAfter = []string{"idle", "worker"}
+		idleClique(t, pcs, "decode").Spec.StartsAfter = []string{"prefill"}
+	})
+	defer cleanup()
+
+	if err := tc.WaitForReadyPods(3); err != nil {
+		t.Fatalf("Idle-aware explicit startup did not become ready: %v", err)
+	}
+	workerName := pcsName + "-0-worker"
+	prefillName := pcsName + "-0-workers-0-prefill"
+	decodeName := pcsName + "-0-workers-0-decode"
+	expected := map[string][]string{
+		workerName:  nil,
+		prefillName: {workerName},
+		decodeName:  {prefillName},
+	}
+	for name, dependencies := range expected {
+		pclq := waitForPCLQ(t, ctx, tc, name)
+		if !slices.Equal(pclq.Spec.StartsAfter, dependencies) {
+			t.Fatalf("PodClique %s startsAfter = %v, want %v", name, pclq.Spec.StartsAfter, dependencies)
+		}
+	}
 }
 
 // Helper function to get the Ready condition's LastTransitionTime from a pod

--- a/operator/e2e/tests/update/ondelete_test.go
+++ b/operator/e2e/tests/update/ondelete_test.go
@@ -151,6 +151,34 @@ func Test_OD2_ManualDeletionCreatesUpdatedPod(t *testing.T) {
 	tests.Logger.Info("OnDelete Update - Manual Deletion Creates Updated Pod test (OD-2) completed successfully!")
 }
 
+func Test_OD12_IdlePodCliqueDoesNotBlockUpdate(t *testing.T) {
+	tc, cleanup := setupIdleUpdateTest(t)
+	defer cleanup()
+
+	if err := updatePCSUpdateStrategy(tc, grovev1alpha1.OnDeleteStrategy); err != nil {
+		t.Fatalf("Failed to select OnDelete strategy: %v", err)
+	}
+	if err := triggerPodCliqueUpdate(tc, "worker"); err != nil {
+		t.Fatalf("Failed to update idle PodClique template: %v", err)
+	}
+	if err := waitForOnDeleteUpdateCompleteWithTimeout(tc, time.Minute); err != nil {
+		t.Fatalf("Idle PodClique blocked OnDelete completion: %v", err)
+	}
+	if err := scalePodCliqueInPCS(tc, "worker", 1); err != nil {
+		t.Fatalf("Failed to wake updated PodClique: %v", err)
+	}
+	if err := tc.WaitForReadyPods(1); err != nil {
+		t.Fatalf("Updated PodClique did not become ready after wake: %v", err)
+	}
+	pods, err := getPodsForClique(tc, "worker")
+	if err != nil || len(pods) != 1 {
+		t.Fatalf("Failed to find woken worker pod: pods=%v err=%v", pods, err)
+	}
+	if err := verifyPodHasUpdatedSpec(tc, pods[0]); err != nil {
+		t.Fatalf("Woken pod did not use updated template: %v", err)
+	}
+}
+
 // Test_OD3_ScaleInPrefersOutdatedPods tests that during scale-in, pods with outdated templates are deleted first.
 // Scenario OD-3 (from proposal Testcase 1):
 // 1. Initialize a 10-node Grove cluster

--- a/operator/e2e/tests/update/rolling_recreate_test.go
+++ b/operator/e2e/tests/update/rolling_recreate_test.go
@@ -284,6 +284,31 @@ func Test_RU10_RollingUpdateInsufficientResources(t *testing.T) {
 	tests.Logger.Info("Rolling Update with insufficient resources test (RU-10) completed successfully!")
 }
 
+func Test_RU22_IdlePodCliqueDoesNotBlockUpdate(t *testing.T) {
+	tc, cleanup := setupIdleUpdateTest(t)
+	defer cleanup()
+
+	if err := triggerPodCliqueUpdate(tc, "worker"); err != nil {
+		t.Fatalf("Failed to update idle PodClique template: %v", err)
+	}
+	if err := waitForRollingUpdateComplete(tc, 1); err != nil {
+		t.Fatalf("Idle PodClique blocked RollingRecreate completion: %v", err)
+	}
+	if err := scalePodCliqueInPCS(tc, "worker", 1); err != nil {
+		t.Fatalf("Failed to wake updated PodClique: %v", err)
+	}
+	if err := tc.WaitForReadyPods(1); err != nil {
+		t.Fatalf("Updated PodClique did not become ready after wake: %v", err)
+	}
+	pods, err := getPodsForClique(tc, "worker")
+	if err != nil || len(pods) != 1 {
+		t.Fatalf("Failed to find woken worker pod: pods=%v err=%v", pods, err)
+	}
+	if err := verifyPodHasUpdatedSpec(tc, pods[0]); err != nil {
+		t.Fatalf("Woken pod did not use updated template: %v", err)
+	}
+}
+
 // Test_RU11_RollingUpdateWithPCSScaleOut tests rolling update with scale-out on PCS
 // Scenario RU-11:
 // 1. Initialize a 30-node Grove cluster

--- a/operator/e2e/tests/update/zero_replica_test.go
+++ b/operator/e2e/tests/update/zero_replica_test.go
@@ -1,0 +1,55 @@
+//go:build e2e
+
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package update
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ai-dynamo/grove/operator/e2e/grove/workload"
+	"github.com/ai-dynamo/grove/operator/e2e/testctx"
+	"github.com/ai-dynamo/grove/operator/e2e/tests"
+)
+
+func setupIdleUpdateTest(t *testing.T) (*testctx.TestContext, func()) {
+	t.Helper()
+	const workloadName = "workload-idle-wake"
+
+	ctx := context.Background()
+	tc, cleanup := testctx.PrepareTest(ctx, t, 1,
+		testctx.WithWorkload(&testctx.WorkloadConfig{
+			Name:         workloadName,
+			YAMLPath:     "../../yaml/workload-idle-wake.yaml",
+			Namespace:    "default",
+			ExpectedPods: 0,
+		}),
+	)
+	if _, err := tc.DeployAndVerifyWorkload(); err != nil {
+		cleanup()
+		t.Fatalf("Failed to deploy idle workload: %v", err)
+	}
+
+	workloadManager := workload.NewWorkloadManager(tc.Client, tests.Logger)
+	if _, err := workloadManager.WaitForPodClique(
+		ctx, tc.Namespace, workloadName+"-0-worker", tc.Timeout, tc.Interval,
+	); err != nil {
+		cleanup()
+		t.Fatalf("Failed to wait for idle PodClique: %v", err)
+	}
+
+	return tc, cleanup
+}

--- a/operator/e2e/tests/zero_replica_test.go
+++ b/operator/e2e/tests/zero_replica_test.go
@@ -1,0 +1,840 @@
+//go:build e2e
+
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"slices"
+	"strconv"
+	"testing"
+	"time"
+
+	apicommon "github.com/ai-dynamo/grove/operator/api/common"
+	apiconstants "github.com/ai-dynamo/grove/operator/api/common/constants"
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/ai-dynamo/grove/operator/e2e/setup"
+	"github.com/ai-dynamo/grove/operator/e2e/testctx"
+	internalconstants "github.com/ai-dynamo/grove/operator/internal/constants"
+	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+const zeroReplicaObservationWindow = 5 * time.Second
+
+func Test_ZR1_AllIdleBootstrapAndStaleBreach(t *testing.T) {
+	const pcsName = "zero-bootstrap"
+	ctx := context.Background()
+	tc, cleanup := prepareIdleWorkload(t, ctx, 1, pcsName, 0, nil)
+	defer cleanup()
+
+	workerName := pcsName + "-0-worker"
+	pcsgName := pcsName + "-0-workers"
+	worker := waitForPCLQ(t, ctx, tc, workerName)
+	pcsg := waitForPCSG(t, ctx, tc, pcsgName)
+	waitForAllIdleBootstrap(t, ctx, tc, pcsName)
+
+	beforePCLQEvents := countEvents(t, ctx, tc, worker.UID, internalconstants.ReasonAllScheduledReplicasLost)
+	beforePCSGEvents := countEvents(t, ctx, tc, pcsg.UID, internalconstants.ReasonAllScheduledReplicasLost)
+	setStaleBreachConditions(t, ctx, tc, workerName, pcsgName)
+	restartOperator(t, ctx, tc)
+
+	waitForPCLQConditionReason(t, ctx, tc, workerName, apiconstants.ConditionReasonIdle)
+	waitForPCSGConditionReason(t, ctx, tc, pcsgName, apiconstants.ConditionReasonIdle)
+	assertStableFor(t, ctx, zeroReplicaObservationWindow, func(ctx context.Context) error {
+		currentWorker := &grovecorev1alpha1.PodClique{}
+		if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: workerName}, currentWorker); err != nil {
+			return err
+		}
+		if currentWorker.UID != worker.UID {
+			return fmt.Errorf("idle PodClique UID changed: %s -> %s", worker.UID, currentWorker.UID)
+		}
+		currentPCSG := &grovecorev1alpha1.PodCliqueScalingGroup{}
+		if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: pcsgName}, currentPCSG); err != nil {
+			return err
+		}
+		if currentPCSG.UID != pcsg.UID {
+			return fmt.Errorf("idle PodCliqueScalingGroup UID changed: %s -> %s", pcsg.UID, currentPCSG.UID)
+		}
+		if got := countEvents(t, ctx, tc, worker.UID, internalconstants.ReasonAllScheduledReplicasLost); got != beforePCLQEvents {
+			return fmt.Errorf("PodClique AllScheduledReplicasLost event count changed: %d -> %d", beforePCLQEvents, got)
+		}
+		if got := countEvents(t, ctx, tc, pcsg.UID, internalconstants.ReasonAllScheduledReplicasLost); got != beforePCSGEvents {
+			return fmt.Errorf("PodCliqueScalingGroup AllScheduledReplicasLost event count changed: %d -> %d", beforePCSGEvents, got)
+		}
+		return nil
+	})
+}
+
+func Test_ZR2_StandaloneLifecycle(t *testing.T) {
+	const pcsName = "zero-standalone"
+	ctx := context.Background()
+	tc, cleanup := prepareIdleWorkload(t, ctx, 3, pcsName, 3, nil)
+	defer cleanup()
+
+	workerName := pcsName + "-0-worker"
+	if err := tc.WaitForReadyPods(3); err != nil {
+		t.Fatalf("Initial standalone pods did not become ready: %v", err)
+	}
+	waitForStandaloneMembership(t, ctx, tc, pcsName, "worker", 3)
+	initialPods := podsForClique(t, tc, workerName)
+	initialLocations := podUIDLocations(initialPods)
+	initialPodGangs := podGangNameSet(t, ctx, tc, pcsName)
+	initialEpoch := maxPGMEpoch(t, ctx, tc, pcsName)
+
+	updateScale(t, ctx, tc, &grovecorev1alpha1.PodClique{
+		ObjectMeta: metav1.ObjectMeta{Name: workerName, Namespace: tc.Namespace},
+	}, 1)
+	waitForPodCountAndReady(t, tc, 1)
+	waitForStandaloneMembership(t, ctx, tc, pcsName, "worker", 1)
+	assertRetainedPodLocation(t, podsForClique(t, tc, workerName), initialLocations)
+
+	updateScale(t, ctx, tc, &grovecorev1alpha1.PodClique{
+		ObjectMeta: metav1.ObjectMeta{Name: workerName, Namespace: tc.Namespace},
+	}, 0)
+	waitForAllIdle(t, ctx, tc, pcsName, pcsName+"-0-workers-0-prefill", pcsName+"-0-workers-0-decode")
+	waitForAllIdleBootstrap(t, ctx, tc, pcsName)
+
+	updateScale(t, ctx, tc, &grovecorev1alpha1.PodClique{
+		ObjectMeta: metav1.ObjectMeta{Name: workerName, Namespace: tc.Namespace},
+	}, 1)
+	waitForPodCountAndReady(t, tc, 1)
+	waitForStandaloneMembership(t, ctx, tc, pcsName, "worker", 1)
+	if wakeEpoch := maxPGMEpoch(t, ctx, tc, pcsName); wakeEpoch <= initialEpoch {
+		t.Fatalf("wake epoch = %d, want greater than initial epoch %d", wakeEpoch, initialEpoch)
+	}
+	for name := range podGangNameSet(t, ctx, tc, pcsName) {
+		if initialPodGangs.Has(name) {
+			t.Fatalf("wake reused materialized PodGang %s", name)
+		}
+	}
+
+	updateScale(t, ctx, tc, &grovecorev1alpha1.PodClique{
+		ObjectMeta: metav1.ObjectMeta{Name: workerName, Namespace: tc.Namespace},
+	}, 3)
+	waitForPodCountAndReady(t, tc, 3)
+	waitForStandaloneMembership(t, ctx, tc, pcsName, "worker", 3)
+	assertScaleStatus(t, ctx, tc, &grovecorev1alpha1.PodClique{
+		ObjectMeta: metav1.ObjectMeta{Name: workerName, Namespace: tc.Namespace},
+	}, 3, true)
+}
+
+func Test_ZR3_PodCliqueScalingGroupLifecycle(t *testing.T) {
+	const pcsName = "zero-pcsg"
+	ctx := context.Background()
+	tc, cleanup := prepareIdleWorkload(t, ctx, 6, pcsName, 0, func(pcs *grovecorev1alpha1.PodCliqueSet) {
+		config := idlePCSGConfig(t, pcs)
+		config.Replicas = ptr.To(int32(3))
+	})
+	defer cleanup()
+
+	pcsgName := pcsName + "-0-workers"
+	if err := tc.WaitForReadyPods(6); err != nil {
+		t.Fatalf("Initial scaling-group pods did not become ready: %v", err)
+	}
+	waitForPCSGMembership(t, ctx, tc, pcsName, "workers", []int32{0, 1, 2})
+	retainedPCLQUIDs := pclqUIDsForPCSGIndex(t, ctx, tc, pcsgName, "0")
+	retainedPodLocations := podUIDLocations(podsForPCSGIndex(t, tc, "0"))
+	initialPodGangs := podGangNameSet(t, ctx, tc, pcsName)
+
+	updateScale(t, ctx, tc, &grovecorev1alpha1.PodCliqueScalingGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: pcsgName, Namespace: tc.Namespace},
+	}, 1)
+	waitForPodCountAndReady(t, tc, 2)
+	waitForPCSGMembership(t, ctx, tc, pcsName, "workers", []int32{0})
+	waitForPCSGChildrenAbsent(t, ctx, tc, pcsgName, 1, 2)
+	assertPCLQUIDs(t, ctx, tc, retainedPCLQUIDs)
+	assertRetainedPodLocation(t, podsForPCSGIndex(t, tc, "0"), retainedPodLocations)
+
+	updateScale(t, ctx, tc, &grovecorev1alpha1.PodCliqueScalingGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: pcsgName, Namespace: tc.Namespace},
+	}, 0)
+	waitForAllIdle(t, ctx, tc, pcsName, pcsgName+"-0-prefill", pcsgName+"-0-decode")
+	waitForAllIdleBootstrap(t, ctx, tc, pcsName)
+
+	updateScale(t, ctx, tc, &grovecorev1alpha1.PodCliqueScalingGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: pcsgName, Namespace: tc.Namespace},
+	}, 2)
+	waitForPodCountAndReady(t, tc, 4)
+	waitForPCSGMembership(t, ctx, tc, pcsName, "workers", []int32{0, 1})
+	for name := range podGangNameSet(t, ctx, tc, pcsName) {
+		if initialPodGangs.Has(name) {
+			t.Fatalf("PCSG wake reused materialized PodGang %s", name)
+		}
+	}
+}
+
+func Test_ZR4_AdmissionValidationAndRetry(t *testing.T) {
+	const pcsName = "zero-admission"
+	ctx := context.Background()
+	tc, cleanup := prepareIdleWorkload(t, ctx, 4, pcsName, 0, func(pcs *grovecorev1alpha1.PodCliqueSet) {
+		guarded := idleClique(t, pcs, "guarded")
+		guarded.Spec.MinAvailable = ptr.To(int32(3))
+	})
+	defer cleanup()
+
+	template := idleClique(t, loadIdlePCS(t, "unused"), "worker").Spec
+	invalidPCLQ := &grovecorev1alpha1.PodClique{
+		ObjectMeta: metav1.ObjectMeta{Name: "invalid-pclq", Namespace: tc.Namespace},
+		Spec:       template,
+	}
+	invalidPCLQ.Spec.Replicas = 1
+	invalidPCLQ.Spec.MinAvailable = ptr.To(int32(2))
+	requireInvalidCause(t, tc.Client.Create(ctx, invalidPCLQ), "spec")
+	assertObjectNotFound(t, ctx, tc, client.ObjectKeyFromObject(invalidPCLQ), &grovecorev1alpha1.PodClique{})
+
+	invalidPCSG := &grovecorev1alpha1.PodCliqueScalingGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "invalid-pcsg", Namespace: tc.Namespace},
+		Spec: grovecorev1alpha1.PodCliqueScalingGroupSpec{
+			Replicas:     1,
+			MinAvailable: ptr.To(int32(2)),
+			CliqueNames:  []string{"worker"},
+		},
+	}
+	requireInvalidCause(t, tc.Client.Create(ctx, invalidPCSG), "spec")
+	assertObjectNotFound(t, ctx, tc, client.ObjectKeyFromObject(invalidPCSG), &grovecorev1alpha1.PodCliqueScalingGroup{})
+
+	invalidPCS := loadIdlePCS(t, "invalid-pcs-template")
+	invalidTemplate := idleClique(t, invalidPCS, "worker")
+	invalidTemplate.Spec.Replicas = 1
+	invalidTemplate.Spec.MinAvailable = ptr.To(int32(2))
+	requireInvalidCause(t, tc.Client.Create(ctx, invalidPCS), "spec.template.cliques[1].spec")
+	assertObjectNotFound(t, ctx, tc, client.ObjectKeyFromObject(invalidPCS), &grovecorev1alpha1.PodCliqueSet{})
+
+	guardedName := pcsName + "-0-guarded"
+	waitForPCLQ(t, ctx, tc, guardedName)
+	assertRejectedReplicaUpdate(t, ctx, tc, guardedName, 1)
+
+	updateScale(t, ctx, tc, &grovecorev1alpha1.PodClique{
+		ObjectMeta: metav1.ObjectMeta{Name: guardedName, Namespace: tc.Namespace},
+	}, 4)
+	waitForPodCountAndReady(t, tc, 4)
+	assertRejectedReplicaUpdate(t, ctx, tc, guardedName, 2)
+
+	beforeEvents := countEvents(t, ctx, tc, waitForPCLQ(t, ctx, tc, guardedName).UID, "")
+	for range 3 {
+		assertRejectedScaleUpdate(t, ctx, tc, guardedName, 2)
+	}
+	guarded := waitForPCLQ(t, ctx, tc, guardedName)
+	if guarded.Spec.Replicas != 4 {
+		t.Fatalf("stored replicas = %d after rejected retries, want 4", guarded.Spec.Replicas)
+	}
+	if got := countEvents(t, ctx, tc, guarded.UID, ""); got != beforeEvents {
+		t.Fatalf("warning event count changed after rejected scale retries: %d -> %d", beforeEvents, got)
+	}
+
+	updateScale(t, ctx, tc, &grovecorev1alpha1.PodClique{
+		ObjectMeta: metav1.ObjectMeta{Name: guardedName, Namespace: tc.Namespace},
+	}, 0)
+	waitForAllIdle(t, ctx, tc, pcsName, pcsName+"-0-workers-0-prefill", pcsName+"-0-workers-0-decode")
+	assertScaleStatus(t, ctx, tc, &grovecorev1alpha1.PodClique{
+		ObjectMeta: metav1.ObjectMeta{Name: guardedName, Namespace: tc.Namespace},
+	}, 0, true)
+}
+
+func Test_ZR5_PodCliqueSetReplicaIsolation(t *testing.T) {
+	const pcsName = "zero-isolation"
+	ctx := context.Background()
+	tc, cleanup := prepareIdleWorkload(t, ctx, 2, pcsName, 1, func(pcs *grovecorev1alpha1.PodCliqueSet) {
+		pcs.Spec.Replicas = 2
+	})
+	defer cleanup()
+
+	if err := tc.WaitForReadyPods(2); err != nil {
+		t.Fatalf("Initial replica-isolation pods did not become ready: %v", err)
+	}
+	replicaOnePCLQ := pcsName + "-1-worker"
+	replicaOnePods := podsForClique(t, tc, replicaOnePCLQ)
+	replicaOneLocations := podUIDLocations(replicaOnePods)
+	replicaOnePGM := getPGM(t, ctx, tc, pcsName, 1).DeepCopy()
+	replicaOnePodGangs := podGangUIDsForPCSReplica(t, ctx, tc, pcsName, "1")
+
+	updateScale(t, ctx, tc, &grovecorev1alpha1.PodClique{
+		ObjectMeta: metav1.ObjectMeta{Name: pcsName + "-0-worker", Namespace: tc.Namespace},
+	}, 0)
+	waitForPodCountAndReady(t, tc, 1)
+	assertRetainedPodLocation(t, podsForClique(t, tc, replicaOnePCLQ), replicaOneLocations)
+	if current := getPGM(t, ctx, tc, pcsName, 1); !reflect.DeepEqual(replicaOnePGM.Spec.Entries, current.Spec.Entries) {
+		t.Fatalf("PodGangMap for untouched PCS replica changed")
+	}
+	assertPodGangUIDs(t, ctx, tc, replicaOnePodGangs)
+}
+
+func prepareIdleWorkload(
+	t *testing.T,
+	ctx context.Context,
+	workerNodes int,
+	name string,
+	workerReplicas int32,
+	mutate func(*grovecorev1alpha1.PodCliqueSet),
+) (*testctx.TestContext, func()) {
+	t.Helper()
+	tc, cleanup := testctx.PrepareTest(ctx, t, workerNodes,
+		testctx.WithWorkload(&testctx.WorkloadConfig{
+			Name:         name,
+			Namespace:    "default",
+			ExpectedPods: int(workerReplicas),
+		}),
+	)
+	pcs := loadIdlePCS(t, name)
+	idleClique(t, pcs, "worker").Spec.Replicas = workerReplicas
+	if mutate != nil {
+		mutate(pcs)
+	}
+	if err := tc.Client.Create(ctx, pcs); err != nil {
+		cleanup()
+		t.Fatalf("Failed to create PodCliqueSet %s: %v", name, err)
+	}
+	return tc, cleanup
+}
+
+func loadIdlePCS(t *testing.T, name string) *grovecorev1alpha1.PodCliqueSet {
+	t.Helper()
+	data, err := os.ReadFile("../yaml/workload-idle-wake.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read idle workload fixture: %v", err)
+	}
+	pcs := &grovecorev1alpha1.PodCliqueSet{}
+	if err := yaml.Unmarshal(data, pcs); err != nil {
+		t.Fatalf("Failed to decode idle workload fixture: %v", err)
+	}
+	pcs.Name = name
+	pcs.Namespace = "default"
+	pcs.ResourceVersion = ""
+	pcs.UID = ""
+	pcs.Labels["app"] = name
+	return pcs
+}
+
+func idleClique(t *testing.T, pcs *grovecorev1alpha1.PodCliqueSet, name string) *grovecorev1alpha1.PodCliqueTemplateSpec {
+	t.Helper()
+	for i := range pcs.Spec.Template.Cliques {
+		if pcs.Spec.Template.Cliques[i].Name == name {
+			return pcs.Spec.Template.Cliques[i]
+		}
+	}
+	t.Fatalf("PodClique template %s not found", name)
+	return nil
+}
+
+func idlePCSGConfig(t *testing.T, pcs *grovecorev1alpha1.PodCliqueSet) *grovecorev1alpha1.PodCliqueScalingGroupConfig {
+	t.Helper()
+	for i := range pcs.Spec.Template.PodCliqueScalingGroupConfigs {
+		if pcs.Spec.Template.PodCliqueScalingGroupConfigs[i].Name == "workers" {
+			return &pcs.Spec.Template.PodCliqueScalingGroupConfigs[i]
+		}
+	}
+	t.Fatal("PodCliqueScalingGroup config workers not found")
+	return nil
+}
+
+func waitForAllIdleBootstrap(t *testing.T, ctx context.Context, tc *testctx.TestContext, pcsName string) {
+	t.Helper()
+	if err := wait.PollUntilContextTimeout(ctx, tc.Interval, tc.Timeout, true, func(ctx context.Context) (bool, error) {
+		pods, err := tc.ListPods()
+		if err != nil || len(pods.Items) != 0 {
+			return false, err
+		}
+		if len(listPodGangs(t, ctx, tc, pcsName).Items) != 0 {
+			return false, nil
+		}
+		pclqs := &grovecorev1alpha1.PodCliqueList{}
+		if err := tc.Client.List(ctx, pclqs,
+			client.InNamespace(tc.Namespace),
+			client.MatchingLabels{apicommon.LabelPartOfKey: pcsName},
+		); err != nil {
+			return false, err
+		}
+		for i := range pclqs.Items {
+			owner := metav1.GetControllerOfNoCopy(&pclqs.Items[i])
+			if owner != nil && owner.Kind == apiconstants.KindPodCliqueScalingGroup {
+				return false, nil
+			}
+		}
+		pgm := getPGM(t, ctx, tc, pcsName, 0)
+		var baseAnchor, scaleOut bool
+		for i := range pgm.Spec.Entries {
+			entry := &pgm.Spec.Entries[i]
+			if len(entry.PodCliques) != 0 || hasPCSGIndices(entry.PCSGReplicaIndices) {
+				return false, nil
+			}
+			if entry.Role == grovecorev1alpha1.PodGangEntryRoleAnchor &&
+				entry.AnchorIndex != nil && *entry.AnchorIndex == 0 {
+				baseAnchor = true
+			}
+			if entry.Role == grovecorev1alpha1.PodGangEntryRoleScaleOut {
+				scaleOut = true
+			}
+		}
+		pcs := &grovecorev1alpha1.PodCliqueSet{}
+		if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: pcsName}, pcs); err != nil {
+			return false, err
+		}
+		return baseAnchor && scaleOut && pcs.Status.AvailableReplicas == pcs.Spec.Replicas, nil
+	}); err != nil {
+		t.Fatalf("All-idle bootstrap did not converge: %v", err)
+	}
+}
+
+func hasPCSGIndices(indices map[string][]int32) bool {
+	for _, values := range indices {
+		if len(values) != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func setStaleBreachConditions(t *testing.T, ctx context.Context, tc *testctx.TestContext, pclqName, pcsgName string) {
+	t.Helper()
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		pclq := &grovecorev1alpha1.PodClique{}
+		if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: pclqName}, pclq); err != nil {
+			return err
+		}
+		meta.SetStatusCondition(&pclq.Status.Conditions, metav1.Condition{
+			Type:               apiconstants.ConditionTypeMinAvailableBreached,
+			Status:             metav1.ConditionTrue,
+			Reason:             apiconstants.ConditionReasonInsufficientScheduledPods,
+			ObservedGeneration: pclq.Generation,
+		})
+		return tc.Client.Status().Update(ctx, pclq)
+	}); err != nil {
+		t.Fatalf("Failed to seed stale PodClique breach: %v", err)
+	}
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		pcsg := &grovecorev1alpha1.PodCliqueScalingGroup{}
+		if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: pcsgName}, pcsg); err != nil {
+			return err
+		}
+		meta.SetStatusCondition(&pcsg.Status.Conditions, metav1.Condition{
+			Type:               apiconstants.ConditionTypeMinAvailableBreached,
+			Status:             metav1.ConditionTrue,
+			Reason:             apiconstants.ConditionReasonInsufficientAvailablePCSGReplicas,
+			ObservedGeneration: pcsg.Generation,
+		})
+		return tc.Client.Status().Update(ctx, pcsg)
+	}); err != nil {
+		t.Fatalf("Failed to seed stale PodCliqueScalingGroup breach: %v", err)
+	}
+}
+
+func waitForPCSG(t *testing.T, ctx context.Context, tc *testctx.TestContext, name string) *grovecorev1alpha1.PodCliqueScalingGroup {
+	t.Helper()
+	var result *grovecorev1alpha1.PodCliqueScalingGroup
+	if err := wait.PollUntilContextTimeout(ctx, tc.Interval, tc.Timeout, true, func(ctx context.Context) (bool, error) {
+		pcsg := &grovecorev1alpha1.PodCliqueScalingGroup{}
+		if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: name}, pcsg); err != nil {
+			return false, client.IgnoreNotFound(err)
+		}
+		result = pcsg
+		return true, nil
+	}); err != nil {
+		t.Fatalf("PodCliqueScalingGroup %s did not appear: %v", name, err)
+	}
+	return result
+}
+
+func waitForPCSGConditionReason(t *testing.T, ctx context.Context, tc *testctx.TestContext, name, reason string) {
+	t.Helper()
+	if err := wait.PollUntilContextTimeout(ctx, tc.Interval, tc.Timeout, true, func(ctx context.Context) (bool, error) {
+		pcsg := &grovecorev1alpha1.PodCliqueScalingGroup{}
+		if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: name}, pcsg); err != nil {
+			return false, client.IgnoreNotFound(err)
+		}
+		condition := meta.FindStatusCondition(pcsg.Status.Conditions, apiconstants.ConditionTypeMinAvailableBreached)
+		return condition != nil && condition.Status == metav1.ConditionFalse &&
+			condition.Reason == reason && condition.ObservedGeneration == pcsg.Generation, nil
+	}); err != nil {
+		t.Fatalf("PodCliqueScalingGroup %s condition did not reach reason %s: %v", name, reason, err)
+	}
+}
+
+func countEvents(t *testing.T, ctx context.Context, tc *testctx.TestContext, uid types.UID, reason string) int {
+	t.Helper()
+	events := &corev1.EventList{}
+	if err := tc.Client.List(ctx, events, client.InNamespace(tc.Namespace)); err != nil {
+		t.Fatalf("Failed to list events: %v", err)
+	}
+	count := 0
+	for i := range events.Items {
+		event := &events.Items[i]
+		if event.InvolvedObject.UID == uid && (reason == "" || event.Reason == reason) &&
+			(reason != "" || event.Type == corev1.EventTypeWarning) {
+			count++
+		}
+	}
+	return count
+}
+
+func assertStableFor(t *testing.T, ctx context.Context, duration time.Duration, check func(context.Context) error) {
+	t.Helper()
+	deadline := time.Now().Add(duration)
+	for {
+		if err := check(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+func updateScale(t *testing.T, ctx context.Context, tc *testctx.TestContext, obj client.Object, replicas int32) {
+	t.Helper()
+	scale := &autoscalingv1.Scale{
+		ObjectMeta: metav1.ObjectMeta{Name: obj.GetName(), Namespace: obj.GetNamespace()},
+		Spec:       autoscalingv1.ScaleSpec{Replicas: replicas},
+	}
+	if err := tc.Client.SubResource("scale").Update(ctx, obj, client.WithSubResourceBody(scale)); err != nil {
+		t.Fatalf("Failed to scale %T %s to %d: %v", obj, obj.GetName(), replicas, err)
+	}
+}
+
+func assertScaleStatus(t *testing.T, ctx context.Context, tc *testctx.TestContext, obj client.Object, replicas int32, wantSelector bool) {
+	t.Helper()
+	scale := &autoscalingv1.Scale{}
+	if err := tc.Client.SubResource("scale").Get(ctx, obj, scale); err != nil {
+		t.Fatalf("Failed to get scale for %T %s: %v", obj, obj.GetName(), err)
+	}
+	if scale.Spec.Replicas != replicas {
+		t.Fatalf("scale spec replicas = %d, want %d", scale.Spec.Replicas, replicas)
+	}
+	if wantSelector && scale.Status.Selector == "" {
+		t.Fatal("scale status selector is empty")
+	}
+}
+
+func waitForPodCountAndReady(t *testing.T, tc *testctx.TestContext, count int) {
+	t.Helper()
+	if _, err := tc.WaitForPodCount(count); err != nil {
+		t.Fatalf("Pod count did not converge to %d: %v", count, err)
+	}
+	if err := tc.WaitForReadyPods(count); err != nil {
+		t.Fatalf("Ready pod count did not converge to %d: %v", count, err)
+	}
+}
+
+func waitForStandaloneMembership(t *testing.T, ctx context.Context, tc *testctx.TestContext, pcsName, cliqueName string, replicas int32) {
+	t.Helper()
+	if err := wait.PollUntilContextTimeout(ctx, tc.Interval, tc.Timeout, true, func(ctx context.Context) (bool, error) {
+		pgm := getPGM(t, ctx, tc, pcsName, 0)
+		total := int32(0)
+		for i := range pgm.Spec.Entries {
+			total += pgm.Spec.Entries[i].PodCliques[cliqueName]
+		}
+		if total != replicas {
+			return false, nil
+		}
+		podGangs := listPodGangs(t, ctx, tc, pcsName)
+		podGroups := 0
+		references := 0
+		for i := range podGangs.Items {
+			for _, group := range podGangs.Items[i].Spec.PodGroups {
+				if group.Name == pcsName+"-0-"+cliqueName {
+					podGroups++
+					references += len(group.PodReferences)
+				}
+			}
+		}
+		return podGroups == 1 && references == int(replicas), nil
+	}); err != nil {
+		t.Fatalf("Standalone membership did not converge to %d: %v", replicas, err)
+	}
+}
+
+func waitForPCSGMembership(t *testing.T, ctx context.Context, tc *testctx.TestContext, pcsName, pcsgName string, want []int32) {
+	t.Helper()
+	slices.Sort(want)
+	if err := wait.PollUntilContextTimeout(ctx, tc.Interval, tc.Timeout, true, func(ctx context.Context) (bool, error) {
+		pgm := getPGM(t, ctx, tc, pcsName, 0)
+		var got []int32
+		for i := range pgm.Spec.Entries {
+			got = append(got, pgm.Spec.Entries[i].PCSGReplicaIndices[pcsgName]...)
+		}
+		slices.Sort(got)
+		return slices.Equal(got, want), nil
+	}); err != nil {
+		t.Fatalf("PCSG membership did not converge to %v: %v", want, err)
+	}
+}
+
+func getPGM(t *testing.T, ctx context.Context, tc *testctx.TestContext, pcsName string, replica int) *grovecorev1alpha1.PodGangMap {
+	t.Helper()
+	pgm := &grovecorev1alpha1.PodGangMap{}
+	name := apicommon.GeneratePodGangMapName(apicommon.ResourceNameReplica{Name: pcsName, Replica: replica})
+	if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: name}, pgm); err != nil {
+		t.Fatalf("Failed to get PodGangMap %s: %v", name, err)
+	}
+	return pgm
+}
+
+func maxPGMEpoch(t *testing.T, ctx context.Context, tc *testctx.TestContext, pcsName string) int64 {
+	t.Helper()
+	var maxEpoch int64
+	for _, entry := range getPGM(t, ctx, tc, pcsName, 0).Spec.Entries {
+		epoch, err := strconv.ParseInt(entry.Epoch, 10, 64)
+		if err != nil {
+			t.Fatalf("Invalid epoch %q: %v", entry.Epoch, err)
+		}
+		maxEpoch = max(maxEpoch, epoch)
+	}
+	return maxEpoch
+}
+
+func podGangNameSet(t *testing.T, ctx context.Context, tc *testctx.TestContext, pcsName string) stringSet {
+	t.Helper()
+	result := stringSet{}
+	for _, podGang := range listPodGangs(t, ctx, tc, pcsName).Items {
+		result[podGang.Name] = struct{}{}
+	}
+	return result
+}
+
+func podsForClique(t *testing.T, tc *testctx.TestContext, pclqName string) []corev1.Pod {
+	t.Helper()
+	pods, err := tc.ListPods()
+	if err != nil {
+		t.Fatalf("Failed to list pods: %v", err)
+	}
+	var result []corev1.Pod
+	for _, pod := range pods.Items {
+		if pod.Labels[apicommon.LabelPodClique] == pclqName {
+			result = append(result, pod)
+		}
+	}
+	return result
+}
+
+func podsForPCSGIndex(t *testing.T, tc *testctx.TestContext, index string) []corev1.Pod {
+	t.Helper()
+	pods, err := tc.ListPods()
+	if err != nil {
+		t.Fatalf("Failed to list pods: %v", err)
+	}
+	var result []corev1.Pod
+	for _, pod := range pods.Items {
+		if pod.Labels[apicommon.LabelPodCliqueScalingGroupReplicaIndex] == index {
+			result = append(result, pod)
+		}
+	}
+	return result
+}
+
+func podUIDLocations(pods []corev1.Pod) map[types.UID]string {
+	result := make(map[types.UID]string, len(pods))
+	for _, pod := range pods {
+		result[pod.UID] = pod.Spec.NodeName
+	}
+	return result
+}
+
+func assertRetainedPodLocation(t *testing.T, pods []corev1.Pod, original map[types.UID]string) {
+	t.Helper()
+	if len(pods) == 0 {
+		t.Fatal("no retained pods found")
+	}
+	for _, pod := range pods {
+		node, ok := original[pod.UID]
+		if !ok {
+			t.Fatalf("pod %s has new UID %s", pod.Name, pod.UID)
+		}
+		if pod.Spec.NodeName != node {
+			t.Fatalf("pod %s moved from node %s to %s", pod.Name, node, pod.Spec.NodeName)
+		}
+	}
+}
+
+func waitForPCSGChildrenAbsent(t *testing.T, ctx context.Context, tc *testctx.TestContext, pcsgName string, indices ...int) {
+	t.Helper()
+	if err := wait.PollUntilContextTimeout(ctx, tc.Interval, tc.Timeout, true, func(ctx context.Context) (bool, error) {
+		for _, index := range indices {
+			for _, clique := range []string{"prefill", "decode"} {
+				name := fmt.Sprintf("%s-%d-%s", pcsgName, index, clique)
+				err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: name}, &grovecorev1alpha1.PodClique{})
+				if err == nil {
+					return false, nil
+				}
+				if !apierrors.IsNotFound(err) {
+					return false, err
+				}
+			}
+		}
+		return true, nil
+	}); err != nil {
+		t.Fatalf("Scaled-in PCSG children remained: %v", err)
+	}
+}
+
+func pclqUIDsForPCSGIndex(t *testing.T, ctx context.Context, tc *testctx.TestContext, pcsgName, index string) map[string]types.UID {
+	t.Helper()
+	result := map[string]types.UID{}
+	for _, clique := range []string{"prefill", "decode"} {
+		name := pcsgName + "-" + index + "-" + clique
+		pclq := waitForPCLQ(t, ctx, tc, name)
+		result[name] = pclq.UID
+	}
+	return result
+}
+
+func assertPCLQUIDs(t *testing.T, ctx context.Context, tc *testctx.TestContext, want map[string]types.UID) {
+	t.Helper()
+	for name, uid := range want {
+		pclq := &grovecorev1alpha1.PodClique{}
+		if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: name}, pclq); err != nil {
+			t.Fatalf("Failed to get retained PodClique %s: %v", name, err)
+		}
+		if pclq.UID != uid {
+			t.Fatalf("PodClique %s UID changed: %s -> %s", name, uid, pclq.UID)
+		}
+	}
+}
+
+func requireInvalidCause(t *testing.T, err error, field string) {
+	t.Helper()
+	if !apierrors.IsInvalid(err) {
+		t.Fatalf("error = %v, want StatusReasonInvalid", err)
+	}
+	statusErr, ok := err.(apierrors.APIStatus)
+	if !ok {
+		t.Fatalf("error type %T does not implement APIStatus", err)
+	}
+	status := statusErr.Status()
+	if status.Reason != metav1.StatusReasonInvalid || status.Details == nil {
+		t.Fatalf("status = %#v, want Invalid with details", status)
+	}
+	for _, cause := range status.Details.Causes {
+		if cause.Field == field {
+			return
+		}
+	}
+	t.Fatalf("field causes = %#v, want exact field %q", status.Details.Causes, field)
+}
+
+func assertObjectNotFound(t *testing.T, ctx context.Context, tc *testctx.TestContext, key client.ObjectKey, obj client.Object) {
+	t.Helper()
+	if err := tc.Client.Get(ctx, key, obj); !apierrors.IsNotFound(err) {
+		t.Fatalf("Get %T %s after rejected create = %v, want NotFound", obj, key, err)
+	}
+}
+
+func assertRejectedReplicaUpdate(t *testing.T, ctx context.Context, tc *testctx.TestContext, name string, replicas int32) {
+	t.Helper()
+	before := waitForPCLQ(t, ctx, tc, name)
+	updated := before.DeepCopy()
+	updated.Spec.Replicas = replicas
+	requireInvalidCause(t, tc.Client.Update(ctx, updated), "spec")
+	after := waitForPCLQ(t, ctx, tc, name)
+	if after.Spec.Replicas != before.Spec.Replicas || after.ResourceVersion != before.ResourceVersion {
+		t.Fatalf("rejected update changed stored object: replicas %d -> %d, resourceVersion %s -> %s",
+			before.Spec.Replicas, after.Spec.Replicas, before.ResourceVersion, after.ResourceVersion)
+	}
+	assertRejectedScaleUpdate(t, ctx, tc, name, replicas)
+}
+
+func assertRejectedScaleUpdate(t *testing.T, ctx context.Context, tc *testctx.TestContext, name string, replicas int32) {
+	t.Helper()
+	before := waitForPCLQ(t, ctx, tc, name)
+	scale := &autoscalingv1.Scale{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: tc.Namespace},
+		Spec:       autoscalingv1.ScaleSpec{Replicas: replicas},
+	}
+	requireInvalidCause(t, tc.Client.SubResource("scale").Update(ctx, before, client.WithSubResourceBody(scale)), "spec")
+	after := waitForPCLQ(t, ctx, tc, name)
+	if after.Spec.Replicas != before.Spec.Replicas {
+		t.Fatalf("rejected scale changed stored replicas: %d -> %d", before.Spec.Replicas, after.Spec.Replicas)
+	}
+}
+
+func podGangUIDsForPCSReplica(t *testing.T, ctx context.Context, tc *testctx.TestContext, pcsName, replica string) map[string]types.UID {
+	t.Helper()
+	result := map[string]types.UID{}
+	for _, podGang := range listPodGangs(t, ctx, tc, pcsName).Items {
+		if podGang.Labels[apicommon.LabelPodCliqueSetReplicaIndex] == replica {
+			result[podGang.Name] = podGang.UID
+		}
+	}
+	if len(result) == 0 {
+		t.Fatalf("no PodGangs found for PCS replica %s", replica)
+	}
+	return result
+}
+
+func assertPodGangUIDs(t *testing.T, ctx context.Context, tc *testctx.TestContext, want map[string]types.UID) {
+	t.Helper()
+	for name, uid := range want {
+		podGang := &groveschedulerv1alpha1.PodGang{}
+		if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: name}, podGang); err != nil {
+			t.Fatalf("Failed to get retained PodGang %s: %v", name, err)
+		}
+		if podGang.UID != uid {
+			t.Fatalf("PodGang %s UID changed: %s -> %s", name, uid, podGang.UID)
+		}
+	}
+}
+
+func restartOperator(t *testing.T, ctx context.Context, tc *testctx.TestContext) {
+	t.Helper()
+	operatorPods := &corev1.PodList{}
+	if err := tc.Client.List(ctx, operatorPods,
+		client.InNamespace(setup.OperatorNamespace),
+		setup.OperatorPodLabels,
+	); err != nil {
+		t.Fatalf("Failed to list operator pods: %v", err)
+	}
+	if len(operatorPods.Items) != 1 {
+		t.Fatalf("operator pod count = %d, want 1", len(operatorPods.Items))
+	}
+	oldUID := operatorPods.Items[0].UID
+	if err := tc.Client.Delete(ctx, &operatorPods.Items[0]); err != nil {
+		t.Fatalf("Failed to restart operator pod %s: %v", operatorPods.Items[0].Name, err)
+	}
+	if err := wait.PollUntilContextTimeout(ctx, tc.Interval, tc.Timeout, true, func(ctx context.Context) (bool, error) {
+		current := &corev1.PodList{}
+		if err := tc.Client.List(ctx, current,
+			client.InNamespace(setup.OperatorNamespace),
+			setup.OperatorPodLabels,
+		); err != nil {
+			return false, err
+		}
+		for i := range current.Items {
+			if current.Items[i].UID != oldUID && isPodReady(&current.Items[i]) {
+				return true, nil
+			}
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatalf("Operator did not recover after restart: %v", err)
+	}
+}

--- a/operator/e2e/tests/zero_replica_test.go
+++ b/operator/e2e/tests/zero_replica_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ai-dynamo/grove/operator/e2e/setup"
 	"github.com/ai-dynamo/grove/operator/e2e/testctx"
 	internalconstants "github.com/ai-dynamo/grove/operator/internal/constants"
+	k8sutils "github.com/ai-dynamo/grove/operator/internal/utils/kubernetes"
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -126,12 +127,15 @@ func Test_ZR2_StandaloneLifecycle(t *testing.T) {
 	}, 1)
 	waitForPodCountAndReady(t, tc, 1)
 	waitForStandaloneMembership(t, ctx, tc, pcsName, "worker", 1)
-	if wakeEpoch := maxPGMEpoch(t, ctx, tc, pcsName); wakeEpoch <= initialEpoch {
-		t.Fatalf("wake epoch = %d, want greater than initial epoch %d", wakeEpoch, initialEpoch)
+	if wakeEpoch := maxPGMEpoch(t, ctx, tc, pcsName); wakeEpoch != initialEpoch {
+		t.Fatalf("standalone wake changed anchor epoch: %d -> %d", initialEpoch, wakeEpoch)
 	}
-	for name := range podGangNameSet(t, ctx, tc, pcsName) {
-		if initialPodGangs.Has(name) {
-			t.Fatalf("wake reused materialized PodGang %s", name)
+	if names := podGangNameSet(t, ctx, tc, pcsName); !reflect.DeepEqual(initialPodGangs, names) {
+		t.Fatalf("standalone wake changed anchor names: %v -> %v", initialPodGangs, names)
+	}
+	for _, pod := range podsForClique(t, tc, workerName) {
+		if _, existed := initialLocations[pod.UID]; existed {
+			t.Fatalf("standalone wake retained an old pod %s", pod.Name)
 		}
 	}
 
@@ -151,6 +155,7 @@ func Test_ZR3_PodCliqueScalingGroupLifecycle(t *testing.T) {
 	tc, cleanup := prepareIdleWorkload(t, ctx, 6, pcsName, 0, func(pcs *grovecorev1alpha1.PodCliqueSet) {
 		config := idlePCSGConfig(t, pcs)
 		config.Replicas = ptr.To(int32(3))
+		config.MinAvailable = ptr.To(int32(2))
 	})
 	defer cleanup()
 
@@ -165,10 +170,10 @@ func Test_ZR3_PodCliqueScalingGroupLifecycle(t *testing.T) {
 
 	updateScale(t, ctx, tc, &grovecorev1alpha1.PodCliqueScalingGroup{
 		ObjectMeta: metav1.ObjectMeta{Name: pcsgName, Namespace: tc.Namespace},
-	}, 1)
-	waitForPodCountAndReady(t, tc, 2)
-	waitForPCSGMembership(t, ctx, tc, pcsName, "workers", []int32{0})
-	waitForPCSGChildrenAbsent(t, ctx, tc, pcsgName, 1, 2)
+	}, 2)
+	waitForPodCountAndReady(t, tc, 4)
+	waitForPCSGMembership(t, ctx, tc, pcsName, "workers", []int32{0, 1})
+	waitForPCSGChildrenAbsent(t, ctx, tc, pcsgName, 2)
 	assertPCLQUIDs(t, ctx, tc, retainedPCLQUIDs)
 	assertRetainedPodLocation(t, podsForPCSGIndex(t, tc, "0"), retainedPodLocations)
 
@@ -183,6 +188,33 @@ func Test_ZR3_PodCliqueScalingGroupLifecycle(t *testing.T) {
 	}, 2)
 	waitForPodCountAndReady(t, tc, 4)
 	waitForPCSGMembership(t, ctx, tc, pcsName, "workers", []int32{0, 1})
+	pgm := getPGM(t, ctx, tc, pcsName, 0)
+	var scaleOutEpoch string
+	for _, entry := range pgm.Spec.Entries {
+		if entry.Role == grovecorev1alpha1.PodGangEntryRoleAnchor && len(entry.PCSGReplicaIndices) != 0 {
+			t.Fatal("PCSG wake restored cross-replica anchor membership")
+		}
+		if entry.Role == grovecorev1alpha1.PodGangEntryRoleScaleOut {
+			if !slices.Equal(entry.PCSGReplicaIndices["workers"], []int32{0, 1}) || len(entry.DependsOn) != 0 {
+				t.Fatalf("unexpected PCSG-only wake entry: %+v", entry)
+			}
+			scaleOutEpoch = entry.Epoch
+		}
+	}
+	if scaleOutEpoch == "" {
+		t.Fatal("PCSG wake has no ScaleOut entry")
+	}
+	wokenNames := podGangNameSet(t, ctx, tc, pcsName)
+	if len(wokenNames) != 2 {
+		t.Fatalf("PCSG wake created %d PodGangs, want one per replica", len(wokenNames))
+	}
+	for index := range 2 {
+		name := apicommon.GenerateNonAnchorPodGangName(
+			apicommon.ResourceNameReplica{Name: pcsName, Replica: 0}, scaleOutEpoch, "workers", int32(index))
+		if !wokenNames.Has(name) {
+			t.Fatalf("missing scaled PodGang %s", name)
+		}
+	}
 	for name := range podGangNameSet(t, ctx, tc, pcsName) {
 		if initialPodGangs.Has(name) {
 			t.Fatalf("PCSG wake reused materialized PodGang %s", name)
@@ -284,6 +316,97 @@ func Test_ZR5_PodCliqueSetReplicaIsolation(t *testing.T) {
 		t.Fatalf("PodGangMap for untouched PCS replica changed")
 	}
 	assertPodGangUIDs(t, ctx, tc, replicaOnePodGangs)
+}
+
+func Test_ZR6_StandaloneWakePreservesRunningAnchor(t *testing.T) {
+	const (
+		pcsName  = "zero-running-anchor"
+		wakeGate = "test.grove.io/hold-wake"
+	)
+	ctx := context.Background()
+	tc, cleanup := prepareIdleWorkload(t, ctx, 7, pcsName, 1, func(pcs *grovecorev1alpha1.PodCliqueSet) {
+		guarded := idleClique(t, pcs, "guarded")
+		guarded.Spec.MinAvailable = ptr.To(int32(2))
+		guarded.Spec.PodSpec.SchedulingGates = []corev1.PodSchedulingGate{{Name: wakeGate}}
+	})
+	defer cleanup()
+	waitForPodCountAndReady(t, tc, 1)
+	routerName := pcsName + "-0-worker"
+	guardedName := pcsName + "-0-guarded"
+	pcsgName := pcsName + "-0-workers"
+	routerLocations := podUIDLocations(podsForClique(t, tc, routerName))
+	initialGangs := podGangUIDsForPCSReplica(t, ctx, tc, pcsName, "0")
+	pgm := getPGM(t, ctx, tc, pcsName, 0)
+	if len(pgm.Spec.Entries) != 2 {
+		t.Fatalf("unexpected initial PodGangMap entries: %v", pgm.Spec.Entries)
+	}
+	var anchorEpoch string
+	for _, entry := range pgm.Spec.Entries {
+		if entry.Role == grovecorev1alpha1.PodGangEntryRoleAnchor {
+			anchorEpoch = entry.Epoch
+		}
+	}
+	anchorKey := client.ObjectKey{Namespace: tc.Namespace, Name: apicommon.GenerateAnchorPodGangName(
+		apicommon.ResourceNameReplica{Name: pcsName, Replica: 0}, anchorEpoch)}
+	anchor := &groveschedulerv1alpha1.PodGang{}
+	if err := wait.PollUntilContextTimeout(ctx, tc.Interval, tc.Timeout, true, func(ctx context.Context) (bool, error) {
+		if err := tc.Client.Get(ctx, anchorKey, anchor); err != nil {
+			return false, err
+		}
+		return anchor.Status.LastScheduled != nil, nil
+	}); err != nil {
+		t.Fatalf("running anchor did not record scheduling: %v", err)
+	}
+	lastScheduled := anchor.Status.LastScheduled.DeepCopy()
+
+	scaleIdleComponents(t, ctx, tc, guardedName, pcsgName, 2)
+	if err := wait.PollUntilContextTimeout(ctx, tc.Interval, tc.Timeout, true, func(ctx context.Context) (bool, error) {
+		if err := tc.Client.Get(ctx, anchorKey, anchor); err != nil {
+			return false, err
+		}
+		pcsg := &grovecorev1alpha1.PodCliqueScalingGroup{}
+		if err := tc.Client.Get(ctx, client.ObjectKey{Namespace: tc.Namespace, Name: pcsgName}, pcsg); err != nil {
+			return false, err
+		}
+		for _, group := range anchor.Spec.PodGroups {
+			if group.Name == guardedName && group.MinReplicas == 2 && len(group.PodReferences) == 2 {
+				return pcsg.Status.AvailableReplicas == 2 &&
+					meta.IsStatusConditionFalse(anchor.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeScheduled)), nil
+			}
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatalf("PCSG wake waited for the restored standalone group: %v", err)
+	}
+	if !lastScheduled.Equal(anchor.Status.LastScheduled) {
+		t.Fatal("pending standalone wake changed the anchor scheduling history")
+	}
+	assertPodGangUIDs(t, ctx, tc, initialGangs)
+	assertRetainedPodLocation(t, podsForClique(t, tc, routerName), routerLocations)
+	for _, pod := range podsForClique(t, tc, routerName) {
+		if !k8sutils.IsPodReady(&pod) {
+			t.Fatalf("running anchor pod %s became unready", pod.Name)
+		}
+	}
+	pending := podsForClique(t, tc, guardedName)
+	if len(pending) != 2 {
+		t.Fatalf("restored standalone has %d pods, want 2", len(pending))
+	}
+	for i := range pending {
+		if pending[i].Spec.NodeName != "" {
+			t.Fatalf("held standalone pod %s was scheduled", pending[i].Name)
+		}
+		patch := client.MergeFrom(pending[i].DeepCopy())
+		pending[i].Spec.SchedulingGates = slices.DeleteFunc(pending[i].Spec.SchedulingGates, func(gate corev1.PodSchedulingGate) bool {
+			return gate.Name == wakeGate
+		})
+		if err := tc.Client.Patch(ctx, &pending[i], patch); err != nil {
+			t.Fatalf("failed to release wake gate: %v", err)
+		}
+	}
+	waitForPodCountAndReady(t, tc, 7)
+	waitForStandaloneMembership(t, ctx, tc, pcsName, "guarded", 2)
+	assertRetainedPodLocation(t, podsForClique(t, tc, routerName), routerLocations)
 }
 
 func prepareIdleWorkload(

--- a/operator/e2e/yaml/workload-idle-wake.yaml
+++ b/operator/e2e/yaml/workload-idle-wake.yaml
@@ -1,0 +1,170 @@
+---
+apiVersion: grove.io/v1alpha1
+kind: PodCliqueSet
+metadata:
+  name: workload-idle-wake
+  labels:
+    app: workload-idle-wake
+spec:
+  replicas: 1
+  template:
+    terminationDelay: 10s
+    cliqueStartupType: CliqueStartupTypeInOrder
+    cliques:
+      - name: idle
+        labels:
+          kai.scheduler/queue: test
+        spec:
+          roleName: idle
+          replicas: 0
+          minAvailable: 1
+          podSpec:
+            schedulerName: kai-scheduler
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node_role.e2e.grove.nvidia.com
+                          operator: In
+                          values:
+                            - agent
+            tolerations:
+              - key: node_role.e2e.grove.nvidia.com
+                operator: Equal
+                value: agent
+                effect: NoSchedule
+            containers:
+              - name: idle
+                image: registry:5001/busybox:latest
+                command: ["sleep", "infinity"]
+                resources:
+                  requests:
+                    memory: 80Mi
+      - name: worker
+        labels:
+          kai.scheduler/queue: test
+        spec:
+          roleName: worker
+          replicas: 0
+          minAvailable: 1
+          podSpec:
+            schedulerName: kai-scheduler
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node_role.e2e.grove.nvidia.com
+                          operator: In
+                          values:
+                            - agent
+            tolerations:
+              - key: node_role.e2e.grove.nvidia.com
+                operator: Equal
+                value: agent
+                effect: NoSchedule
+            containers:
+              - name: worker
+                image: registry:5001/busybox:latest
+                command: ["sleep", "infinity"]
+                resources:
+                  requests:
+                    memory: 80Mi
+      - name: guarded
+        labels:
+          kai.scheduler/queue: test
+        spec:
+          roleName: guarded
+          replicas: 0
+          minAvailable: 2
+          podSpec:
+            schedulerName: kai-scheduler
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node_role.e2e.grove.nvidia.com
+                          operator: In
+                          values:
+                            - agent
+            tolerations:
+              - key: node_role.e2e.grove.nvidia.com
+                operator: Equal
+                value: agent
+                effect: NoSchedule
+            containers:
+              - name: guarded
+                image: registry:5001/busybox:latest
+                command: ["sleep", "infinity"]
+                resources:
+                  requests:
+                    memory: 80Mi
+      - name: prefill
+        labels:
+          kai.scheduler/queue: test
+        spec:
+          roleName: prefill
+          replicas: 1
+          minAvailable: 1
+          podSpec:
+            schedulerName: kai-scheduler
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node_role.e2e.grove.nvidia.com
+                          operator: In
+                          values:
+                            - agent
+            tolerations:
+              - key: node_role.e2e.grove.nvidia.com
+                operator: Equal
+                value: agent
+                effect: NoSchedule
+            containers:
+              - name: prefill
+                image: registry:5001/busybox:latest
+                command: ["sleep", "infinity"]
+                resources:
+                  requests:
+                    memory: 80Mi
+      - name: decode
+        labels:
+          kai.scheduler/queue: test
+        spec:
+          roleName: decode
+          replicas: 1
+          minAvailable: 1
+          podSpec:
+            schedulerName: kai-scheduler
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node_role.e2e.grove.nvidia.com
+                          operator: In
+                          values:
+                            - agent
+            tolerations:
+              - key: node_role.e2e.grove.nvidia.com
+                operator: Equal
+                value: agent
+                effect: NoSchedule
+            containers:
+              - name: decode
+                image: registry:5001/busybox:latest
+                command: ["sleep", "infinity"]
+                resources:
+                  requests:
+                    memory: 80Mi
+    podCliqueScalingGroups:
+      - name: workers
+        replicas: 0
+        minAvailable: 1
+        cliqueNames:
+          - prefill
+          - decode

--- a/operator/internal/controller/common/component/utils/podclique.go
+++ b/operator/internal/controller/common/component/utils/podclique.go
@@ -94,56 +94,40 @@ func GroupPCLQsByPCSReplicaIndex(pclqs []grovecorev1alpha1.PodClique) (map[int][
 	return grouped, nil
 }
 
-// InitialScheduleGrace is the small window after PodCliqueScalingGroup creation in which a flipped
-// status condition is treated as the first-time-set rather than a transition from a different state.
-// WasPCSGEverHealthy uses it to absorb the gap between the apiserver setting CreationTimestamp and
-// the first reconcile that mutates the MinAvailableBreached condition.
-const InitialScheduleGrace = 5 * time.Second
-
-// WasPCLQEverScheduled reports whether the PodClique has ever reached the PodCliqueScheduled=True
-// state. It reads Status.LastScheduled, a durable marker stamped in the same status reconcile that
-// first sets PodCliqueScheduled to True and never reset once set. A nil value means no reconcile has
-// yet observed the PodClique meet its scheduled count.
-func WasPCLQEverScheduled(pclq *grovecorev1alpha1.PodClique) bool {
-	return pclq.Status.LastScheduled != nil
-}
-
-// WasPCSGEverHealthy reports whether the PodCliqueScalingGroup has ever reached the
-// MinAvailableBreached=False state since creation. Mirrors WasPCLQEverScheduled but reads the
-// PCSG's own MinAvailableBreached condition (PCSGs have no PodCliqueScheduled equivalent).
-// Used to gate gang-termination so an initial-startup PCSG that has not yet stabilized is left
-// alone — only regressions from a previously-healthy state get recycled.
-// Shares the observed-transitions-only limitation documented on WasPCLQEverScheduled.
-func WasPCSGEverHealthy(pcsg *grovecorev1alpha1.PodCliqueScalingGroup) bool {
-	cond := meta.FindStatusCondition(pcsg.Status.Conditions, constants.ConditionTypeMinAvailableBreached)
-	if cond == nil {
+// IsMinAvailableBreachArmed reports whether the current generation has observed a healthy state.
+// Initial scheduling, idle, and update states deliberately reset the latch.
+func IsMinAvailableBreachArmed(conditions []metav1.Condition, generation int64) bool {
+	cond := meta.FindStatusCondition(conditions, constants.ConditionTypeMinAvailableBreached)
+	if cond == nil || cond.ObservedGeneration != generation {
 		return false
 	}
-	if cond.Status == metav1.ConditionFalse {
+	switch cond.Reason {
+	case constants.ConditionReasonSufficientReadyPods,
+		constants.ConditionReasonScheduledReplicasBelowMinAvailable,
+		constants.ConditionReasonInsufficientReadyPods,
+		constants.ConditionReasonSufficientAvailablePCSGReplicas,
+		constants.ConditionReasonInsufficientAvailablePCSGReplicas:
 		return true
+	default:
+		return false
 	}
-	return cond.LastTransitionTime.After(pcsg.CreationTimestamp.Add(InitialScheduleGrace))
 }
 
 // GetMinAvailableBreachedPCLQInfo filters PodCliques that have grovecorev1alpha1.ConditionTypeMinAvailableBreached set to true.
 // For each such PodClique it returns the name of the PodClique a duration to wait for before terminationDelay is breached.
-//
-// PodCliques that have never been scheduled (per WasPCLQEverScheduled) are excluded — the
-// MinAvailableBreached condition is still True on them (operators can observe the state) but
-// gang-termination would only churn-loop Pending pods against a cluster that already cannot
-// schedule them. Recycling makes sense only after a workload has been healthy and then regressed.
 func GetMinAvailableBreachedPCLQInfo(pclqs []grovecorev1alpha1.PodClique, terminationDelay time.Duration, since time.Time) ([]string, time.Duration) {
 	pclqCandidateNames := make([]string, 0, len(pclqs))
 	waitForDurations := make([]time.Duration, 0, len(pclqs))
 	for _, pclq := range pclqs {
+		if pclq.Spec.Replicas == 0 {
+			continue
+		}
 		cond := meta.FindStatusCondition(pclq.Status.Conditions, constants.ConditionTypeMinAvailableBreached)
 		if cond == nil {
 			continue
 		}
-		if cond.Status != metav1.ConditionTrue {
-			continue
-		}
-		if !WasPCLQEverScheduled(&pclq) {
+		if cond.Status != metav1.ConditionTrue ||
+			!IsMinAvailableBreachArmed(pclq.Status.Conditions, pclq.Generation) {
 			continue
 		}
 		pclqCandidateNames = append(pclqCandidateNames, pclq.Name)

--- a/operator/internal/controller/common/component/utils/podclique_test.go
+++ b/operator/internal/controller/common/component/utils/podclique_test.go
@@ -415,127 +415,74 @@ func TestIsLastPCLQUpdateCompleted(t *testing.T) {
 	}
 }
 
-// TestWasPCLQEverScheduled verifies the signal used to gate gang-termination reads the durable
-// Status.LastScheduled marker: set means the PodClique was scheduled at least once, nil means never.
-func TestWasPCLQEverScheduled(t *testing.T) {
-	scheduledAt := metav1.Now()
+func TestIsMinAvailableBreachArmed(t *testing.T) {
 	tests := []struct {
-		name string
-		pclq *grovecorev1alpha1.PodClique
-		want bool
+		name       string
+		generation int64
+		condition  *metav1.Condition
+		want       bool
 	}{
-		{
-			name: "LastScheduled nil (never scheduled)",
-			pclq: &grovecorev1alpha1.PodClique{},
-			want: false,
-		},
-		{
-			name: "LastScheduled set (scheduled at least once)",
-			pclq: &grovecorev1alpha1.PodClique{
-				Status: grovecorev1alpha1.PodCliqueStatus{LastScheduled: &scheduledAt},
-			},
-			want: true,
-		},
+		{name: "missing condition", generation: 1},
+		{name: "legacy condition without observed generation", generation: 1, condition: &metav1.Condition{Reason: constants.ConditionReasonInsufficientReadyPods}},
+		{name: "initial scheduling", generation: 1, condition: &metav1.Condition{Reason: constants.ConditionReasonInitialScheduling, ObservedGeneration: 1}},
+		{name: "idle", generation: 1, condition: &metav1.Condition{Reason: constants.ConditionReasonIdle, ObservedGeneration: 1}},
+		{name: "update", generation: 1, condition: &metav1.Condition{Reason: constants.ConditionReasonUpdateInProgress, ObservedGeneration: 1}},
+		{name: "healthy PodClique", generation: 1, condition: &metav1.Condition{Reason: constants.ConditionReasonSufficientReadyPods, ObservedGeneration: 1}, want: true},
+		{name: "regressed PodClique", generation: 1, condition: &metav1.Condition{Reason: constants.ConditionReasonInsufficientReadyPods, ObservedGeneration: 1}, want: true},
+		{name: "healthy PCSG", generation: 1, condition: &metav1.Condition{Reason: constants.ConditionReasonSufficientAvailablePCSGReplicas, ObservedGeneration: 1}, want: true},
+		{name: "stale generation", generation: 2, condition: &metav1.Condition{Reason: constants.ConditionReasonSufficientReadyPods, ObservedGeneration: 1}},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			actual := WasPCLQEverScheduled(tc.pclq)
-			assert.Equal(t, tc.want, actual)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var conditions []metav1.Condition
+			if tt.condition != nil {
+				condition := *tt.condition
+				condition.Type = constants.ConditionTypeMinAvailableBreached
+				conditions = []metav1.Condition{condition}
+			}
+			assert.Equal(t, tt.want, IsMinAvailableBreachArmed(conditions, tt.generation))
 		})
 	}
 }
 
-// TestWasPCSGEverHealthy covers the PCSG analog: MinAvailableBreached=False at some point
-// since creation means the PCSG was ever in a healthy state.
-func TestWasPCSGEverHealthy(t *testing.T) {
-	created := metav1.Now()
-	wellAfterCreate := metav1.NewTime(created.Add(InitialScheduleGrace + time.Second))
-	withinGraceOfCreate := metav1.NewTime(created.Add(time.Millisecond * 100))
-
-	tests := []struct {
-		name string
-		pcsg *grovecorev1alpha1.PodCliqueScalingGroup
-		want bool
-	}{
+func TestGetMinAvailableBreachedPCLQInfoUsesPersistentReason(t *testing.T) {
+	now := time.Now()
+	condition := func(reason string, observedGeneration int64) []metav1.Condition {
+		return []metav1.Condition{{
+			Type:               constants.ConditionTypeMinAvailableBreached,
+			Status:             metav1.ConditionTrue,
+			Reason:             reason,
+			ObservedGeneration: observedGeneration,
+			LastTransitionTime: metav1.NewTime(now.Add(-2 * time.Hour)),
+		}}
+	}
+	pclqs := []grovecorev1alpha1.PodClique{
 		{
-			name: "no MinAvailableBreached condition (fresh) — never healthy",
-			pcsg: &grovecorev1alpha1.PodCliqueScalingGroup{ObjectMeta: metav1.ObjectMeta{CreationTimestamp: created}},
-			want: false,
+			ObjectMeta: metav1.ObjectMeta{Name: "initial", Generation: 1},
+			Spec:       grovecorev1alpha1.PodCliqueSpec{Replicas: 1},
+			Status:     grovecorev1alpha1.PodCliqueStatus{Conditions: condition(constants.ConditionReasonInitialScheduling, 1)},
 		},
 		{
-			name: "MinAvailableBreached=True set near creation — never healthy",
-			pcsg: &grovecorev1alpha1.PodCliqueScalingGroup{
-				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: created},
-				Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{Conditions: []metav1.Condition{{
-					Type:               constants.ConditionTypeMinAvailableBreached,
-					Status:             metav1.ConditionTrue,
-					LastTransitionTime: withinGraceOfCreate,
-				}}},
-			},
-			want: false,
+			ObjectMeta: metav1.ObjectMeta{Name: "legacy", Generation: 1},
+			Spec:       grovecorev1alpha1.PodCliqueSpec{Replicas: 1},
+			Status:     grovecorev1alpha1.PodCliqueStatus{Conditions: condition(constants.ConditionReasonInsufficientReadyPods, 0)},
 		},
 		{
-			name: "MinAvailableBreached=False now — currently healthy",
-			pcsg: &grovecorev1alpha1.PodCliqueScalingGroup{
-				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: created},
-				Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{Conditions: []metav1.Condition{{
-					Type:               constants.ConditionTypeMinAvailableBreached,
-					Status:             metav1.ConditionFalse,
-					LastTransitionTime: wellAfterCreate,
-				}}},
-			},
-			want: true,
+			ObjectMeta: metav1.ObjectMeta{Name: "regressed", Generation: 1},
+			Spec:       grovecorev1alpha1.PodCliqueSpec{Replicas: 1},
+			Status:     grovecorev1alpha1.PodCliqueStatus{Conditions: condition(constants.ConditionReasonInsufficientReadyPods, 1)},
 		},
 		{
-			name: "MinAvailableBreached=True but flipped well after create — was healthy, regressed",
-			pcsg: &grovecorev1alpha1.PodCliqueScalingGroup{
-				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: created},
-				Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{Conditions: []metav1.Condition{{
-					Type:               constants.ConditionTypeMinAvailableBreached,
-					Status:             metav1.ConditionTrue,
-					LastTransitionTime: wellAfterCreate,
-				}}},
-			},
-			want: true,
+			ObjectMeta: metav1.ObjectMeta{Name: "idle", Generation: 1},
+			Spec:       grovecorev1alpha1.PodCliqueSpec{Replicas: 0},
+			Status:     grovecorev1alpha1.PodCliqueStatus{Conditions: condition(constants.ConditionReasonInsufficientReadyPods, 1)},
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, WasPCSGEverHealthy(tc.pcsg))
-		})
-	}
-}
-
-// TestGetMinAvailableBreachedPCLQInfoFiltersNeverScheduled pins the action-gate: PCLQs that
-// have MinAvailableBreached=True but were never PodCliqueScheduled=True are excluded from the
-// candidate list — gang-termination must not fire on them.
-func TestGetMinAvailableBreachedPCLQInfoFiltersNeverScheduled(t *testing.T) {
-	scheduledAt := metav1.Now()
-	pclqBreachedNeverScheduled := grovecorev1alpha1.PodClique{
-		ObjectMeta: metav1.ObjectMeta{Name: "never-scheduled"},
-		Status: grovecorev1alpha1.PodCliqueStatus{
-			Conditions: []metav1.Condition{{
-				Type:   constants.ConditionTypeMinAvailableBreached,
-				Status: metav1.ConditionTrue,
-			}},
-		},
-	}
-	pclqBreachedAfterScheduled := grovecorev1alpha1.PodClique{
-		ObjectMeta: metav1.ObjectMeta{Name: "scheduled-once"},
-		Status: grovecorev1alpha1.PodCliqueStatus{
-			LastScheduled: &scheduledAt,
-			Conditions: []metav1.Condition{{
-				Type:   constants.ConditionTypeMinAvailableBreached,
-				Status: metav1.ConditionTrue,
-			}},
-		},
-	}
-
-	pclqs := []grovecorev1alpha1.PodClique{pclqBreachedNeverScheduled, pclqBreachedAfterScheduled}
-	actual, _ := GetMinAvailableBreachedPCLQInfo(pclqs, time.Hour, time.Now())
-	assert.Equal(t, []string{"scheduled-once"}, actual, "never-scheduled PodClique must be filtered out")
+	names, waitFor := GetMinAvailableBreachedPCLQInfo(pclqs, time.Hour, now)
+	assert.Equal(t, []string{"regressed"}, names)
+	assert.LessOrEqual(t, waitFor, time.Duration(0))
 }
 
 func TestGroupPCLQsByPCSReplicaIndex(t *testing.T) {

--- a/operator/internal/controller/common/component/utils/podcliquescalinggroup.go
+++ b/operator/internal/controller/common/component/utils/podcliquescalinggroup.go
@@ -87,6 +87,31 @@ func GenerateDependencyNamesForBasePodGang(pcs *grovecorev1alpha1.PodCliqueSet, 
 	return parentPCLQNames
 }
 
+// StartupDependencies resolves in-order or explicit dependencies within the materialized PodGang.
+// The caller validates StartupType and supplies candidate names for its ownership scope.
+func StartupDependencies(pcs *grovecorev1alpha1.PodCliqueSet, foundAtIndex int, startsAfter []string, activePCLQNames Set[string], candidates func(string) []string) []string {
+	activeDependencies := func(cliqueName string) []string {
+		return lo.Filter(lo.Uniq(candidates(cliqueName)), func(name string, _ int) bool {
+			return activePCLQNames.Has(name)
+		})
+	}
+	switch *pcs.Spec.Template.StartupType {
+	case grovecorev1alpha1.CliqueStartupTypeInOrder:
+		for index := foundAtIndex - 1; index >= 0; index-- {
+			if dependencies := activeDependencies(pcs.Spec.Template.Cliques[index].Name); len(dependencies) > 0 {
+				return dependencies
+			}
+		}
+	case grovecorev1alpha1.CliqueStartupTypeExplicit:
+		dependencies := make([]string, 0)
+		for _, cliqueName := range startsAfter {
+			dependencies = append(dependencies, activeDependencies(cliqueName)...)
+		}
+		return lo.Uniq(dependencies)
+	}
+	return nil
+}
+
 // GroupPCSGsByPCSReplicaIndex filters PCSGs that have a PodCliqueSetReplicaIndex label and groups them by the PCS replica index.
 // A PodCliqueSetReplicaIndex label that is not a valid integer is a contract violation and returns an error.
 func GroupPCSGsByPCSReplicaIndex(pcsgs []grovecorev1alpha1.PodCliqueScalingGroup) (map[int][]grovecorev1alpha1.PodCliqueScalingGroup, error) {

--- a/operator/internal/controller/common/component/utils/podcliquescalinggroup_test.go
+++ b/operator/internal/controller/common/component/utils/podcliquescalinggroup_test.go
@@ -27,6 +27,22 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+func TestStartupDependenciesPreservesOrderWithoutDuplicates(t *testing.T) {
+	pcs := testutils.NewPodCliqueSetBuilder("pcs", "default", "uid").
+		WithCliqueStartupType(ptr.To(grovecorev1alpha1.CliqueStartupTypeExplicit)).
+		Build()
+	candidates := map[string][]string{
+		"prefill": {"pcs-0-sg-0-prefill", "pcs-0-sg-1-prefill", "pcs-0-sg-0-prefill"},
+		"router":  {"pcs-0-router"},
+		"idle":    {"pcs-0-idle"},
+	}
+	active := NewSet([]string{"pcs-0-router", "pcs-0-sg-0-prefill"})
+	actual := StartupDependencies(pcs, 0, []string{"prefill", "router", "prefill", "idle"}, active, func(name string) []string {
+		return candidates[name]
+	})
+	assert.Equal(t, []string{"pcs-0-sg-0-prefill", "pcs-0-router"}, actual)
+}
+
 func TestFindScalingGroupConfigForClique(t *testing.T) {
 	// Create test scaling group configurations
 	scalingGroupConfigs := []grovecorev1alpha1.PodCliqueScalingGroupConfig{

--- a/operator/internal/controller/common/component/utils/podgangmap.go
+++ b/operator/internal/controller/common/component/utils/podgangmap.go
@@ -88,7 +88,7 @@ func PodGangNameForPCSGReplica(pgm *grovecorev1alpha1.PodGangMap, rnr apicommon.
 	return apicommon.GenerateNonAnchorPodGangName(rnr, entry.Epoch, pcsgName, pcsgReplicaIndex), nil
 }
 
-// IsPodGangEntryEmpty reports whether an entry has active members.
+// IsPodGangEntryEmpty reports whether an entry has no active members.
 func IsPodGangEntryEmpty(entry grovecorev1alpha1.PodGangEntry) bool {
 	for _, count := range entry.PodCliques {
 		if count > 0 {
@@ -103,36 +103,27 @@ func IsPodGangEntryEmpty(entry grovecorev1alpha1.PodGangEntry) bool {
 	return true
 }
 
-// StandalonePCLQMembership resolves membership, optionally within one generation.
-func StandalonePCLQMembership(entries []grovecorev1alpha1.PodGangEntry, generationHash, cliqueName string) (*grovecorev1alpha1.PodGangEntry, int32, error) {
+// FindPodGangEntryForStandalonePCLQ resolves active membership in one generation.
+func FindPodGangEntryForStandalonePCLQ(entries []grovecorev1alpha1.PodGangEntry, generationHash, cliqueName string) (*grovecorev1alpha1.PodGangEntry, error) {
 	var found *grovecorev1alpha1.PodGangEntry
-	var replicas int32
 	for i := range entries {
 		entry := &entries[i]
 		if entry.Role != grovecorev1alpha1.PodGangEntryRoleAnchor ||
 			(generationHash != "" && entry.PodCliqueSetGenerationHash != generationHash) {
 			continue
 		}
-		count, ok := entry.PodCliques[cliqueName]
-		if !ok {
+		if _, ok := entry.PodCliques[cliqueName]; !ok {
 			continue
 		}
 		if found != nil {
-			return nil, 0, fmt.Errorf("standalone PodClique %q belongs to multiple anchor entries", cliqueName)
+			return nil, fmt.Errorf("standalone PodClique %q belongs to multiple anchor entries", cliqueName)
 		}
 		found = entry
-		replicas = count
 	}
-	return found, replicas, nil
-}
-
-// FindPodGangEntryForStandalonePCLQ resolves active membership in one generation.
-func FindPodGangEntryForStandalonePCLQ(entries []grovecorev1alpha1.PodGangEntry, generationHash, cliqueName string) (*grovecorev1alpha1.PodGangEntry, error) {
-	entry, replicas, err := StandalonePCLQMembership(entries, generationHash, cliqueName)
-	if err != nil || replicas <= 0 {
-		return nil, err
+	if found != nil && found.PodCliques[cliqueName] <= 0 {
+		return nil, nil
 	}
-	return entry, nil
+	return found, nil
 }
 
 // PodGangNameForStandalonePCLQ returns the PodGang owning an active standalone PodClique.

--- a/operator/internal/controller/common/component/utils/podgangmap.go
+++ b/operator/internal/controller/common/component/utils/podgangmap.go
@@ -88,6 +88,132 @@ func PodGangNameForPCSGReplica(pgm *grovecorev1alpha1.PodGangMap, rnr apicommon.
 	return apicommon.GenerateNonAnchorPodGangName(rnr, entry.Epoch, pcsgName, pcsgReplicaIndex), nil
 }
 
+// IsPodGangEntryEmpty reports whether an entry has active members.
+func IsPodGangEntryEmpty(entry grovecorev1alpha1.PodGangEntry) bool {
+	for _, count := range entry.PodCliques {
+		if count > 0 {
+			return false
+		}
+	}
+	for _, indices := range entry.PCSGReplicaIndices {
+		if len(indices) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// StandalonePCLQMembership resolves membership, optionally within one generation.
+func StandalonePCLQMembership(entries []grovecorev1alpha1.PodGangEntry, generationHash, cliqueName string) (*grovecorev1alpha1.PodGangEntry, int32, error) {
+	var found *grovecorev1alpha1.PodGangEntry
+	var replicas int32
+	for i := range entries {
+		entry := &entries[i]
+		if entry.Role != grovecorev1alpha1.PodGangEntryRoleAnchor ||
+			(generationHash != "" && entry.PodCliqueSetGenerationHash != generationHash) {
+			continue
+		}
+		count, ok := entry.PodCliques[cliqueName]
+		if !ok {
+			continue
+		}
+		if found != nil {
+			return nil, 0, fmt.Errorf("standalone PodClique %q belongs to multiple anchor entries", cliqueName)
+		}
+		found = entry
+		replicas = count
+	}
+	return found, replicas, nil
+}
+
+// FindPodGangEntryForStandalonePCLQ resolves active membership in one generation.
+func FindPodGangEntryForStandalonePCLQ(entries []grovecorev1alpha1.PodGangEntry, generationHash, cliqueName string) (*grovecorev1alpha1.PodGangEntry, error) {
+	entry, replicas, err := StandalonePCLQMembership(entries, generationHash, cliqueName)
+	if err != nil || replicas <= 0 {
+		return nil, err
+	}
+	return entry, nil
+}
+
+// PodGangNameForStandalonePCLQ returns the PodGang owning an active standalone PodClique.
+func PodGangNameForStandalonePCLQ(pgm *grovecorev1alpha1.PodGangMap, rnr apicommon.ResourceNameReplica, generationHash, cliqueName string) (string, error) {
+	entry, err := FindPodGangEntryForStandalonePCLQ(pgm.Spec.Entries, generationHash, cliqueName)
+	if err != nil {
+		return "", err
+	}
+	if entry != nil {
+		return apicommon.GenerateAnchorPodGangName(rnr, entry.Epoch), nil
+	}
+	return "", fmt.Errorf("no anchor entry owns active standalone PodClique %q in PodGangMap %s", cliqueName, pgm.Name)
+}
+
+// ActivePodCliqueNamesForPodGang returns the PodClique FQNs materialized in podGangName.
+func ActivePodCliqueNamesForPodGang(pcs *grovecorev1alpha1.PodCliqueSet, pgm *grovecorev1alpha1.PodGangMap, rnr apicommon.ResourceNameReplica, podGangName string) (Set[string], error) {
+	for i := range pgm.Spec.Entries {
+		entry := &pgm.Spec.Entries[i]
+		if entry.Role == grovecorev1alpha1.PodGangEntryRoleAnchor {
+			if apicommon.GenerateAnchorPodGangName(rnr, entry.Epoch) == podGangName {
+				return ActivePodCliqueNamesForEntry(pcs, rnr, entry)
+			}
+			continue
+		}
+		for pcsgName, indices := range entry.PCSGReplicaIndices {
+			for _, index := range indices {
+				if apicommon.GenerateNonAnchorPodGangName(rnr, entry.Epoch, pcsgName, index) != podGangName {
+					continue
+				}
+				pcsgConfig, ok := lo.Find(pcs.Spec.Template.PodCliqueScalingGroupConfigs, func(config grovecorev1alpha1.PodCliqueScalingGroupConfig) bool {
+					return config.Name == pcsgName
+				})
+				if !ok {
+					return nil, fmt.Errorf("PodGangMap %s references unknown PodCliqueScalingGroup %q", pgm.Name, pcsgName)
+				}
+				return podCliqueNamesForPCSGReplica(rnr, pcsgConfig, index), nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("PodGang %q is not materialized by PodGangMap %s", podGangName, pgm.Name)
+}
+
+// ActivePodCliqueNamesForEntry resolves and validates every active member in an entry.
+func ActivePodCliqueNamesForEntry(pcs *grovecorev1alpha1.PodCliqueSet, rnr apicommon.ResourceNameReplica, entry *grovecorev1alpha1.PodGangEntry) (Set[string], error) {
+	names := make(Set[string])
+	standaloneNames, _ := GetExpectedPCLQNamesGroupByOwner(pcs)
+	standaloneSet := NewSet(standaloneNames)
+	for cliqueName, replicas := range entry.PodCliques {
+		if replicas <= 0 {
+			continue
+		}
+		if !standaloneSet.Has(cliqueName) {
+			return nil, fmt.Errorf("PodGangMap entry %q references unknown standalone PodClique %q", entry.Epoch, cliqueName)
+		}
+		names[apicommon.GeneratePodCliqueName(rnr, cliqueName)] = struct{}{}
+	}
+	for pcsgName, indices := range entry.PCSGReplicaIndices {
+		config, ok := lo.Find(pcs.Spec.Template.PodCliqueScalingGroupConfigs, func(config grovecorev1alpha1.PodCliqueScalingGroupConfig) bool {
+			return config.Name == pcsgName
+		})
+		if !ok {
+			return nil, fmt.Errorf("PodGangMap entry %q references unknown PodCliqueScalingGroup %q", entry.Epoch, pcsgName)
+		}
+		for _, index := range indices {
+			for name := range podCliqueNamesForPCSGReplica(rnr, config, index) {
+				names[name] = struct{}{}
+			}
+		}
+	}
+	return names, nil
+}
+
+func podCliqueNamesForPCSGReplica(rnr apicommon.ResourceNameReplica, config grovecorev1alpha1.PodCliqueScalingGroupConfig, index int32) Set[string] {
+	pcsgName := apicommon.GeneratePodCliqueScalingGroupName(rnr, config.Name)
+	names := make(Set[string], len(config.CliqueNames))
+	for _, cliqueName := range config.CliqueNames {
+		names[apicommon.GeneratePodCliqueName(apicommon.ResourceNameReplica{Name: pcsgName, Replica: int(index)}, cliqueName)] = struct{}{}
+	}
+	return names
+}
+
 // DependsOnForEpoch returns the epochs that the PodGangMap entry with the given epoch depends on
 // before its pods may be scheduled. An empty result means the entry has no scheduling dependency. It
 // returns an error when no entry carries the epoch, which the caller treats as requeue-worthy rather
@@ -112,13 +238,17 @@ func DependsOnForEpoch(pgm *grovecorev1alpha1.PodGangMap, epoch string) ([]strin
 // and during a rolling update only the under-update replica's entries advance, so a lagging replica
 // is resolved against its own entries.
 func podGangEntryForPCSGReplica(pgm *grovecorev1alpha1.PodGangMap, pcsgName string, pcsgReplicaIndex int32) (*grovecorev1alpha1.PodGangEntry, error) {
+	entry, err := FindPodGangEntryForPCSGReplica(pgm.Spec.Entries, "", pcsgName, pcsgReplicaIndex)
+	if err != nil || entry != nil {
+		return entry, err
+	}
 	var scaleOut *grovecorev1alpha1.PodGangEntry
 	for i := range pgm.Spec.Entries {
 		entry := &pgm.Spec.Entries[i]
-		if lo.Contains(entry.PCSGReplicaIndices[pcsgName], pcsgReplicaIndex) {
-			return entry, nil
-		}
 		if entry.Role == grovecorev1alpha1.PodGangEntryRoleScaleOut {
+			if scaleOut != nil {
+				return nil, fmt.Errorf("PodGangMap %s has multiple ScaleOut entries", pgm.Name)
+			}
 			scaleOut = entry
 		}
 	}
@@ -128,11 +258,28 @@ func podGangEntryForPCSGReplica(pgm *grovecorev1alpha1.PodGangMap, pcsgName stri
 	return nil, fmt.Errorf("no PodGangMap entry owns replica index %d of PodCliqueScalingGroup %q and no ScaleOut entry exists in PodGangMap %s", pcsgReplicaIndex, pcsgName, pgm.Name)
 }
 
-// AnchorPodGangEpoch returns the epoch of the AnchorIndex 0 anchor entry of the PodGangMap. Standalone
-// PodCliques always belong to this entry. It returns an error when no such anchor entry exists, a
-// contract violation that must be re-queued.
-// NOTE: When coherent-updates update strategy (GREP-393) is introduced then post coherent update it is possible
-// that there are more than one anchor entry. This function will have to be adapted to support that.
+// FindPodGangEntryForPCSGReplica resolves exact membership, optionally within one generation.
+func FindPodGangEntryForPCSGReplica(entries []grovecorev1alpha1.PodGangEntry, generationHash, pcsgName string, replicaIndex int32) (*grovecorev1alpha1.PodGangEntry, error) {
+	var found *grovecorev1alpha1.PodGangEntry
+	for i := range entries {
+		entry := &entries[i]
+		if generationHash != "" && entry.PodCliqueSetGenerationHash != generationHash {
+			continue
+		}
+		if !lo.Contains(entry.PCSGReplicaIndices[pcsgName], replicaIndex) {
+			continue
+		}
+		if found != nil {
+			return nil, fmt.Errorf("PodCliqueScalingGroup %q replica index %d belongs to multiple PodGangMap entries", pcsgName, replicaIndex)
+		}
+		found = entry
+	}
+	return found, nil
+}
+
+// AnchorPodGangEpoch returns the epoch of the AnchorIndex 0 anchor entry of the PodGangMap. It is
+// used as the placeholder label for a newly created idle standalone PodClique, which has no active
+// membership to resolve. Active standalone PodCliques use PodGangNameForStandalonePCLQ instead.
 func AnchorPodGangEpoch(pgm *grovecorev1alpha1.PodGangMap) (string, error) {
 	for i := range pgm.Spec.Entries {
 		entry := &pgm.Spec.Entries[i]

--- a/operator/internal/controller/common/component/utils/podgangmap_test.go
+++ b/operator/internal/controller/common/component/utils/podgangmap_test.go
@@ -287,3 +287,120 @@ func TestIndexPodGangEntriesByEpoch(t *testing.T) {
 		assert.Empty(t, actual)
 	})
 }
+
+func TestPodGangNameForStandalonePCLQ(t *testing.T) {
+	rnr := apicommon.ResourceNameReplica{Name: "pcs", Replica: 0}
+	pgm := testutils.NewPodGangMapBuilder("pcs", "default", "uid", 0).WithEntries(
+		testutils.NewPodGangEntryBuilder("hash", "1000").
+			WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).
+			WithAnchorIndex(0).
+			WithPodCliques(map[string]int32{"router": 1}).
+			Build(),
+		testutils.NewPodGangEntryBuilder("hash", "1001").
+			WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).
+			WithAnchorIndex(1).
+			WithPodCliques(map[string]int32{"worker": 2}).
+			Build(),
+	).Build()
+
+	actual, err := PodGangNameForStandalonePCLQ(pgm, rnr, "hash", "worker")
+	require.NoError(t, err)
+	assert.Equal(t, apicommon.GenerateAnchorPodGangName(rnr, "1001"), actual)
+
+	_, err = PodGangNameForStandalonePCLQ(pgm, rnr, "hash", "idle")
+	require.Error(t, err)
+
+	t.Run("rejects duplicate membership", func(t *testing.T) {
+		duplicate := pgm.DeepCopy()
+		duplicate.Spec.Entries[0].PodCliques["worker"] = 1
+		_, err := PodGangNameForStandalonePCLQ(duplicate, rnr, "hash", "worker")
+		require.Error(t, err)
+	})
+
+	t.Run("ignores membership from another generation", func(t *testing.T) {
+		otherGeneration := pgm.DeepCopy()
+		otherGeneration.Spec.Entries[1].PodCliqueSetGenerationHash = "old"
+		_, err := PodGangNameForStandalonePCLQ(otherGeneration, rnr, "hash", "worker")
+		require.Error(t, err)
+	})
+}
+
+func TestActivePodCliqueNamesForPodGang(t *testing.T) {
+	const (
+		pcsName   = "pcs"
+		namespace = "default"
+		pcsgName  = "sg"
+	)
+	rnr := apicommon.ResourceNameReplica{Name: pcsName, Replica: 0}
+	pcs := testutils.NewPodCliqueSetBuilder(pcsName, namespace, "uid").
+		WithStandaloneClique("router").
+		WithStandaloneCliqueReplicas("idle", 0).
+		WithScalingGroupConfig(pcsgName, []string{"prefill", "decode"}, 2, 1).
+		Build()
+	pgm := testutils.NewPodGangMapBuilder(pcsName, namespace, "uid", 0).WithEntries(
+		testutils.NewPodGangEntryBuilder("hash", "1000").
+			WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).
+			WithAnchorIndex(0).
+			WithPodCliques(map[string]int32{"router": 1, "idle": 0}).
+			WithPCSGReplicaIndices(map[string][]int32{pcsgName: {0}}).
+			Build(),
+		testutils.NewPodGangEntryBuilder("hash", "1001").
+			WithRole(grovecorev1alpha1.PodGangEntryRoleTail).
+			WithPCSGReplicaIndices(map[string][]int32{pcsgName: {1}}).
+			Build(),
+	).Build()
+
+	t.Run("anchor includes positive standalone and colocated PCSG members", func(t *testing.T) {
+		actual, err := ActivePodCliqueNamesForPodGang(pcs, pgm, rnr, apicommon.GenerateAnchorPodGangName(rnr, "1000"))
+		require.NoError(t, err)
+		assert.Equal(t, NewSet([]string{
+			"pcs-0-router",
+			"pcs-0-sg-0-prefill",
+			"pcs-0-sg-0-decode",
+		}), actual)
+	})
+
+	t.Run("non-anchor includes only the materialized PCSG replica", func(t *testing.T) {
+		actual, err := ActivePodCliqueNamesForPodGang(pcs, pgm, rnr, apicommon.GenerateNonAnchorPodGangName(rnr, "1001", pcsgName, 1))
+		require.NoError(t, err)
+		assert.Equal(t, NewSet([]string{
+			"pcs-0-sg-1-prefill",
+			"pcs-0-sg-1-decode",
+		}), actual)
+	})
+
+	t.Run("unknown PodGang is an error", func(t *testing.T) {
+		_, err := ActivePodCliqueNamesForPodGang(pcs, pgm, rnr, "missing")
+		require.Error(t, err)
+	})
+
+	t.Run("unknown standalone membership is an error", func(t *testing.T) {
+		entry := pgm.Spec.Entries[0].DeepCopy()
+		entry.PodCliques["unknown"] = 1
+		_, err := ActivePodCliqueNamesForEntry(pcs, rnr, entry)
+		require.Error(t, err)
+	})
+
+	t.Run("unknown scaling group membership is an error", func(t *testing.T) {
+		entry := pgm.Spec.Entries[0].DeepCopy()
+		entry.PCSGReplicaIndices["unknown"] = []int32{0}
+		_, err := ActivePodCliqueNamesForEntry(pcs, rnr, entry)
+		require.Error(t, err)
+	})
+}
+
+func TestFindPodGangEntryForPCSGReplica(t *testing.T) {
+	entries := []grovecorev1alpha1.PodGangEntry{
+		testutils.NewAnchorEntry("hash", "1000", 0, "sg", 0),
+		testutils.NewTailEntry("hash", "1001", "sg", 1),
+	}
+
+	entry, err := FindPodGangEntryForPCSGReplica(entries, "hash", "sg", 1)
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	assert.Equal(t, "1001", entry.Epoch)
+
+	duplicate := append(entries, testutils.NewScaleOutEntry("hash", "1002", "sg", 1))
+	_, err = FindPodGangEntryForPCSGReplica(duplicate, "hash", "sg", 1)
+	require.Error(t, err)
+}

--- a/operator/internal/controller/podclique/components/pod/syncflow.go
+++ b/operator/internal/controller/podclique/components/pod/syncflow.go
@@ -472,6 +472,13 @@ func (r _resource) fetchPodGangsForGatedPods(ctx context.Context, gatedPods []*c
 // satisfied. Each distinct dependency epoch is resolved with a single List, memoized across entries.
 func (r _resource) resolveDependencySatisfiedByEpoch(ctx context.Context, ss *syncSnapshot) (map[string]bool, error) {
 	epochScheduled := make(map[string]bool)
+	for _, entry := range ss.pgm.Spec.Entries {
+		// Idle slots have no materialized PodGang to schedule. Keep their epoch references intact
+		// so a later wake resumes the dependency without rewriting active entries.
+		if componentutils.IsPodGangEntryEmpty(entry) {
+			epochScheduled[entry.Epoch] = true
+		}
+	}
 	satisfiedByEpoch := make(map[string]bool, len(ss.pgm.Spec.Entries))
 	for _, entry := range ss.pgm.Spec.Entries {
 		satisfied := true

--- a/operator/internal/controller/podclique/components/pod/syncflow_test.go
+++ b/operator/internal/controller/podclique/components/pod/syncflow_test.go
@@ -181,6 +181,20 @@ func TestResolveDependencySatisfiedByEpoch(t *testing.T) {
 			expected:        map[string]bool{testAnchor0Epoch: true, testTailEpoch: false},
 		},
 		{
+			name: "idle anchor needs no materialized PodGang",
+			entries: []grovecorev1alpha1.PodGangEntry{
+				testutils.NewPodGangEntryBuilder("hash", testAnchor0Epoch).
+					WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).WithAnchorIndex(0).Build(),
+				scaleOutEntry(testScaleOutEpoch, testAnchor0Epoch),
+			},
+			expected: map[string]bool{testAnchor0Epoch: true, testScaleOutEpoch: true},
+		},
+		{
+			name:     "unknown dependency still blocks scheduling",
+			entries:  []grovecorev1alpha1.PodGangEntry{scaleOutEntry(testScaleOutEpoch, "missing")},
+			expected: map[string]bool{testScaleOutEpoch: false},
+		},
+		{
 			name: "dependency epoch belonging to a tail is resolved the same as an anchor",
 			entries: []grovecorev1alpha1.PodGangEntry{
 				anchorEntry(),
@@ -215,6 +229,9 @@ func TestResolveDependencySatisfiedByEpoch(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var objects []client.Object
 			for _, entry := range tc.entries {
+				if componentutils.IsPodGangEntryEmpty(entry) {
+					continue
+				}
 				builder := testutils.NewPodGangBuilder(podGangNameForEpoch(entry.Epoch), testNamespace).
 					WithLabels(map[string]string{
 						apicommon.LabelPartOfKey:                testPCSName,
@@ -590,6 +607,7 @@ func anchorEntry() grovecorev1alpha1.PodGangEntry {
 	return testutils.NewPodGangEntryBuilder("hash", testAnchor0Epoch).
 		WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).
 		WithAnchorIndex(0).
+		WithPodCliques(map[string]int32{testCliqueName: 1}).
 		Build()
 }
 
@@ -597,6 +615,7 @@ func anchorDependentEntry(epoch string, anchorIndex int32, dependsOnEpoch string
 	return testutils.NewPodGangEntryBuilder("hash", epoch).
 		WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).
 		WithAnchorIndex(anchorIndex).
+		WithPodCliques(map[string]int32{testCliqueName: 1}).
 		WithDependsOn(dependsOnEpoch).
 		Build()
 }
@@ -604,6 +623,7 @@ func anchorDependentEntry(epoch string, anchorIndex int32, dependsOnEpoch string
 func tailEntry(epoch, dependsOnEpoch string) grovecorev1alpha1.PodGangEntry {
 	return testutils.NewPodGangEntryBuilder("hash", epoch).
 		WithRole(grovecorev1alpha1.PodGangEntryRoleTail).
+		WithPCSGReplicaIndices(map[string][]int32{"workers": {0}}).
 		WithDependsOn(dependsOnEpoch).
 		Build()
 }
@@ -611,6 +631,7 @@ func tailEntry(epoch, dependsOnEpoch string) grovecorev1alpha1.PodGangEntry {
 func scaleOutEntry(epoch, dependsOnEpoch string) grovecorev1alpha1.PodGangEntry {
 	return testutils.NewPodGangEntryBuilder("hash", epoch).
 		WithRole(grovecorev1alpha1.PodGangEntryRoleScaleOut).
+		WithPCSGReplicaIndices(map[string][]int32{"workers": {1}}).
 		WithDependsOn(dependsOnEpoch).
 		Build()
 }

--- a/operator/internal/controller/podclique/reconcilestatus.go
+++ b/operator/internal/controller/podclique/reconcilestatus.go
@@ -200,12 +200,8 @@ func mutateSelector(pcsName string, pclq *grovecorev1alpha1.PodClique) error {
 // event gives operators a discrete, log-visible signal that a previously-running workload is
 // fully down (and that gang termination is now armed and will fire after TerminationDelay).
 func (r *Reconciler) emitAllScheduledReplicasLostIfNeeded(pclq *grovecorev1alpha1.PodClique, originalScheduled int32) {
-	// GREP-0677: a scale-to-zero transition is intentional, not a loss. Do not emit the warning
-	// (and do not imply gang termination is armed) when the PodClique is idle.
-	if pclq.Spec.Replicas == 0 {
-		return
-	}
-	if originalScheduled > 0 && pclq.Status.ScheduledReplicas == 0 {
+	// Scaling to zero is intentional, not a loss.
+	if pclq.Spec.Replicas != 0 && originalScheduled > 0 && pclq.Status.ScheduledReplicas == 0 {
 		r.eventRecorder.Eventf(pclq, corev1.EventTypeWarning, internalconstants.ReasonAllScheduledReplicasLost,
 			"All scheduled pods lost (was %d). Gang termination will fire after TerminationDelay if the PodClique stays below MinAvailable; investigate node availability or capacity.",
 			originalScheduled)
@@ -293,9 +289,7 @@ func computeMinAvailableBreachedCondition(pclq *grovecorev1alpha1.PodClique, num
 // mutatePodCliqueScheduledCondition updates the PodCliqueScheduled condition based on scheduled pod counts
 func mutatePodCliqueScheduledCondition(pclq *grovecorev1alpha1.PodClique) {
 	newCondition := computePodCliqueScheduledCondition(pclq)
-	if k8sutils.HasConditionChanged(pclq.Status.Conditions, newCondition) {
-		meta.SetStatusCondition(&pclq.Status.Conditions, newCondition)
-	}
+	meta.SetStatusCondition(&pclq.Status.Conditions, newCondition)
 }
 
 // mutateLastScheduled advances Status.LastScheduled to now when the PodCliqueScheduled condition

--- a/operator/internal/controller/podclique/reconcilestatus.go
+++ b/operator/internal/controller/podclique/reconcilestatus.go
@@ -200,6 +200,11 @@ func mutateSelector(pcsName string, pclq *grovecorev1alpha1.PodClique) error {
 // event gives operators a discrete, log-visible signal that a previously-running workload is
 // fully down (and that gang termination is now armed and will fire after TerminationDelay).
 func (r *Reconciler) emitAllScheduledReplicasLostIfNeeded(pclq *grovecorev1alpha1.PodClique, originalScheduled int32) {
+	// GREP-0677: a scale-to-zero transition is intentional, not a loss. Do not emit the warning
+	// (and do not imply gang termination is armed) when the PodClique is idle.
+	if pclq.Spec.Replicas == 0 {
+		return
+	}
 	if originalScheduled > 0 && pclq.Status.ScheduledReplicas == 0 {
 		r.eventRecorder.Eventf(pclq, corev1.EventTypeWarning, internalconstants.ReasonAllScheduledReplicasLost,
 			"All scheduled pods lost (was %d). Gang termination will fire after TerminationDelay if the PodClique stays below MinAvailable; investigate node availability or capacity.",
@@ -210,65 +215,79 @@ func (r *Reconciler) emitAllScheduledReplicasLostIfNeeded(pclq *grovecorev1alpha
 // mutateMinAvailableBreachedCondition updates the MinAvailableBreached condition based on pod availability
 func mutateMinAvailableBreachedCondition(pclq *grovecorev1alpha1.PodClique, numNotReadyPodsWithContainersInError, numPodsStartedButNotReady int) {
 	newCondition := computeMinAvailableBreachedCondition(pclq, numNotReadyPodsWithContainersInError, numPodsStartedButNotReady)
-	if k8sutils.HasConditionChanged(pclq.Status.Conditions, newCondition) {
-		meta.SetStatusCondition(&pclq.Status.Conditions, newCondition)
-	}
+	meta.SetStatusCondition(&pclq.Status.Conditions, newCondition)
 }
 
 // computeMinAvailableBreachedCondition calculates the MinAvailableBreached condition status based on pod availability
 func computeMinAvailableBreachedCondition(pclq *grovecorev1alpha1.PodClique, numPodsHavingAtleastOneContainerWithNonZeroExitCode, numPodsStartedButNotReady int) metav1.Condition {
-	if componentutils.IsPCLQAutoUpdateInProgress(pclq) {
+	if pclq.Spec.Replicas == 0 {
 		return metav1.Condition{
-			Type:    constants.ConditionTypeMinAvailableBreached,
-			Status:  metav1.ConditionUnknown,
-			Reason:  constants.ConditionReasonUpdateInProgress,
-			Message: "Update is in progress",
+			Type:               constants.ConditionTypeMinAvailableBreached,
+			Status:             metav1.ConditionFalse,
+			Reason:             constants.ConditionReasonIdle,
+			Message:            "PodClique is idle (spec.replicas == 0); not a required gang member",
+			ObservedGeneration: pclq.Generation,
+			LastTransitionTime: metav1.Now(),
 		}
 	}
-	// dereferencing is considered safe as MinAvailable will always be set by the defaulting webhook. If this changes in the future,
-	// make sure that you check for nil explicitly.
+	if componentutils.IsPCLQAutoUpdateInProgress(pclq) {
+		return metav1.Condition{
+			Type:               constants.ConditionTypeMinAvailableBreached,
+			Status:             metav1.ConditionUnknown,
+			Reason:             constants.ConditionReasonUpdateInProgress,
+			Message:            "Update is in progress",
+			ObservedGeneration: pclq.Generation,
+		}
+	}
+	// MinAvailable is guaranteed by API defaulting.
 	minAvailable := int(*pclq.Spec.MinAvailable)
 	scheduledReplicas := int(pclq.Status.ScheduledReplicas)
 	now := metav1.Now()
+	armed := componentutils.IsMinAvailableBreachArmed(pclq.Status.Conditions, pclq.Generation)
+	if pclq.Status.ReadyReplicas >= *pclq.Spec.MinAvailable {
+		return metav1.Condition{
+			Type:               constants.ConditionTypeMinAvailableBreached,
+			Status:             metav1.ConditionFalse,
+			Reason:             constants.ConditionReasonSufficientReadyPods,
+			Message:            fmt.Sprintf("Sufficient ready pods found. expected at least: %d, found: %d", minAvailable, pclq.Status.ReadyReplicas),
+			ObservedGeneration: pclq.Generation,
+			LastTransitionTime: now,
+		}
+	}
 
-	// scheduledReplicas < MinAvailable always breaches. TerminationDelay (default 4h) is
-	// the natural grace window: during a normal startup the breach flickers True briefly
-	// and resolves before TerminationDelay; a workload that stays below MinAvailable past
-	// TerminationDelay is genuinely stuck and gang-terminating gives the scheduler a fresh
-	// PodGang to retry against the current cluster state. This covers both the partial-
-	// regression case (0 < scheduled < MinAvailable) and the full-regression case
-	// (scheduled == 0 after the workload was once healthy).
+	var condition metav1.Condition
 	if scheduledReplicas < minAvailable {
-		return metav1.Condition{
-			Type:               constants.ConditionTypeMinAvailableBreached,
-			Status:             metav1.ConditionTrue,
-			Reason:             constants.ConditionReasonScheduledReplicasBelowMinAvailable,
-			Message:            fmt.Sprintf("Scheduled replicas (%d) below MinAvailable (%d)", scheduledReplicas, minAvailable),
-			LastTransitionTime: now,
+		condition = metav1.Condition{
+			Type:    constants.ConditionTypeMinAvailableBreached,
+			Status:  metav1.ConditionTrue,
+			Reason:  constants.ConditionReasonScheduledReplicasBelowMinAvailable,
+			Message: fmt.Sprintf("Scheduled replicas (%d) below MinAvailable (%d)", scheduledReplicas, minAvailable),
+		}
+	} else {
+		readyOrStartingPods := scheduledReplicas - numPodsHavingAtleastOneContainerWithNonZeroExitCode - numPodsStartedButNotReady
+		if readyOrStartingPods < minAvailable {
+			condition = metav1.Condition{
+				Type:    constants.ConditionTypeMinAvailableBreached,
+				Status:  metav1.ConditionTrue,
+				Reason:  constants.ConditionReasonInsufficientReadyPods,
+				Message: fmt.Sprintf("Insufficient ready or starting pods. expected at least: %d, found: %d", minAvailable, readyOrStartingPods),
+			}
+		} else {
+			condition = metav1.Condition{
+				Type:    constants.ConditionTypeMinAvailableBreached,
+				Status:  metav1.ConditionFalse,
+				Reason:  constants.ConditionReasonSufficientReadyPods,
+				Message: fmt.Sprintf("Sufficient ready or starting pods found. expected at least: %d, found: %d", minAvailable, readyOrStartingPods),
+			}
 		}
 	}
-
-	readyOrStartingPods := scheduledReplicas - numPodsHavingAtleastOneContainerWithNonZeroExitCode - numPodsStartedButNotReady
-	// pclq.Status.ReadyReplicas do not account for Pods which are not yet ready and are in the process of starting/initializing.
-	// This allows sufficient time specially for pods that have long-running init containers or slow-to-start main containers.
-	// Therefore, we take Pods that are NotReady and at least one of their containers have exited with a non-zero exit code. Kubelet
-	// has attempted to start the containers within the Pod at least once and failed. These pods count towards unavailability.
-	if readyOrStartingPods < minAvailable {
-		return metav1.Condition{
-			Type:               constants.ConditionTypeMinAvailableBreached,
-			Status:             metav1.ConditionTrue,
-			Reason:             constants.ConditionReasonInsufficientReadyPods,
-			Message:            fmt.Sprintf("Insufficient ready or starting pods. expected at least: %d, found: %d", minAvailable, readyOrStartingPods),
-			LastTransitionTime: now,
-		}
+	if !armed {
+		condition.Reason = constants.ConditionReasonInitialScheduling
+		condition.Message = fmt.Sprintf("Waiting for at least %d ready replicas before enabling gang termination", minAvailable)
 	}
-	return metav1.Condition{
-		Type:               constants.ConditionTypeMinAvailableBreached,
-		Status:             metav1.ConditionFalse,
-		Reason:             constants.ConditionReasonSufficientReadyPods,
-		Message:            fmt.Sprintf("Either sufficient ready or starting pods found. expected at least: %d, found: %d", minAvailable, readyOrStartingPods),
-		LastTransitionTime: now,
-	}
+	condition.ObservedGeneration = pclq.Generation
+	condition.LastTransitionTime = now
+	return condition
 }
 
 // mutatePodCliqueScheduledCondition updates the PodCliqueScheduled condition based on scheduled pod counts
@@ -297,12 +316,23 @@ func mutateLastScheduled(pclq *grovecorev1alpha1.PodClique, originalStatus *grov
 // computePodCliqueScheduledCondition calculates the PodCliqueScheduled condition based on minimum availability requirements
 func computePodCliqueScheduledCondition(pclq *grovecorev1alpha1.PodClique) metav1.Condition {
 	now := metav1.Now()
+	if pclq.Spec.Replicas == 0 {
+		return metav1.Condition{
+			Type:               constants.ConditionTypePodCliqueScheduled,
+			Status:             metav1.ConditionTrue,
+			Reason:             constants.ConditionReasonSufficientScheduledPods,
+			Message:            "PodClique is intentionally idle with replicas 0",
+			ObservedGeneration: pclq.Generation,
+			LastTransitionTime: now,
+		}
+	}
 	if pclq.Status.ScheduledReplicas < *pclq.Spec.MinAvailable {
 		return metav1.Condition{
 			Type:               constants.ConditionTypePodCliqueScheduled,
 			Status:             metav1.ConditionFalse,
 			Reason:             constants.ConditionReasonInsufficientScheduledPods,
 			Message:            fmt.Sprintf("Insufficient scheduled pods. expected at least: %d, found: %d", *pclq.Spec.MinAvailable, pclq.Status.ScheduledReplicas),
+			ObservedGeneration: pclq.Generation,
 			LastTransitionTime: now,
 		}
 	}
@@ -311,6 +341,7 @@ func computePodCliqueScheduledCondition(pclq *grovecorev1alpha1.PodClique) metav
 		Status:             metav1.ConditionTrue,
 		Reason:             constants.ConditionReasonSufficientScheduledPods,
 		Message:            fmt.Sprintf("Sufficient scheduled pods found. expected at least: %d, found: %d", *pclq.Spec.MinAvailable, pclq.Status.ScheduledReplicas),
+		ObservedGeneration: pclq.Generation,
 		LastTransitionTime: now,
 	}
 }

--- a/operator/internal/controller/podclique/reconcilestatus_test.go
+++ b/operator/internal/controller/podclique/reconcilestatus_test.go
@@ -17,6 +17,7 @@ package podclique
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -661,6 +662,32 @@ func TestMutateMinAvailableBreachedConditionUpdatesObservedGeneration(t *testing
 	condition := meta.FindStatusCondition(pclq.Status.Conditions, constants.ConditionTypeMinAvailableBreached)
 	require.NotNil(t, condition)
 	assert.Equal(t, int64(2), condition.ObservedGeneration)
+}
+
+func TestMutatePodCliqueScheduledConditionUpdatesObservedGeneration(t *testing.T) {
+	for _, replicas := range []int32{0, 1} {
+		t.Run(fmt.Sprintf("replicas=%d", replicas), func(t *testing.T) {
+			pclq := &grovecorev1alpha1.PodClique{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec: grovecorev1alpha1.PodCliqueSpec{
+					Replicas: replicas, MinAvailable: ptr.To(int32(1)),
+				},
+				Status: grovecorev1alpha1.PodCliqueStatus{ScheduledReplicas: replicas},
+			}
+			previous := computePodCliqueScheduledCondition(pclq)
+			previous.LastTransitionTime = metav1.NewTime(time.Unix(100, 0))
+			pclq.Status.Conditions = []metav1.Condition{previous}
+			pclq.Generation++
+
+			mutatePodCliqueScheduledCondition(pclq)
+
+			condition := meta.FindStatusCondition(pclq.Status.Conditions, constants.ConditionTypePodCliqueScheduled)
+			require.NotNil(t, condition)
+			assert.Equal(t, pclq.Generation, condition.ObservedGeneration)
+			assert.Equal(t, previous.LastTransitionTime, condition.LastTransitionTime)
+			assert.Equal(t, previous.Status, condition.Status)
+		})
+	}
 }
 
 // TestComputePodCliqueScheduledConditionTreatsZeroReplicasAsScheduled verifies GREP-0677: an idle

--- a/operator/internal/controller/podclique/reconcilestatus_test.go
+++ b/operator/internal/controller/podclique/reconcilestatus_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -468,15 +469,17 @@ func createReadyOwnedPodWithHash(name string, owner *grovecorev1alpha1.PodClique
 func TestEmitAllScheduledReplicasLostIfNeeded(t *testing.T) {
 	tests := []struct {
 		name              string
+		replicas          int32
 		originalScheduled int32
 		nowScheduled      int32
 		wantEvent         bool
 	}{
-		{name: "non-zero to zero emits event", originalScheduled: 3, nowScheduled: 0, wantEvent: true},
-		{name: "zero to zero stays silent (initial startup)", originalScheduled: 0, nowScheduled: 0, wantEvent: false},
-		{name: "non-zero to non-zero stays silent (partial regression handled by breach)", originalScheduled: 3, nowScheduled: 2, wantEvent: false},
-		{name: "zero to non-zero stays silent (recovery)", originalScheduled: 0, nowScheduled: 3, wantEvent: false},
-		{name: "stable non-zero stays silent (steady state)", originalScheduled: 3, nowScheduled: 3, wantEvent: false},
+		{name: "non-zero to zero emits event", replicas: 3, originalScheduled: 3, nowScheduled: 0, wantEvent: true},
+		{name: "zero to zero stays silent (initial startup)", replicas: 3, originalScheduled: 0, nowScheduled: 0, wantEvent: false},
+		{name: "non-zero to non-zero stays silent (partial regression handled by breach)", replicas: 3, originalScheduled: 3, nowScheduled: 2, wantEvent: false},
+		{name: "zero to non-zero stays silent (recovery)", replicas: 3, originalScheduled: 0, nowScheduled: 3, wantEvent: false},
+		{name: "stable non-zero stays silent (steady state)", replicas: 3, originalScheduled: 3, nowScheduled: 3, wantEvent: false},
+		{name: "idle PodClique replicas 0 stays silent (intentional scale-to-zero)", replicas: 0, originalScheduled: 3, nowScheduled: 0, wantEvent: false},
 	}
 
 	for _, tt := range tests {
@@ -484,6 +487,7 @@ func TestEmitAllScheduledReplicasLostIfNeeded(t *testing.T) {
 			recorder := record.NewFakeRecorder(2)
 			r := &Reconciler{eventRecorder: recorder}
 			pclq := &grovecorev1alpha1.PodClique{
+				Spec:   grovecorev1alpha1.PodCliqueSpec{Replicas: tt.replicas},
 				Status: grovecorev1alpha1.PodCliqueStatus{ScheduledReplicas: tt.nowScheduled},
 			}
 
@@ -524,6 +528,7 @@ func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testin
 		{
 			name: "0 < scheduled < MinAvailable breaches",
 			pclq: &grovecorev1alpha1.PodClique{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
 				Spec: grovecorev1alpha1.PodCliqueSpec{
 					Replicas:     3,
 					MinAvailable: ptr.To(int32(3)),
@@ -544,6 +549,7 @@ func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testin
 							Type:               constants.ConditionTypeMinAvailableBreached,
 							Status:             metav1.ConditionFalse,
 							Reason:             constants.ConditionReasonSufficientReadyPods,
+							ObservedGeneration: 1,
 							LastTransitionTime: pastTransition,
 						},
 					},
@@ -558,6 +564,7 @@ func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testin
 			// window to schedule before the workload is recycled.
 			name: "previously-healthy PCLQ loses all scheduled pods — breaches",
 			pclq: &grovecorev1alpha1.PodClique{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
 				Spec: grovecorev1alpha1.PodCliqueSpec{
 					Replicas:     2,
 					MinAvailable: ptr.To(int32(2)),
@@ -569,9 +576,10 @@ func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testin
 					ReadyReplicas:      0,
 					Conditions: []metav1.Condition{
 						{
-							Type:               constants.ConditionTypePodCliqueScheduled,
-							Status:             metav1.ConditionTrue,
-							Reason:             constants.ConditionReasonSufficientScheduledPods,
+							Type:               constants.ConditionTypeMinAvailableBreached,
+							Status:             metav1.ConditionFalse,
+							Reason:             constants.ConditionReasonSufficientReadyPods,
+							ObservedGeneration: 1,
 							LastTransitionTime: pastTransition,
 						},
 					},
@@ -581,11 +589,7 @@ func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testin
 			wantReason: constants.ConditionReasonScheduledReplicasBelowMinAvailable,
 		},
 		{
-			// A fresh PCLQ that has not yet scheduled any pods still breaches
-			// under the always-breach rule. TerminationDelay (4h) is the grace
-			// window: if pods schedule in time the breach resolves before any
-			// termination action.
-			name: "fresh PCLQ never scheduled — also breaches (TerminationDelay is the grace)",
+			name: "fresh PCLQ never scheduled is not armed",
 			pclq: &grovecorev1alpha1.PodClique{
 				Spec: grovecorev1alpha1.PodCliqueSpec{
 					Replicas:     3,
@@ -599,7 +603,25 @@ func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testin
 				},
 			},
 			wantStatus: metav1.ConditionTrue,
-			wantReason: constants.ConditionReasonScheduledReplicasBelowMinAvailable,
+			wantReason: constants.ConditionReasonInitialScheduling,
+		},
+		{
+			// GREP-0677: an idle standalone PodClique (replicas: 0) is intentionally idle and
+			// never breaches MinAvailable, regardless of observed scheduled/ready pods.
+			name: "idle PodClique replicas 0 does not breach",
+			pclq: &grovecorev1alpha1.PodClique{
+				Spec: grovecorev1alpha1.PodCliqueSpec{
+					Replicas:     0,
+					MinAvailable: ptr.To(int32(1)),
+				},
+				Status: grovecorev1alpha1.PodCliqueStatus{
+					ObservedGeneration: ptr.To(int64(1)),
+					ScheduledReplicas:  0,
+					ReadyReplicas:      0,
+				},
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: constants.ConditionReasonIdle,
 		},
 	}
 
@@ -613,6 +635,50 @@ func TestComputeMinAvailableBreachedConditionPartialScheduleRegression(t *testin
 			assert.Equal(t, tt.wantReason, condition.Reason, "MinAvailableBreached reason mismatch")
 		})
 	}
+}
+
+func TestMutateMinAvailableBreachedConditionUpdatesObservedGeneration(t *testing.T) {
+	pclq := &grovecorev1alpha1.PodClique{
+		ObjectMeta: metav1.ObjectMeta{Generation: 2},
+		Spec: grovecorev1alpha1.PodCliqueSpec{
+			Replicas:     1,
+			MinAvailable: ptr.To(int32(1)),
+		},
+		Status: grovecorev1alpha1.PodCliqueStatus{
+			ReadyReplicas: 1,
+			Conditions: []metav1.Condition{{
+				Type:               constants.ConditionTypeMinAvailableBreached,
+				Status:             metav1.ConditionFalse,
+				Reason:             constants.ConditionReasonSufficientReadyPods,
+				Message:            "Sufficient ready pods found. expected at least: 1, found: 1",
+				ObservedGeneration: 1,
+			}},
+		},
+	}
+
+	mutateMinAvailableBreachedCondition(pclq, 0, 0)
+
+	condition := meta.FindStatusCondition(pclq.Status.Conditions, constants.ConditionTypeMinAvailableBreached)
+	require.NotNil(t, condition)
+	assert.Equal(t, int64(2), condition.ObservedGeneration)
+}
+
+// TestComputePodCliqueScheduledConditionTreatsZeroReplicasAsScheduled verifies GREP-0677: an idle
+// standalone PodClique (replicas: 0) is treated as scheduled so it does not hold the parent back.
+func TestComputePodCliqueScheduledConditionTreatsZeroReplicasAsScheduled(t *testing.T) {
+	pclq := &grovecorev1alpha1.PodClique{
+		Spec: grovecorev1alpha1.PodCliqueSpec{
+			Replicas:     0,
+			MinAvailable: ptr.To(int32(1)),
+		},
+		Status: grovecorev1alpha1.PodCliqueStatus{ScheduledReplicas: 0},
+	}
+
+	condition := computePodCliqueScheduledCondition(pclq)
+
+	assert.Equal(t, constants.ConditionTypePodCliqueScheduled, condition.Type)
+	assert.Equal(t, metav1.ConditionTrue, condition.Status)
+	assert.Equal(t, constants.ConditionReasonSufficientScheduledPods, condition.Reason)
 }
 
 // TestReconcileStatusRequeuesOnConflict verifies that when the optimistic-locked status patch is

--- a/operator/internal/controller/podcliquescalinggroup/components/podclique/podclique.go
+++ b/operator/internal/controller/podcliquescalinggroup/components/podclique/podclique.go
@@ -437,57 +437,14 @@ func identifyFullyQualifiedStartupDependencyNames(pcs *grovecorev1alpha1.PodCliq
 		// If it is still nil, then by not returning an error we break the API contract. It is a bug that should be fixed.
 		return nil, groveerr.New(errCodeMissingStartupType, component.OperationSync, fmt.Sprintf("PodClique: %v has nil StartupType", client.ObjectKeyFromObject(pclq)))
 	}
-	switch *cliqueStartupType {
-	case grovecorev1alpha1.CliqueStartupTypeInOrder:
-		return getInOrderStartupDependencies(pcs, pcsReplicaIndex, pcsg, pcsgReplicaIndex, foundAtIndex, activePCLQNames), nil
-	case grovecorev1alpha1.CliqueStartupTypeExplicit:
-		return getExplicitStartupDependencies(pcs, pcsReplicaIndex, pcsg, pcsgReplicaIndex, pclq, activePCLQNames), nil
-	default:
-		return nil, nil
-	}
-}
-
-// getInOrderStartupDependencies returns the nearest active preceding clique in the same PodGang.
-func getInOrderStartupDependencies(pcs *grovecorev1alpha1.PodCliqueSet, pcsReplicaIndex int, pcsg *grovecorev1alpha1.PodCliqueScalingGroup, pcsgReplicaIndex, foundAtIndex int, activePCLQNames componentutils.Set[string]) []string {
-	for index := foundAtIndex - 1; index >= 0; index-- {
-		dependencies := activeDependencies(startupDependencyCandidates(
-			pcs, pcsReplicaIndex, pcsg, pcsgReplicaIndex, pcs.Spec.Template.Cliques[index].Name,
-		), activePCLQNames)
-		if len(dependencies) > 0 {
-			return dependencies
+	return componentutils.StartupDependencies(pcs, foundAtIndex, pclq.Spec.StartsAfter, activePCLQNames, func(cliqueName string) []string {
+		candidates := componentutils.GenerateDependencyNamesForBasePodGang(pcs, pcsReplicaIndex, cliqueName)
+		if slices.Contains(pcsg.Spec.CliqueNames, cliqueName) {
+			candidates = append(candidates, apicommon.GeneratePodCliqueName(
+				apicommon.ResourceNameReplica{Name: pcsg.Name, Replica: pcsgReplicaIndex}, cliqueName))
 		}
-	}
-	return nil
-}
-
-// getExplicitStartupDependencies generates fully qualified names for explicitly defined startup dependencies
-func getExplicitStartupDependencies(pcs *grovecorev1alpha1.PodCliqueSet, pcsReplicaIndex int, pcsg *grovecorev1alpha1.PodCliqueScalingGroup, pcsgReplicaIndex int, pclq *grovecorev1alpha1.PodClique, activePCLQNames componentutils.Set[string]) []string {
-	var candidates []string
-	for _, dependency := range pclq.Spec.StartsAfter {
-		candidates = append(candidates, startupDependencyCandidates(pcs, pcsReplicaIndex, pcsg, pcsgReplicaIndex, dependency)...)
-	}
-	return activeDependencies(candidates, activePCLQNames)
-}
-
-func startupDependencyCandidates(pcs *grovecorev1alpha1.PodCliqueSet, pcsReplicaIndex int, pcsg *grovecorev1alpha1.PodCliqueScalingGroup, pcsgReplicaIndex int, cliqueName string) []string {
-	candidates := componentutils.GenerateDependencyNamesForBasePodGang(pcs, pcsReplicaIndex, cliqueName)
-	if slices.Contains(pcsg.Spec.CliqueNames, cliqueName) {
-		candidates = append(candidates, apicommon.GeneratePodCliqueName(
-			apicommon.ResourceNameReplica{Name: pcsg.Name, Replica: pcsgReplicaIndex}, cliqueName))
-	}
-	return candidates
-}
-
-func activeDependencies(candidates []string, activePCLQNames componentutils.Set[string]) []string {
-	dependencies := make([]string, 0, len(candidates))
-	seen := make(componentutils.Set[string], len(candidates))
-	for _, candidate := range candidates {
-		if activePCLQNames.Has(candidate) && !seen.Has(candidate) {
-			dependencies = append(dependencies, candidate)
-			seen[candidate] = struct{}{}
-		}
-	}
-	return dependencies
+		return candidates
+	}), nil
 }
 
 // getPodCliqueSelectorLabels creates label selector map for identifying PodCliques belonging to a PodCliqueScalingGroup

--- a/operator/internal/controller/podcliquescalinggroup/components/podclique/podclique.go
+++ b/operator/internal/controller/podcliquescalinggroup/components/podclique/podclique.go
@@ -64,6 +64,7 @@ const (
 	errCodeSyncPCSGResourceClaim                         grovecorev1alpha1.ErrorCode = "ERR_SYNC_PCSG_RESOURCE_CLAIM"
 	errCodeGetPodGangMap                                 grovecorev1alpha1.ErrorCode = "ERR_GET_PODGANGMAP"
 	errCodeSyncPCSGPodIndexOffsets                       grovecorev1alpha1.ErrorCode = "ERR_SYNC_PCSG_POD_INDEX_OFFSETS"
+	errCodeListPodGangs                                  grovecorev1alpha1.ErrorCode = "ERR_LIST_PODGANGS"
 )
 
 var (
@@ -346,7 +347,15 @@ func (r _resource) buildResource(logger logr.Logger, ss *syncSnapshot, pcsgRepli
 	}
 	pcsgTemplateNumPods := r.getPCSGTemplateNumPods(pcs, pcsg)
 	r.addEnvironmentVariablesToPodContainerSpecs(pclq, pcsgTemplateNumPods)
-	dependentPCLQNames, err := identifyFullyQualifiedStartupDependencyNames(pcs, pcsReplicaIndex, pcsg, pcsgReplicaIndex, pclq, foundAtIndex)
+	activePCLQNames, err := componentutils.ActivePodCliqueNamesForPodGang(pcs, ss.pgm, rnr, podGangName)
+	if err != nil {
+		return groveerr.WrapError(err,
+			errCodeBuildPodClique,
+			component.OperationSync,
+			fmt.Sprintf("failed to resolve active PodCliques for PodClique: %v", pclqObjectKey),
+		)
+	}
+	dependentPCLQNames, err := identifyFullyQualifiedStartupDependencyNames(pcs, pcsReplicaIndex, pcsg, pcsgReplicaIndex, pclq, foundAtIndex, activePCLQNames)
 	if err != nil {
 		return err
 	}
@@ -421,7 +430,7 @@ func getPCSReplicaFromPCSG(pcsg *grovecorev1alpha1.PodCliqueScalingGroup) (int, 
 }
 
 // identifyFullyQualifiedStartupDependencyNames resolves startup dependencies based on PCS startup type configuration
-func identifyFullyQualifiedStartupDependencyNames(pcs *grovecorev1alpha1.PodCliqueSet, pcsReplicaIndex int, pcsg *grovecorev1alpha1.PodCliqueScalingGroup, pcsgReplicaIndex int, pclq *grovecorev1alpha1.PodClique, foundAtIndex int) ([]string, error) {
+func identifyFullyQualifiedStartupDependencyNames(pcs *grovecorev1alpha1.PodCliqueSet, pcsReplicaIndex int, pcsg *grovecorev1alpha1.PodCliqueScalingGroup, pcsgReplicaIndex int, pclq *grovecorev1alpha1.PodClique, foundAtIndex int, activePCLQNames componentutils.Set[string]) ([]string, error) {
 	cliqueStartupType := pcs.Spec.Template.StartupType
 	if cliqueStartupType == nil {
 		// Ideally this should never happen as the defaulting webhook should set it v1alpha1.CliqueStartupTypeInOrder as the default value.
@@ -430,56 +439,55 @@ func identifyFullyQualifiedStartupDependencyNames(pcs *grovecorev1alpha1.PodCliq
 	}
 	switch *cliqueStartupType {
 	case grovecorev1alpha1.CliqueStartupTypeInOrder:
-		return getInOrderStartupDependencies(pcs, pcsReplicaIndex, pcsg, pcsgReplicaIndex, foundAtIndex), nil
+		return getInOrderStartupDependencies(pcs, pcsReplicaIndex, pcsg, pcsgReplicaIndex, foundAtIndex, activePCLQNames), nil
 	case grovecorev1alpha1.CliqueStartupTypeExplicit:
-		return getExplicitStartupDependencies(pcs, pcsReplicaIndex, pcsg, pcsgReplicaIndex, pclq), nil
+		return getExplicitStartupDependencies(pcs, pcsReplicaIndex, pcsg, pcsgReplicaIndex, pclq, activePCLQNames), nil
 	default:
 		return nil, nil
 	}
 }
 
-// getInOrderStartupDependencies generates dependencies for in-order startup by including all preceding PodCliques in the same replica
-func getInOrderStartupDependencies(pcs *grovecorev1alpha1.PodCliqueSet, pcsReplicaIndex int, pcsg *grovecorev1alpha1.PodCliqueScalingGroup, pcsgReplicaIndex, foundAtIndex int) []string {
-	if foundAtIndex == 0 {
-		return nil
+// getInOrderStartupDependencies returns the nearest active preceding clique in the same PodGang.
+func getInOrderStartupDependencies(pcs *grovecorev1alpha1.PodCliqueSet, pcsReplicaIndex int, pcsg *grovecorev1alpha1.PodCliqueScalingGroup, pcsgReplicaIndex, foundAtIndex int, activePCLQNames componentutils.Set[string]) []string {
+	for index := foundAtIndex - 1; index >= 0; index-- {
+		dependencies := activeDependencies(startupDependencyCandidates(
+			pcs, pcsReplicaIndex, pcsg, pcsgReplicaIndex, pcs.Spec.Template.Cliques[index].Name,
+		), activePCLQNames)
+		if len(dependencies) > 0 {
+			return dependencies
+		}
 	}
-	parentCliqueName := pcs.Spec.Template.Cliques[foundAtIndex-1].Name
-
-	// Current pcsgReplicaIndex belongs to the base PodGang
-	if pcsgReplicaIndex < int(*pcsg.Spec.MinAvailable) {
-		return componentutils.GenerateDependencyNamesForBasePodGang(pcs, pcsReplicaIndex, parentCliqueName)
-	}
-
-	// Startup ordering is only enforced within a PodGang.
-	// PodCliques that belong to the base PodGang are not considered for startsAfter in scaled PodGangs.
-	if !slices.Contains(pcsg.Spec.CliqueNames, parentCliqueName) {
-		return nil
-	}
-
-	return []string{
-		apicommon.GeneratePodCliqueName(apicommon.ResourceNameReplica{Name: pcsg.Name, Replica: pcsgReplicaIndex}, parentCliqueName),
-	}
+	return nil
 }
 
 // getExplicitStartupDependencies generates fully qualified names for explicitly defined startup dependencies
-func getExplicitStartupDependencies(pcs *grovecorev1alpha1.PodCliqueSet, pcsReplicaIndex int, pcsg *grovecorev1alpha1.PodCliqueScalingGroup, pcsgReplicaIndex int, pclq *grovecorev1alpha1.PodClique) []string {
-	parentCliqueNames := make([]string, 0, len(pclq.Spec.StartsAfter))
-	// Current pcsgReplicaIndex belongs to the base PodGang
-	if pcsgReplicaIndex < int(*pcsg.Spec.MinAvailable) {
-		for _, dependency := range pclq.Spec.StartsAfter {
-			parentCliqueNames = append(parentCliqueNames, componentutils.GenerateDependencyNamesForBasePodGang(pcs, pcsReplicaIndex, dependency)...)
-		}
-		return parentCliqueNames
-	}
-
+func getExplicitStartupDependencies(pcs *grovecorev1alpha1.PodCliqueSet, pcsReplicaIndex int, pcsg *grovecorev1alpha1.PodCliqueScalingGroup, pcsgReplicaIndex int, pclq *grovecorev1alpha1.PodClique, activePCLQNames componentutils.Set[string]) []string {
+	var candidates []string
 	for _, dependency := range pclq.Spec.StartsAfter {
-		// Startup ordering is only enforced within the scaled PodCliqueScalingGroup's corresponding PodGang.
-		if !slices.Contains(pcsg.Spec.CliqueNames, dependency) {
-			continue
-		}
-		parentCliqueNames = append(parentCliqueNames, apicommon.GeneratePodCliqueName(apicommon.ResourceNameReplica{Name: pcsg.Name, Replica: pcsgReplicaIndex}, dependency))
+		candidates = append(candidates, startupDependencyCandidates(pcs, pcsReplicaIndex, pcsg, pcsgReplicaIndex, dependency)...)
 	}
-	return parentCliqueNames
+	return activeDependencies(candidates, activePCLQNames)
+}
+
+func startupDependencyCandidates(pcs *grovecorev1alpha1.PodCliqueSet, pcsReplicaIndex int, pcsg *grovecorev1alpha1.PodCliqueScalingGroup, pcsgReplicaIndex int, cliqueName string) []string {
+	candidates := componentutils.GenerateDependencyNamesForBasePodGang(pcs, pcsReplicaIndex, cliqueName)
+	if slices.Contains(pcsg.Spec.CliqueNames, cliqueName) {
+		candidates = append(candidates, apicommon.GeneratePodCliqueName(
+			apicommon.ResourceNameReplica{Name: pcsg.Name, Replica: pcsgReplicaIndex}, cliqueName))
+	}
+	return candidates
+}
+
+func activeDependencies(candidates []string, activePCLQNames componentutils.Set[string]) []string {
+	dependencies := make([]string, 0, len(candidates))
+	seen := make(componentutils.Set[string], len(candidates))
+	for _, candidate := range candidates {
+		if activePCLQNames.Has(candidate) && !seen.Has(candidate) {
+			dependencies = append(dependencies, candidate)
+			seen[candidate] = struct{}{}
+		}
+	}
+	return dependencies
 }
 
 // getPodCliqueSelectorLabels creates label selector map for identifying PodCliques belonging to a PodCliqueScalingGroup

--- a/operator/internal/controller/podcliquescalinggroup/components/podclique/podclique_test.go
+++ b/operator/internal/controller/podcliquescalinggroup/components/podclique/podclique_test.go
@@ -26,10 +26,12 @@ import (
 	groveclientscheme "github.com/ai-dynamo/grove/operator/internal/client"
 	"github.com/ai-dynamo/grove/operator/internal/constants"
 	"github.com/ai-dynamo/grove/operator/internal/controller/common/component"
+	componentutils "github.com/ai-dynamo/grove/operator/internal/controller/common/component/utils"
 	groveerr "github.com/ai-dynamo/grove/operator/internal/errors"
 	"github.com/ai-dynamo/grove/operator/internal/mnnvl"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
+	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -661,6 +664,8 @@ func TestIdentifyFullyQualifiedStartupDependencyNames(t *testing.T) {
 		foundAtIndex int
 		// expected are the expected dependency names
 		expected []string
+		// active are the PodCliques materialized in the target PodGang
+		active []string
 		// expectError indicates if an error is expected
 		expectError bool
 	}{
@@ -728,6 +733,7 @@ func TestIdentifyFullyQualifiedStartupDependencyNames(t *testing.T) {
 			pclq:         &grovecorev1alpha1.PodClique{},
 			foundAtIndex: 1,
 			expected:     []string{"test-pcs-0-clique1"},
+			active:       []string{"test-pcs-0-clique1", "test-pcsg-1-clique2"},
 			expectError:  false,
 		},
 		{
@@ -765,6 +771,7 @@ func TestIdentifyFullyQualifiedStartupDependencyNames(t *testing.T) {
 			},
 			foundAtIndex: 1,
 			expected:     []string{"test-pcs-0-clique1"},
+			active:       []string{"test-pcs-0-clique1", "test-pcsg-0-clique2"},
 			expectError:  false,
 		},
 		{
@@ -806,6 +813,7 @@ func TestIdentifyFullyQualifiedStartupDependencyNames(t *testing.T) {
 				tc.pcsgReplica,
 				tc.pclq,
 				tc.foundAtIndex,
+				componentutils.NewSet(tc.active),
 			)
 
 			if tc.expectError {
@@ -816,6 +824,54 @@ func TestIdentifyFullyQualifiedStartupDependencyNames(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStartupDependenciesStayWithinMaterializedPodGang(t *testing.T) {
+	startupType := grovecorev1alpha1.CliqueStartupTypeInOrder
+	pcs := testutils.NewPodCliqueSetBuilder("test-pcs", "default", "uid").
+		WithCliqueStartupType(&startupType).
+		WithStandaloneClique("router").
+		WithStandaloneCliqueReplicas("idle", 0).
+		WithScalingGroupConfig("sg", []string{"prefill", "decode"}, 2, 1).
+		Build()
+	pcsg := testutils.NewPodCliqueScalingGroupBuilder("test-pcs-0-sg", "default", "test-pcs", 0).
+		WithCliqueNames([]string{"prefill", "decode"}).
+		WithMinAvailable(1).
+		Build()
+	pclq := &grovecorev1alpha1.PodClique{}
+
+	t.Run("anchor skips idle predecessor and finds nearest active clique", func(t *testing.T) {
+		active := componentutils.NewSet([]string{
+			"test-pcs-0-router",
+			"test-pcs-0-sg-0-prefill",
+			"test-pcs-0-sg-0-decode",
+		})
+		actual, err := identifyFullyQualifiedStartupDependencyNames(pcs, 0, pcsg, 0, pclq, 2, active)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"test-pcs-0-router"}, actual)
+	})
+
+	t.Run("non-anchor depends only on its own active predecessor", func(t *testing.T) {
+		active := componentutils.NewSet([]string{
+			"test-pcs-0-sg-1-prefill",
+			"test-pcs-0-sg-1-decode",
+		})
+		actual, err := identifyFullyQualifiedStartupDependencyNames(pcs, 0, pcsg, 1, pclq, 3, active)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"test-pcs-0-sg-1-prefill"}, actual)
+	})
+
+	t.Run("explicit drops dependencies outside the target PodGang", func(t *testing.T) {
+		startupType = grovecorev1alpha1.CliqueStartupTypeExplicit
+		pclq.Spec.StartsAfter = []string{"router", "prefill"}
+		active := componentutils.NewSet([]string{
+			"test-pcs-0-sg-1-prefill",
+			"test-pcs-0-sg-1-decode",
+		})
+		actual, err := identifyFullyQualifiedStartupDependencyNames(pcs, 0, pcsg, 1, pclq, 3, active)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"test-pcs-0-sg-1-prefill"}, actual)
+	})
 }
 
 // Helper function to check if an env var exists in a slice
@@ -1050,6 +1106,10 @@ func TestBuildResource_MNNVLInjection(t *testing.T) {
 				Spec: grovecorev1alpha1.PodCliqueSetSpec{
 					Template: grovecorev1alpha1.PodCliqueSetTemplateSpec{
 						StartupType: ptr.To(grovecorev1alpha1.CliqueStartupTypeAnyOrder),
+						PodCliqueScalingGroupConfigs: []grovecorev1alpha1.PodCliqueScalingGroupConfig{{
+							Name:        "sg",
+							CliqueNames: []string{pclqTemplateName},
+						}},
 						Cliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
 							{
 								Name:        pclqTemplateName,
@@ -1153,6 +1213,10 @@ func TestBuildResource_StripsTopologyAnnotation(t *testing.T) {
 		Spec: grovecorev1alpha1.PodCliqueSetSpec{
 			Template: grovecorev1alpha1.PodCliqueSetTemplateSpec{
 				StartupType: ptr.To(grovecorev1alpha1.CliqueStartupTypeAnyOrder),
+				PodCliqueScalingGroupConfigs: []grovecorev1alpha1.PodCliqueScalingGroupConfig{{
+					Name:        "sg",
+					CliqueNames: []string{"worker"},
+				}},
 				Cliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
 					{
 						Name: "worker",
@@ -1332,5 +1396,94 @@ func TestResolvePodGangName(t *testing.T) {
 		).Build()
 		_, err := resolvePodGangName(anchorOnly, rnr, pcsg, 5)
 		require.Error(t, err)
+	})
+}
+
+func TestEnsurePCSGScaleInReady(t *testing.T) {
+	const (
+		pcsName        = "test-pcs"
+		namespace      = "default"
+		pcsgConfigName = "sg"
+	)
+	pcsUID := types.UID("pcs-uid")
+	rnr := apicommon.ResourceNameReplica{Name: pcsName, Replica: 0}
+	pcsgName := apicommon.GeneratePodCliqueScalingGroupName(rnr, pcsgConfigName)
+	pcs := &grovecorev1alpha1.PodCliqueSet{
+		ObjectMeta: metav1.ObjectMeta{Name: pcsName, Namespace: namespace, UID: pcsUID},
+	}
+	pcsg := &grovecorev1alpha1.PodCliqueScalingGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: pcsgName, Namespace: namespace},
+		Spec: grovecorev1alpha1.PodCliqueScalingGroupSpec{
+			Replicas:    1,
+			CliqueNames: []string{"leader", "worker"},
+		},
+	}
+	pgm := testutils.NewPodGangMapBuilder(pcsName, namespace, pcsUID, 0).WithEntries(
+		testutils.NewPodGangEntryBuilder("hash", "1000").
+			WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).
+			WithAnchorIndex(0).
+			WithPCSGReplicaIndices(map[string][]int32{pcsgConfigName: {0}}).
+			Build(),
+	).Build()
+	targetPCLQName := apicommon.GeneratePodCliqueName(apicommon.ResourceNameReplica{Name: pcsgName, Replica: 1}, "worker")
+
+	newPodGang := func(name, podGroupName string, ownerUID types.UID) *groveschedulerv1alpha1.PodGang {
+		pg := testutils.NewPodGangBuilder(name, namespace).
+			WithLabels(map[string]string{
+				apicommon.LabelManagedByKey: apicommon.LabelManagedByValue,
+				apicommon.LabelPartOfKey:    pcsName,
+				apicommon.LabelComponentKey: apicommon.LabelComponentNamePodGang,
+			}).
+			WithPodGroup(podGroupName, 1).
+			Build()
+		pg.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: grovecorev1alpha1.SchemeGroupVersion.String(),
+			Kind:       "PodCliqueSet",
+			Name:       pcsName,
+			UID:        ownerUID,
+			Controller: ptr.To(true),
+		}}
+		return pg
+	}
+	newSnapshot := func(pgm *grovecorev1alpha1.PodGangMap) *syncSnapshot {
+		return &syncSnapshot{pcs: pcs.DeepCopy(), pcsg: pcsg.DeepCopy(), pcsReplicaIndex: 0, pgm: pgm}
+	}
+	run := func(t *testing.T, pgm *grovecorev1alpha1.PodGangMap, podGangs ...*groveschedulerv1alpha1.PodGang) error {
+		objects := make([]client.Object, 0, len(podGangs))
+		for _, podGang := range podGangs {
+			objects = append(objects, podGang)
+		}
+		r := _resource{client: testutils.NewTestClientBuilder().WithObjects(objects...).Build()}
+		return r.ensurePCSGScaleInReady(t.Context(), newSnapshot(pgm), []string{"1"})
+	}
+
+	t.Run("allows deletion after gang membership converges", func(t *testing.T) {
+		require.NoError(t, run(t, pgm.DeepCopy()))
+	})
+
+	t.Run("waits for PodGangMap membership removal", func(t *testing.T) {
+		stalePGM := pgm.DeepCopy()
+		stalePGM.Spec.Entries[0].PCSGReplicaIndices[pcsgConfigName] = []int32{0, 1}
+		testutils.AssertGroveError(t, &groveerr.GroveError{Code: groveerr.ErrCodeRequeueAfter, Operation: component.OperationSync}, run(t, stalePGM))
+	})
+
+	t.Run("waits for owned PodGang references", func(t *testing.T) {
+		stalePodGang := newPodGang("test-pcs-0-1000", targetPCLQName, pcsUID)
+		testutils.AssertGroveError(t, &groveerr.GroveError{Code: groveerr.ErrCodeRequeueAfter, Operation: component.OperationSync}, run(t, pgm.DeepCopy(), stalePodGang))
+	})
+
+	t.Run("ignores PodGroups for retained replica indices", func(t *testing.T) {
+		retainedPCLQName := apicommon.GeneratePodCliqueName(apicommon.ResourceNameReplica{Name: pcsgName, Replica: 0}, "worker")
+		require.NoError(t, run(t, pgm.DeepCopy(), newPodGang("test-pcs-0-1000", retainedPCLQName, pcsUID)))
+	})
+
+	t.Run("ignores PodGangs not owned by the PodCliqueSet", func(t *testing.T) {
+		require.NoError(t, run(t, pgm.DeepCopy(), newPodGang("foreign", targetPCLQName, types.UID("other-uid"))))
+	})
+
+	t.Run("waits for Grove-owned PodGangMap", func(t *testing.T) {
+		foreignPGM := pgm.DeepCopy()
+		delete(foreignPGM.Labels, apicommon.LabelManagedByKey)
+		testutils.AssertGroveError(t, &groveerr.GroveError{Code: groveerr.ErrCodeRequeueAfter, Operation: component.OperationSync}, run(t, foreignPGM))
 	})
 }

--- a/operator/internal/controller/podcliquescalinggroup/components/podclique/sync.go
+++ b/operator/internal/controller/podcliquescalinggroup/components/podclique/sync.go
@@ -27,6 +27,7 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/ai-dynamo/grove/operator/internal/controller/common/component"
 	componentutils "github.com/ai-dynamo/grove/operator/internal/controller/common/component/utils"
+	ctrlutils "github.com/ai-dynamo/grove/operator/internal/controller/utils"
 	groveerr "github.com/ai-dynamo/grove/operator/internal/errors"
 	"github.com/ai-dynamo/grove/operator/internal/resourceclaim"
 	"github.com/ai-dynamo/grove/operator/internal/utils"
@@ -34,6 +35,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -250,12 +252,82 @@ func (r _resource) triggerDeletionOfExcessPCSGReplicas(ctx context.Context, logg
 		logger.Info("Found more PodCliques than expected, triggering deletion of excess PodCliques", "expected", int(ss.pcsg.Spec.Replicas), "existing", existingPCSGReplicas, "diff", diff)
 		reason := "Delete excess PodCliqueScalingGroup replicas"
 		replicaIndicesToDelete := computePCSGReplicasToDelete(existingPCSGReplicas, int(ss.pcsg.Spec.Replicas))
+		if err := r.ensurePCSGScaleInReady(ctx, ss, replicaIndicesToDelete); err != nil {
+			return err
+		}
 		deletionTasks := r.createDeleteTasks(logger, ss.pcs, pcsgObjectKey.Name, replicaIndicesToDelete, reason)
 		if err := r.triggerDeletionOfPodCliques(ctx, logger, pcsgObjectKey, deletionTasks); err != nil {
 			return err
 		}
 
 		return ss.refreshExistingPCLQs(ss.pcsg)
+	}
+	return nil
+}
+
+// ensurePCSGScaleInReady prevents member PodCliques from being deleted until their replica indices
+// have left the PodGangMap and all Grove-owned PodGangs have dropped their PodGroups.
+func (r _resource) ensurePCSGScaleInReady(ctx context.Context, ss *syncSnapshot, replicaIndices []string) error {
+	requeue := func(message string) error {
+		return groveerr.New(groveerr.ErrCodeRequeueAfter, component.OperationSync, message)
+	}
+	if !ctrlutils.IsManagedByGrove(ss.pgm.Labels) || !metav1.IsControlledBy(ss.pgm, ss.pcs) {
+		return requeue(fmt.Sprintf("PodGangMap %s has not converged under PodCliqueSet ownership", ss.pgm.Name))
+	}
+
+	rnr := apicommon.ResourceNameReplica{Name: ss.pcs.Name, Replica: ss.pcsReplicaIndex}
+	pcsgConfigName, err := apicommon.ExtractScalingGroupNameFromPCSGFQN(ss.pcsg.Name, rnr)
+	if err != nil {
+		return groveerr.WrapError(err, errCodeParsePodCliqueScalingGroupReplicaIndex, component.OperationSync,
+			fmt.Sprintf("failed to resolve PodCliqueScalingGroup config name for %s", ss.pcsg.Name))
+	}
+	targetIndexSet := componentutils.NewSet(replicaIndices)
+	targetIndices := make([]int32, 0, len(targetIndexSet))
+	for index := range targetIndexSet {
+		replicaIndex, err := strconv.Atoi(index)
+		if err != nil {
+			return groveerr.WrapError(err, errCodeParsePodCliqueScalingGroupReplicaIndex, component.OperationSync,
+				fmt.Sprintf("invalid PodCliqueScalingGroup replica index %q", index))
+		}
+		targetIndices = append(targetIndices, int32(replicaIndex))
+		entry, err := componentutils.FindPodGangEntryForPCSGReplica(ss.pgm.Spec.Entries, "", pcsgConfigName, int32(replicaIndex))
+		if err != nil {
+			return requeue(fmt.Sprintf("PodGangMap %s has invalid membership for PodCliqueScalingGroup %s: %v", ss.pgm.Name, ss.pcsg.Name, err))
+		}
+		if entry != nil {
+			return requeue(fmt.Sprintf("PodGangMap %s still references PodCliqueScalingGroup %s replica index %d", ss.pgm.Name, ss.pcsg.Name, replicaIndex))
+		}
+	}
+
+	targetPCLQNames := componentutils.NewSet([]string{})
+	for _, replicaIndex := range targetIndices {
+		for _, cliqueName := range ss.pcsg.Spec.CliqueNames {
+			targetPCLQNames[apicommon.GeneratePodCliqueName(apicommon.ResourceNameReplica{
+				Name: ss.pcsg.Name, Replica: int(replicaIndex),
+			}, cliqueName)] = struct{}{}
+		}
+	}
+	for i := range ss.existingPCLQs {
+		if targetIndexSet.Has(ss.existingPCLQs[i].Labels[apicommon.LabelPodCliqueScalingGroupReplicaIndex]) {
+			targetPCLQNames[ss.existingPCLQs[i].Name] = struct{}{}
+		}
+	}
+
+	podGangs, err := componentutils.GetExistingPodGangs(ctx, r.client, ss.pcs.ObjectMeta, ss.pcs.Namespace)
+	if err != nil {
+		return groveerr.WrapError(err, errCodeListPodGangs, component.OperationSync,
+			fmt.Sprintf("failed to list PodGangs for PodCliqueSet %s", client.ObjectKeyFromObject(ss.pcs)))
+	}
+	for i := range podGangs {
+		podGang := &podGangs[i]
+		if !ctrlutils.IsManagedPodGang(podGang) || !metav1.IsControlledBy(podGang, ss.pcs) {
+			continue
+		}
+		for _, podGroup := range podGang.Spec.PodGroups {
+			if targetPCLQNames.Has(podGroup.Name) {
+				return requeue(fmt.Sprintf("PodGang %s still references PodClique %s", podGang.Name, podGroup.Name))
+			}
+		}
 	}
 	return nil
 }

--- a/operator/internal/controller/podcliquescalinggroup/components/podclique/sync.go
+++ b/operator/internal/controller/podcliquescalinggroup/components/podclique/sync.go
@@ -282,14 +282,13 @@ func (r _resource) ensurePCSGScaleInReady(ctx context.Context, ss *syncSnapshot,
 			fmt.Sprintf("failed to resolve PodCliqueScalingGroup config name for %s", ss.pcsg.Name))
 	}
 	targetIndexSet := componentutils.NewSet(replicaIndices)
-	targetIndices := make([]int32, 0, len(targetIndexSet))
+	targetPCLQNames := make(componentutils.Set[string])
 	for index := range targetIndexSet {
 		replicaIndex, err := strconv.Atoi(index)
 		if err != nil {
 			return groveerr.WrapError(err, errCodeParsePodCliqueScalingGroupReplicaIndex, component.OperationSync,
 				fmt.Sprintf("invalid PodCliqueScalingGroup replica index %q", index))
 		}
-		targetIndices = append(targetIndices, int32(replicaIndex))
 		entry, err := componentutils.FindPodGangEntryForPCSGReplica(ss.pgm.Spec.Entries, "", pcsgConfigName, int32(replicaIndex))
 		if err != nil {
 			return requeue(fmt.Sprintf("PodGangMap %s has invalid membership for PodCliqueScalingGroup %s: %v", ss.pgm.Name, ss.pcsg.Name, err))
@@ -297,13 +296,9 @@ func (r _resource) ensurePCSGScaleInReady(ctx context.Context, ss *syncSnapshot,
 		if entry != nil {
 			return requeue(fmt.Sprintf("PodGangMap %s still references PodCliqueScalingGroup %s replica index %d", ss.pgm.Name, ss.pcsg.Name, replicaIndex))
 		}
-	}
-
-	targetPCLQNames := componentutils.NewSet([]string{})
-	for _, replicaIndex := range targetIndices {
 		for _, cliqueName := range ss.pcsg.Spec.CliqueNames {
 			targetPCLQNames[apicommon.GeneratePodCliqueName(apicommon.ResourceNameReplica{
-				Name: ss.pcsg.Name, Replica: int(replicaIndex),
+				Name: ss.pcsg.Name, Replica: replicaIndex,
 			}, cliqueName)] = struct{}{}
 		}
 	}

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
@@ -74,7 +74,7 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 	// mutateReplicas already ignores them via its [0, Spec.Replicas) loop bounds.
 	pclqsPerPCSGReplica = pruneStrayPCSGPCLQs(pcsg, pclqsPerPCSGReplica)
 	mutateReplicas(logger, pcs, pcsg, pclqsPerPCSGReplica)
-	mutateMinAvailableBreachedCondition(logger, pcsg, pclqsPerPCSGReplica)
+	mutateMinAvailableBreachedCondition(logger, pcsg)
 	r.emitAllScheduledReplicasLostIfNeeded(pcsg, originalStatus.ScheduledReplicas)
 
 	if err = mutateSelector(pcs, pcsg); err != nil {
@@ -210,6 +210,11 @@ func isPCSGChildPCLQUpdated(pclq *grovecorev1alpha1.PodClique, expectedPCLQPodTe
 // event gives operators a discrete, log-visible signal that a previously-running workload is
 // fully down (and that gang termination is now armed and will fire after TerminationDelay).
 func (r *Reconciler) emitAllScheduledReplicasLostIfNeeded(pcsg *grovecorev1alpha1.PodCliqueScalingGroup, originalScheduled int32) {
+	// GREP-0677: a scale-to-zero transition is intentional, not a loss. Do not emit the warning
+	// (and do not imply gang termination is armed) when the PCSG is idle.
+	if pcsg.Spec.Replicas == 0 {
+		return
+	}
 	if originalScheduled > 0 && pcsg.Status.ScheduledReplicas == 0 {
 		r.eventRecorder.Eventf(pcsg, corev1.EventTypeWarning, internalconstants.ReasonAllScheduledReplicasLost,
 			"All scheduled replicas lost (was %d). Gang termination will fire after TerminationDelay if the PCSG stays below MinAvailable; investigate node availability or capacity.",
@@ -218,114 +223,66 @@ func (r *Reconciler) emitAllScheduledReplicasLostIfNeeded(pcsg *grovecorev1alpha
 }
 
 // mutateMinAvailableBreachedCondition updates the MinAvailableBreached condition based on replica availability.
-//
-// Whenever the computed condition is False (the PCSG is healthy) and the GangTerminationInProgress
-// condition is present, the latter is removed. The flag is only ever set while the PCSG is in
-// breach, so the first False observed with the flag still set is the recovery; clearing it
-// re-arms the next breach episode so a fresh regression can be recycled.
-func mutateMinAvailableBreachedCondition(logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup, pclqsPerPCSGReplica map[string][]grovecorev1alpha1.PodClique) {
-	newCondition := computeMinAvailableBreachedCondition(logger, pcsg, pclqsPerPCSGReplica)
-	if k8sutils.HasConditionChanged(pcsg.Status.Conditions, newCondition) {
+func mutateMinAvailableBreachedCondition(logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup) {
+	newCondition := computeMinAvailableBreachedCondition(pcsg)
+	if meta.SetStatusCondition(&pcsg.Status.Conditions, newCondition) {
 		logger.Info("Updating MinAvailableBreached condition for PodCliqueScalingGroup",
 			"pcsg", client.ObjectKeyFromObject(pcsg),
 			"type", newCondition.Type,
 			"status", newCondition.Status,
 			"reason", newCondition.Reason)
-		meta.SetStatusCondition(&pcsg.Status.Conditions, newCondition)
-	}
-	if newCondition.Status == metav1.ConditionFalse &&
-		meta.IsStatusConditionTrue(pcsg.Status.Conditions, constants.ConditionTypeGangTerminationInProgress) {
-		logger.Info("Clearing GangTerminationInProgress condition — PCSG recovered",
-			"pcsg", client.ObjectKeyFromObject(pcsg))
-		meta.RemoveStatusCondition(&pcsg.Status.Conditions, constants.ConditionTypeGangTerminationInProgress)
 	}
 }
 
-// computeMinAvailableBreachedCondition computes the MinAvailableBreached condition for the
-// PodCliqueScalingGroup. Definition:
-//
-//   - A PCSG replica is in breach if at least one of its PodCliques is in breach
-//     (MinAvailableBreached=True on the PCLQ).
-//   - The PCSG itself is in breach when the number of replicas NOT in breach is less than
-//     pcsg.Spec.MinAvailable. Per-replica restart is handled separately by the PCSG sync
-//     flow; the condition computed here is the signal the PCS-level gang-termination
-//     handler reads to decide whether to restart the whole PCS replica.
-//
-// Rolling update short-circuits this to Unknown so gang termination doesn't fire mid-update.
-func computeMinAvailableBreachedCondition(logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup, pclqsPerPCSGReplica map[string][]grovecorev1alpha1.PodClique) metav1.Condition {
-	if componentutils.IsPCSGUpdateInProgress(pcsg) {
+// computeMinAvailableBreachedCondition uses AvailableReplicas as the durable health signal.
+func computeMinAvailableBreachedCondition(pcsg *grovecorev1alpha1.PodCliqueScalingGroup) metav1.Condition {
+	if pcsg.Spec.Replicas == 0 {
 		return metav1.Condition{
-			Type:    constants.ConditionTypeMinAvailableBreached,
-			Status:  metav1.ConditionUnknown,
-			Reason:  constants.ConditionReasonUpdateInProgress,
-			Message: "Update is in progress",
+			Type:               constants.ConditionTypeMinAvailableBreached,
+			Status:             metav1.ConditionFalse,
+			Reason:             constants.ConditionReasonIdle,
+			Message:            "PodCliqueScalingGroup is idle (spec.replicas == 0); not a required gang member",
+			ObservedGeneration: pcsg.Generation,
 		}
 	}
-
+	if componentutils.IsPCSGUpdateInProgress(pcsg) {
+		return metav1.Condition{
+			Type:               constants.ConditionTypeMinAvailableBreached,
+			Status:             metav1.ConditionUnknown,
+			Reason:             constants.ConditionReasonUpdateInProgress,
+			Message:            "Update is in progress",
+			ObservedGeneration: pcsg.Generation,
+		}
+	}
 	// The apiserver defaults Spec.MinAvailable to 1 (+kubebuilder:default), but objects
 	// persisted under an older CRD schema can still read back nil until their next write —
 	// dereferencing unguarded would crash-loop the operator off a single legacy object.
-	minAvailable := 1
+	minAvailable := int32(1)
 	if pcsg.Spec.MinAvailable != nil {
-		minAvailable = int(*pcsg.Spec.MinAvailable)
-	} else {
-		logger.Info("PCSG has nil Spec.MinAvailable; assuming API default of 1", "pcsg", client.ObjectKeyFromObject(pcsg))
+		minAvailable = *pcsg.Spec.MinAvailable
 	}
-	notInBreachReplicas := computeNotInBreachReplicas(logger, pcsg, pclqsPerPCSGReplica)
-	if notInBreachReplicas < minAvailable {
+	if pcsg.Status.AvailableReplicas >= minAvailable {
 		return metav1.Condition{
-			Type:    constants.ConditionTypeMinAvailableBreached,
-			Status:  metav1.ConditionTrue,
-			Reason:  constants.ConditionReasonInsufficientAvailablePCSGReplicas,
-			Message: fmt.Sprintf("PCSG replicas not in breach (%d) below MinAvailable (%d)", notInBreachReplicas, minAvailable),
+			Type:               constants.ConditionTypeMinAvailableBreached,
+			Status:             metav1.ConditionFalse,
+			Reason:             constants.ConditionReasonSufficientAvailablePCSGReplicas,
+			Message:            fmt.Sprintf("Available replicas (%d) meet MinAvailable (%d)", pcsg.Status.AvailableReplicas, minAvailable),
+			ObservedGeneration: pcsg.Generation,
 		}
+	}
+	reason := constants.ConditionReasonInsufficientAvailablePCSGReplicas
+	message := fmt.Sprintf("Available replicas (%d) below MinAvailable (%d)", pcsg.Status.AvailableReplicas, minAvailable)
+	if !componentutils.IsMinAvailableBreachArmed(pcsg.Status.Conditions, pcsg.Generation) {
+		reason = constants.ConditionReasonInitialScheduling
+		message = fmt.Sprintf("Waiting for at least %d available replicas before enabling gang termination", minAvailable)
 	}
 	return metav1.Condition{
-		Type:    constants.ConditionTypeMinAvailableBreached,
-		Status:  metav1.ConditionFalse,
-		Reason:  constants.ConditionReasonSufficientAvailablePCSGReplicas,
-		Message: fmt.Sprintf("PCSG replicas not in breach (%d) meets MinAvailable (%d)", notInBreachReplicas, minAvailable),
+		Type:               constants.ConditionTypeMinAvailableBreached,
+		Status:             metav1.ConditionTrue,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: pcsg.Generation,
 	}
-}
-
-// computeNotInBreachReplicas counts PCSG replicas that are healthy for the purpose of the PCSG-level
-// MinAvailableBreached signal. A replica counts as not-in-breach only when it is *complete* — all
-// expected PodCliques (len(Spec.CliqueNames)) exist and are non-terminating — AND none of those
-// PodCliques has MinAvailableBreached=True.
-//
-// Completeness is required because a partially-created replica (e.g. one whose pc-c was deleted and
-// not yet recreated) has no breached PodClique yet is still not a valid healthy replica. Counting it
-// as not-in-breach would spuriously report the PCSG healthy and would also poison the was-healthy gate,
-// which reads a MinAvailableBreached=False as evidence that the PCSG was once healthy. This mirrors
-// computeReplicaStatus, which likewise treats a replica as unscheduled/unavailable unless all expected
-// PodCliques exist.
-//
-// Iteration is bounded to expected replica indexes [0, Spec.Replicas) so stale-index children left
-// behind during scale-down neither inflate nor deflate the count.
-func computeNotInBreachReplicas(logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup, pclqsPerPCSGReplica map[string][]grovecorev1alpha1.PodClique) int {
-	expectedPCLQsPerReplica := len(pcsg.Spec.CliqueNames)
-	var notInBreachReplicas int
-	for replicaIndex := 0; replicaIndex < int(pcsg.Spec.Replicas); replicaIndex++ {
-		pcsgReplicaIndex := strconv.Itoa(replicaIndex)
-		nonTerminatingPCLQs := lo.Filter(pclqsPerPCSGReplica[pcsgReplicaIndex], func(pclq grovecorev1alpha1.PodClique, _ int) bool {
-			return !k8sutils.IsResourceTerminating(pclq.ObjectMeta)
-		})
-		if len(nonTerminatingPCLQs) != expectedPCLQsPerReplica {
-			logger.Info("PodCliqueScalingGroup replica is incomplete; not counting it as not-in-breach",
-				"pcsgReplicaIndex", pcsgReplicaIndex, "expectedPCLQs", expectedPCLQsPerReplica, "actualPCLQs", len(nonTerminatingPCLQs))
-			continue
-		}
-		anyBreached := lo.SomeBy(nonTerminatingPCLQs, func(pclq grovecorev1alpha1.PodClique) bool {
-			return k8sutils.IsConditionTrue(pclq.Status.Conditions, constants.ConditionTypeMinAvailableBreached)
-		})
-		if anyBreached {
-			logger.Info("PodCliqueScalingGroup replica has at least one PodClique with MinAvailableBreached=True",
-				"pcsgReplicaIndex", pcsgReplicaIndex)
-			continue
-		}
-		notInBreachReplicas++
-	}
-	return notInBreachReplicas
 }
 
 // getPodCliquesPerPCSGReplica retrieves and groups PodCliques by their PCSG replica index

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
@@ -210,12 +210,8 @@ func isPCSGChildPCLQUpdated(pclq *grovecorev1alpha1.PodClique, expectedPCLQPodTe
 // event gives operators a discrete, log-visible signal that a previously-running workload is
 // fully down (and that gang termination is now armed and will fire after TerminationDelay).
 func (r *Reconciler) emitAllScheduledReplicasLostIfNeeded(pcsg *grovecorev1alpha1.PodCliqueScalingGroup, originalScheduled int32) {
-	// GREP-0677: a scale-to-zero transition is intentional, not a loss. Do not emit the warning
-	// (and do not imply gang termination is armed) when the PCSG is idle.
-	if pcsg.Spec.Replicas == 0 {
-		return
-	}
-	if originalScheduled > 0 && pcsg.Status.ScheduledReplicas == 0 {
+	// Scaling to zero is intentional, not a loss.
+	if pcsg.Spec.Replicas != 0 && originalScheduled > 0 && pcsg.Status.ScheduledReplicas == 0 {
 		r.eventRecorder.Eventf(pcsg, corev1.EventTypeWarning, internalconstants.ReasonAllScheduledReplicasLost,
 			"All scheduled replicas lost (was %d). Gang termination will fire after TerminationDelay if the PCSG stays below MinAvailable; investigate node availability or capacity.",
 			originalScheduled)

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus_test.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -108,14 +109,6 @@ func TestComputeReplicaStatus(t *testing.T) {
 	}
 }
 
-// healthyPCSGReplica returns a complete PCSG replica entry (one non-terminating, non-breached
-// PCLQ). The tests using this set Spec.CliqueNames to a single name so the replica counts as
-// complete; computeNotInBreachReplicas only counts a replica as not-in-breach when all expected
-// PodCliques exist and none has MinAvailableBreached=True.
-func healthyPCSGReplica() []grovecorev1alpha1.PodClique {
-	return []grovecorev1alpha1.PodClique{{}}
-}
-
 // breachedPCSGReplica returns a complete PCSG replica entry with one breached PCLQ.
 func breachedPCSGReplica() []grovecorev1alpha1.PodClique {
 	return []grovecorev1alpha1.PodClique{{
@@ -128,155 +121,112 @@ func breachedPCSGReplica() []grovecorev1alpha1.PodClique {
 	}}
 }
 
-// incompletePCSGReplica returns a replica entry that is missing PodCliques relative to
-// Spec.CliqueNames (an empty PCLQ list). It has no breached PCLQ but must NOT be counted as
-// not-in-breach, because a partially-created replica is not a valid healthy replica.
-func incompletePCSGReplica() []grovecorev1alpha1.PodClique {
-	return []grovecorev1alpha1.PodClique{}
-}
-
-// TestComputeMinAvailableBreachedCondition exercises the PCSG-level breach formula:
-// the PCSG is in breach when (not-in-breach replicas) < MinAvailable. A replica counts as
-// not-in-breach only when it is complete (all Spec.CliqueNames PodCliques exist and are
-// non-terminating) AND none of them is breached; incomplete replicas are never counted as
-// not-in-breach. Each fixture replica carries one PodClique, so the PCSG sets CliqueNames to a
-// single name.
 func TestComputeMinAvailableBreachedCondition(t *testing.T) {
 	tests := []struct {
-		name         string
-		replicas     int32
-		minAvailable *int32
-		pclqsMap     map[string][]grovecorev1alpha1.PodClique
-		wantStatus   metav1.ConditionStatus
-		wantReason   string
+		name              string
+		generation        int64
+		replicas          int32
+		minAvailable      *int32
+		availableReplicas int32
+		previousReason    string
+		previousObserved  int64
+		wantStatus        metav1.ConditionStatus
+		wantReason        string
 	}{
 		{
-			name:     "all replicas healthy, none breached",
-			replicas: 3,
-			pclqsMap: map[string][]grovecorev1alpha1.PodClique{
-				"0": healthyPCSGReplica(),
-				"1": healthyPCSGReplica(),
-				"2": healthyPCSGReplica(),
-			},
-			wantStatus: metav1.ConditionFalse,
-			wantReason: "SufficientAvailablePodCliqueScalingGroupReplicas",
+			name:              "available replicas meet quorum",
+			generation:        1,
+			replicas:          3,
+			minAvailable:      ptr.To(int32(2)),
+			availableReplicas: 2,
+			wantStatus:        metav1.ConditionFalse,
+			wantReason:        constants.ConditionReasonSufficientAvailablePCSGReplicas,
 		},
 		{
-			name:         "1 of 5 replicas breached, MinAvailable=2 — not in breach",
-			replicas:     5,
-			minAvailable: ptr.To(int32(2)),
-			pclqsMap: map[string][]grovecorev1alpha1.PodClique{
-				"0": breachedPCSGReplica(),
-				"1": healthyPCSGReplica(),
-				"2": healthyPCSGReplica(),
-				"3": healthyPCSGReplica(),
-				"4": healthyPCSGReplica(),
-			},
-			wantStatus: metav1.ConditionFalse,
-			wantReason: "SufficientAvailablePodCliqueScalingGroupReplicas",
-		},
-		{
-			// GT-4 step 4 scenario: WL2 sg-x has 2 replicas, MinAvailable=1.
-			// Killing all pc-c pods of replica 0 breaches that replica; replica 1
-			// stays healthy. notInBreach=1 == MinAvailable=1 → PCSG NOT in breach.
-			// PCS-level handler must NOT delete the whole PCS replica here; only
-			// the PCSG-level scoped restart should fire.
-			name:         "1 of 2 replicas breached, MinAvailable=1 — not in breach (PCSG-scoped restart only)",
-			replicas:     2,
+			name:         "idle PCSG does not breach",
+			generation:   2,
+			replicas:     0,
 			minAvailable: ptr.To(int32(1)),
-			pclqsMap: map[string][]grovecorev1alpha1.PodClique{
-				"0": breachedPCSGReplica(),
-				"1": healthyPCSGReplica(),
-			},
-			wantStatus: metav1.ConditionFalse,
-			wantReason: "SufficientAvailablePodCliqueScalingGroupReplicas",
+			wantStatus:   metav1.ConditionFalse,
+			wantReason:   constants.ConditionReasonIdle,
 		},
 		{
-			// GT-4 step 6: both PCSG replicas breached. notInBreach=0 < 1 → PCSG
-			// in breach. PCS-level handler should restart the whole PCS replica.
-			name:         "both replicas breached, MinAvailable=1 — in breach (escalates to PCS-level)",
-			replicas:     2,
-			minAvailable: ptr.To(int32(1)),
-			pclqsMap: map[string][]grovecorev1alpha1.PodClique{
-				"0": breachedPCSGReplica(),
-				"1": breachedPCSGReplica(),
-			},
-			wantStatus: metav1.ConditionTrue,
-			wantReason: "InsufficientAvailablePodCliqueScalingGroupReplicas",
-		},
-		{
-			name:         "2 of 3 replicas breached, MinAvailable=2 — in breach",
+			name:         "fresh unavailable PCSG is not armed",
+			generation:   1,
 			replicas:     3,
 			minAvailable: ptr.To(int32(2)),
-			pclqsMap: map[string][]grovecorev1alpha1.PodClique{
-				"0": breachedPCSGReplica(),
-				"1": breachedPCSGReplica(),
-				"2": healthyPCSGReplica(),
-			},
-			wantStatus: metav1.ConditionTrue,
-			wantReason: "InsufficientAvailablePodCliqueScalingGroupReplicas",
-		},
-		{
-			// No replicas exist yet (mid-creation / scale-up). notInBreach=0 < min → breach.
-			// TerminationDelay (default 4h) absorbs the startup window before any action fires.
-			name:         "no replicas exist yet — in breach (startup)",
-			replicas:     3,
-			minAvailable: ptr.To(int32(2)),
-			pclqsMap:     map[string][]grovecorev1alpha1.PodClique{},
 			wantStatus:   metav1.ConditionTrue,
-			wantReason:   "InsufficientAvailablePodCliqueScalingGroupReplicas",
+			wantReason:   constants.ConditionReasonInitialScheduling,
 		},
 		{
-			// Replica 0 is incomplete (its pc-c was deleted and not yet recreated) so it has no
-			// breached PodClique but is not a valid healthy replica; replica 1 is breached.
-			// notInBreach=0 < MinAvailable=1 → in breach. An incomplete replica must not be
-			// mistaken for a healthy one (which would also poison the was-healthy gate).
-			name:         "one replica incomplete, one breached, MinAvailable=1 — in breach",
-			replicas:     2,
-			minAvailable: ptr.To(int32(1)),
-			pclqsMap: map[string][]grovecorev1alpha1.PodClique{
-				"0": incompletePCSGReplica(),
-				"1": breachedPCSGReplica(),
-			},
-			wantStatus: metav1.ConditionTrue,
-			wantReason: "InsufficientAvailablePodCliqueScalingGroupReplicas",
+			name:              "previously healthy PCSG regression is actionable",
+			generation:        1,
+			replicas:          3,
+			minAvailable:      ptr.To(int32(2)),
+			availableReplicas: 1,
+			previousReason:    constants.ConditionReasonSufficientAvailablePCSGReplicas,
+			previousObserved:  1,
+			wantStatus:        metav1.ConditionTrue,
+			wantReason:        constants.ConditionReasonInsufficientAvailablePCSGReplicas,
 		},
 		{
-			// Replica 0 is incomplete, replica 1 is complete and healthy. notInBreach=1 ==
-			// MinAvailable=1 → not in breach (the one complete replica satisfies MinAvailable).
-			name:         "one replica incomplete, one healthy, MinAvailable=1 — not in breach",
-			replicas:     2,
-			minAvailable: ptr.To(int32(1)),
-			pclqsMap: map[string][]grovecorev1alpha1.PodClique{
-				"0": incompletePCSGReplica(),
-				"1": healthyPCSGReplica(),
-			},
-			wantStatus: metav1.ConditionFalse,
-			wantReason: "SufficientAvailablePodCliqueScalingGroupReplicas",
+			name:             "initial state survives controller restart",
+			generation:       1,
+			replicas:         2,
+			minAvailable:     ptr.To(int32(1)),
+			previousReason:   constants.ConditionReasonInitialScheduling,
+			previousObserved: 1,
+			wantStatus:       metav1.ConditionTrue,
+			wantReason:       constants.ConditionReasonInitialScheduling,
+		},
+		{
+			name:           "legacy condition without observed generation is reset",
+			generation:     1,
+			replicas:       2,
+			minAvailable:   ptr.To(int32(1)),
+			previousReason: constants.ConditionReasonInsufficientAvailablePCSGReplicas,
+			wantStatus:     metav1.ConditionTrue,
+			wantReason:     constants.ConditionReasonInitialScheduling,
+		},
+		{
+			name:              "legacy nil minAvailable uses API default",
+			generation:        1,
+			replicas:          1,
+			availableReplicas: 1,
+			wantStatus:        metav1.ConditionFalse,
+			wantReason:        constants.ConditionReasonSufficientAvailablePCSGReplicas,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			minAvailable := tt.minAvailable
-			if minAvailable == nil {
-				minAvailable = &tt.replicas
+			var conditions []metav1.Condition
+			if tt.previousReason != "" {
+				conditions = []metav1.Condition{{
+					Type:               constants.ConditionTypeMinAvailableBreached,
+					Status:             metav1.ConditionTrue,
+					Reason:             tt.previousReason,
+					ObservedGeneration: tt.previousObserved,
+				}}
 			}
 			pcsg := &grovecorev1alpha1.PodCliqueScalingGroup{
+				ObjectMeta: metav1.ObjectMeta{Generation: tt.generation},
 				Spec: grovecorev1alpha1.PodCliqueScalingGroupSpec{
 					Replicas:     tt.replicas,
-					MinAvailable: minAvailable,
-					// Each fixture replica carries exactly one PodClique, so a single clique name
-					// makes healthy/breached replicas "complete" and empty ones "incomplete".
-					CliqueNames: []string{"pc"},
+					MinAvailable: tt.minAvailable,
+				},
+				Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{
+					AvailableReplicas: tt.availableReplicas,
+					Conditions:        conditions,
 				},
 			}
 
-			condition := computeMinAvailableBreachedCondition(logr.Discard(), pcsg, tt.pclqsMap)
+			condition := computeMinAvailableBreachedCondition(pcsg)
 
 			assert.Equal(t, "MinAvailableBreached", condition.Type)
 			assert.Equal(t, tt.wantStatus, condition.Status)
 			assert.Equal(t, tt.wantReason, condition.Reason)
+			assert.Equal(t, tt.generation, condition.ObservedGeneration)
 		})
 	}
 }
@@ -288,15 +238,17 @@ func TestComputeMinAvailableBreachedCondition(t *testing.T) {
 func TestEmitAllScheduledReplicasLostIfNeeded(t *testing.T) {
 	tests := []struct {
 		name              string
+		replicas          int32
 		originalScheduled int32
 		nowScheduled      int32
 		wantEvent         bool
 	}{
-		{name: "non-zero to zero emits event", originalScheduled: 3, nowScheduled: 0, wantEvent: true},
-		{name: "zero to zero stays silent (initial startup)", originalScheduled: 0, nowScheduled: 0, wantEvent: false},
-		{name: "non-zero to non-zero stays silent (partial regression handled by breach)", originalScheduled: 3, nowScheduled: 2, wantEvent: false},
-		{name: "zero to non-zero stays silent (recovery)", originalScheduled: 0, nowScheduled: 3, wantEvent: false},
-		{name: "stable non-zero stays silent (steady state)", originalScheduled: 3, nowScheduled: 3, wantEvent: false},
+		{name: "non-zero to zero emits event", replicas: 3, originalScheduled: 3, nowScheduled: 0, wantEvent: true},
+		{name: "zero to zero stays silent (initial startup)", replicas: 3, originalScheduled: 0, nowScheduled: 0, wantEvent: false},
+		{name: "non-zero to non-zero stays silent (partial regression handled by breach)", replicas: 3, originalScheduled: 3, nowScheduled: 2, wantEvent: false},
+		{name: "zero to non-zero stays silent (recovery)", replicas: 3, originalScheduled: 0, nowScheduled: 3, wantEvent: false},
+		{name: "stable non-zero stays silent (steady state)", replicas: 3, originalScheduled: 3, nowScheduled: 3, wantEvent: false},
+		{name: "idle PCSG replicas 0 stays silent (intentional scale-to-zero)", replicas: 0, originalScheduled: 3, nowScheduled: 0, wantEvent: false},
 	}
 
 	for _, tt := range tests {
@@ -304,6 +256,7 @@ func TestEmitAllScheduledReplicasLostIfNeeded(t *testing.T) {
 			recorder := record.NewFakeRecorder(2)
 			r := &Reconciler{eventRecorder: recorder}
 			pcsg := &grovecorev1alpha1.PodCliqueScalingGroup{
+				Spec:   grovecorev1alpha1.PodCliqueScalingGroupSpec{Replicas: tt.replicas},
 				Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{ScheduledReplicas: tt.nowScheduled},
 			}
 
@@ -371,7 +324,7 @@ func TestComputeMinAvailableBreachedConditionUpdateInProgress(t *testing.T) {
 				},
 			}
 
-			condition := computeMinAvailableBreachedCondition(logr.Discard(), pcsg, tt.pclqsMap)
+			condition := computeMinAvailableBreachedCondition(pcsg)
 
 			assert.Equal(t, constants.ConditionTypeMinAvailableBreached, condition.Type)
 			assert.Equal(t, tt.wantStatus, condition.Status, "MinAvailableBreached status mismatch")
@@ -1031,57 +984,57 @@ func assertCondition(t *testing.T, pcsg *grovecorev1alpha1.PodCliqueScalingGroup
 	assert.Equal(t, expectBreached, isBreached, "condition breach status mismatch")
 }
 
-// TestMutateMinAvailableBreachedConditionClearsGangTerminationInProgress pins the second half
-// of the in-progress-flag loop-break design: when MinAvailableBreached transitions from True
-// (or unset) to False, the PCSG status reconciler must also remove the
-// GangTerminationInProgress condition so the next regression can be recycled.
-func TestMutateMinAvailableBreachedConditionClearsGangTerminationInProgress(t *testing.T) {
+func TestMutateMinAvailableBreachedConditionRecordsRecovery(t *testing.T) {
 	pcsg := &grovecorev1alpha1.PodCliqueScalingGroup{
+		ObjectMeta: metav1.ObjectMeta{Generation: 1},
 		Spec: grovecorev1alpha1.PodCliqueScalingGroupSpec{
 			Replicas:     2,
 			MinAvailable: ptr.To(int32(1)),
-			// Each fixture replica carries one PodClique, so a single clique name makes the
-			// recovered replicas count as complete and not-in-breach.
-			CliqueNames: []string{"pc"},
 		},
 		Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{
-			Conditions: []metav1.Condition{
-				{
-					Type:   constants.ConditionTypeMinAvailableBreached,
-					Status: metav1.ConditionTrue,
-					Reason: constants.ConditionReasonScheduledReplicasBelowMinAvailable,
-				},
-				{
-					Type:   constants.ConditionTypeGangTerminationInProgress,
-					Status: metav1.ConditionTrue,
-					Reason: constants.ConditionReasonGangTerminationActive,
-				},
-			},
+			AvailableReplicas: 1,
+			Conditions: []metav1.Condition{{
+				Type:               constants.ConditionTypeMinAvailableBreached,
+				Status:             metav1.ConditionTrue,
+				Reason:             constants.ConditionReasonInitialScheduling,
+				ObservedGeneration: 1,
+			}},
 		},
 	}
-	pclqsHealthy := map[string][]grovecorev1alpha1.PodClique{
-		"0": healthyPCSGReplica(),
-		"1": healthyPCSGReplica(),
+
+	mutateMinAvailableBreachedCondition(logr.Discard(), pcsg)
+
+	condition := meta.FindStatusCondition(pcsg.Status.Conditions, constants.ConditionTypeMinAvailableBreached)
+	require.NotNil(t, condition)
+	assert.Equal(t, metav1.ConditionFalse, condition.Status)
+	assert.Equal(t, constants.ConditionReasonSufficientAvailablePCSGReplicas, condition.Reason)
+	assert.Equal(t, int64(1), condition.ObservedGeneration)
+}
+
+func TestMutateMinAvailableBreachedConditionUpdatesObservedGeneration(t *testing.T) {
+	pcsg := &grovecorev1alpha1.PodCliqueScalingGroup{
+		ObjectMeta: metav1.ObjectMeta{Generation: 2},
+		Spec: grovecorev1alpha1.PodCliqueScalingGroupSpec{
+			Replicas:     1,
+			MinAvailable: ptr.To(int32(1)),
+		},
+		Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{
+			AvailableReplicas: 1,
+			Conditions: []metav1.Condition{{
+				Type:               constants.ConditionTypeMinAvailableBreached,
+				Status:             metav1.ConditionFalse,
+				Reason:             constants.ConditionReasonSufficientAvailablePCSGReplicas,
+				Message:            "Available replicas (1) meet MinAvailable (1)",
+				ObservedGeneration: 1,
+			}},
+		},
 	}
 
-	mutateMinAvailableBreachedCondition(logr.Discard(), pcsg, pclqsHealthy)
+	mutateMinAvailableBreachedCondition(logr.Discard(), pcsg)
 
-	// MinAvailableBreached must now be False (recovery).
-	breach := pcsg.Status.Conditions
-	var breachStatus metav1.ConditionStatus
-	for _, c := range breach {
-		if c.Type == constants.ConditionTypeMinAvailableBreached {
-			breachStatus = c.Status
-		}
-	}
-	assert.Equal(t, metav1.ConditionFalse, breachStatus, "MinAvailableBreached should be False after recovery")
-
-	// GangTerminationInProgress must have been cleared.
-	for _, c := range pcsg.Status.Conditions {
-		if c.Type == constants.ConditionTypeGangTerminationInProgress {
-			t.Fatalf("GangTerminationInProgress condition should have been removed on recovery, still present with status %s", c.Status)
-		}
-	}
+	condition := meta.FindStatusCondition(pcsg.Status.Conditions, constants.ConditionTypeMinAvailableBreached)
+	require.NotNil(t, condition)
+	assert.Equal(t, int64(2), condition.ObservedGeneration)
 }
 
 // TestMutateSelector verifies the /scale selector is published for PCSGs regardless of whether

--- a/operator/internal/controller/podcliqueset/components/podclique/podclique.go
+++ b/operator/internal/controller/podcliqueset/components/podclique/podclique.go
@@ -318,17 +318,16 @@ func (r _resource) buildResource(logger logr.Logger, pcs *grovecorev1alpha1.PodC
 	}
 	// Add finalizer at creation so PCLQ controller does not need a separate PATCH on first reconcile.
 	controllerutil.AddFinalizer(pclq, apiconstants.FinalizerPodClique)
-	// A standalone PodClique always belongs to the anchor PodGang, so its PodGang name is derived from
-	// the anchor entry's epoch in the PodGangMap.
-	epoch, err := componentutils.AnchorPodGangEpoch(pgm)
-	if err != nil {
-		return groveerr.WrapError(err,
-			errSyncPodClique,
-			component.OperationSync,
-			fmt.Sprintf("failed to resolve anchor PodGang epoch for PodClique: %v", pclqObjectKey),
-		)
+	rnr := apicommon.ResourceNameReplica{Name: pcs.Name, Replica: pcsReplica}
+	desiredReplicas := pclqTemplateSpec.Spec.Replicas
+	if pclqExists {
+		desiredReplicas = pclq.Spec.Replicas
 	}
-	podGangName := apicommon.GenerateAnchorPodGangName(apicommon.ResourceNameReplica{Name: pcs.Name, Replica: pcsReplica}, epoch)
+	podGangName, err := resolvePodGangName(pgm, rnr, *pcs.Status.CurrentGenerationHash, pclqTemplateSpec.Name, desiredReplicas, pclq.Labels[apicommon.LabelPodGang])
+	if err != nil {
+		return groveerr.WrapError(err, errSyncPodClique, component.OperationSync,
+			fmt.Sprintf("failed to resolve PodGang name for PodClique: %v", pclqObjectKey))
+	}
 	pclq.Labels = getLabels(pcs, pcsReplica, pclqObjectKey, pclqTemplateSpec, podGangName)
 	pclq.Annotations = maps.Clone(pclqTemplateSpec.Annotations)
 	// PodGang owns topology selection; do not propagate a template topology annotation to PodClique pods.
@@ -346,11 +345,19 @@ func (r _resource) buildResource(logger logr.Logger, pcs *grovecorev1alpha1.PodC
 	} else {
 		pclq.Spec = *pclqTemplateSpec.Spec.DeepCopy()
 	}
-	var dependentPclqNames []string
-	if dependentPclqNames, err = identifyFullyQualifiedStartupDependencyNames(pcs, pclq, pcsReplica, foundAtIndex); err != nil {
-		return err
+	if desiredReplicas == 0 {
+		pclq.Spec.StartsAfter = nil
+	} else {
+		activePCLQNames, activeErr := componentutils.ActivePodCliqueNamesForPodGang(pcs, pgm, rnr, podGangName)
+		if activeErr != nil {
+			return groveerr.WrapError(activeErr, errSyncPodClique, component.OperationSync,
+				fmt.Sprintf("failed to resolve active PodCliques for PodClique: %v", pclqObjectKey))
+		}
+		pclq.Spec.StartsAfter, err = identifyFullyQualifiedStartupDependencyNames(pcs, pclq, pcsReplica, foundAtIndex, activePCLQNames)
+		if err != nil {
+			return err
+		}
 	}
-	pclq.Spec.StartsAfter = dependentPclqNames
 
 	// Inject MNNVL resourceClaims: resolve group hierarchically (PCLQ → PCS).
 	groupName, mnnvlEnabled := mnnvl.ResolveGroupNameHierarchically(pclqTemplateSpec.Annotations, pcs.Annotations)
@@ -361,8 +368,22 @@ func (r _resource) buildResource(logger logr.Logger, pcs *grovecorev1alpha1.PodC
 	return nil
 }
 
+func resolvePodGangName(pgm *grovecorev1alpha1.PodGangMap, rnr apicommon.ResourceNameReplica, generationHash, cliqueName string, replicas int32, existingPodGangName string) (string, error) {
+	if replicas > 0 {
+		return componentutils.PodGangNameForStandalonePCLQ(pgm, rnr, generationHash, cliqueName)
+	}
+	if existingPodGangName != "" {
+		return existingPodGangName, nil
+	}
+	epoch, err := componentutils.AnchorPodGangEpoch(pgm)
+	if err != nil {
+		return "", err
+	}
+	return apicommon.GenerateAnchorPodGangName(rnr, epoch), nil
+}
+
 // identifyFullyQualifiedStartupDependencyNames determines the PodClique startup dependencies based on StartupType.
-func identifyFullyQualifiedStartupDependencyNames(pcs *grovecorev1alpha1.PodCliqueSet, pclq *grovecorev1alpha1.PodClique, pcsReplicaIndex, foundAtIndex int) ([]string, error) {
+func identifyFullyQualifiedStartupDependencyNames(pcs *grovecorev1alpha1.PodCliqueSet, pclq *grovecorev1alpha1.PodClique, pcsReplicaIndex, foundAtIndex int, activePCLQNames componentutils.Set[string]) ([]string, error) {
 	cliqueStartupType := pcs.Spec.Template.StartupType
 	if cliqueStartupType == nil {
 		// Ideally this should never happen as the defaulting webhook should set it v1alpha1.CliqueStartupTypeInOrder as the default value.
@@ -371,28 +392,45 @@ func identifyFullyQualifiedStartupDependencyNames(pcs *grovecorev1alpha1.PodCliq
 	}
 	switch *cliqueStartupType {
 	case grovecorev1alpha1.CliqueStartupTypeInOrder:
-		return getInOrderStartupDependencies(pcs, pcsReplicaIndex, foundAtIndex), nil
+		return getInOrderStartupDependencies(pcs, pcsReplicaIndex, foundAtIndex, activePCLQNames), nil
 	case grovecorev1alpha1.CliqueStartupTypeExplicit:
-		return getExplicitStartupDependencies(pcs, pcsReplicaIndex, pclq), nil
+		return getExplicitStartupDependencies(pcs, pcsReplicaIndex, pclq, activePCLQNames), nil
 	default:
 		return nil, nil
 	}
 }
 
-// getInOrderStartupDependencies returns the previous clique as a dependency for in-order startup.
-func getInOrderStartupDependencies(pcs *grovecorev1alpha1.PodCliqueSet, pcsReplicaIndex, foundAtIndex int) []string {
-	if foundAtIndex == 0 {
-		return nil
+// getInOrderStartupDependencies returns the nearest active preceding clique in the same PodGang.
+func getInOrderStartupDependencies(pcs *grovecorev1alpha1.PodCliqueSet, pcsReplicaIndex, foundAtIndex int, activePCLQNames componentutils.Set[string]) []string {
+	for index := foundAtIndex - 1; index >= 0; index-- {
+		dependencies := activeDependencies(
+			componentutils.GenerateDependencyNamesForBasePodGang(pcs, pcsReplicaIndex, pcs.Spec.Template.Cliques[index].Name),
+			activePCLQNames,
+		)
+		if len(dependencies) > 0 {
+			return dependencies
+		}
 	}
-	previousCliqueName := pcs.Spec.Template.Cliques[foundAtIndex-1].Name
-	return componentutils.GenerateDependencyNamesForBasePodGang(pcs, pcsReplicaIndex, previousCliqueName)
+	return nil
 }
 
 // getExplicitStartupDependencies resolves explicitly declared startup dependencies.
-func getExplicitStartupDependencies(pcs *grovecorev1alpha1.PodCliqueSet, pcsReplicaIndex int, pclq *grovecorev1alpha1.PodClique) []string {
+func getExplicitStartupDependencies(pcs *grovecorev1alpha1.PodCliqueSet, pcsReplicaIndex int, pclq *grovecorev1alpha1.PodClique, activePCLQNames componentutils.Set[string]) []string {
 	dependencies := make([]string, 0, len(pclq.Spec.StartsAfter))
 	for _, dependency := range pclq.Spec.StartsAfter {
 		dependencies = append(dependencies, componentutils.GenerateDependencyNamesForBasePodGang(pcs, pcsReplicaIndex, dependency)...)
+	}
+	return activeDependencies(dependencies, activePCLQNames)
+}
+
+func activeDependencies(candidates []string, activePCLQNames componentutils.Set[string]) []string {
+	dependencies := make([]string, 0, len(candidates))
+	seen := make(componentutils.Set[string], len(candidates))
+	for _, candidate := range candidates {
+		if activePCLQNames.Has(candidate) && !seen.Has(candidate) {
+			dependencies = append(dependencies, candidate)
+			seen[candidate] = struct{}{}
+		}
 	}
 	return dependencies
 }

--- a/operator/internal/controller/podcliqueset/components/podclique/podclique.go
+++ b/operator/internal/controller/podcliqueset/components/podclique/podclique.go
@@ -390,49 +390,9 @@ func identifyFullyQualifiedStartupDependencyNames(pcs *grovecorev1alpha1.PodCliq
 		// If it is still nil, then by not returning an error we break the API contract. It is a bug that should be fixed.
 		return nil, groveerr.New(errSyncPodClique, component.OperationSync, fmt.Sprintf("PodClique: %v has nil StartupType", client.ObjectKeyFromObject(pclq)))
 	}
-	switch *cliqueStartupType {
-	case grovecorev1alpha1.CliqueStartupTypeInOrder:
-		return getInOrderStartupDependencies(pcs, pcsReplicaIndex, foundAtIndex, activePCLQNames), nil
-	case grovecorev1alpha1.CliqueStartupTypeExplicit:
-		return getExplicitStartupDependencies(pcs, pcsReplicaIndex, pclq, activePCLQNames), nil
-	default:
-		return nil, nil
-	}
-}
-
-// getInOrderStartupDependencies returns the nearest active preceding clique in the same PodGang.
-func getInOrderStartupDependencies(pcs *grovecorev1alpha1.PodCliqueSet, pcsReplicaIndex, foundAtIndex int, activePCLQNames componentutils.Set[string]) []string {
-	for index := foundAtIndex - 1; index >= 0; index-- {
-		dependencies := activeDependencies(
-			componentutils.GenerateDependencyNamesForBasePodGang(pcs, pcsReplicaIndex, pcs.Spec.Template.Cliques[index].Name),
-			activePCLQNames,
-		)
-		if len(dependencies) > 0 {
-			return dependencies
-		}
-	}
-	return nil
-}
-
-// getExplicitStartupDependencies resolves explicitly declared startup dependencies.
-func getExplicitStartupDependencies(pcs *grovecorev1alpha1.PodCliqueSet, pcsReplicaIndex int, pclq *grovecorev1alpha1.PodClique, activePCLQNames componentutils.Set[string]) []string {
-	dependencies := make([]string, 0, len(pclq.Spec.StartsAfter))
-	for _, dependency := range pclq.Spec.StartsAfter {
-		dependencies = append(dependencies, componentutils.GenerateDependencyNamesForBasePodGang(pcs, pcsReplicaIndex, dependency)...)
-	}
-	return activeDependencies(dependencies, activePCLQNames)
-}
-
-func activeDependencies(candidates []string, activePCLQNames componentutils.Set[string]) []string {
-	dependencies := make([]string, 0, len(candidates))
-	seen := make(componentutils.Set[string], len(candidates))
-	for _, candidate := range candidates {
-		if activePCLQNames.Has(candidate) && !seen.Has(candidate) {
-			dependencies = append(dependencies, candidate)
-			seen[candidate] = struct{}{}
-		}
-	}
-	return dependencies
+	return componentutils.StartupDependencies(pcs, foundAtIndex, pclq.Spec.StartsAfter, activePCLQNames, func(cliqueName string) []string {
+		return componentutils.GenerateDependencyNamesForBasePodGang(pcs, pcsReplicaIndex, cliqueName)
+	}), nil
 }
 
 // getPodCliqueSelectorLabels returns labels for selecting all PodCliques of a PodCliqueSet.

--- a/operator/internal/controller/podcliqueset/components/podclique/podclique_test.go
+++ b/operator/internal/controller/podcliqueset/components/podclique/podclique_test.go
@@ -19,11 +19,13 @@ import (
 	"fmt"
 	"testing"
 
+	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	apiconstants "github.com/ai-dynamo/grove/operator/api/common/constants"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	groveclientscheme "github.com/ai-dynamo/grove/operator/internal/client"
 	"github.com/ai-dynamo/grove/operator/internal/constants"
 	"github.com/ai-dynamo/grove/operator/internal/controller/common/component"
+	componentutils "github.com/ai-dynamo/grove/operator/internal/controller/common/component/utils"
 	groveerr "github.com/ai-dynamo/grove/operator/internal/errors"
 	"github.com/ai-dynamo/grove/operator/internal/mnnvl"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
@@ -428,6 +430,7 @@ func TestBuildResource_MNNVLInjection(t *testing.T) {
 			pcsBuilder := testutils.NewPodCliqueSetBuilder(testPCSName, testPCSNamespace, uuid.NewUUID()).
 				WithReplicas(1).
 				WithCliqueStartupType(ptr.To(grovecorev1alpha1.CliqueStartupTypeAnyOrder)).
+				WithPodCliqueSetGenerationHash(ptr.To("hash")).
 				WithAnnotations(tc.pcsAnnotations)
 
 			// Create PodCliqueTemplateSpec with containers and optional annotations
@@ -460,7 +463,10 @@ func TestBuildResource_MNNVLInjection(t *testing.T) {
 			// name from the anchor entry's epoch.
 			pgm := testutils.NewPodGangMapBuilder(testPCSName, testPCSNamespace, uuid.NewUUID(), pcsReplica).WithEntries(
 				testutils.NewPodGangEntryBuilder("hash", "1000").
-					WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).WithAnchorIndex(0).Build(),
+					WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).
+					WithAnchorIndex(0).
+					WithPodCliques(map[string]int32{pclqTemplateName: 1}).
+					Build(),
 			).Build()
 			err := operator.buildResource(logr.Discard(), pcs, pcsReplica, false, pgm, pclq)
 			require.NoError(t, err)
@@ -498,6 +504,7 @@ func TestBuildResource_StripsTopologyAnnotation(t *testing.T) {
 	pcs := testutils.NewPodCliqueSetBuilder(testPCSName, testPCSNamespace, uuid.NewUUID()).
 		WithReplicas(1).
 		WithCliqueStartupType(ptr.To(grovecorev1alpha1.CliqueStartupTypeAnyOrder)).
+		WithPodCliqueSetGenerationHash(ptr.To("hash")).
 		WithPodCliqueTemplateSpec(
 			testutils.NewPodCliqueTemplateSpecBuilder("worker").
 				WithAnnotations(map[string]string{
@@ -520,7 +527,10 @@ func TestBuildResource_StripsTopologyAnnotation(t *testing.T) {
 	// from the anchor entry's epoch.
 	pgm := testutils.NewPodGangMapBuilder(testPCSName, testPCSNamespace, uuid.NewUUID(), 0).WithEntries(
 		testutils.NewPodGangEntryBuilder("hash", "1000").
-			WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).WithAnchorIndex(0).Build(),
+			WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).
+			WithAnchorIndex(0).
+			WithPodCliques(map[string]int32{"worker": 1}).
+			Build(),
 	).Build()
 	err := operator.buildResource(logr.Discard(), pcs, 0, false, pgm, pclq)
 	require.NoError(t, err)
@@ -528,6 +538,61 @@ func TestBuildResource_StripsTopologyAnnotation(t *testing.T) {
 	assert.Equal(t, "yes", pclq.Annotations["example.com/keep"])
 	_, hasTopologyAnnotation := pclq.Annotations[apiconstants.AnnotationTopologyName]
 	assert.False(t, hasTopologyAnnotation)
+}
+
+func TestResolvePodGangName(t *testing.T) {
+	rnr := apicommon.ResourceNameReplica{Name: testPCSName, Replica: 0}
+	pgm := testutils.NewPodGangMapBuilder(testPCSName, testPCSNamespace, "uid", 0).WithEntries(
+		testutils.NewPodGangEntryBuilder("hash", "1000").
+			WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).
+			WithAnchorIndex(0).
+			Build(),
+		testutils.NewPodGangEntryBuilder("hash", "1001").
+			WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).
+			WithAnchorIndex(1).
+			WithPodCliques(map[string]int32{"worker": 1}).
+			Build(),
+	).Build()
+
+	t.Run("active clique uses its actual anchor", func(t *testing.T) {
+		actual, err := resolvePodGangName(pgm, rnr, "hash", "worker", 1, "")
+		require.NoError(t, err)
+		assert.Equal(t, apicommon.GenerateAnchorPodGangName(rnr, "1001"), actual)
+	})
+
+	t.Run("idle existing clique retains its label", func(t *testing.T) {
+		actual, err := resolvePodGangName(pgm, rnr, "hash", "worker", 0, "old-podgang")
+		require.NoError(t, err)
+		assert.Equal(t, "old-podgang", actual)
+	})
+
+	t.Run("new idle clique uses the retained base anchor", func(t *testing.T) {
+		actual, err := resolvePodGangName(pgm, rnr, "hash", "idle", 0, "")
+		require.NoError(t, err)
+		assert.Equal(t, apicommon.GenerateAnchorPodGangName(rnr, "1000"), actual)
+	})
+}
+
+func TestIdentifyFullyQualifiedStartupDependencyNames(t *testing.T) {
+	startupType := grovecorev1alpha1.CliqueStartupTypeInOrder
+	pcs := testutils.NewPodCliqueSetBuilder(testPCSName, testPCSNamespace, "uid").
+		WithCliqueStartupType(&startupType).
+		WithPodCliqueParameters("router", 1, nil).
+		WithPodCliqueParameters("idle", 0, nil).
+		WithPodCliqueParameters("worker", 1, nil).
+		Build()
+	pclq := &grovecorev1alpha1.PodClique{ObjectMeta: metav1.ObjectMeta{Name: "coyote-0-worker"}}
+	active := componentutils.NewSet([]string{"coyote-0-router", "coyote-0-worker"})
+
+	actual, err := identifyFullyQualifiedStartupDependencyNames(pcs, pclq, 0, 2, active)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"coyote-0-router"}, actual)
+
+	startupType = grovecorev1alpha1.CliqueStartupTypeExplicit
+	pclq.Spec.StartsAfter = []string{"router", "idle"}
+	actual, err = identifyFullyQualifiedStartupDependencyNames(pcs, pclq, 0, 2, active)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"coyote-0-router"}, actual)
 }
 
 // triageContainersByMNNVLClaim separates containers into those with MNNVL claim and those without.

--- a/operator/internal/controller/podcliqueset/components/podcliquesetreplica/gangterminate.go
+++ b/operator/internal/controller/podcliqueset/components/podcliquesetreplica/gangterminate.go
@@ -166,33 +166,20 @@ func (r _resource) getExistingPCLQsByNames(ctx context.Context, namespace string
 	return pclqs, notFoundPCLQFQNs, nil
 }
 
-// getMinAvailableBreachedPCSGInfo filters PodCliqueScalingGroups that have grovecorev1alpha1.ConditionTypeMinAvailableBreached set to true.
-// It returns the names of all such PodCliqueScalingGroups and minimum of all the waitDurations.
-//
-// Two gates run on top of the MinAvailableBreached=True check:
-//
-//  1. WasPCSGEverHealthy — a PCSG that has never reached MinAvailableBreached=False since
-//     creation is in initial-startup, not a regression. Gang termination would just churn-loop
-//     Pending pods against a cluster that already cannot schedule them.
-//  2. GangTerminationInProgress=True — a previous fire is already in flight; re-firing while
-//     it's still in flight would also churn-loop. The flag is set by createPCSReplicaDeleteTask
-//     after the DeleteAllOf succeeds, and cleared by the PCSG status reconciler once it
-//     observes MinAvailableBreached=False (recovery).
+// getMinAvailableBreachedPCSGInfo returns actionable PCSG breaches and the shortest remaining delay.
 func getMinAvailableBreachedPCSGInfo(pcsgs []grovecorev1alpha1.PodCliqueScalingGroup, terminationDelay time.Duration, since time.Time) ([]string, time.Duration) {
 	pcsgCandidateNames := make([]string, 0, len(pcsgs))
 	waitForDurations := make([]time.Duration, 0, len(pcsgs))
 	for _, pcsg := range pcsgs {
+		if pcsg.Spec.Replicas == 0 {
+			continue
+		}
 		cond := meta.FindStatusCondition(pcsg.Status.Conditions, apiconstants.ConditionTypeMinAvailableBreached)
 		if cond == nil {
 			continue
 		}
-		if cond.Status != metav1.ConditionTrue {
-			continue
-		}
-		if !componentutils.WasPCSGEverHealthy(&pcsg) {
-			continue
-		}
-		if meta.IsStatusConditionTrue(pcsg.Status.Conditions, apiconstants.ConditionTypeGangTerminationInProgress) {
+		if cond.Status != metav1.ConditionTrue ||
+			!componentutils.IsMinAvailableBreachArmed(pcsg.Status.Conditions, pcsg.Generation) {
 			continue
 		}
 		pcsgCandidateNames = append(pcsgCandidateNames, pcsg.Name)
@@ -206,26 +193,8 @@ func getMinAvailableBreachedPCSGInfo(pcsgs []grovecorev1alpha1.PodCliqueScalingG
 	return pcsgCandidateNames, waitForDurations[0]
 }
 
-// createPCSReplicaDeleteTask creates a Task to delete all the PodCliques that are part of a PCS replica.
-//
-// After the DeleteAllOf succeeds we set GangTerminationInProgress=True on every PCSG in the
-// PCS replica, including PCSGs whose own PodCliques weren't the reason for this fire (their
-// PCLQs are collateral damage of the PCS-replica-wide delete and would otherwise re-trigger
-// the breach loop on the next reconcile). The PCSG status reconciler clears this flag once
-// it observes MinAvailableBreached=False, so a successful recycle naturally re-arms the
-// next breach episode.
-//
-// Ordering is action-first / flag-second: if the controller crashes between the DeleteAllOf
-// and the flag writes, the next reconcile sees the breach still True (new PCLQs Pending) with
-// no flag set, fires once more (one extra churn), and converges.
-//
-// The DeleteAllOf runs unconditionally on every fire. A GangTerminationInProgress flag on a
-// sibling PCSG proves only that SOME earlier fire recycled this replica, not that THIS fire's
-// delete ran — breach episodes on sibling PCSGs can overlap (one still recovering while
-// another regresses anew), so gating the delete on existing flags would suppress a legitimate
-// new fire indefinitely. Re-running the delete after a partial flag-write failure is instead
-// kept rare by retrying the flag writes inline (see markGangTerminationInProgress), and kept
-// harmless by the convergence property above.
+// createPCSReplicaDeleteTask deletes all PodCliques in one PCS replica and resets surviving PCSGs
+// to initial scheduling so newly-created children cannot immediately retrigger termination.
 func (r _resource) createPCSReplicaDeleteTask(logger logr.Logger, pcs *grovecorev1alpha1.PodCliqueSet, pcsReplicaIndex int, reason string) utils.Task {
 	return utils.Task{
 		Name: fmt.Sprintf("DeletePCSReplicaPodCliques-%d", pcsReplicaIndex),
@@ -254,41 +223,24 @@ func (r _resource) createPCSReplicaDeleteTask(logger logr.Logger, pcs *grovecore
 			logger.Info("Deleted PCS replica PodCliques", "pcsReplicaIndex", pcsReplicaIndex, "reason", reason)
 			r.eventRecorder.Eventf(pcs, corev1.EventTypeNormal, constants.ReasonPodCliqueSetReplicaDeleteSuccessful, "PodCliqueSet replica %d deleted", pcsReplicaIndex)
 
-			// Mark every PCSG in this PCS replica as having a recycle in flight. The status
-			// reconciler clears it once it observes MinAvailableBreached=False (recovery).
-			// Flag writes are attempted for ALL PCSGs before returning — a failure on one must
-			// not leave the rest unflagged, or the gate would stay inconsistent across PCSGs
-			// until the task is retried.
-			var flagErrs []error
+			var resetErrs []error
 			for i := range pcsgList.Items {
-				if err := r.markGangTerminationInProgress(ctx, client.ObjectKeyFromObject(&pcsgList.Items[i]), pcsReplicaIndex); err != nil {
-					logger.Error(err, "failed to mark GangTerminationInProgress on PCSG", "pcsg", client.ObjectKeyFromObject(&pcsgList.Items[i]))
-					flagErrs = append(flagErrs, err)
+				if err := r.resetPCSGToInitialScheduling(ctx, client.ObjectKeyFromObject(&pcsgList.Items[i]), pcsReplicaIndex); err != nil {
+					logger.Error(err, "failed to reset PCSG gang-termination state", "pcsg", client.ObjectKeyFromObject(&pcsgList.Items[i]))
+					resetErrs = append(resetErrs, err)
 				}
 			}
-			return errors.Join(flagErrs...)
+			return errors.Join(resetErrs...)
 		},
 	}
 }
 
-// flagWriteBackoff bounds the inline retries of a GangTerminationInProgress flag write to
-// ~1.5s of cumulative sleep. Long enough to ride out conflicts and brief apiserver blips,
-// short enough not to starve the reconcile worker pool.
-var flagWriteBackoff = wait.Backoff{Steps: 6, Duration: 25 * time.Millisecond, Factor: 2.0, Jitter: 0.1}
+var statusWriteBackoff = wait.Backoff{Steps: 6, Duration: 25 * time.Millisecond, Factor: 2.0, Jitter: 0.1}
 
-// markGangTerminationInProgress sets GangTerminationInProgress=True on the PCSG status.
-// The PCSG status reconciler mutates Status.Conditions concurrently (e.g. updating
-// MinAvailableBreached), so the patch carries an optimistic lock and re-reads the latest
-// object on conflict — a plain merge-patch computed from a stale List item would silently
-// overwrite the reconciler's writes.
-//
-// Conflicts AND transient apiserver errors are retried inline (bounded by flagWriteBackoff):
-// a flag write that fails past the delete makes the whole task retry, and a retried task
-// re-runs the DeleteAllOf — recycling the just-recreated PodCliques once more. Absorbing
-// transient failures here keeps that churn confined to genuine outages. A NotFound PCSG was
-// deleted concurrently and needs no suppression, so it counts as success.
-func (r _resource) markGangTerminationInProgress(ctx context.Context, pcsgObjectKey client.ObjectKey, pcsReplicaIndex int) error {
-	return retry.OnError(flagWriteBackoff, k8sutils.IsRetriableAPIError, func() error {
+// resetPCSGToInitialScheduling uses an optimistic status patch because the PCSG status reconciler
+// writes the same condition concurrently.
+func (r _resource) resetPCSGToInitialScheduling(ctx context.Context, pcsgObjectKey client.ObjectKey, pcsReplicaIndex int) error {
+	return retry.OnError(statusWriteBackoff, k8sutils.IsRetriableAPIError, func() error {
 		latest := &grovecorev1alpha1.PodCliqueScalingGroup{}
 		if err := r.client.Get(ctx, pcsgObjectKey, latest); err != nil {
 			if apierrors.IsNotFound(err) {
@@ -296,15 +248,22 @@ func (r _resource) markGangTerminationInProgress(ctx context.Context, pcsgObject
 			}
 			return err
 		}
-		if meta.IsStatusConditionTrue(latest.Status.Conditions, apiconstants.ConditionTypeGangTerminationInProgress) {
+		if latest.Spec.Replicas == 0 {
+			return nil
+		}
+		condition := meta.FindStatusCondition(latest.Status.Conditions, apiconstants.ConditionTypeMinAvailableBreached)
+		if condition != nil &&
+			condition.ObservedGeneration == latest.Generation &&
+			condition.Reason == apiconstants.ConditionReasonInitialScheduling {
 			return nil
 		}
 		patch := client.MergeFromWithOptions(latest.DeepCopy(), client.MergeFromWithOptimisticLock{})
 		meta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
-			Type:    apiconstants.ConditionTypeGangTerminationInProgress,
-			Status:  metav1.ConditionTrue,
-			Reason:  apiconstants.ConditionReasonGangTerminationActive,
-			Message: fmt.Sprintf("Gang termination fired at PCS-replica scope for PCS replica %d; this PCSG's PodCliques were deleted as part of the recycle", pcsReplicaIndex),
+			Type:               apiconstants.ConditionTypeMinAvailableBreached,
+			Status:             metav1.ConditionTrue,
+			Reason:             apiconstants.ConditionReasonInitialScheduling,
+			Message:            fmt.Sprintf("Waiting for PCSG recovery after gang termination of PCS replica %d", pcsReplicaIndex),
+			ObservedGeneration: latest.Generation,
 		})
 		if err := r.client.Status().Patch(ctx, latest, patch); err != nil && !apierrors.IsNotFound(err) {
 			return err

--- a/operator/internal/controller/podcliqueset/components/podcliquesetreplica/gangterminate_test.go
+++ b/operator/internal/controller/podcliqueset/components/podcliquesetreplica/gangterminate_test.go
@@ -35,26 +35,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-// TestGetMinAvailableBreachedPCSGInfoGangTerminationGate pins the PCS-level gate added to break
-// the post-recycle loop: a PCSG that is currently MinAvailableBreached=True but already carries
-// GangTerminationInProgress=True must NOT appear in the breach-candidate list — a previous
-// recycle is in flight, the action would just churn.
-func TestGetMinAvailableBreachedPCSGInfoGangTerminationGate(t *testing.T) {
+func TestGetMinAvailableBreachedPCSGInfoUsesPersistentReason(t *testing.T) {
 	pastTransition := metav1.NewTime(time.Now().Add(-1 * time.Hour))
 	now := time.Now()
 	terminationDelay := 10 * time.Second
 
-	breachedTrue := metav1.Condition{
-		Type:               apiconstants.ConditionTypeMinAvailableBreached,
-		Status:             metav1.ConditionTrue,
-		Reason:             apiconstants.ConditionReasonScheduledReplicasBelowMinAvailable,
-		LastTransitionTime: pastTransition,
-	}
-	inProgressTrue := metav1.Condition{
-		Type:               apiconstants.ConditionTypeGangTerminationInProgress,
-		Status:             metav1.ConditionTrue,
-		Reason:             apiconstants.ConditionReasonGangTerminationActive,
-		LastTransitionTime: pastTransition,
+	condition := func(status metav1.ConditionStatus, reason string, observedGeneration int64) metav1.Condition {
+		return metav1.Condition{
+			Type:               apiconstants.ConditionTypeMinAvailableBreached,
+			Status:             status,
+			Reason:             reason,
+			ObservedGeneration: observedGeneration,
+			LastTransitionTime: pastTransition,
+		}
 	}
 
 	tests := []struct {
@@ -63,61 +56,52 @@ func TestGetMinAvailableBreachedPCSGInfoGangTerminationGate(t *testing.T) {
 		wantInList bool
 	}{
 		{
-			name: "breached, no in-progress flag — candidate for fire",
+			name: "healthy then regressed",
 			pcsg: grovecorev1alpha1.PodCliqueScalingGroup{
-				ObjectMeta: metav1.ObjectMeta{Name: "pcsg-fresh-breach"},
+				ObjectMeta: metav1.ObjectMeta{Name: "pcsg-regressed", Generation: 1},
 				Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{
-					Conditions: []metav1.Condition{breachedTrue},
+					Conditions: []metav1.Condition{condition(metav1.ConditionTrue, apiconstants.ConditionReasonInsufficientAvailablePCSGReplicas, 1)},
 				},
 			},
 			wantInList: true,
 		},
 		{
-			name: "breached AND in-progress flag set — skipped (recycle in flight)",
+			name: "initial scheduling is skipped",
 			pcsg: grovecorev1alpha1.PodCliqueScalingGroup{
-				ObjectMeta: metav1.ObjectMeta{Name: "pcsg-recycling"},
+				ObjectMeta: metav1.ObjectMeta{Name: "pcsg-initial", Generation: 1},
 				Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{
-					Conditions: []metav1.Condition{breachedTrue, inProgressTrue},
+					Conditions: []metav1.Condition{condition(metav1.ConditionTrue, apiconstants.ConditionReasonInitialScheduling, 1)},
 				},
 			},
 			wantInList: false,
 		},
 		{
-			name: "not breached, in-progress flag still set — skipped (no action needed)",
+			name: "legacy condition is skipped",
 			pcsg: grovecorev1alpha1.PodCliqueScalingGroup{
-				ObjectMeta: metav1.ObjectMeta{Name: "pcsg-recovered-but-stale-flag"},
+				ObjectMeta: metav1.ObjectMeta{Name: "pcsg-legacy", Generation: 1},
 				Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{
-					Conditions: []metav1.Condition{
-						{Type: apiconstants.ConditionTypeMinAvailableBreached, Status: metav1.ConditionFalse, LastTransitionTime: pastTransition},
-						inProgressTrue,
-					},
+					Conditions: []metav1.Condition{condition(metav1.ConditionTrue, apiconstants.ConditionReasonInsufficientAvailablePCSGReplicas, 0)},
 				},
 			},
 			wantInList: false,
 		},
 		{
-			name: "no MinAvailableBreached condition at all — skipped",
+			name: "healthy condition is skipped",
 			pcsg: grovecorev1alpha1.PodCliqueScalingGroup{
-				ObjectMeta: metav1.ObjectMeta{Name: "pcsg-fresh"},
+				ObjectMeta: metav1.ObjectMeta{Name: "pcsg-healthy", Generation: 1},
+				Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{
+					Conditions: []metav1.Condition{condition(metav1.ConditionFalse, apiconstants.ConditionReasonSufficientAvailablePCSGReplicas, 1)},
+				},
 			},
 			wantInList: false,
 		},
 		{
-			name: "breached but never healthy (initial startup) — skipped by wasHealthy gate",
+			name: "idle is skipped",
 			pcsg: grovecorev1alpha1.PodCliqueScalingGroup{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "pcsg-initial-startup",
-					CreationTimestamp: metav1.NewTime(now.Add(-2 * time.Second)),
-				},
+				ObjectMeta: metav1.ObjectMeta{Name: "pcsg-idle", Generation: 1},
+				Spec:       grovecorev1alpha1.PodCliqueScalingGroupSpec{Replicas: 0},
 				Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{
-					Conditions: []metav1.Condition{
-						{
-							Type:               apiconstants.ConditionTypeMinAvailableBreached,
-							Status:             metav1.ConditionTrue,
-							Reason:             apiconstants.ConditionReasonScheduledReplicasBelowMinAvailable,
-							LastTransitionTime: metav1.NewTime(now.Add(-1 * time.Second)),
-						},
-					},
+					Conditions: []metav1.Condition{condition(metav1.ConditionTrue, apiconstants.ConditionReasonInsufficientAvailablePCSGReplicas, 1)},
 				},
 			},
 			wantInList: false,
@@ -126,6 +110,9 @@ func TestGetMinAvailableBreachedPCSGInfoGangTerminationGate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.pcsg.Name != "pcsg-idle" {
+				tc.pcsg.Spec.Replicas = 1
+			}
 			names, _ := getMinAvailableBreachedPCSGInfo([]grovecorev1alpha1.PodCliqueScalingGroup{tc.pcsg}, terminationDelay, now)
 			if tc.wantInList {
 				assert.Equal(t, []string{tc.pcsg.Name}, names, "expected PCSG in breach candidate list")
@@ -136,12 +123,7 @@ func TestGetMinAvailableBreachedPCSGInfoGangTerminationGate(t *testing.T) {
 	}
 }
 
-// TestCreatePCSReplicaDeleteTaskIgnoresStaleSiblingFlag pins the cross-episode overlap case:
-// sg-b still carries GangTerminationInProgress from an earlier fire (its recycled pods have
-// not recovered yet) while a NEW fire targets the replica because sg-a regressed again. The
-// stale sibling flag must not suppress the DeleteAllOf — gating the delete on existing flags
-// would leave sg-a breached, freshly flagged, and never recycled (permanent suppression).
-func TestCreatePCSReplicaDeleteTaskIgnoresStaleSiblingFlag(t *testing.T) {
+func TestCreatePCSReplicaDeleteTaskResetsPCSGState(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, grovecorev1alpha1.AddToScheme(scheme))
 
@@ -154,15 +136,18 @@ func TestCreatePCSReplicaDeleteTaskIgnoresStaleSiblingFlag(t *testing.T) {
 	)
 
 	sgA := &grovecorev1alpha1.PodCliqueScalingGroup{
-		ObjectMeta: metav1.ObjectMeta{Name: "pcs-0-sg-a", Namespace: "default", Labels: replicaLabels},
+		ObjectMeta: metav1.ObjectMeta{Name: "pcs-0-sg-a", Namespace: "default", Labels: replicaLabels, Generation: 1},
+		Spec:       grovecorev1alpha1.PodCliqueScalingGroupSpec{Replicas: 1},
 	}
 	sgB := &grovecorev1alpha1.PodCliqueScalingGroup{
-		ObjectMeta: metav1.ObjectMeta{Name: "pcs-0-sg-b", Namespace: "default", Labels: replicaLabels},
+		ObjectMeta: metav1.ObjectMeta{Name: "pcs-0-sg-b", Namespace: "default", Labels: replicaLabels, Generation: 1},
+		Spec:       grovecorev1alpha1.PodCliqueScalingGroupSpec{Replicas: 1},
 		Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{
 			Conditions: []metav1.Condition{{
-				Type:               apiconstants.ConditionTypeGangTerminationInProgress,
+				Type:               apiconstants.ConditionTypeMinAvailableBreached,
 				Status:             metav1.ConditionTrue,
-				Reason:             apiconstants.ConditionReasonGangTerminationActive,
+				Reason:             apiconstants.ConditionReasonInsufficientAvailablePCSGReplicas,
+				ObservedGeneration: 1,
 				LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			}},
 		},
@@ -178,18 +163,20 @@ func TestCreatePCSReplicaDeleteTaskIgnoresStaleSiblingFlag(t *testing.T) {
 		Build()
 	r := _resource{client: cl, eventRecorder: record.NewFakeRecorder(10)}
 
-	task := r.createPCSReplicaDeleteTask(logr.Discard(), pcs, 0, "sg-a regressed again")
+	task := r.createPCSReplicaDeleteTask(logr.Discard(), pcs, 0, "gang regression")
 	require.NoError(t, task.Fn(context.Background()))
 
-	// The delete must have run despite sg-b's stale flag.
 	pclqList := &grovecorev1alpha1.PodCliqueList{}
 	require.NoError(t, cl.List(context.Background(), pclqList, client.InNamespace("default"), client.MatchingLabels(replicaLabels)))
-	assert.Empty(t, pclqList.Items, "PodCliques must be deleted even when a sibling PCSG carries a stale GangTerminationInProgress flag")
+	assert.Empty(t, pclqList.Items)
 
-	// Both PCSGs end up flagged: sg-a freshly, sg-b unchanged.
 	for _, name := range []string{sgA.Name, sgB.Name} {
 		got := &grovecorev1alpha1.PodCliqueScalingGroup{}
 		require.NoError(t, cl.Get(context.Background(), client.ObjectKey{Name: name, Namespace: "default"}, got))
-		assert.True(t, meta.IsStatusConditionTrue(got.Status.Conditions, apiconstants.ConditionTypeGangTerminationInProgress), "expected %s to carry GangTerminationInProgress", name)
+		condition := meta.FindStatusCondition(got.Status.Conditions, apiconstants.ConditionTypeMinAvailableBreached)
+		require.NotNil(t, condition)
+		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+		assert.Equal(t, apiconstants.ConditionReasonInitialScheduling, condition.Reason)
+		assert.Equal(t, got.Generation, condition.ObservedGeneration)
 	}
 }

--- a/operator/internal/controller/podcliqueset/components/podcliquesetreplica/rollingupdate.go
+++ b/operator/internal/controller/podcliqueset/components/podcliquesetreplica/rollingupdate.go
@@ -281,11 +281,19 @@ func isPCLQUpdateComplete(pcs *grovecorev1alpha1.PodCliqueSet, pclq *grovecorev1
 	if err != nil || expectedPodTemplateHash == "" {
 		return false
 	}
-	return pclq.Labels[apicommon.LabelPodTemplateHash] == expectedPodTemplateHash &&
+	hashesConverged := pclq.Labels[apicommon.LabelPodTemplateHash] == expectedPodTemplateHash &&
 		pclq.Status.CurrentPodTemplateHash != nil &&
 		*pclq.Status.CurrentPodTemplateHash == expectedPodTemplateHash &&
 		pclq.Status.CurrentPodCliqueSetGenerationHash != nil &&
-		*pclq.Status.CurrentPodCliqueSetGenerationHash == *pcs.Status.CurrentGenerationHash &&
+		*pclq.Status.CurrentPodCliqueSetGenerationHash == *pcs.Status.CurrentGenerationHash
+	// GREP-0677: an idle standalone PodClique (replicas: 0) has no pods to roll, so a
+	// RollingRecreate completes for it once its hashes converge. Requiring
+	// UpdatedReplicas/ReadyReplicas >= MinAvailable would stall the update forever (zero pods
+	// can never reach MinAvailable).
+	if pclq.Spec.Replicas == 0 {
+		return hashesConverged
+	}
+	return hashesConverged &&
 		pclq.Status.UpdatedReplicas >= *pclq.Spec.MinAvailable &&
 		pclq.Status.ReadyReplicas >= *pclq.Spec.MinAvailable
 }

--- a/operator/internal/controller/podcliqueset/components/podcliquesetreplica/rollingupdate.go
+++ b/operator/internal/controller/podcliqueset/components/podcliquesetreplica/rollingupdate.go
@@ -281,21 +281,14 @@ func isPCLQUpdateComplete(pcs *grovecorev1alpha1.PodCliqueSet, pclq *grovecorev1
 	if err != nil || expectedPodTemplateHash == "" {
 		return false
 	}
-	hashesConverged := pclq.Labels[apicommon.LabelPodTemplateHash] == expectedPodTemplateHash &&
+	// Idle cliques have no pods to roll, but their hashes must still converge.
+	return pclq.Labels[apicommon.LabelPodTemplateHash] == expectedPodTemplateHash &&
 		pclq.Status.CurrentPodTemplateHash != nil &&
 		*pclq.Status.CurrentPodTemplateHash == expectedPodTemplateHash &&
 		pclq.Status.CurrentPodCliqueSetGenerationHash != nil &&
-		*pclq.Status.CurrentPodCliqueSetGenerationHash == *pcs.Status.CurrentGenerationHash
-	// GREP-0677: an idle standalone PodClique (replicas: 0) has no pods to roll, so a
-	// RollingRecreate completes for it once its hashes converge. Requiring
-	// UpdatedReplicas/ReadyReplicas >= MinAvailable would stall the update forever (zero pods
-	// can never reach MinAvailable).
-	if pclq.Spec.Replicas == 0 {
-		return hashesConverged
-	}
-	return hashesConverged &&
-		pclq.Status.UpdatedReplicas >= *pclq.Spec.MinAvailable &&
-		pclq.Status.ReadyReplicas >= *pclq.Spec.MinAvailable
+		*pclq.Status.CurrentPodCliqueSetGenerationHash == *pcs.Status.CurrentGenerationHash &&
+		(pclq.Spec.Replicas == 0 || (pclq.Status.UpdatedReplicas >= *pclq.Spec.MinAvailable &&
+			pclq.Status.ReadyReplicas >= *pclq.Spec.MinAvailable))
 }
 
 // isAutoUpdateInProgress checks if an update is currently in progress.

--- a/operator/internal/controller/podcliqueset/components/podcliquesetreplica/rollingupdate_test.go
+++ b/operator/internal/controller/podcliqueset/components/podcliquesetreplica/rollingupdate_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podcliquesetreplica
+
+import (
+	"testing"
+
+	apicommon "github.com/ai-dynamo/grove/operator/api/common"
+	componentutils "github.com/ai-dynamo/grove/operator/internal/controller/common/component/utils"
+	testutils "github.com/ai-dynamo/grove/operator/test/utils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	testPCSName      = "test-pcs"
+	testPCSNamespace = "default"
+)
+
+// TestIsPCLQUpdateCompleteIdle verifies GREP-0677: a RollingRecreate completes for an idle
+// standalone PodClique (replicas: 0) once its hashes converge, and does not stall waiting for
+// UpdatedReplicas/ReadyReplicas >= MinAvailable (which zero pods can never satisfy).
+func TestIsPCLQUpdateCompleteIdle(t *testing.T) {
+	hash := "h"
+	pcsUID := uuid.NewUUID()
+	pcs := testutils.NewPodCliqueSetBuilder(testPCSName, testPCSNamespace, pcsUID).
+		WithStandaloneClique("worker").
+		WithPodCliqueSetGenerationHash(&hash).
+		Build()
+
+	pclq := testutils.NewPodCliqueBuilder(testPCSName, pcsUID, "worker", testPCSNamespace, 0).Build()
+	expectedTemplateHash, err := componentutils.GetExpectedPCLQPodTemplateHash(pcs, pclq.ObjectMeta)
+	require.NoError(t, err)
+	if pclq.Labels == nil {
+		pclq.Labels = map[string]string{}
+	}
+	pclq.Labels[apicommon.LabelPodTemplateHash] = expectedTemplateHash
+	pclq.Status.CurrentPodTemplateHash = ptr.To(expectedTemplateHash)
+	pclq.Status.CurrentPodCliqueSetGenerationHash = ptr.To(hash)
+	// Idle: no pods, so ready/updated stay at zero.
+	pclq.Spec.Replicas = 0
+	pclq.Status.ReadyReplicas = 0
+	pclq.Status.UpdatedReplicas = 0
+
+	assert.True(t, isPCLQUpdateComplete(pcs, pclq), "idle PCLQ with converged hashes must be update-complete")
+
+	stale := pclq.DeepCopy()
+	stale.Status.CurrentPodCliqueSetGenerationHash = ptr.To("old")
+	assert.False(t, isPCLQUpdateComplete(pcs, stale), "idle PCLQ with stale generation hash must not be update-complete")
+}

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
@@ -190,7 +190,15 @@ func (r _resource) computeExpectedPodGangs(ctx context.Context, ss *syncState) (
 // (PodCliqueScalingGroup, replica index) it carries.
 func (r _resource) buildPodGangInfosFromEntry(ss *syncState, pcsReplicaIndex int, pgEntry grovecorev1alpha1.PodGangEntry) ([]*podGangInfo, error) {
 	if pgEntry.Role == grovecorev1alpha1.PodGangEntryRoleAnchor {
-		rnr := apicommon.ResourceNameReplica{Name: ss.pcs.Name, Replica: pcsReplicaIndex}
+		if componentutils.IsPodGangEntryEmpty(pgEntry) {
+			return nil, nil
+		}
+	}
+	rnr := apicommon.ResourceNameReplica{Name: ss.pcs.Name, Replica: pcsReplicaIndex}
+	if _, err := componentutils.ActivePodCliqueNamesForEntry(ss.pcs, rnr, &pgEntry); err != nil {
+		return nil, err
+	}
+	if pgEntry.Role == grovecorev1alpha1.PodGangEntryRoleAnchor {
 		pg := &podGangInfo{
 			fqn:                apicommon.GenerateAnchorPodGangName(rnr, pgEntry.Epoch),
 			pcsReplicaIndex:    pcsReplicaIndex,
@@ -773,6 +781,15 @@ func (ss *syncState) initializeAssignedAndUnassignedPodsForPCS() {
 				pgi.refreshAssociatedPCLQPods(pclqName, pod.Name)
 			} else {
 				ss.unassignedPodsByPCLQ[pclqName] = append(ss.unassignedPodsByPCLQ[pclqName], pod)
+			}
+		}
+	}
+	for _, podGang := range ss.expectedPodGangs {
+		for i := range podGang.pclqs {
+			pclq := &podGang.pclqs[i]
+			slices.Sort(pclq.associatedPodNames)
+			if len(pclq.associatedPodNames) > int(pclq.replicas) {
+				pclq.associatedPodNames = pclq.associatedPodNames[:pclq.replicas]
 			}
 		}
 	}

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
@@ -189,10 +189,8 @@ func (r _resource) computeExpectedPodGangs(ctx context.Context, ss *syncState) (
 // replica indices the entry holds. A non-anchor entry (Tail or ScaleOut) yields one PodGang per
 // (PodCliqueScalingGroup, replica index) it carries.
 func (r _resource) buildPodGangInfosFromEntry(ss *syncState, pcsReplicaIndex int, pgEntry grovecorev1alpha1.PodGangEntry) ([]*podGangInfo, error) {
-	if pgEntry.Role == grovecorev1alpha1.PodGangEntryRoleAnchor {
-		if componentutils.IsPodGangEntryEmpty(pgEntry) {
-			return nil, nil
-		}
+	if pgEntry.Role == grovecorev1alpha1.PodGangEntryRoleAnchor && componentutils.IsPodGangEntryEmpty(pgEntry) {
+		return nil, nil
 	}
 	rnr := apicommon.ResourceNameReplica{Name: ss.pcs.Name, Replica: pcsReplicaIndex}
 	if _, err := componentutils.ActivePodCliqueNamesForEntry(ss.pcs, rnr, &pgEntry); err != nil {

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow_test.go
@@ -1508,15 +1508,17 @@ func TestInitializeAssignedAndUnassignedPodsForPCS(t *testing.T) {
 		return pod
 	}
 
-	assignedPodGang := &podGangInfo{fqn: "test-pcs-0-1000", pclqs: []pclqInfo{{fqn: pclqName}}}
+	assignedPodGang := &podGangInfo{fqn: "test-pcs-0-1000", pclqs: []pclqInfo{{fqn: pclqName, replicas: 1}}}
 	ss := &syncState{
 		existingPCLQPods: map[string][]v1.Pod{
 			pclqName: {
+				makePod("assigned-1", "test-pcs-0-1000"),
 				makePod("assigned-0", "test-pcs-0-1000"),
 				makePod("unassigned-0", ""),
 				makePod("unknown-0", "test-pcs-0-9999"),
 			},
 		},
+		expectedPodGangs:      []*podGangInfo{assignedPodGang},
 		expectedPodGangByName: map[string]*podGangInfo{assignedPodGang.fqn: assignedPodGang},
 		unassignedPodsByPCLQ:  make(map[string][]v1.Pod),
 	}
@@ -2075,4 +2077,21 @@ func makeClusterTopologyBindingWithLevels(name string, levels []grovecorev1alpha
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec:       grovecorev1alpha1.ClusterTopologyBindingSpec{Levels: levels},
 	}
+}
+
+// TestBuildPodGangInfosFromEmptyAnchorEntry verifies that an empty anchor entry materializes no
+// PodGang (GREP-0677).
+func TestBuildPodGangInfosFromEmptyAnchorEntry(t *testing.T) {
+	r := &_resource{}
+	ss := &syncState{}
+	emptyAnchor := grovecorev1alpha1.PodGangEntry{
+		Role:        grovecorev1alpha1.PodGangEntryRoleAnchor,
+		Epoch:       "100",
+		AnchorIndex: ptr.To[int32](0),
+	}
+
+	infos, err := r.buildPodGangInfosFromEntry(ss, 0, emptyAnchor)
+
+	require.NoError(t, err)
+	assert.Empty(t, infos, "empty anchor entry must not materialize a PodGang")
 }

--- a/operator/internal/controller/podcliqueset/components/podgangmap/entry.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/entry.go
@@ -17,6 +17,7 @@ package podgangmap
 import (
 	"cmp"
 	"fmt"
+	"math"
 	"slices"
 	"strconv"
 
@@ -60,20 +61,67 @@ func sortEntriesByEpoch(entries []grovecorev1alpha1.PodGangEntry) error {
 	return nil
 }
 
-// isPodGangEntryEmpty reports whether an entry carries no standalone PodClique pods and no
-// PodCliqueScalingGroup replica indices.
-func isPodGangEntryEmpty(entry grovecorev1alpha1.PodGangEntry) bool {
-	for _, count := range entry.PodCliques {
-		if count > 0 {
-			return false
+// findAnchorEntryByIndex returns the current-generation anchor entry with the given AnchorIndex, or
+// nil when absent.
+func findAnchorEntryByIndex(entries []grovecorev1alpha1.PodGangEntry, currentHash string, anchorIndex int32) *grovecorev1alpha1.PodGangEntry {
+	for i := range entries {
+		if entries[i].Role == grovecorev1alpha1.PodGangEntryRoleAnchor &&
+			entries[i].PodCliqueSetGenerationHash == currentHash &&
+			entries[i].AnchorIndex != nil && *entries[i].AnchorIndex == anchorIndex {
+			return &entries[i]
 		}
 	}
-	for _, indices := range entry.PCSGReplicaIndices {
-		if len(indices) > 0 {
-			return false
+	return nil
+}
+
+// nextAnchorIndex returns the smallest non-negative AnchorIndex not already used by a
+// current-generation anchor entry. Bootstrap anchors take index 0; a wake that cannot reuse an
+// existing anchor takes the next free index.
+func nextAnchorIndex(entries []grovecorev1alpha1.PodGangEntry, currentHash string) int32 {
+	used := make(map[int32]struct{})
+	for i := range entries {
+		if entries[i].Role == grovecorev1alpha1.PodGangEntryRoleAnchor &&
+			entries[i].PodCliqueSetGenerationHash == currentHash &&
+			entries[i].AnchorIndex != nil {
+			used[*entries[i].AnchorIndex] = struct{}{}
 		}
 	}
-	return true
+	var idx int32
+	for {
+		if _, taken := used[idx]; !taken {
+			return idx
+		}
+		idx++
+	}
+}
+
+// epochAllocator issues fresh, strictly increasing epoch strings for one PodGangMap reconcile.
+type epochAllocator struct {
+	next int64
+}
+
+// newEpochAllocator starts after both unixNano and every existing epoch.
+func newEpochAllocator(entries []grovecorev1alpha1.PodGangEntry, unixNano int64) (*epochAllocator, error) {
+	next := unixNano
+	for i := range entries {
+		existing, err := strconv.ParseInt(entries[i].Epoch, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("PodGangMap entry has invalid epoch %q: %w", entries[i].Epoch, err)
+		}
+		if existing >= next {
+			if existing == math.MaxInt64 {
+				return nil, fmt.Errorf("PodGangMap entry epoch %q cannot be incremented", entries[i].Epoch)
+			}
+			next = existing + 1
+		}
+	}
+	return &epochAllocator{next: next}, nil
+}
+
+func (a *epochAllocator) allocate() string {
+	epoch := strconv.FormatInt(a.next, 10)
+	a.next++
+	return epoch
 }
 
 // advanceEntriesGenerationHash sets every entry's PodCliqueSetGenerationHash to

--- a/operator/internal/controller/podcliqueset/components/podgangmap/entry.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/entry.go
@@ -61,40 +61,6 @@ func sortEntriesByEpoch(entries []grovecorev1alpha1.PodGangEntry) error {
 	return nil
 }
 
-// findAnchorEntryByIndex returns the current-generation anchor entry with the given AnchorIndex, or
-// nil when absent.
-func findAnchorEntryByIndex(entries []grovecorev1alpha1.PodGangEntry, currentHash string, anchorIndex int32) *grovecorev1alpha1.PodGangEntry {
-	for i := range entries {
-		if entries[i].Role == grovecorev1alpha1.PodGangEntryRoleAnchor &&
-			entries[i].PodCliqueSetGenerationHash == currentHash &&
-			entries[i].AnchorIndex != nil && *entries[i].AnchorIndex == anchorIndex {
-			return &entries[i]
-		}
-	}
-	return nil
-}
-
-// nextAnchorIndex returns the smallest non-negative AnchorIndex not already used by a
-// current-generation anchor entry. Bootstrap anchors take index 0; a wake that cannot reuse an
-// existing anchor takes the next free index.
-func nextAnchorIndex(entries []grovecorev1alpha1.PodGangEntry, currentHash string) int32 {
-	used := make(map[int32]struct{})
-	for i := range entries {
-		if entries[i].Role == grovecorev1alpha1.PodGangEntryRoleAnchor &&
-			entries[i].PodCliqueSetGenerationHash == currentHash &&
-			entries[i].AnchorIndex != nil {
-			used[*entries[i].AnchorIndex] = struct{}{}
-		}
-	}
-	var idx int32
-	for {
-		if _, taken := used[idx]; !taken {
-			return idx
-		}
-		idx++
-	}
-}
-
 // epochAllocator issues fresh, strictly increasing epoch strings for one PodGangMap reconcile.
 type epochAllocator struct {
 	next int64

--- a/operator/internal/controller/podcliqueset/components/podgangmap/entry_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/entry_test.go
@@ -15,10 +15,12 @@
 package podgangmap
 
 import (
+	"math"
 	"strconv"
 	"testing"
 
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	componentutils "github.com/ai-dynamo/grove/operator/internal/controller/common/component/utils"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
 	"github.com/stretchr/testify/assert"
@@ -98,7 +100,7 @@ func TestIsPodGangEntryEmpty(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := isPodGangEntryEmpty(tt.entry)
+			actual := componentutils.IsPodGangEntryEmpty(tt.entry)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}
@@ -213,4 +215,91 @@ func entriesWithGenerationHashes(hashes []string) []grovecorev1alpha1.PodGangEnt
 		entries = append(entries, testutils.NewPodGangEntryBuilder(h, strconv.Itoa(i)).Build())
 	}
 	return entries
+}
+
+func TestFindAnchorEntryForStandalonePCLQ(t *testing.T) {
+	const hash = "gen-1"
+	anchor0 := testutils.NewPodGangEntryBuilder(hash, "100").
+		WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).
+		WithAnchorIndex(0).
+		WithPodCliques(map[string]int32{"router": 1, "decode": 2}).
+		Build()
+	tail := testutils.NewPodGangEntryBuilder(hash, "101").
+		WithRole(grovecorev1alpha1.PodGangEntryRoleTail).
+		WithPCSGReplicaIndices(map[string][]int32{"prefill": {2}}).
+		Build()
+	oldGenAnchor := testutils.NewPodGangEntryBuilder("old-gen", "50").
+		WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).
+		WithAnchorIndex(0).
+		WithPodCliques(map[string]int32{"legacy": 1}).
+		Build()
+	entries := []grovecorev1alpha1.PodGangEntry{anchor0, tail, oldGenAnchor}
+
+	got, err := componentutils.FindPodGangEntryForStandalonePCLQ(entries, hash, "router")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "100", got.Epoch)
+
+	got, err = componentutils.FindPodGangEntryForStandalonePCLQ(entries, hash, "missing")
+	require.NoError(t, err)
+	assert.Nil(t, got, "unknown clique has no owning anchor")
+	got, err = componentutils.FindPodGangEntryForStandalonePCLQ(entries, hash, "legacy")
+	require.NoError(t, err)
+	assert.Nil(t, got, "old-generation anchor is not a match")
+}
+
+func TestFindAnchorEntryByIndex(t *testing.T) {
+	const hash = "gen-1"
+	anchor0 := testutils.NewPodGangEntryBuilder(hash, "100").WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).WithAnchorIndex(0).Build()
+	anchor1 := testutils.NewPodGangEntryBuilder(hash, "200").WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).WithAnchorIndex(1).Build()
+	entries := []grovecorev1alpha1.PodGangEntry{anchor0, anchor1}
+
+	require.NotNil(t, findAnchorEntryByIndex(entries, hash, 1))
+	assert.Equal(t, "200", findAnchorEntryByIndex(entries, hash, 1).Epoch)
+	assert.Nil(t, findAnchorEntryByIndex(entries, hash, 2))
+}
+
+func TestNextAnchorIndex(t *testing.T) {
+	const hash = "gen-1"
+	assert.Equal(t, int32(0), nextAnchorIndex(nil, hash), "empty entries start at 0")
+
+	anchor0 := testutils.NewPodGangEntryBuilder(hash, "100").WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).WithAnchorIndex(0).Build()
+	assert.Equal(t, int32(1), nextAnchorIndex([]grovecorev1alpha1.PodGangEntry{anchor0}, hash))
+
+	anchor2 := testutils.NewPodGangEntryBuilder(hash, "300").WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).WithAnchorIndex(2).Build()
+	// 0 and 2 used → next free is 1.
+	assert.Equal(t, int32(1), nextAnchorIndex([]grovecorev1alpha1.PodGangEntry{anchor0, anchor2}, hash))
+}
+
+func TestEpochAllocator(t *testing.T) {
+	const hash = "gen-1"
+	e100 := testutils.NewPodGangEntryBuilder(hash, "100").Build()
+	e250 := testutils.NewPodGangEntryBuilder(hash, "250").Build()
+	entries := []grovecorev1alpha1.PodGangEntry{e100, e250}
+
+	t.Run("allocates monotonically after existing epochs", func(t *testing.T) {
+		allocator, err := newEpochAllocator(entries, 200)
+		require.NoError(t, err)
+		assert.Equal(t, "251", allocator.allocate())
+		assert.Equal(t, "252", allocator.allocate())
+	})
+	t.Run("uses a later clock value", func(t *testing.T) {
+		allocator, err := newEpochAllocator(entries, 999)
+		require.NoError(t, err)
+		assert.Equal(t, "999", allocator.allocate())
+	})
+	t.Run("uses the clock value without entries", func(t *testing.T) {
+		allocator, err := newEpochAllocator(nil, 42)
+		require.NoError(t, err)
+		assert.Equal(t, "42", allocator.allocate())
+	})
+	t.Run("rejects invalid existing epoch", func(t *testing.T) {
+		_, err := newEpochAllocator(entriesWithEpochs([]string{"invalid"}), 42)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects exhausted epoch space", func(t *testing.T) {
+		_, err := newEpochAllocator(entriesWithEpochs([]string{strconv.FormatInt(math.MaxInt64, 10)}), 42)
+		require.Error(t, err)
+	})
 }

--- a/operator/internal/controller/podcliqueset/components/podgangmap/entry_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/entry_test.go
@@ -248,29 +248,6 @@ func TestFindAnchorEntryForStandalonePCLQ(t *testing.T) {
 	assert.Nil(t, got, "old-generation anchor is not a match")
 }
 
-func TestFindAnchorEntryByIndex(t *testing.T) {
-	const hash = "gen-1"
-	anchor0 := testutils.NewPodGangEntryBuilder(hash, "100").WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).WithAnchorIndex(0).Build()
-	anchor1 := testutils.NewPodGangEntryBuilder(hash, "200").WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).WithAnchorIndex(1).Build()
-	entries := []grovecorev1alpha1.PodGangEntry{anchor0, anchor1}
-
-	require.NotNil(t, findAnchorEntryByIndex(entries, hash, 1))
-	assert.Equal(t, "200", findAnchorEntryByIndex(entries, hash, 1).Epoch)
-	assert.Nil(t, findAnchorEntryByIndex(entries, hash, 2))
-}
-
-func TestNextAnchorIndex(t *testing.T) {
-	const hash = "gen-1"
-	assert.Equal(t, int32(0), nextAnchorIndex(nil, hash), "empty entries start at 0")
-
-	anchor0 := testutils.NewPodGangEntryBuilder(hash, "100").WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).WithAnchorIndex(0).Build()
-	assert.Equal(t, int32(1), nextAnchorIndex([]grovecorev1alpha1.PodGangEntry{anchor0}, hash))
-
-	anchor2 := testutils.NewPodGangEntryBuilder(hash, "300").WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).WithAnchorIndex(2).Build()
-	// 0 and 2 used → next free is 1.
-	assert.Equal(t, int32(1), nextAnchorIndex([]grovecorev1alpha1.PodGangEntry{anchor0, anchor2}, hash))
-}
-
 func TestEpochAllocator(t *testing.T) {
 	const hash = "gen-1"
 	e100 := testutils.NewPodGangEntryBuilder(hash, "100").Build()

--- a/operator/internal/controller/podcliqueset/components/podgangmap/hibernation_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/hibernation_test.go
@@ -1,0 +1,240 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podgangmap
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	componentutils "github.com/ai-dynamo/grove/operator/internal/controller/common/component/utils"
+	testutils "github.com/ai-dynamo/grove/operator/test/utils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clocktesting "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
+)
+
+func TestReconcileHibernatingComponents(t *testing.T) {
+	pcs := testutils.NewPodCliqueSetBuilder(testPCSName, testNamespace, testPCSUID).
+		WithStandaloneCliqueReplicas("router", 1).
+		WithStandaloneCliqueReplicas("worker", 0).
+		WithScalingGroupConfig(testPCSGName, []string{"c"}, 0, 2).
+		WithPodCliqueSetGenerationHash(ptr.To(testGenHash)).Build()
+	tests := []struct {
+		name            string
+		entries         []grovecorev1alpha1.PodGangEntry
+		cliques         []grovecorev1alpha1.PodClique
+		groups          []grovecorev1alpha1.PodCliqueScalingGroup
+		wantAnchorCount int
+		wantAnchorIndex int32
+		wantWorker      int32
+		wantIndices     []int32
+		wantEpoch       string
+		wantDependsOn   []string
+	}{
+		{
+			name: "standalone wake restores the running anchor",
+			entries: []grovecorev1alpha1.PodGangEntry{
+				anchorEntry(map[string]int32{"router": 1}, nil), scaleOutEntry(nil),
+			},
+			cliques:         []grovecorev1alpha1.PodClique{standalonePCLQ("worker", 3)},
+			wantAnchorCount: 1,
+			wantWorker:      3,
+			wantEpoch:       "102",
+			wantDependsOn:   []string{"100"},
+		},
+		{
+			name: "PCSG wake places every replica in scaleout behind the running anchor",
+			entries: []grovecorev1alpha1.PodGangEntry{
+				anchorEntry(map[string]int32{"router": 1}, nil), scaleOutEntry(nil),
+			},
+			groups:          []grovecorev1alpha1.PodCliqueScalingGroup{pcsg(3)},
+			wantAnchorCount: 1,
+			wantIndices:     []int32{0, 1, 2},
+			wantEpoch:       "5000",
+			wantDependsOn:   []string{"100"},
+		},
+		{
+			name: "PCSG-only wake does not depend on an unmaterialized anchor",
+			entries: []grovecorev1alpha1.PodGangEntry{
+				anchorEntry(nil, nil), scaleOutEntry(nil),
+			},
+			groups:          []grovecorev1alpha1.PodCliqueScalingGroup{pcsg(2)},
+			wantAnchorCount: 1,
+			wantIndices:     []int32{0, 1},
+			wantEpoch:       "5000",
+		},
+		{
+			name: "concurrent wake restores standalone anchor and independently scales PCSG replicas",
+			entries: []grovecorev1alpha1.PodGangEntry{
+				anchorEntry(nil, nil), scaleOutEntry(nil),
+			},
+			cliques:         []grovecorev1alpha1.PodClique{standalonePCLQ("worker", 3)},
+			groups:          []grovecorev1alpha1.PodCliqueScalingGroup{pcsg(2)},
+			wantAnchorCount: 1,
+			wantWorker:      3,
+			wantIndices:     []int32{0, 1},
+			wantEpoch:       "5000",
+			wantDependsOn:   []string{"100"},
+		},
+		{
+			name: "standalone wake after PCSG wake leaves active scaleout dependencies unchanged",
+			entries: []grovecorev1alpha1.PodGangEntry{
+				anchorEntry(nil, nil),
+				testutils.NewPodGangEntryBuilder(testGenHash, "102").
+					WithRole(grovecorev1alpha1.PodGangEntryRoleScaleOut).
+					WithPCSGReplicaIndices(map[string][]int32{testPCSGName: {0, 1}}).Build(),
+			},
+			cliques:         []grovecorev1alpha1.PodClique{standalonePCLQ("worker", 3)},
+			groups:          []grovecorev1alpha1.PodCliqueScalingGroup{pcsg(3)},
+			wantAnchorCount: 1,
+			wantWorker:      3,
+			wantIndices:     []int32{0, 1, 2},
+			wantEpoch:       "102",
+		},
+		{
+			name: "post-coherent wake selects the highest anchor and preserves empty anchor slots",
+			entries: []grovecorev1alpha1.PodGangEntry{
+				anchorEntry(nil, nil),
+				testutils.NewPodGangEntryBuilder(testGenHash, "200").
+					WithRole(grovecorev1alpha1.PodGangEntryRoleAnchor).WithAnchorIndex(2).Build(),
+				scaleOutEntry(nil),
+			},
+			cliques:         []grovecorev1alpha1.PodClique{standalonePCLQ("worker", 3)},
+			groups:          []grovecorev1alpha1.PodCliqueScalingGroup{pcsg(2)},
+			wantAnchorCount: 2,
+			wantAnchorIndex: 2,
+			wantWorker:      3,
+			wantIndices:     []int32{0, 1},
+			wantEpoch:       "5000",
+			wantDependsOn:   []string{"200"},
+		},
+		{
+			name: "anchor scale-in and PCSG wake do not leave a dangling dependency",
+			entries: []grovecorev1alpha1.PodGangEntry{
+				anchorEntry(map[string]int32{"router": 1}, nil), scaleOutEntry(nil),
+			},
+			cliques:         []grovecorev1alpha1.PodClique{standalonePCLQ("router", 0)},
+			groups:          []grovecorev1alpha1.PodCliqueScalingGroup{pcsg(2)},
+			wantAnchorCount: 1,
+			wantIndices:     []int32{0, 1},
+			wantEpoch:       "5000",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pgm := &grovecorev1alpha1.PodGangMap{Spec: grovecorev1alpha1.PodGangMapSpec{Entries: tt.entries}}
+			before := pgm.DeepCopy()
+			clk := clocktesting.NewFakeClock(time.Unix(0, 5000))
+			entries, err := reconcileEntries(clk, pcs, 0, pgm, nil, tt.cliques, tt.groups)
+			require.NoError(t, err)
+			assert.Equal(t, before, pgm, "reconciliation must not mutate the cached object")
+			anchors := currentGenerationAnchorsByIndexDesc(entries, testGenHash)
+			require.Len(t, anchors, tt.wantAnchorCount)
+			assert.Equal(t, tt.wantAnchorIndex, *anchors[0].AnchorIndex)
+			assert.Equal(t, tt.wantWorker, anchors[0].PodCliques["worker"])
+			originalAnchors := currentGenerationAnchorsByIndexDesc(tt.entries, testGenHash)
+			require.Len(t, anchors, len(originalAnchors))
+			for i, anchor := range anchors {
+				assert.Empty(t, anchor.PCSGReplicaIndices)
+				assert.Equal(t, originalAnchors[i].AnchorIndex, anchor.AnchorIndex)
+				assert.Equal(t, originalAnchors[i].Epoch, anchor.Epoch)
+			}
+			scaleOut := testutils.EntryByRole(entries, grovecorev1alpha1.PodGangEntryRoleScaleOut)
+			require.Equal(t, grovecorev1alpha1.PodGangEntryRoleScaleOut, scaleOut.Role)
+			assert.Equal(t, tt.wantIndices, scaleOut.PCSGReplicaIndices[testPCSGName])
+			assert.Equal(t, tt.wantEpoch, scaleOut.Epoch)
+			assert.Equal(t, tt.wantDependsOn, scaleOut.DependsOn)
+
+			pgm.Spec.Entries = entries
+			repeated, err := reconcileEntries(clk, pcs, 0, pgm, nil, tt.cliques, tt.groups)
+			require.NoError(t, err)
+			assert.Equal(t, entries, repeated, "steady state must not churn epochs or membership")
+		})
+	}
+}
+
+func TestRepeatedHibernationAfterGenerationChange(t *testing.T) {
+	pcs := testutils.NewPodCliqueSetBuilder(testPCSName, testNamespace, testPCSUID).
+		WithStandaloneCliqueReplicas("worker", 0).
+		WithScalingGroupConfig(testPCSGName, []string{"c"}, 0, 2).
+		WithPodCliqueSetGenerationHash(ptr.To("new-hash")).Build()
+	pgm := &grovecorev1alpha1.PodGangMap{Spec: grovecorev1alpha1.PodGangMapSpec{
+		Entries: []grovecorev1alpha1.PodGangEntry{anchorEntry(nil, nil), scaleOutEntry(nil)},
+	}}
+	clk := clocktesting.NewFakeClock(time.Unix(0, 50))
+	previousEpoch := int64(102)
+	for range 3 {
+		woken, err := reconcileEntries(clk, pcs, 0, pgm, nil,
+			[]grovecorev1alpha1.PodClique{standalonePCLQ("worker", 2)},
+			[]grovecorev1alpha1.PodCliqueScalingGroup{pcsg(2)})
+		require.NoError(t, err)
+		require.Len(t, woken, 2)
+		scaleOut := testutils.EntryByRole(woken, grovecorev1alpha1.PodGangEntryRoleScaleOut)
+		assert.Equal(t, []int32{0, 1}, scaleOut.PCSGReplicaIndices[testPCSGName])
+		assert.Equal(t, []string{"100"}, scaleOut.DependsOn)
+		assert.Equal(t, "new-hash", scaleOut.PodCliqueSetGenerationHash)
+		epoch, err := strconv.ParseInt(scaleOut.Epoch, 10, 64)
+		require.NoError(t, err)
+		assert.Greater(t, epoch, previousEpoch)
+		previousEpoch = epoch
+		pgm.Spec.Entries = woken
+
+		idle, err := reconcileEntries(clk, pcs, 0, pgm, nil,
+			[]grovecorev1alpha1.PodClique{standalonePCLQ("worker", 0)},
+			[]grovecorev1alpha1.PodCliqueScalingGroup{pcsg(0)})
+		require.NoError(t, err)
+		require.Len(t, idle, 2)
+		for _, entry := range idle {
+			assert.True(t, componentutils.IsPodGangEntryEmpty(entry))
+		}
+		assert.Equal(t, "100", testutils.EntryByRole(idle, grovecorev1alpha1.PodGangEntryRoleAnchor).Epoch)
+		pgm.Spec.Entries = idle
+	}
+}
+
+func TestMultiplePCSGWakesShareScaleOutWithoutJoiningAnchor(t *testing.T) {
+	pcs := testutils.NewPodCliqueSetBuilder(testPCSName, testNamespace, testPCSUID).
+		WithStandaloneCliqueReplicas("router", 1).
+		WithScalingGroupConfig(testPCSGName, []string{"prefill"}, 0, 2).
+		WithScalingGroupConfig("decode", []string{"decode"}, 0, 2).
+		WithPodCliqueSetGenerationHash(ptr.To(testGenHash)).Build()
+	pgm := &grovecorev1alpha1.PodGangMap{Spec: grovecorev1alpha1.PodGangMapSpec{
+		Entries: []grovecorev1alpha1.PodGangEntry{
+			anchorEntry(map[string]int32{"router": 1}, nil), scaleOutEntry(nil),
+		},
+	}}
+	decode := pcsg(2)
+	decode.Name = testPCSName + "-0-decode"
+	clk := clocktesting.NewFakeClock(time.Unix(0, 5000))
+	groups := []grovecorev1alpha1.PodCliqueScalingGroup{pcsg(3), decode}
+	entries, err := reconcileEntries(clk, pcs, 0, pgm, nil, nil, groups)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.Equal(t, pgm.Spec.Entries[0], testutils.EntryByRole(entries, grovecorev1alpha1.PodGangEntryRoleAnchor))
+	scaleOut := testutils.EntryByRole(entries, grovecorev1alpha1.PodGangEntryRoleScaleOut)
+	require.Equal(t, grovecorev1alpha1.PodGangEntryRoleScaleOut, scaleOut.Role)
+	assert.Equal(t, map[string][]int32{testPCSGName: {0, 1, 2}, "decode": {0, 1}}, scaleOut.PCSGReplicaIndices)
+	assert.Equal(t, "5000", scaleOut.Epoch)
+	assert.Equal(t, []string{"100"}, scaleOut.DependsOn)
+
+	reversed, err := reconcileEntries(clk, pcs, 0, pgm, nil, nil,
+		[]grovecorev1alpha1.PodCliqueScalingGroup{decode, pcsg(3)})
+	require.NoError(t, err)
+	assert.Equal(t, entries, reversed, "PCSG observation order must not change wake placement")
+}

--- a/operator/internal/controller/podcliqueset/components/podgangmap/steadystate.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/steadystate.go
@@ -131,7 +131,7 @@ func buildBootstrapTailEntry(pcs *grovecorev1alpha1.PodCliqueSet, epoch, anchorE
 	for _, pcsgConfig := range pcs.Spec.Template.PodCliqueScalingGroupConfigs {
 		replicas := *pcsgConfig.Replicas
 		minAvailable := *pcsgConfig.MinAvailable
-		if replicas == 0 || replicas <= minAvailable {
+		if replicas <= minAvailable {
 			continue
 		}
 		pcsgReplicaIndices[pcsgConfig.Name] = lo.RangeFrom(minAvailable, int(replicas-minAvailable))
@@ -318,8 +318,7 @@ func reconcilePCSGReplicaIndices(entries []grovecorev1alpha1.PodGangEntry,
 			return err
 		}
 		currentCount := countPCSGReplicaIndices(entries, pcsgConfigName)
-		desired := int(pcsg.Spec.Replicas)
-		diff := desired - currentCount
+		diff := int(pcsg.Spec.Replicas) - currentCount
 		switch {
 		case diff > 0:
 			if err := appendScaleOutReplicaIndices(entries, currentHash, pcsgConfigName, lo.RangeFrom[int32](int32(currentCount), diff)); err != nil {
@@ -449,12 +448,8 @@ func drainPriority(entry grovecorev1alpha1.PodGangEntry) int {
 // updates. Empty entries from older generations and empty tails are removed.
 func removeEmptyEntries(entries []grovecorev1alpha1.PodGangEntry, currentGenerationHash string) []grovecorev1alpha1.PodGangEntry {
 	return slices.DeleteFunc(entries, func(entry grovecorev1alpha1.PodGangEntry) bool {
-		if entry.Role == grovecorev1alpha1.PodGangEntryRoleScaleOut &&
-			entry.PodCliqueSetGenerationHash == currentGenerationHash {
-			return false
-		}
-		if entry.Role == grovecorev1alpha1.PodGangEntryRoleAnchor &&
-			entry.PodCliqueSetGenerationHash == currentGenerationHash {
+		if entry.PodCliqueSetGenerationHash == currentGenerationHash &&
+			(entry.Role == grovecorev1alpha1.PodGangEntryRoleAnchor || entry.Role == grovecorev1alpha1.PodGangEntryRoleScaleOut) {
 			return false
 		}
 		return componentutils.IsPodGangEntryEmpty(entry)

--- a/operator/internal/controller/podcliqueset/components/podgangmap/steadystate.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/steadystate.go
@@ -16,6 +16,7 @@ package podgangmap
 
 import (
 	"cmp"
+	"fmt"
 	"slices"
 	"sort"
 	"strconv"
@@ -92,19 +93,28 @@ func epochOrDefault(epochByRole map[grovecorev1alpha1.PodGangEntryRole]int64, ro
 	return defaultEpoch
 }
 
-// buildBootstrapAnchorEntry returns the anchor entry carrying every standalone PodClique's full
-// Replicas count and every PodCliqueScalingGroup's MinAvailable replicas (PCSG indices
-// [0, MinAvailable)). DependsOn is nil.
+// buildBootstrapAnchorEntry returns the anchor entry carrying every active standalone PodClique's
+// full Replicas count and every active PodCliqueScalingGroup's MinAvailable replicas (PCSG indices
+// [0, MinAvailable)). Idle components are omitted. DependsOn is nil.
 func buildBootstrapAnchorEntry(pcs *grovecorev1alpha1.PodCliqueSet, epoch string) grovecorev1alpha1.PodGangEntry {
 	entry := newPodGangEntry(epoch, *pcs.Status.CurrentGenerationHash, nil)
 	entry.Role = grovecorev1alpha1.PodGangEntryRoleAnchor
 	// A bootstrap PodGangMap has a single anchor, whose index is 0.
 	entry.AnchorIndex = ptr.To[int32](0)
-	entry.PodCliques = componentutils.GetStandalonePCLQReplicasFromPCSTemplateSpec(pcs)
+	entry.PodCliques = make(map[string]int32)
+	for name, replicas := range componentutils.GetStandalonePCLQReplicasFromPCSTemplateSpec(pcs) {
+		if replicas > 0 {
+			entry.PodCliques[name] = replicas
+		}
+	}
 
+	pcsgReplicas := componentutils.GetPCSGReplicasFromPCSTemplateSpec(pcs)
 	pcsgMinAvailable := componentutils.GetPCSGMinAvailableFromPCSTemplateSpec(pcs)
 	entry.PCSGReplicaIndices = make(map[string][]int32, len(pcsgMinAvailable))
 	for name, minAvailable := range pcsgMinAvailable {
+		if pcsgReplicas[name] == 0 {
+			continue
+		}
 		entry.PCSGReplicaIndices[name] = lo.RangeFrom[int32](0, int(minAvailable))
 	}
 	return entry
@@ -121,7 +131,7 @@ func buildBootstrapTailEntry(pcs *grovecorev1alpha1.PodCliqueSet, epoch, anchorE
 	for _, pcsgConfig := range pcs.Spec.Template.PodCliqueScalingGroupConfigs {
 		replicas := *pcsgConfig.Replicas
 		minAvailable := *pcsgConfig.MinAvailable
-		if replicas == minAvailable {
+		if replicas == 0 || replicas <= minAvailable {
 			continue
 		}
 		pcsgReplicaIndices[pcsgConfig.Name] = lo.RangeFrom(minAvailable, int(replicas-minAvailable))
@@ -170,7 +180,13 @@ func reconcileEntries(clk clock.Clock,
 		scaleOutEpoch string
 	)
 	if pgm == nil || len(pgm.Spec.Entries) == 0 {
-		entries, scaleOutEpoch = buildBootstrapEntries(clk, pcs, existingPodGangs)
+		reconstructionSource := existingPodGangs
+		if pgm != nil {
+			// An existing entry-less PodGangMap represents an intentional idle state. Wake it with
+			// fresh epochs rather than adopting a PodGang that may still be terminating.
+			reconstructionSource = nil
+		}
+		entries, scaleOutEpoch = buildBootstrapEntries(clk, pcs, reconstructionSource)
 	} else {
 		// Deep-copy the existing entries so mutations here do not alias the snapshot's PodGangMap.
 		entries = clonePodGangEntries(pgm.Spec.Entries)
@@ -179,30 +195,145 @@ func reconcileEntries(clk clock.Clock,
 		}
 	}
 
-	refreshStandalonePodCliqueCounts(entries, pcs, standalonePCLQs, pcsReplicaIndex)
-	entries = ensureScaleOutEntry(clk, entries, pcs, scaleOutEpoch)
-	if err := reconcilePCSGReplicaIndices(entries, pcs, pcsgs, pcsReplicaIndex); err != nil {
+	if scaleOutEpoch != "" {
+		entries = ensureScaleOutEntry(entries, pcs, scaleOutEpoch)
+	}
+	epochs, err := newEpochAllocator(entries, clk.Now().UnixNano())
+	if err != nil {
 		return nil, err
 	}
-	return removeEmptyEntries(entries, *pcs.Status.CurrentGenerationHash), nil
+	currentHash := *pcs.Status.CurrentGenerationHash
+	scaleOutCount := countScaleOutEntries(entries, currentHash)
+	if scaleOutCount > 1 {
+		return nil, fmt.Errorf("current generation %q has %d ScaleOut entries", currentHash, scaleOutCount)
+	}
+	if len(pcs.Spec.Template.PodCliqueScalingGroupConfigs) > 0 && scaleOutCount == 0 {
+		entries = ensureScaleOutEntry(entries, pcs, epochs.allocate())
+	}
+	wake := newWakePlacement(entries, currentHash, epochs)
+	entries = refreshStandalonePodCliqueCounts(entries, pcs, standalonePCLQs, pcsReplicaIndex, wake)
+	entries, err = reconcilePCSGReplicaIndices(entries, pcs, pcsgs, pcsReplicaIndex, wake)
+	if err != nil {
+		return nil, err
+	}
+	return removeEmptyEntries(entries, currentHash), nil
 }
 
-// refreshStandalonePodCliqueCounts updates the per-anchor pod counts of each standalone PodClique to
-// match its live Spec.Replicas. Every anchor of the current generation carries a count for every
-// standalone PodClique. This sums a PodClique's counts across those anchors and applies the
-// difference from Spec.Replicas. A scale-out adds to the highest-AnchorIndex anchor. A scale-in
-// drains the highest-AnchorIndex anchor first and moves to the next as each reaches zero. With one
-// anchor this sets that anchor's count to Spec.Replicas.
-func refreshStandalonePodCliqueCounts(entries []grovecorev1alpha1.PodGangEntry, pcs *grovecorev1alpha1.PodCliqueSet, standalonePCLQs []grovecorev1alpha1.PodClique, pcsReplicaIndex int) {
-	anchorsHighestFirst := currentGenerationAnchorsByIndexDesc(entries, *pcs.Status.CurrentGenerationHash)
-	if len(anchorsHighestFirst) == 0 {
-		return
+func countScaleOutEntries(entries []grovecorev1alpha1.PodGangEntry, currentHash string) int {
+	return lo.CountBy(entries, func(entry grovecorev1alpha1.PodGangEntry) bool {
+		return entry.Role == grovecorev1alpha1.PodGangEntryRoleScaleOut &&
+			entry.PodCliqueSetGenerationHash == currentHash
+	})
+}
+
+// wakePlacement coordinates wake operations in one reconcile. When the base anchor is empty, all
+// waking members may reuse it after its epoch is refreshed once.
+type wakePlacement struct {
+	currentHash        string
+	epochs             *epochAllocator
+	reuseBaseAnchor    bool
+	baseEpochRefreshed bool
+}
+
+func newWakePlacement(entries []grovecorev1alpha1.PodGangEntry, currentHash string, epochs *epochAllocator) *wakePlacement {
+	baseAnchor := findAnchorEntryByIndex(entries, currentHash, 0)
+	return &wakePlacement{
+		currentHash:     currentHash,
+		epochs:          epochs,
+		reuseBaseAnchor: baseAnchor != nil && componentutils.IsPodGangEntryEmpty(*baseAnchor),
 	}
+}
+
+func (w *wakePlacement) reusableBaseAnchor(entries []grovecorev1alpha1.PodGangEntry) (*grovecorev1alpha1.PodGangEntry, bool) {
+	if !w.reuseBaseAnchor {
+		return nil, false
+	}
+	baseAnchor := findAnchorEntryByIndex(entries, w.currentHash, 0)
+	if baseAnchor == nil {
+		return nil, false
+	}
+	if !w.baseEpochRefreshed {
+		oldEpoch := baseAnchor.Epoch
+		baseAnchor.Epoch = w.epochs.allocate()
+		rewriteDependsOnEpoch(entries, w.currentHash, oldEpoch, baseAnchor.Epoch)
+		w.baseEpochRefreshed = true
+	}
+	return baseAnchor, true
+}
+
+func rewriteDependsOnEpoch(entries []grovecorev1alpha1.PodGangEntry, currentHash, oldEpoch, newEpoch string) {
+	for i := range entries {
+		if entries[i].PodCliqueSetGenerationHash != currentHash {
+			continue
+		}
+		for j := range entries[i].DependsOn {
+			if entries[i].DependsOn[j] == oldEpoch {
+				entries[i].DependsOn[j] = newEpoch
+			}
+		}
+	}
+}
+
+// refreshStandalonePodCliqueCounts reconciles live standalone PodClique counts across current-
+// generation anchors. Scaling to zero removes membership. Waking from zero uses a fresh anchor
+// instead of expanding an already-scheduled PodGang.
+func refreshStandalonePodCliqueCounts(entries []grovecorev1alpha1.PodGangEntry,
+	pcs *grovecorev1alpha1.PodCliqueSet,
+	standalonePCLQs []grovecorev1alpha1.PodClique,
+	pcsReplicaIndex int,
+	wake *wakePlacement) []grovecorev1alpha1.PodGangEntry {
+	currentHash := *pcs.Status.CurrentGenerationHash
 	pcsRnr := apicommon.ResourceNameReplica{Name: pcs.Name, Replica: pcsReplicaIndex}
+	wokenCliques := make(map[string]int32)
 	for _, standalonePCLQ := range standalonePCLQs {
 		cliqueName := apicommon.ExtractPodCliqueNameFromStandalonePCLQFQN(standalonePCLQ.Name, pcsRnr)
-		reconcileStandaloneCliqueCountAcrossAnchors(anchorsHighestFirst, cliqueName, standalonePCLQ.Spec.Replicas)
+		anchorsHighestFirst := currentGenerationAnchorsByIndexDesc(entries, currentHash)
+		var currentTotal int32
+		for _, anchor := range anchorsHighestFirst {
+			currentTotal += anchor.PodCliques[cliqueName]
+		}
+		switch {
+		case standalonePCLQ.Spec.Replicas == 0:
+			for _, anchor := range anchorsHighestFirst {
+				delete(anchor.PodCliques, cliqueName)
+			}
+		case currentTotal == 0:
+			for _, anchor := range anchorsHighestFirst {
+				delete(anchor.PodCliques, cliqueName)
+			}
+			wokenCliques[cliqueName] = standalonePCLQ.Spec.Replicas
+		default:
+			reconcileStandaloneCliqueCountAcrossAnchors(anchorsHighestFirst, cliqueName, standalonePCLQ.Spec.Replicas)
+		}
 	}
+	if len(wokenCliques) > 0 {
+		entries = placeWokenStandaloneCliques(entries, currentHash, wokenCliques, wake)
+	}
+	return entries
+}
+
+func placeWokenStandaloneCliques(entries []grovecorev1alpha1.PodGangEntry, currentHash string, wokenCliques map[string]int32, wake *wakePlacement) []grovecorev1alpha1.PodGangEntry {
+	if baseAnchor, ok := wake.reusableBaseAnchor(entries); ok {
+		if baseAnchor.PodCliques == nil {
+			baseAnchor.PodCliques = make(map[string]int32, len(wokenCliques))
+		}
+		for name, replicas := range wokenCliques {
+			baseAnchor.PodCliques[name] = replicas
+		}
+		return entries
+	}
+	var dependsOn []string
+	if baseAnchor := findAnchorEntryByIndex(entries, currentHash, 0); baseAnchor != nil {
+		dependsOn = []string{baseAnchor.Epoch}
+	}
+	newAnchor := newPodGangEntry(wake.epochs.allocate(), currentHash, dependsOn)
+	newAnchor.Role = grovecorev1alpha1.PodGangEntryRoleAnchor
+	newAnchor.AnchorIndex = ptr.To(nextAnchorIndex(entries, currentHash))
+	newAnchor.PodCliques = make(map[string]int32, len(wokenCliques))
+	for name, replicas := range wokenCliques {
+		newAnchor.PodCliques[name] = replicas
+	}
+	return append(entries, newAnchor)
 }
 
 // reconcileStandaloneCliqueCountAcrossAnchors drives the clique's total pod count across the anchors
@@ -248,24 +379,73 @@ func currentGenerationAnchorsByIndexDesc(entries []grovecorev1alpha1.PodGangEntr
 }
 
 // reconcilePCSGReplicaIndices diffs each PodCliqueScalingGroup's replica-index count across all
-// entries against its live Spec.Replicas and appends (scale-out) or drains (scale-in) accordingly.
-func reconcilePCSGReplicaIndices(entries []grovecorev1alpha1.PodGangEntry, pcs *grovecorev1alpha1.PodCliqueSet, pcsgs []grovecorev1alpha1.PodCliqueScalingGroup, pcsReplicaIndex int) error {
+// entries against its live Spec.Replicas and appends, drains, or wakes from idle accordingly.
+func reconcilePCSGReplicaIndices(entries []grovecorev1alpha1.PodGangEntry,
+	pcs *grovecorev1alpha1.PodCliqueSet,
+	pcsgs []grovecorev1alpha1.PodCliqueScalingGroup,
+	pcsReplicaIndex int,
+	wake *wakePlacement) ([]grovecorev1alpha1.PodGangEntry, error) {
 	rnr := apicommon.ResourceNameReplica{Name: pcs.Name, Replica: pcsReplicaIndex}
+	currentHash := *pcs.Status.CurrentGenerationHash
 	for _, pcsg := range pcsgs {
 		pcsgConfigName, err := apicommon.ExtractScalingGroupNameFromPCSGFQN(pcsg.Name, rnr)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		currentCount := countPCSGReplicaIndices(entries, pcsgConfigName)
-		diff := int(pcsg.Spec.Replicas) - currentCount
+		desired := int(pcsg.Spec.Replicas)
+		diff := desired - currentCount
 		switch {
+		case currentCount == 0 && desired > 0:
+			if pcsg.Spec.MinAvailable == nil {
+				return nil, fmt.Errorf("PodCliqueScalingGroup %s has nil spec.minAvailable", pcsg.Name)
+			}
+			minAvailable := int(*pcsg.Spec.MinAvailable)
+			if minAvailable > desired {
+				return nil, fmt.Errorf("PodCliqueScalingGroup %s has minAvailable %d greater than replicas %d", pcsg.Name, minAvailable, desired)
+			}
+			entries, err = wakePCSGReplicaIndices(entries, currentHash, pcsgConfigName, desired, minAvailable, wake)
+			if err != nil {
+				return nil, err
+			}
 		case diff > 0:
-			appendScaleOutReplicaIndices(entries, pcsgConfigName, lo.RangeFrom[int32](int32(currentCount), diff))
+			if err := appendScaleOutReplicaIndices(entries, currentHash, pcsgConfigName, lo.RangeFrom[int32](int32(currentCount), diff)); err != nil {
+				return nil, err
+			}
 		case diff < 0:
 			drainReplicaIndicesForScaleIn(entries, pcsgConfigName, -diff)
 		}
 	}
-	return nil
+	return entries, nil
+}
+
+func wakePCSGReplicaIndices(entries []grovecorev1alpha1.PodGangEntry,
+	currentHash, pcsgConfigName string,
+	replicas, minAvailable int,
+	wake *wakePlacement) ([]grovecorev1alpha1.PodGangEntry, error) {
+	anchorIndices := lo.RangeFrom[int32](0, minAvailable)
+	if baseAnchor, ok := wake.reusableBaseAnchor(entries); ok {
+		if baseAnchor.PCSGReplicaIndices == nil {
+			baseAnchor.PCSGReplicaIndices = make(map[string][]int32)
+		}
+		baseAnchor.PCSGReplicaIndices[pcsgConfigName] = anchorIndices
+	} else {
+		var dependsOn []string
+		if baseAnchor := findAnchorEntryByIndex(entries, currentHash, 0); baseAnchor != nil {
+			dependsOn = []string{baseAnchor.Epoch}
+		}
+		newAnchor := newPodGangEntry(wake.epochs.allocate(), currentHash, dependsOn)
+		newAnchor.Role = grovecorev1alpha1.PodGangEntryRoleAnchor
+		newAnchor.AnchorIndex = ptr.To(nextAnchorIndex(entries, currentHash))
+		newAnchor.PCSGReplicaIndices = map[string][]int32{pcsgConfigName: anchorIndices}
+		entries = append(entries, newAnchor)
+	}
+	if replicas > minAvailable {
+		if err := appendScaleOutReplicaIndices(entries, currentHash, pcsgConfigName, lo.RangeFrom[int32](int32(minAvailable), replicas-minAvailable)); err != nil {
+			return nil, err
+		}
+	}
+	return entries, nil
 }
 
 // countPCSGReplicaIndices returns the total number of the given PodCliqueScalingGroup's replica
@@ -281,23 +461,24 @@ func countPCSGReplicaIndices(entries []grovecorev1alpha1.PodGangEntry, pcsgConfi
 // appendScaleOutReplicaIndices appends the given PodCliqueScalingGroup replica indices to the
 // ScaleOut entry. The ScaleOut entry is pre-created by ensureScaleOutEntry, so it is expected to
 // exist here.
-func appendScaleOutReplicaIndices(entries []grovecorev1alpha1.PodGangEntry, pcsgConfigName string, indices []int32) {
+func appendScaleOutReplicaIndices(entries []grovecorev1alpha1.PodGangEntry, currentHash, pcsgConfigName string, indices []int32) error {
 	for i := range entries {
-		if entries[i].Role == grovecorev1alpha1.PodGangEntryRoleScaleOut {
+		if entries[i].Role == grovecorev1alpha1.PodGangEntryRoleScaleOut &&
+			entries[i].PodCliqueSetGenerationHash == currentHash {
 			if entries[i].PCSGReplicaIndices == nil {
 				entries[i].PCSGReplicaIndices = make(map[string][]int32)
 			}
 			entries[i].PCSGReplicaIndices[pcsgConfigName] = append(entries[i].PCSGReplicaIndices[pcsgConfigName], indices...)
 			slices.Sort(entries[i].PCSGReplicaIndices[pcsgConfigName])
-			return
+			return nil
 		}
 	}
+	return fmt.Errorf("current generation %q has no ScaleOut entry", currentHash)
 }
 
 // drainReplicaIndicesForScaleIn removes count of the given PodCliqueScalingGroup's replica indices,
 // draining in role order ScaleOut, then Tail, then Anchor (highest AnchorIndex first, AnchorIndex 0
-// last), and the highest index first within a chosen entry. The webhook guarantees Spec.Replicas
-// stays at or above MinAvailable, so the anchor's MinAvailable indices are never drained.
+// last), and the highest index first within a chosen entry. Scale-to-zero may drain the base anchor.
 func drainReplicaIndicesForScaleIn(entries []grovecorev1alpha1.PodGangEntry, pcsgConfigName string, count int) {
 	order := make([]int, 0, len(entries))
 	for i := range entries {
@@ -323,7 +504,12 @@ func drainReplicaIndicesForScaleIn(entries []grovecorev1alpha1.PodGangEntry, pcs
 		s := entries[idx].PCSGReplicaIndices[pcsgConfigName]
 		slices.Sort(s)
 		take := min(remaining, len(s))
-		entries[idx].PCSGReplicaIndices[pcsgConfigName] = s[:len(s)-take]
+		remainingIndices := s[:len(s)-take]
+		if len(remainingIndices) == 0 {
+			delete(entries[idx].PCSGReplicaIndices, pcsgConfigName)
+		} else {
+			entries[idx].PCSGReplicaIndices[pcsgConfigName] = remainingIndices
+		}
 		remaining -= take
 	}
 }
@@ -341,39 +527,29 @@ func drainPriority(entry grovecorev1alpha1.PodGangEntry) int {
 	}
 }
 
-// removeEmptyEntries drops entries that carry no pods and no replica indices. A ScaleOut entry of the
-// current generation is kept even when empty, but only while a current-generation anchor entry
-// survives. A ScaleOut entry depends on its generation's anchor, so once the last current-generation
-// anchor drains to empty it is removed and its ScaleOut entry is removed with it. A ScaleOut entry of
-// an older generation is never kept when empty.
+// removeEmptyEntries drops entries that carry no pods and no replica indices. The current
+// generation's ScaleOut entry and base anchor are retained as stable slots for later scale-out and
+// wake operations. Empty entries from older generations and non-base anchors are removed.
 func removeEmptyEntries(entries []grovecorev1alpha1.PodGangEntry, currentGenerationHash string) []grovecorev1alpha1.PodGangEntry {
-	keepCurrentGenerationScaleOut := hasNonEmptyCurrentGenerationAnchor(entries, currentGenerationHash)
 	return slices.DeleteFunc(entries, func(entry grovecorev1alpha1.PodGangEntry) bool {
-		if keepCurrentGenerationScaleOut &&
-			entry.Role == grovecorev1alpha1.PodGangEntryRoleScaleOut &&
+		if entry.Role == grovecorev1alpha1.PodGangEntryRoleScaleOut &&
 			entry.PodCliqueSetGenerationHash == currentGenerationHash {
 			return false
 		}
-		return isPodGangEntryEmpty(entry)
-	})
-}
-
-// hasNonEmptyCurrentGenerationAnchor reports whether entries contains a current-generation anchor
-// entry that carries at least one pod or replica index, meaning it will survive empty-entry removal.
-func hasNonEmptyCurrentGenerationAnchor(entries []grovecorev1alpha1.PodGangEntry, currentGenerationHash string) bool {
-	return slices.ContainsFunc(entries, func(entry grovecorev1alpha1.PodGangEntry) bool {
-		return entry.Role == grovecorev1alpha1.PodGangEntryRoleAnchor &&
+		if entry.Role == grovecorev1alpha1.PodGangEntryRoleAnchor &&
 			entry.PodCliqueSetGenerationHash == currentGenerationHash &&
-			!isPodGangEntryEmpty(entry)
+			entry.AnchorIndex != nil && *entry.AnchorIndex == 0 {
+			return false
+		}
+		return componentutils.IsPodGangEntryEmpty(entry)
 	})
 }
 
 // ensureScaleOutEntry appends an empty ScaleOut entry to entries when the PodCliqueSet has any
 // PodCliqueScalingGroup and no current-generation ScaleOut entry is present. The entry depends on the
-// AnchorIndex 0 anchor of the current generation, which is always present in entries when this is
-// called. It uses scaleOutEpoch when set, and a freshly minted epoch otherwise. When a current-generation
-// ScaleOut entry already exists, entries are returned unchanged.
-func ensureScaleOutEntry(clk clock.Clock, entries []grovecorev1alpha1.PodGangEntry, pcs *grovecorev1alpha1.PodCliqueSet, scaleOutEpoch string) []grovecorev1alpha1.PodGangEntry {
+// AnchorIndex 0 anchor of the current generation. When a current-generation ScaleOut entry already
+// exists, entries are returned unchanged.
+func ensureScaleOutEntry(entries []grovecorev1alpha1.PodGangEntry, pcs *grovecorev1alpha1.PodCliqueSet, scaleOutEpoch string) []grovecorev1alpha1.PodGangEntry {
 	if len(pcs.Spec.Template.PodCliqueScalingGroupConfigs) == 0 {
 		return entries
 	}
@@ -386,9 +562,6 @@ func ensureScaleOutEntry(clk clock.Clock, entries []grovecorev1alpha1.PodGangEnt
 		if entry.Role == grovecorev1alpha1.PodGangEntryRoleAnchor && entry.PodCliqueSetGenerationHash == currentHash && entry.AnchorIndex != nil && *entry.AnchorIndex == 0 {
 			anchorEpoch = entry.Epoch
 		}
-	}
-	if scaleOutEpoch == "" {
-		scaleOutEpoch = strconv.FormatInt(clk.Now().UnixNano(), 10)
 	}
 	scaleOut := newPodGangEntry(scaleOutEpoch, currentHash, []string{anchorEpoch})
 	scaleOut.Role = grovecorev1alpha1.PodGangEntryRoleScaleOut

--- a/operator/internal/controller/podcliqueset/components/podgangmap/steadystate.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/steadystate.go
@@ -210,12 +210,18 @@ func reconcileEntries(clk clock.Clock,
 	if len(pcs.Spec.Template.PodCliqueScalingGroupConfigs) > 0 && scaleOutCount == 0 {
 		entries = ensureScaleOutEntry(entries, pcs, epochs.allocate())
 	}
-	wake := newWakePlacement(entries, currentHash, epochs)
-	entries = refreshStandalonePodCliqueCounts(entries, pcs, standalonePCLQs, pcsReplicaIndex, wake)
-	entries, err = reconcilePCSGReplicaIndices(entries, pcs, pcsgs, pcsReplicaIndex, wake)
+	if err = refreshStandalonePodCliqueCounts(entries, pcs, standalonePCLQs, pcsReplicaIndex); err != nil {
+		return nil, err
+	}
+	err = reconcilePCSGReplicaIndices(entries, pcs, pcsgs, pcsReplicaIndex)
 	if err != nil {
 		return nil, err
 	}
+	var previous []grovecorev1alpha1.PodGangEntry
+	if pgm != nil {
+		previous = pgm.Spec.Entries
+	}
+	reconcileScaleOutEntryIdentity(entries, previous, currentHash, epochs)
 	return removeEmptyEntries(entries, currentHash), nil
 }
 
@@ -226,114 +232,30 @@ func countScaleOutEntries(entries []grovecorev1alpha1.PodGangEntry, currentHash 
 	})
 }
 
-// wakePlacement coordinates wake operations in one reconcile. When the base anchor is empty, all
-// waking members may reuse it after its epoch is refreshed once.
-type wakePlacement struct {
-	currentHash        string
-	epochs             *epochAllocator
-	reuseBaseAnchor    bool
-	baseEpochRefreshed bool
-}
-
-func newWakePlacement(entries []grovecorev1alpha1.PodGangEntry, currentHash string, epochs *epochAllocator) *wakePlacement {
-	baseAnchor := findAnchorEntryByIndex(entries, currentHash, 0)
-	return &wakePlacement{
-		currentHash:     currentHash,
-		epochs:          epochs,
-		reuseBaseAnchor: baseAnchor != nil && componentutils.IsPodGangEntryEmpty(*baseAnchor),
-	}
-}
-
-func (w *wakePlacement) reusableBaseAnchor(entries []grovecorev1alpha1.PodGangEntry) (*grovecorev1alpha1.PodGangEntry, bool) {
-	if !w.reuseBaseAnchor {
-		return nil, false
-	}
-	baseAnchor := findAnchorEntryByIndex(entries, w.currentHash, 0)
-	if baseAnchor == nil {
-		return nil, false
-	}
-	if !w.baseEpochRefreshed {
-		oldEpoch := baseAnchor.Epoch
-		baseAnchor.Epoch = w.epochs.allocate()
-		rewriteDependsOnEpoch(entries, w.currentHash, oldEpoch, baseAnchor.Epoch)
-		w.baseEpochRefreshed = true
-	}
-	return baseAnchor, true
-}
-
-func rewriteDependsOnEpoch(entries []grovecorev1alpha1.PodGangEntry, currentHash, oldEpoch, newEpoch string) {
-	for i := range entries {
-		if entries[i].PodCliqueSetGenerationHash != currentHash {
-			continue
-		}
-		for j := range entries[i].DependsOn {
-			if entries[i].DependsOn[j] == oldEpoch {
-				entries[i].DependsOn[j] = newEpoch
-			}
-		}
-	}
-}
-
 // refreshStandalonePodCliqueCounts reconciles live standalone PodClique counts across current-
-// generation anchors. Scaling to zero removes membership. Waking from zero uses a fresh anchor
-// instead of expanding an already-scheduled PodGang.
+// generation anchors. Waking restores membership to the highest-index anchor without changing its
+// identity or the scheduling history used by dependent scaled PodGangs.
 func refreshStandalonePodCliqueCounts(entries []grovecorev1alpha1.PodGangEntry,
 	pcs *grovecorev1alpha1.PodCliqueSet,
 	standalonePCLQs []grovecorev1alpha1.PodClique,
-	pcsReplicaIndex int,
-	wake *wakePlacement) []grovecorev1alpha1.PodGangEntry {
+	pcsReplicaIndex int) error {
 	currentHash := *pcs.Status.CurrentGenerationHash
 	pcsRnr := apicommon.ResourceNameReplica{Name: pcs.Name, Replica: pcsReplicaIndex}
-	wokenCliques := make(map[string]int32)
+	anchorsHighestFirst := currentGenerationAnchorsByIndexDesc(entries, currentHash)
 	for _, standalonePCLQ := range standalonePCLQs {
 		cliqueName := apicommon.ExtractPodCliqueNameFromStandalonePCLQFQN(standalonePCLQ.Name, pcsRnr)
-		anchorsHighestFirst := currentGenerationAnchorsByIndexDesc(entries, currentHash)
-		var currentTotal int32
-		for _, anchor := range anchorsHighestFirst {
-			currentTotal += anchor.PodCliques[cliqueName]
-		}
-		switch {
-		case standalonePCLQ.Spec.Replicas == 0:
+		if standalonePCLQ.Spec.Replicas == 0 {
 			for _, anchor := range anchorsHighestFirst {
 				delete(anchor.PodCliques, cliqueName)
 			}
-		case currentTotal == 0:
-			for _, anchor := range anchorsHighestFirst {
-				delete(anchor.PodCliques, cliqueName)
-			}
-			wokenCliques[cliqueName] = standalonePCLQ.Spec.Replicas
-		default:
-			reconcileStandaloneCliqueCountAcrossAnchors(anchorsHighestFirst, cliqueName, standalonePCLQ.Spec.Replicas)
+			continue
 		}
-	}
-	if len(wokenCliques) > 0 {
-		entries = placeWokenStandaloneCliques(entries, currentHash, wokenCliques, wake)
-	}
-	return entries
-}
-
-func placeWokenStandaloneCliques(entries []grovecorev1alpha1.PodGangEntry, currentHash string, wokenCliques map[string]int32, wake *wakePlacement) []grovecorev1alpha1.PodGangEntry {
-	if baseAnchor, ok := wake.reusableBaseAnchor(entries); ok {
-		if baseAnchor.PodCliques == nil {
-			baseAnchor.PodCliques = make(map[string]int32, len(wokenCliques))
+		if len(anchorsHighestFirst) == 0 {
+			return fmt.Errorf("current generation %q has no anchor for standalone PodClique %s", currentHash, standalonePCLQ.Name)
 		}
-		for name, replicas := range wokenCliques {
-			baseAnchor.PodCliques[name] = replicas
-		}
-		return entries
+		reconcileStandaloneCliqueCountAcrossAnchors(anchorsHighestFirst, cliqueName, standalonePCLQ.Spec.Replicas)
 	}
-	var dependsOn []string
-	if baseAnchor := findAnchorEntryByIndex(entries, currentHash, 0); baseAnchor != nil {
-		dependsOn = []string{baseAnchor.Epoch}
-	}
-	newAnchor := newPodGangEntry(wake.epochs.allocate(), currentHash, dependsOn)
-	newAnchor.Role = grovecorev1alpha1.PodGangEntryRoleAnchor
-	newAnchor.AnchorIndex = ptr.To(nextAnchorIndex(entries, currentHash))
-	newAnchor.PodCliques = make(map[string]int32, len(wokenCliques))
-	for name, replicas := range wokenCliques {
-		newAnchor.PodCliques[name] = replicas
-	}
-	return append(entries, newAnchor)
+	return nil
 }
 
 // reconcileStandaloneCliqueCountAcrossAnchors drives the clique's total pod count across the anchors
@@ -348,6 +270,9 @@ func reconcileStandaloneCliqueCountAcrossAnchors(anchorsHighestFirst []*grovecor
 	diff := desiredTotal - currentTotal
 	switch {
 	case diff > 0:
+		if anchorsHighestFirst[0].PodCliques == nil {
+			anchorsHighestFirst[0].PodCliques = make(map[string]int32)
+		}
 		anchorsHighestFirst[0].PodCliques[cliqueName] += diff
 	case diff < 0:
 		remaining := -diff
@@ -379,73 +304,65 @@ func currentGenerationAnchorsByIndexDesc(entries []grovecorev1alpha1.PodGangEntr
 }
 
 // reconcilePCSGReplicaIndices diffs each PodCliqueScalingGroup's replica-index count across all
-// entries against its live Spec.Replicas and appends, drains, or wakes from idle accordingly.
+// entries against its live Spec.Replicas. Wake is ordinary scale-out: each replica gets its own
+// scaled PodGang, including replicas below the PCSG's MinAvailable index.
 func reconcilePCSGReplicaIndices(entries []grovecorev1alpha1.PodGangEntry,
 	pcs *grovecorev1alpha1.PodCliqueSet,
 	pcsgs []grovecorev1alpha1.PodCliqueScalingGroup,
-	pcsReplicaIndex int,
-	wake *wakePlacement) ([]grovecorev1alpha1.PodGangEntry, error) {
+	pcsReplicaIndex int) error {
 	rnr := apicommon.ResourceNameReplica{Name: pcs.Name, Replica: pcsReplicaIndex}
 	currentHash := *pcs.Status.CurrentGenerationHash
 	for _, pcsg := range pcsgs {
 		pcsgConfigName, err := apicommon.ExtractScalingGroupNameFromPCSGFQN(pcsg.Name, rnr)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		currentCount := countPCSGReplicaIndices(entries, pcsgConfigName)
 		desired := int(pcsg.Spec.Replicas)
 		diff := desired - currentCount
 		switch {
-		case currentCount == 0 && desired > 0:
-			if pcsg.Spec.MinAvailable == nil {
-				return nil, fmt.Errorf("PodCliqueScalingGroup %s has nil spec.minAvailable", pcsg.Name)
-			}
-			minAvailable := int(*pcsg.Spec.MinAvailable)
-			if minAvailable > desired {
-				return nil, fmt.Errorf("PodCliqueScalingGroup %s has minAvailable %d greater than replicas %d", pcsg.Name, minAvailable, desired)
-			}
-			entries, err = wakePCSGReplicaIndices(entries, currentHash, pcsgConfigName, desired, minAvailable, wake)
-			if err != nil {
-				return nil, err
-			}
 		case diff > 0:
 			if err := appendScaleOutReplicaIndices(entries, currentHash, pcsgConfigName, lo.RangeFrom[int32](int32(currentCount), diff)); err != nil {
-				return nil, err
+				return err
 			}
 		case diff < 0:
 			drainReplicaIndicesForScaleIn(entries, pcsgConfigName, -diff)
 		}
 	}
-	return entries, nil
+	return nil
 }
 
-func wakePCSGReplicaIndices(entries []grovecorev1alpha1.PodGangEntry,
-	currentHash, pcsgConfigName string,
-	replicas, minAvailable int,
-	wake *wakePlacement) ([]grovecorev1alpha1.PodGangEntry, error) {
-	anchorIndices := lo.RangeFrom[int32](0, minAvailable)
-	if baseAnchor, ok := wake.reusableBaseAnchor(entries); ok {
-		if baseAnchor.PCSGReplicaIndices == nil {
-			baseAnchor.PCSGReplicaIndices = make(map[string][]int32)
+// reconcileScaleOutEntryIdentity gives an idle slot a fresh scheduling identity. Bootstrap and
+// reconstruction retain their allocated/adopted epochs, and active entries keep their dependencies.
+func reconcileScaleOutEntryIdentity(entries, previous []grovecorev1alpha1.PodGangEntry, currentHash string, epochs *epochAllocator) {
+	for i := range entries {
+		entry := &entries[i]
+		if entry.Role != grovecorev1alpha1.PodGangEntryRoleScaleOut ||
+			entry.PodCliqueSetGenerationHash != currentHash || componentutils.IsPodGangEntryEmpty(*entry) {
+			continue
 		}
-		baseAnchor.PCSGReplicaIndices[pcsgConfigName] = anchorIndices
-	} else {
-		var dependsOn []string
-		if baseAnchor := findAnchorEntryByIndex(entries, currentHash, 0); baseAnchor != nil {
-			dependsOn = []string{baseAnchor.Epoch}
+		for _, old := range previous {
+			if old.Role != entry.Role || old.Epoch != entry.Epoch {
+				continue
+			}
+			if !componentutils.IsPodGangEntryEmpty(old) {
+				return
+			}
+			entry.Epoch = epochs.allocate()
+			break
 		}
-		newAnchor := newPodGangEntry(wake.epochs.allocate(), currentHash, dependsOn)
-		newAnchor.Role = grovecorev1alpha1.PodGangEntryRoleAnchor
-		newAnchor.AnchorIndex = ptr.To(nextAnchorIndex(entries, currentHash))
-		newAnchor.PCSGReplicaIndices = map[string][]int32{pcsgConfigName: anchorIndices}
-		entries = append(entries, newAnchor)
+		entry.DependsOn = materializedAnchorDependency(entries, currentHash)
+		return
 	}
-	if replicas > minAvailable {
-		if err := appendScaleOutReplicaIndices(entries, currentHash, pcsgConfigName, lo.RangeFrom[int32](int32(minAvailable), replicas-minAvailable)); err != nil {
-			return nil, err
+}
+
+func materializedAnchorDependency(entries []grovecorev1alpha1.PodGangEntry, currentHash string) []string {
+	for _, anchor := range currentGenerationAnchorsByIndexDesc(entries, currentHash) {
+		if !componentutils.IsPodGangEntryEmpty(*anchor) {
+			return []string{anchor.Epoch}
 		}
 	}
-	return entries, nil
+	return nil
 }
 
 // countPCSGReplicaIndices returns the total number of the given PodCliqueScalingGroup's replica
@@ -528,8 +445,8 @@ func drainPriority(entry grovecorev1alpha1.PodGangEntry) int {
 }
 
 // removeEmptyEntries drops entries that carry no pods and no replica indices. The current
-// generation's ScaleOut entry and base anchor are retained as stable slots for later scale-out and
-// wake operations. Empty entries from older generations and non-base anchors are removed.
+// generation's ScaleOut entry and anchors are retained as stable slots, including after coherent
+// updates. Empty entries from older generations and empty tails are removed.
 func removeEmptyEntries(entries []grovecorev1alpha1.PodGangEntry, currentGenerationHash string) []grovecorev1alpha1.PodGangEntry {
 	return slices.DeleteFunc(entries, func(entry grovecorev1alpha1.PodGangEntry) bool {
 		if entry.Role == grovecorev1alpha1.PodGangEntryRoleScaleOut &&
@@ -537,8 +454,7 @@ func removeEmptyEntries(entries []grovecorev1alpha1.PodGangEntry, currentGenerat
 			return false
 		}
 		if entry.Role == grovecorev1alpha1.PodGangEntryRoleAnchor &&
-			entry.PodCliqueSetGenerationHash == currentGenerationHash &&
-			entry.AnchorIndex != nil && *entry.AnchorIndex == 0 {
+			entry.PodCliqueSetGenerationHash == currentGenerationHash {
 			return false
 		}
 		return componentutils.IsPodGangEntryEmpty(entry)
@@ -547,23 +463,19 @@ func removeEmptyEntries(entries []grovecorev1alpha1.PodGangEntry, currentGenerat
 
 // ensureScaleOutEntry appends an empty ScaleOut entry to entries when the PodCliqueSet has any
 // PodCliqueScalingGroup and no current-generation ScaleOut entry is present. The entry depends on the
-// AnchorIndex 0 anchor of the current generation. When a current-generation ScaleOut entry already
-// exists, entries are returned unchanged.
+// highest materialized anchor of the current generation, if any. When a current-generation ScaleOut
+// entry already exists, entries are returned unchanged.
 func ensureScaleOutEntry(entries []grovecorev1alpha1.PodGangEntry, pcs *grovecorev1alpha1.PodCliqueSet, scaleOutEpoch string) []grovecorev1alpha1.PodGangEntry {
 	if len(pcs.Spec.Template.PodCliqueScalingGroupConfigs) == 0 {
 		return entries
 	}
 	currentHash := *pcs.Status.CurrentGenerationHash
-	var anchorEpoch string
 	for _, entry := range entries {
 		if entry.Role == grovecorev1alpha1.PodGangEntryRoleScaleOut && entry.PodCliqueSetGenerationHash == currentHash {
 			return entries
 		}
-		if entry.Role == grovecorev1alpha1.PodGangEntryRoleAnchor && entry.PodCliqueSetGenerationHash == currentHash && entry.AnchorIndex != nil && *entry.AnchorIndex == 0 {
-			anchorEpoch = entry.Epoch
-		}
 	}
-	scaleOut := newPodGangEntry(scaleOutEpoch, currentHash, []string{anchorEpoch})
+	scaleOut := newPodGangEntry(scaleOutEpoch, currentHash, materializedAnchorDependency(entries, currentHash))
 	scaleOut.Role = grovecorev1alpha1.PodGangEntryRoleScaleOut
 	return append(entries, scaleOut)
 }

--- a/operator/internal/controller/podcliqueset/components/podgangmap/steadystate_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/steadystate_test.go
@@ -431,9 +431,8 @@ func TestReconcileStandaloneCliqueCountAcrossAnchors(t *testing.T) {
 	}
 }
 
-// TestRemoveEmptyEntries verifies removeEmptyEntries keeps a current-generation empty ScaleOut entry
-// only while a current-generation anchor survives, drops the ScaleOut once its anchor drains to empty
-// and is removed, and never keeps an empty ScaleOut of an older generation.
+// TestRemoveEmptyEntries verifies the current-generation base anchor and ScaleOut entry remain as
+// stable wake slots while other empty entries are removed.
 func TestRemoveEmptyEntries(t *testing.T) {
 	olderGenerationScaleOut := testutils.NewPodGangEntryBuilder("hash0", "099").
 		WithRole(grovecorev1alpha1.PodGangEntryRoleScaleOut).
@@ -456,12 +455,15 @@ func TestRemoveEmptyEntries(t *testing.T) {
 			},
 		},
 		{
-			name: "empty anchor is removed and its empty ScaleOut is removed with it",
+			name: "empty base anchor and ScaleOut are retained for wake",
 			entries: []grovecorev1alpha1.PodGangEntry{
 				anchorEntry(nil, map[string][]int32{testPCSGName: {}}),
 				scaleOutEntry(nil),
 			},
-			wantRoles: []grovecorev1alpha1.PodGangEntryRole{},
+			wantRoles: []grovecorev1alpha1.PodGangEntryRole{
+				grovecorev1alpha1.PodGangEntryRoleAnchor,
+				grovecorev1alpha1.PodGangEntryRoleScaleOut,
+			},
 		},
 		{
 			name: "empty tail is removed while a non-empty anchor and its ScaleOut remain",

--- a/operator/internal/controller/podcliqueset/reconcilestatus.go
+++ b/operator/internal/controller/podcliqueset/reconcilestatus.go
@@ -252,6 +252,11 @@ func (r *Reconciler) computePCLQsStatus(pcs *grovecorev1alpha1.PodCliqueSet, exp
 
 	isAvailable = len(nonTerminatedPCLQs) == expectedStandalonePCLQs &&
 		lo.EveryBy(nonTerminatedPCLQs, func(pclq grovecorev1alpha1.PodClique) bool {
+			// GREP-0677: an idle standalone PodClique (replicas: 0) contributes no required pods, so
+			// it never holds the parent replica back from Available.
+			if pclq.Spec.Replicas == 0 {
+				return true
+			}
 			return pclq.Status.ReadyReplicas >= *pclq.Spec.MinAvailable
 		})
 
@@ -271,11 +276,18 @@ func isStandalonePCLQUpdated(pcs *grovecorev1alpha1.PodCliqueSet, pclq *grovecor
 	if err != nil || expectedPodTemplateHash == "" {
 		return false
 	}
-	return pclq.Labels[apicommon.LabelPodTemplateHash] == expectedPodTemplateHash &&
+	hashesConverged := pclq.Labels[apicommon.LabelPodTemplateHash] == expectedPodTemplateHash &&
 		pclq.Status.CurrentPodTemplateHash != nil &&
 		*pclq.Status.CurrentPodTemplateHash == expectedPodTemplateHash &&
 		pclq.Status.CurrentPodCliqueSetGenerationHash != nil &&
-		*pclq.Status.CurrentPodCliqueSetGenerationHash == *pcs.Status.CurrentGenerationHash &&
+		*pclq.Status.CurrentPodCliqueSetGenerationHash == *pcs.Status.CurrentGenerationHash
+	// GREP-0677: an idle standalone PodClique (replicas: 0) has no pods to roll, so it counts as
+	// updated once its generation and pod-template hashes converge — it never reaches
+	// ReadyReplicas/UpdatedReplicas >= MinAvailable because there are no pods.
+	if pclq.Spec.Replicas == 0 {
+		return hashesConverged
+	}
+	return hashesConverged &&
 		pclq.Status.ReadyReplicas >= *pclq.Spec.MinAvailable &&
 		pclq.Status.UpdatedReplicas >= *pclq.Spec.MinAvailable
 }
@@ -288,6 +300,11 @@ func (r *Reconciler) computePCSGsStatus(pcsGenerationHash *string, expectedPCSGs
 
 	isAvailable = expectedPCSGs == len(nonTerminatedPCSGs) &&
 		lo.EveryBy(nonTerminatedPCSGs, func(pcsg grovecorev1alpha1.PodCliqueScalingGroup) bool {
+			// GREP-0677: an idle PCSG (replicas: 0) contributes no required replicas, so it never
+			// holds the parent replica back from Available.
+			if pcsg.Spec.Replicas == 0 {
+				return true
+			}
 			return pcsg.Status.AvailableReplicas >= *pcsg.Spec.MinAvailable
 		})
 

--- a/operator/internal/controller/podcliqueset/reconcilestatus.go
+++ b/operator/internal/controller/podcliqueset/reconcilestatus.go
@@ -252,12 +252,7 @@ func (r *Reconciler) computePCLQsStatus(pcs *grovecorev1alpha1.PodCliqueSet, exp
 
 	isAvailable = len(nonTerminatedPCLQs) == expectedStandalonePCLQs &&
 		lo.EveryBy(nonTerminatedPCLQs, func(pclq grovecorev1alpha1.PodClique) bool {
-			// GREP-0677: an idle standalone PodClique (replicas: 0) contributes no required pods, so
-			// it never holds the parent replica back from Available.
-			if pclq.Spec.Replicas == 0 {
-				return true
-			}
-			return pclq.Status.ReadyReplicas >= *pclq.Spec.MinAvailable
+			return pclq.Spec.Replicas == 0 || pclq.Status.ReadyReplicas >= *pclq.Spec.MinAvailable
 		})
 
 	isUpdated = isAvailable && lo.EveryBy(nonTerminatedPCLQs, func(pclq grovecorev1alpha1.PodClique) bool {
@@ -276,20 +271,14 @@ func isStandalonePCLQUpdated(pcs *grovecorev1alpha1.PodCliqueSet, pclq *grovecor
 	if err != nil || expectedPodTemplateHash == "" {
 		return false
 	}
-	hashesConverged := pclq.Labels[apicommon.LabelPodTemplateHash] == expectedPodTemplateHash &&
+	// Idle cliques have no pods to roll, but their hashes must still converge.
+	return pclq.Labels[apicommon.LabelPodTemplateHash] == expectedPodTemplateHash &&
 		pclq.Status.CurrentPodTemplateHash != nil &&
 		*pclq.Status.CurrentPodTemplateHash == expectedPodTemplateHash &&
 		pclq.Status.CurrentPodCliqueSetGenerationHash != nil &&
-		*pclq.Status.CurrentPodCliqueSetGenerationHash == *pcs.Status.CurrentGenerationHash
-	// GREP-0677: an idle standalone PodClique (replicas: 0) has no pods to roll, so it counts as
-	// updated once its generation and pod-template hashes converge — it never reaches
-	// ReadyReplicas/UpdatedReplicas >= MinAvailable because there are no pods.
-	if pclq.Spec.Replicas == 0 {
-		return hashesConverged
-	}
-	return hashesConverged &&
-		pclq.Status.ReadyReplicas >= *pclq.Spec.MinAvailable &&
-		pclq.Status.UpdatedReplicas >= *pclq.Spec.MinAvailable
+		*pclq.Status.CurrentPodCliqueSetGenerationHash == *pcs.Status.CurrentGenerationHash &&
+		(pclq.Spec.Replicas == 0 || (pclq.Status.ReadyReplicas >= *pclq.Spec.MinAvailable &&
+			pclq.Status.UpdatedReplicas >= *pclq.Spec.MinAvailable))
 }
 
 // computePCSGsStatus checks if PodCliqueScalingGroups are available and updated.
@@ -300,12 +289,7 @@ func (r *Reconciler) computePCSGsStatus(pcsGenerationHash *string, expectedPCSGs
 
 	isAvailable = expectedPCSGs == len(nonTerminatedPCSGs) &&
 		lo.EveryBy(nonTerminatedPCSGs, func(pcsg grovecorev1alpha1.PodCliqueScalingGroup) bool {
-			// GREP-0677: an idle PCSG (replicas: 0) contributes no required replicas, so it never
-			// holds the parent replica back from Available.
-			if pcsg.Spec.Replicas == 0 {
-				return true
-			}
-			return pcsg.Status.AvailableReplicas >= *pcsg.Spec.MinAvailable
+			return pcsg.Spec.Replicas == 0 || pcsg.Status.AvailableReplicas >= *pcsg.Spec.MinAvailable
 		})
 
 	isUpdated = isAvailable && lo.EveryBy(nonTerminatedPCSGs, func(pcsg grovecorev1alpha1.PodCliqueScalingGroup) bool {

--- a/operator/internal/controller/podcliqueset/reconcilestatus_test.go
+++ b/operator/internal/controller/podcliqueset/reconcilestatus_test.go
@@ -136,6 +136,31 @@ func TestComputePCSAvailableReplicas(t *testing.T) {
 			expectedAvailable: 1,
 		},
 		{
+			// GREP-0677: an idle standalone PodClique and an idle PCSG (replicas: 0) contribute no
+			// required members, so the PCS replica stays Available despite them running zero pods.
+			name: "zero-replica standalone and PCSG members are idle - replica still available",
+			setupPCS: func() *grovecorev1alpha1.PodCliqueSet {
+				return testutils.NewPodCliqueSetBuilder(testPCSName, testNamespace, pcsUID).
+					WithReplicas(1).
+					WithStandaloneCliqueReplicas("worker", 0).
+					WithScalingGroupConfig("compute", []string{"frontend"}, 0, 1).
+					WithPodCliqueSetGenerationHash(&pcsGenerationHash).
+					Build()
+			},
+			childResources: func() []client.Object {
+				return []client.Object{
+					testutils.NewPodCliqueBuilder(testPCSName, pcsUID, "worker", testNamespace, 0).
+						WithReplicas(0).
+						WithOptions(testutils.WithPCLQCurrentPCSGenerationHash(pcsGenerationHash)).Build(),
+					testutils.NewPodCliqueScalingGroupBuilder("test-pcs-0-compute", testNamespace, testPCSName, 0).
+						WithReplicas(0).
+						WithOwnerReference(apicommonconstants.KindPodCliqueSet, testPCSName, pcsUID).
+						WithOptions(testutils.WithPCSGCurrentPCSGenerationHash(pcsGenerationHash)).Build(),
+				}
+			},
+			expectedAvailable: 1,
+		},
+		{
 			name: "only standalone cliques - all healthy",
 			setupPCS: func() *grovecorev1alpha1.PodCliqueSet {
 				return testutils.NewPodCliqueSetBuilder(testPCSName, testNamespace, pcsUID).
@@ -902,6 +927,30 @@ func TestCountUpdatedPCLQs(t *testing.T) {
 			assert.Equal(t, tt.want, countUpdatedPCLQs(tt.pcs, tt.in))
 		})
 	}
+}
+
+// TestIsStandalonePCLQUpdatedIdle verifies GREP-0677: an idle standalone PodClique (replicas: 0)
+// counts as updated once its generation and pod-template hashes converge, without requiring
+// ReadyReplicas/UpdatedReplicas >= MinAvailable (there are no pods to reach it).
+func TestIsStandalonePCLQUpdatedIdle(t *testing.T) {
+	hash := "h"
+	pcsUID := uuid.NewUUID()
+	pcs := testutils.NewPodCliqueSetBuilder(testPCSName, testNamespace, pcsUID).
+		WithStandaloneClique("worker").
+		WithPodCliqueSetGenerationHash(&hash).
+		Build()
+
+	idle := markStandalonePCLQConverged(t, pcs, testutils.NewPodCliqueBuilder(testPCSName, pcsUID, "worker", testNamespace, 0).Build(), hash)
+	idle.Spec.Replicas = 0
+	idle.Status.ReadyReplicas = 0
+	idle.Status.UpdatedReplicas = 0
+
+	assert.True(t, isStandalonePCLQUpdated(pcs, idle), "idle PCLQ with converged hashes must be updated")
+
+	// An idle PCLQ whose hashes have NOT converged is still not updated.
+	stale := idle.DeepCopy()
+	stale.Status.CurrentPodCliqueSetGenerationHash = ptr.To("old")
+	assert.False(t, isStandalonePCLQUpdated(pcs, stale), "idle PCLQ with stale generation hash must not be updated")
 }
 
 func markStandalonePCLQConverged(t testing.TB, pcs *grovecorev1alpha1.PodCliqueSet, pclq *grovecorev1alpha1.PodClique, generationHash string) *grovecorev1alpha1.PodClique {

--- a/operator/internal/crdinstaller/installer_test.go
+++ b/operator/internal/crdinstaller/installer_test.go
@@ -16,6 +16,7 @@ package crdinstaller_test
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	operatorcrds "github.com/ai-dynamo/grove/operator/api/core/v1alpha1/crds"
@@ -32,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
 // buildFakeClient creates a fake client with apiextensionsv1 scheme registered.
@@ -102,6 +104,34 @@ func TestInstallCRDs_AllApplied(t *testing.T) {
 		err := cl.Get(ctx, client.ObjectKey{Name: crdName}, obj)
 		assert.NoError(t, err, "CRD %q should exist after InstallCRDs", crdName)
 	}
+}
+
+func TestInstallCRDs_AcceptedByAPIServer(t *testing.T) {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		t.Skip("KUBEBUILDER_ASSETS is not set")
+	}
+
+	testEnv := &envtest.Environment{}
+	cfg, err := testEnv.Start()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, testEnv.Stop())
+	}()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, apiextensionsv1.AddToScheme(scheme))
+	cl, err := client.New(cfg, client.Options{Scheme: scheme})
+	require.NoError(t, err)
+
+	err = crdinstaller.InstallCRDs(t.Context(), cl, logr.Discard(), []string{
+		operatorcrds.PodCliqueCRD(),
+		operatorcrds.PodCliqueSetCRD(),
+		operatorcrds.PodCliqueScalingGroupCRD(),
+		operatorcrds.ClusterTopologyCRD(),
+		operatorcrds.PodGangMapCRD(),
+		schedulercrds.PodGangCRD(),
+	})
+	require.NoError(t, err)
 }
 
 // TestInstallCRDs_CreatesByName verifies that InstallCRDs creates the CRD with

--- a/operator/internal/scheduler/kai/backend_test.go
+++ b/operator/internal/scheduler/kai/backend_test.go
@@ -178,6 +178,44 @@ func TestBackend_SyncPodGang_CreateAndUpdate(t *testing.T) {
 	assert.Equal(t, int32(4), *gotAfterUpdate.Spec.SubGroups[1].MinMember)
 }
 
+func TestBackend_SyncPodGang_RestoresStandaloneFloor(t *testing.T) {
+	ctx := context.Background()
+	pcs := newPodCliqueSet("wake-pcs", "team-a",
+		podCliqueTemplateWithQueue("router", "team-a"),
+		podCliqueTemplateWithQueue("worker", "team-a"))
+	podGang := testutils.NewPodGangBuilder("running-anchor", "default").
+		WithSchedulerName(string(configv1alpha1.SchedulerNameKai)).Build()
+	setPodCliqueSetControllerOwner(podGang, pcs)
+	router := groveschedulerv1alpha1.PodGroup{Name: "router", MinReplicas: 1,
+		PodReferences: []groveschedulerv1alpha1.NamespacedName{{Name: "router-0", Namespace: "default"}}}
+	podGang.Spec.PodGroups = []groveschedulerv1alpha1.PodGroup{router}
+	cl := testutils.NewTestClientBuilder().WithObjects(pcs, podGang).Build()
+	b := New(cl, cl.Scheme(), record.NewFakeRecorder(10),
+		configv1alpha1.SchedulerProfile{Name: configv1alpha1.SchedulerNameKai})
+	require.NoError(t, b.Init(cl))
+	require.NoError(t, b.SyncPodGang(ctx, podGang))
+	before := &kaischedulingv2alpha2.PodGroup{}
+	require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(podGang), before))
+
+	podGang.Spec.PodGroups = append(podGang.Spec.PodGroups, groveschedulerv1alpha1.PodGroup{
+		Name: "worker", MinReplicas: 2,
+		PodReferences: []groveschedulerv1alpha1.NamespacedName{
+			{Name: "worker-0", Namespace: "default"}, {Name: "worker-1", Namespace: "default"},
+		},
+	})
+	require.NoError(t, b.SyncPodGang(ctx, podGang))
+	after := &kaischedulingv2alpha2.PodGroup{}
+	require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(podGang), after))
+	require.Len(t, after.Spec.SubGroups, 2)
+	assert.Equal(t, before.Spec.SubGroups[0], after.Spec.SubGroups[0], "running router constraints stay intact")
+	assert.Equal(t, "worker", after.Spec.SubGroups[1].Name)
+	require.NotNil(t, after.Spec.SubGroups[1].MinMember)
+	assert.Equal(t, int32(2), *after.Spec.SubGroups[1].MinMember)
+	require.NotNil(t, after.Spec.MinMember)
+	assert.Equal(t, int32(3), *after.Spec.MinMember)
+	assert.Equal(t, before.OwnerReferences, after.OwnerReferences)
+}
+
 func TestBackend_SyncPodGang_SkipsEmptyTopologyConstraintGroups(t *testing.T) {
 	pcs := newPodCliqueSet(
 		"empty-group-pcs",

--- a/operator/internal/testdata/zero-replica-gang-membership.yaml
+++ b/operator/internal/testdata/zero-replica-gang-membership.yaml
@@ -1,0 +1,56 @@
+apiVersion: grove.io/v1alpha1
+kind: PodCliqueSet
+metadata:
+  name: scale-to-zero-deepseek
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    cliqueStartupType: CliqueStartupTypeAnyOrder
+    terminationDelay: 4h
+    cliques:
+    - name: router
+      spec:
+        roleName: router
+        replicas: 1
+        minAvailable: 1
+        podSpec:
+          containers:
+          - name: router
+            image: registry.k8s.io/pause:3.10
+    - name: pleader
+      spec:
+        roleName: pleader
+        replicas: 1
+        minAvailable: 1
+        podSpec:
+          containers:
+          - name: pleader
+            image: registry.k8s.io/pause:3.10
+    - name: pworker
+      spec:
+        roleName: pworker
+        replicas: 1
+        minAvailable: 1
+        podSpec:
+          containers:
+          - name: pworker
+            image: registry.k8s.io/pause:3.10
+    # decode is an intentionally idle standalone PodClique (GREP-0677): replicas 0
+    # with a positive minAvailable. It contributes no PodGroup and does not breach.
+    - name: decode
+      spec:
+        roleName: decode
+        replicas: 0
+        minAvailable: 1
+        podSpec:
+          containers:
+          - name: decode
+            image: registry.k8s.io/pause:3.10
+    podCliqueScalingGroups:
+    # prefill is an intentionally idle PodCliqueScalingGroup (GREP-0677): replicas 0
+    # with a positive minAvailable. It materializes no scaled PodGang while idle.
+    - name: prefill
+      cliqueNames: [pleader, pworker]
+      replicas: 0
+      minAvailable: 1

--- a/operator/internal/webhook/admission/pclq/validation/handler.go
+++ b/operator/internal/webhook/admission/pclq/validation/handler.go
@@ -1,0 +1,107 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	apicommon "github.com/ai-dynamo/grove/operator/api/common"
+	"github.com/ai-dynamo/grove/operator/api/common/constants"
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+
+	"github.com/go-logr/logr"
+	admissionv1 "k8s.io/api/admission/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const denialMessage = "spec.replicas cannot be changed on a PodClique owned by a PodCliqueScalingGroup; scale the owning PodCliqueScalingGroup instead"
+
+// Handler validates PodClique updates, including the scale subresource.
+type Handler struct {
+	reader client.Reader
+	logger logr.Logger
+}
+
+// NewHandler creates a PodClique validation handler.
+func NewHandler(mgr manager.Manager) *Handler {
+	return &Handler{
+		reader: mgr.GetAPIReader(),
+		logger: mgr.GetLogger().WithName("webhook").WithName(Name),
+	}
+}
+
+// Handle rejects independent scaling of PodCliques owned by a PodCliqueScalingGroup.
+func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if req.Operation != admissionv1.Update {
+		return admission.Allowed("operation does not update a PodClique")
+	}
+	if req.SubResource == "scale" {
+		return h.validateScaleUpdate(ctx, req)
+	}
+	return h.validatePodCliqueUpdate(req)
+}
+
+func (h *Handler) validatePodCliqueUpdate(req admission.Request) admission.Response {
+	oldPCLQ := &grovecorev1alpha1.PodClique{}
+	newPCLQ := &grovecorev1alpha1.PodClique{}
+	if err := json.Unmarshal(req.OldObject.Raw, oldPCLQ); err != nil {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("decoding old PodClique: %w", err))
+	}
+	if err := json.Unmarshal(req.Object.Raw, newPCLQ); err != nil {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("decoding new PodClique: %w", err))
+	}
+	if oldPCLQ.Spec.Replicas != newPCLQ.Spec.Replicas &&
+		(isScalingGroupOwned(oldPCLQ) || isScalingGroupOwned(newPCLQ)) {
+		return admission.Denied(denialMessage)
+	}
+	return admission.Allowed("PodClique update is valid")
+}
+
+func (h *Handler) validateScaleUpdate(ctx context.Context, req admission.Request) admission.Response {
+	scale := &autoscalingv1.Scale{}
+	if err := json.Unmarshal(req.Object.Raw, scale); err != nil {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("decoding Scale: %w", err))
+	}
+
+	pclq := &grovecorev1alpha1.PodClique{}
+	if err := h.reader.Get(ctx, client.ObjectKey{Namespace: req.Namespace, Name: req.Name}, pclq); err != nil {
+		h.logger.Error(err, "Failed to read PodClique for scale validation")
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("reading PodClique: %w", err))
+	}
+	if !isScalingGroupOwned(pclq) {
+		return admission.Allowed("standalone PodClique scale update is valid")
+	}
+	if scale.Spec.Replicas != pclq.Spec.Replicas {
+		return admission.Denied(denialMessage)
+	}
+	return admission.Allowed("PodClique scale update does not change replicas")
+}
+
+func isScalingGroupOwned(pclq *grovecorev1alpha1.PodClique) bool {
+	if owner := metav1.GetControllerOfNoCopy(pclq); owner != nil &&
+		owner.APIVersion == grovecorev1alpha1.SchemeGroupVersion.String() &&
+		owner.Kind == constants.KindPodCliqueScalingGroup {
+		return true
+	}
+	_, ok := pclq.Labels[apicommon.LabelPodCliqueScalingGroup]
+	return ok
+}

--- a/operator/internal/webhook/admission/pclq/validation/handler_test.go
+++ b/operator/internal/webhook/admission/pclq/validation/handler_test.go
@@ -1,0 +1,296 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	apicommon "github.com/ai-dynamo/grove/operator/api/common"
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	testutils "github.com/ai-dynamo/grove/operator/test/utils"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestHandlePodCliqueUpdate(t *testing.T) {
+	owned := testutils.NewPCSGPodCliqueBuilder("owned", "default", "pcs", "group", 0, 0).WithReplicas(1).Build()
+	setPCSGControllerOwner(owned, "group")
+	standalone := testutils.NewPodCliqueBuilder("pcs", types.UID("uid"), "worker", "default", 0).WithReplicas(1).Build()
+
+	tests := []struct {
+		name    string
+		oldPCLQ *grovecorev1alpha1.PodClique
+		newPCLQ *grovecorev1alpha1.PodClique
+		allowed bool
+		message string
+	}{
+		{
+			name:    "owned replica change is denied",
+			oldPCLQ: owned,
+			newPCLQ: owned.DeepCopy(),
+			allowed: false,
+			message: denialMessage,
+		},
+		{
+			name:    "owned unchanged replicas are allowed",
+			oldPCLQ: owned,
+			newPCLQ: owned.DeepCopy(),
+			allowed: true,
+			message: "PodClique update is valid",
+		},
+		{
+			name:    "standalone replica change is allowed",
+			oldPCLQ: standalone,
+			newPCLQ: standalone.DeepCopy(),
+			allowed: true,
+			message: "PodClique update is valid",
+		},
+		{
+			name:    "removing ownership while changing replicas is denied",
+			oldPCLQ: owned,
+			newPCLQ: owned.DeepCopy(),
+			allowed: false,
+			message: denialMessage,
+		},
+		{
+			name:    "removing owner label does not bypass controller ownership",
+			oldPCLQ: owned,
+			newPCLQ: owned.DeepCopy(),
+			allowed: false,
+			message: denialMessage,
+		},
+		{
+			name:    "adding ownership while changing replicas is denied",
+			oldPCLQ: standalone,
+			newPCLQ: standalone.DeepCopy(),
+			allowed: false,
+			message: denialMessage,
+		},
+	}
+	tests[0].newPCLQ.Spec.Replicas = 0
+	tests[2].newPCLQ.Spec.Replicas = 0
+	delete(tests[3].newPCLQ.Labels, apicommon.LabelPodCliqueScalingGroup)
+	tests[3].newPCLQ.Spec.Replicas = 0
+	delete(tests[4].newPCLQ.Labels, apicommon.LabelPodCliqueScalingGroup)
+	tests[4].newPCLQ.Spec.Replicas = 0
+	tests[5].newPCLQ.Labels[apicommon.LabelPodCliqueScalingGroup] = "group"
+	tests[5].newPCLQ.Spec.Replicas = 0
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldRaw, err := json.Marshal(tt.oldPCLQ)
+			require.NoError(t, err)
+			newRaw, err := json.Marshal(tt.newPCLQ)
+			require.NoError(t, err)
+
+			resp := (&Handler{}).Handle(t.Context(), admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Update,
+				OldObject: runtime.RawExtension{Raw: oldRaw},
+				Object:    runtime.RawExtension{Raw: newRaw},
+			}})
+			assert.Equal(t, tt.allowed, resp.Allowed)
+			require.NotNil(t, resp.Result)
+			assert.Equal(t, tt.message, resp.Result.Message)
+		})
+	}
+}
+
+func TestHandlePodCliqueUpdateDecodeErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		oldRaw  []byte
+		newRaw  []byte
+		wantErr string
+	}{
+		{name: "invalid old object", oldRaw: []byte("{"), newRaw: []byte("{}"), wantErr: "decoding old PodClique"},
+		{name: "invalid new object", oldRaw: []byte("{}"), newRaw: []byte("{"), wantErr: "decoding new PodClique"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := (&Handler{}).Handle(t.Context(), admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Update,
+				OldObject: runtime.RawExtension{Raw: tt.oldRaw},
+				Object:    runtime.RawExtension{Raw: tt.newRaw},
+			}})
+			assert.False(t, resp.Allowed)
+			require.NotNil(t, resp.Result)
+			assert.EqualValues(t, http.StatusBadRequest, resp.Result.Code)
+			assert.Contains(t, resp.Result.Message, tt.wantErr)
+		})
+	}
+}
+
+func TestHandleScaleUpdate(t *testing.T) {
+	owned := testutils.NewPCSGPodCliqueBuilder("owned", "default", "pcs", "group", 0, 0).WithReplicas(1).Build()
+	setPCSGControllerOwner(owned, "group")
+	delete(owned.Labels, apicommon.LabelPodCliqueScalingGroup)
+	legacyOwned := testutils.NewPCSGPodCliqueBuilder("legacy-owned", "default", "pcs", "group", 0, 0).WithReplicas(1).Build()
+	standalone := testutils.NewPodCliqueBuilder("pcs", types.UID("uid"), "worker", "default", 0).WithReplicas(1).Build()
+	cl := testutils.NewTestClientBuilder().WithObjects(owned, legacyOwned, standalone).Build()
+	h := &Handler{reader: cl, logger: logr.Discard()}
+
+	tests := []struct {
+		name     string
+		pclqName string
+		replicas int32
+		allowed  bool
+		message  string
+	}{
+		{name: "owned replica change is denied", pclqName: owned.Name, replicas: 0, allowed: false, message: denialMessage},
+		{name: "owned unchanged replicas are allowed", pclqName: owned.Name, replicas: 1, allowed: true, message: "PodClique scale update does not change replicas"},
+		{name: "legacy label ownership is denied", pclqName: legacyOwned.Name, replicas: 0, allowed: false, message: denialMessage},
+		{name: "standalone replica change is allowed", pclqName: standalone.Name, replicas: 0, allowed: true, message: "standalone PodClique scale update is valid"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := h.Handle(t.Context(), admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Name:        tt.pclqName,
+				Namespace:   "default",
+				Operation:   admissionv1.Update,
+				SubResource: "scale",
+				Object:      runtime.RawExtension{Raw: marshalScale(t, tt.pclqName, tt.replicas)},
+			}})
+			assert.Equal(t, tt.allowed, resp.Allowed)
+			require.NotNil(t, resp.Result)
+			assert.Equal(t, tt.message, resp.Result.Message)
+		})
+	}
+}
+
+func TestHandleScaleUpdateErrors(t *testing.T) {
+	owned := testutils.NewPCSGPodCliqueBuilder("owned", "default", "pcs", "group", 0, 0).Build()
+	getErr := apierrors.NewInternalError(errors.New("injected get failure"))
+	cl := testutils.NewTestClientBuilder().
+		WithObjects(owned).
+		RecordErrorForObjects(testutils.ClientMethodGet, getErr, types.NamespacedName{Namespace: owned.Namespace, Name: owned.Name}).
+		Build()
+	h := &Handler{reader: cl, logger: logr.Discard()}
+
+	tests := []struct {
+		name     string
+		raw      []byte
+		pclqName string
+		wantCode int
+		wantErr  string
+	}{
+		{name: "invalid scale object", raw: []byte("{"), pclqName: owned.Name, wantCode: http.StatusBadRequest, wantErr: "decoding Scale"},
+		{name: "PodClique read failure", raw: marshalScale(t, owned.Name, 0), pclqName: owned.Name, wantCode: http.StatusInternalServerError, wantErr: "reading PodClique"},
+		{name: "PodClique not found", raw: marshalScale(t, "missing", 0), pclqName: "missing", wantCode: http.StatusInternalServerError, wantErr: "reading PodClique"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := h.Handle(t.Context(), admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Name:        tt.pclqName,
+				Namespace:   "default",
+				Operation:   admissionv1.Update,
+				SubResource: "scale",
+				Object:      runtime.RawExtension{Raw: tt.raw},
+			}})
+			assert.False(t, resp.Allowed)
+			require.NotNil(t, resp.Result)
+			assert.EqualValues(t, tt.wantCode, resp.Result.Code)
+			assert.Contains(t, resp.Result.Message, tt.wantErr)
+		})
+	}
+}
+
+func TestHandleAllowsNonUpdateOperation(t *testing.T) {
+	resp := (&Handler{}).Handle(t.Context(), admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+		Operation: admissionv1.Create,
+	}})
+	assert.True(t, resp.Allowed)
+	require.NotNil(t, resp.Result)
+	assert.Equal(t, "operation does not update a PodClique", resp.Result.Message)
+}
+
+func TestIsScalingGroupOwned(t *testing.T) {
+	controller := true
+	tests := []struct {
+		name  string
+		pclq  *grovecorev1alpha1.PodClique
+		owned bool
+	}{
+		{
+			name: "controller owner",
+			pclq: &grovecorev1alpha1.PodClique{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: grovecorev1alpha1.SchemeGroupVersion.String(),
+				Kind:       "PodCliqueScalingGroup",
+				Controller: &controller,
+			}}}},
+			owned: true,
+		},
+		{
+			name:  "legacy label",
+			pclq:  &grovecorev1alpha1.PodClique{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{apicommon.LabelPodCliqueScalingGroup: "group"}}},
+			owned: true,
+		},
+		{
+			name: "non-controller owner",
+			pclq: &grovecorev1alpha1.PodClique{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: grovecorev1alpha1.SchemeGroupVersion.String(),
+				Kind:       "PodCliqueScalingGroup",
+			}}}},
+		},
+		{
+			name: "different API version",
+			pclq: &grovecorev1alpha1.PodClique{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "grove.io/v2",
+				Kind:       "PodCliqueScalingGroup",
+				Controller: &controller,
+			}}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.owned, isScalingGroupOwned(tt.pclq))
+		})
+	}
+}
+
+func setPCSGControllerOwner(pclq *grovecorev1alpha1.PodClique, name string) {
+	controller := true
+	pclq.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: grovecorev1alpha1.SchemeGroupVersion.String(),
+		Kind:       "PodCliqueScalingGroup",
+		Name:       name,
+		Controller: &controller,
+	}}
+}
+
+func marshalScale(t *testing.T, name string, replicas int32) []byte {
+	t.Helper()
+	raw, err := json.Marshal(&autoscalingv1.Scale{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec:       autoscalingv1.ScaleSpec{Replicas: replicas},
+	})
+	require.NoError(t, err)
+	return raw
+}

--- a/operator/internal/webhook/admission/pclq/validation/register.go
+++ b/operator/internal/webhook/admission/pclq/validation/register.go
@@ -1,0 +1,33 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	// Name is the name of the PodClique validating webhook handler.
+	Name        = "podclique-validating-webhook"
+	webhookPath = "/webhooks/validate-podclique"
+)
+
+// RegisterWithManager registers the webhook with the manager.
+func (h *Handler) RegisterWithManager(mgr manager.Manager) error {
+	webhook := (&admission.Webhook{Handler: h}).WithRecoverPanic(true)
+	mgr.GetWebhookServer().Register(webhookPath, webhook)
+	return nil
+}

--- a/operator/internal/webhook/admission/pclq/validation/register_test.go
+++ b/operator/internal/webhook/admission/pclq/validation/register_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"testing"
+
+	testutils "github.com/ai-dynamo/grove/operator/test/utils"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+func TestRegisterWithManager(t *testing.T) {
+	cl := testutils.NewTestClientBuilder().Build()
+	mgr := &testutils.FakeManager{
+		Client:        cl,
+		Scheme:        cl.Scheme(),
+		Logger:        logr.Discard(),
+		WebhookServer: webhook.NewServer(webhook.Options{Port: 9443}),
+	}
+
+	require.NoError(t, NewHandler(mgr).RegisterWithManager(mgr))
+}

--- a/operator/internal/webhook/admission/pcs/defaulting/podcliqueset.go
+++ b/operator/internal/webhook/admission/pcs/defaulting/podcliqueset.go
@@ -63,17 +63,18 @@ func defaultHeadlessServiceConfig(headlessServiceConfig *grovecorev1alpha1.Headl
 	return headlessServiceConfig
 }
 
-// defaultPodCliqueTemplateSpecs applies defaults to each PodClique template including replicas, minAvailable, and autoscaling configuration.
+// defaultPodCliqueTemplateSpecs applies defaults to each PodClique template including minAvailable and
+// autoscaling configuration. GREP-0677: Replicas is no longer rewritten from 0 to 1 here — an omitted
+// value is defaulted to 1 by the schema default, while an explicit 0 is preserved as the intentional
+// idle state. MinAvailable defaults to max(1, replicas) so an idle template (replicas: 0) still gets a
+// positive quorum.
 func defaultPodCliqueTemplateSpecs(cliqueSpecs []*grovecorev1alpha1.PodCliqueTemplateSpec) []*grovecorev1alpha1.PodCliqueTemplateSpec {
 	defaultedCliqueSpecs := make([]*grovecorev1alpha1.PodCliqueTemplateSpec, 0, len(cliqueSpecs))
 	for _, cliqueSpec := range cliqueSpecs {
 		defaultedCliqueSpec := cliqueSpec.DeepCopy()
 		defaultedCliqueSpec.Spec.PodSpec = *defaultPodSpec(&cliqueSpec.Spec.PodSpec)
-		if defaultedCliqueSpec.Spec.Replicas == 0 {
-			defaultedCliqueSpec.Spec.Replicas = 1
-		}
 		if cliqueSpec.Spec.MinAvailable == nil {
-			defaultedCliqueSpec.Spec.MinAvailable = ptr.To(cliqueSpec.Spec.Replicas)
+			defaultedCliqueSpec.Spec.MinAvailable = ptr.To(max(int32(1), cliqueSpec.Spec.Replicas))
 		}
 		if cliqueSpec.Spec.ScaleConfig != nil {
 			if cliqueSpec.Spec.ScaleConfig.MinReplicas == nil {

--- a/operator/internal/webhook/admission/pcs/defaulting/podcliqueset_additional_test.go
+++ b/operator/internal/webhook/admission/pcs/defaulting/podcliqueset_additional_test.go
@@ -36,7 +36,7 @@ func TestDefaultPodCliqueTemplateSpecs(t *testing.T) {
 		verify func(*testing.T, []*grovecorev1alpha1.PodCliqueTemplateSpec)
 	}{
 		{
-			name: "replicas defaults to 1 when 0",
+			name: "explicit replicas 0 is preserved and minAvailable defaults to 1",
 			input: []*grovecorev1alpha1.PodCliqueTemplateSpec{
 				{
 					Name: "clique1",
@@ -49,7 +49,11 @@ func TestDefaultPodCliqueTemplateSpecs(t *testing.T) {
 			},
 			verify: func(t *testing.T, result []*grovecorev1alpha1.PodCliqueTemplateSpec) {
 				require.Len(t, result, 1)
-				assert.Equal(t, int32(1), result[0].Spec.Replicas)
+				// GREP-0677: the webhook no longer rewrites 0 to 1 — the schema default applies to
+				// omitted values, while an explicit 0 is preserved as the idle state.
+				assert.Equal(t, int32(0), result[0].Spec.Replicas)
+				require.NotNil(t, result[0].Spec.MinAvailable)
+				assert.Equal(t, int32(1), *result[0].Spec.MinAvailable, "minAvailable defaults to max(1, replicas)")
 			},
 		},
 		{

--- a/operator/internal/webhook/admission/pcs/validation/podcliqueset.go
+++ b/operator/internal/webhook/admission/pcs/validation/podcliqueset.go
@@ -354,10 +354,10 @@ func (v *pcsValidator) validatePodCliqueScalingGroupConfigs(fldPath *field.Path)
 		allErrs = append(allErrs, v.validateScalingGroupPodCliqueNames(scalingGroupConfig.Name, allPodCliqueSetCliqueNames,
 			scalingGroupConfig.CliqueNames, fldPath.Index(i).Child("cliqueNames"), fldPath.Index(i).Child("name"))...)
 
-		// validate Replicas field
+		// validate Replicas field. GREP-0677: 0 is a valid intentional idle state.
 		if scalingGroupConfig.Replicas != nil {
-			if *scalingGroupConfig.Replicas <= 0 {
-				allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("replicas"), *scalingGroupConfig.Replicas, "must be greater than 0"))
+			if *scalingGroupConfig.Replicas < 0 {
+				allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("replicas"), *scalingGroupConfig.Replicas, "must be greater than or equal to 0"))
 			}
 		}
 
@@ -368,9 +368,11 @@ func (v *pcsValidator) validatePodCliqueScalingGroupConfigs(fldPath *field.Path)
 			}
 		}
 
-		// validate MinAvailable <= Replicas
+		// validate MinAvailable <= Replicas. GREP-0677: an idle PCSG (replicas: 0) keeps its
+		// positive MinAvailable; the quorum applies again when it becomes active. Positive
+		// below-quorum replica counts are rejected.
 		if scalingGroupConfig.Replicas != nil && scalingGroupConfig.MinAvailable != nil {
-			if *scalingGroupConfig.MinAvailable > *scalingGroupConfig.Replicas {
+			if *scalingGroupConfig.Replicas > 0 && *scalingGroupConfig.MinAvailable > *scalingGroupConfig.Replicas {
 				allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("minAvailable"), *scalingGroupConfig.MinAvailable, "minAvailable must not be greater than replicas"))
 			}
 		}
@@ -520,8 +522,9 @@ func (v *pcsValidator) validateScalingGroupPodCliqueNames(pcsgName string, allPc
 func (v *pcsValidator) validatePodCliqueSpec(name string, cliqueSpec grovecorev1alpha1.PodCliqueSpec, fldPath *field.Path) ([]string, field.ErrorList) {
 	allErrs := field.ErrorList{}
 
-	if cliqueSpec.Replicas <= 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("replicas"), cliqueSpec.Replicas, "must be greater than 0"))
+	// GREP-0677: 0 replicas is a valid intentional idle state.
+	if cliqueSpec.Replicas < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("replicas"), cliqueSpec.Replicas, "must be greater than or equal to 0"))
 	}
 
 	// Ideally this should never happen, the defaulting webhook will always set the default value for minAvailable.
@@ -532,7 +535,9 @@ func (v *pcsValidator) validatePodCliqueSpec(name string, cliqueSpec grovecorev1
 		if *cliqueSpec.MinAvailable <= 0 {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("minAvailable"), *cliqueSpec.MinAvailable, "must be greater than 0"))
 		}
-		if *cliqueSpec.MinAvailable > cliqueSpec.Replicas {
+		// GREP-0677: an idle PodClique (replicas: 0) keeps its positive MinAvailable; the quorum
+		// applies again when it becomes active. Positive below-quorum replica counts are rejected.
+		if cliqueSpec.Replicas > 0 && *cliqueSpec.MinAvailable > cliqueSpec.Replicas {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("minAvailable"), *cliqueSpec.MinAvailable, "minAvailable must not be greater than replicas"))
 		}
 	}

--- a/operator/internal/webhook/admission/pcs/validation/podcliqueset_test.go
+++ b/operator/internal/webhook/admission/pcs/validation/podcliqueset_test.go
@@ -366,8 +366,21 @@ func TestPodCliqueScalingGroupConfigValidation(t *testing.T) {
 			cliqueTemplates: []string{"prefill"},
 			errorMatchers: []testutils.ErrorMatcher{
 				{ErrorType: field.ErrorTypeInvalid, Field: "spec.template.podCliqueScalingGroups[0].replicas"},
-				{ErrorType: field.ErrorTypeInvalid, Field: "spec.template.podCliqueScalingGroups[0].minAvailable"},
 			},
+		},
+		{
+			// GREP-0677: replicas 0 is a valid intentional idle state at the template level.
+			description: "Valid idle PCSG (replicas 0 with positive minAvailable)",
+			pcsName:     "inference",
+			scalingGroups: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
+				{
+					Name:         "workers",
+					CliqueNames:  []string{"prefill"},
+					Replicas:     ptr.To(int32(0)),
+					MinAvailable: ptr.To(int32(2)),
+				},
+			},
+			cliqueTemplates: []string{"prefill"},
 		},
 		{
 			description: "Invalid MinAvailable (zero value)",
@@ -1931,5 +1944,72 @@ func createTestClusterTopology() *grovecorev1alpha1.ClusterTopologyBinding {
 				{Domain: grovecorev1alpha1.TopologyDomainHost, Key: "kubernetes.io/hostname"},
 			},
 		},
+	}
+}
+
+// TestStandaloneCliqueZeroReplicaValidation verifies GREP-0677 at the PodCliqueSet template level for
+// standalone PodCliques: replicas 0 with a positive minAvailable is valid (intentional idle), a
+// positive below-quorum replica count is rejected, and a negative replica count is rejected.
+func TestStandaloneCliqueZeroReplicaValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		replicas      int32
+		minAvailable  int32
+		errorMatchers []testutils.ErrorMatcher
+	}{
+		{
+			name:         "idle: replicas 0 with positive minAvailable is valid",
+			replicas:     0,
+			minAvailable: 2,
+		},
+		{
+			name:         "positive below-quorum replicas is rejected",
+			replicas:     1,
+			minAvailable: 2,
+			errorMatchers: []testutils.ErrorMatcher{
+				{ErrorType: field.ErrorTypeInvalid, Field: "spec.template.cliques[0].spec.minAvailable"},
+			},
+		},
+		{
+			name:         "negative replicas is rejected",
+			replicas:     -1,
+			minAvailable: 1,
+			errorMatchers: []testutils.ErrorMatcher{
+				{ErrorType: field.ErrorTypeInvalid, Field: "spec.template.cliques[0].spec.replicas"},
+			},
+		},
+		{
+			name:         "replicas at minAvailable is valid",
+			replicas:     2,
+			minAvailable: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clique := testutils.NewPodCliqueTemplateSpecBuilder("worker").
+				WithReplicas(tt.replicas).
+				WithRoleName("worker-role").
+				WithMinAvailable(tt.minAvailable).
+				Build()
+			pcs := testutils.NewPodCliqueSetBuilder("inference", "default", uuid.NewUUID()).
+				WithReplicas(1).
+				WithTerminationDelay(4 * time.Hour).
+				WithCliqueStartupType(ptr.To(grovecorev1alpha1.CliqueStartupTypeAnyOrder)).
+				WithPodCliqueTemplateSpec(clique).
+				Build()
+
+			validator := newPCSValidator(pcs, admissionv1.Create, defaultTASConfig(), groveconfigv1alpha1.SchedulerConfiguration{
+				Profiles:           []groveconfigv1alpha1.SchedulerProfile{{Name: groveconfigv1alpha1.SchedulerNameKube}},
+				DefaultProfileName: string(groveconfigv1alpha1.SchedulerNameKube),
+			}, nil, testutils.NewDefaultFakeRegistry())
+			_, errs := validator.validate()
+
+			if tt.errorMatchers != nil {
+				testutils.AssertErrorMatches(t, errs, tt.errorMatchers)
+			} else {
+				require.NoError(t, errs.ToAggregate())
+			}
+		})
 	}
 }

--- a/operator/internal/webhook/register.go
+++ b/operator/internal/webhook/register.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ai-dynamo/grove/operator/internal/constants"
 	"github.com/ai-dynamo/grove/operator/internal/scheduler"
 	ctvalidation "github.com/ai-dynamo/grove/operator/internal/webhook/admission/clustertopology/validation"
+	pclqvalidation "github.com/ai-dynamo/grove/operator/internal/webhook/admission/pclq/validation"
 	"github.com/ai-dynamo/grove/operator/internal/webhook/admission/pcs/authorization"
 	"github.com/ai-dynamo/grove/operator/internal/webhook/admission/pcs/defaulting"
 	pcsvalidation "github.com/ai-dynamo/grove/operator/internal/webhook/admission/pcs/validation"
@@ -45,6 +46,11 @@ func Register(mgr manager.Manager, operatorCfg *configv1alpha1.OperatorConfigura
 	slog.Info("Registering webhook with manager", "handler", pcsvalidation.Name)
 	if err := pcsValidatingWebhook.RegisterWithManager(mgr); err != nil {
 		return fmt.Errorf("failed adding %s webhook handler: %v", pcsvalidation.Name, err)
+	}
+	pclqValidatingWebhook := pclqvalidation.NewHandler(mgr)
+	slog.Info("Registering webhook with manager", "handler", pclqvalidation.Name)
+	if err := pclqValidatingWebhook.RegisterWithManager(mgr); err != nil {
+		return fmt.Errorf("failed adding %s webhook handler: %v", pclqvalidation.Name, err)
 	}
 	ctValidatingWebhook := ctvalidation.NewHandler(mgr, schedRegistry)
 	slog.Info("Registering webhook with manager", "handler", ctvalidation.Name)

--- a/operator/test/utils/manager.go
+++ b/operator/test/utils/manager.go
@@ -26,6 +26,7 @@ import (
 type FakeManager struct {
 	manager.Manager
 	Client        client.Client
+	APIReader     client.Reader
 	Scheme        *runtime.Scheme
 	Logger        logr.Logger
 	WebhookServer webhook.Server
@@ -33,6 +34,14 @@ type FakeManager struct {
 
 // GetClient returns the client registered with the fake manager
 func (f *FakeManager) GetClient() client.Client {
+	return f.Client
+}
+
+// GetAPIReader returns the direct reader registered with the fake manager.
+func (f *FakeManager) GetAPIReader() client.Reader {
+	if f.APIReader != nil {
+		return f.APIReader
+	}
 	return f.Client
 }
 

--- a/operator/test/webhook/setup_test.go
+++ b/operator/test/webhook/setup_test.go
@@ -62,6 +62,7 @@ func TestSetup(t *testing.T) {
 	require.ElementsMatch(t, []string{
 		"/webhooks/default-podcliqueset",
 		"/webhooks/validate-clustertopology",
+		"/webhooks/validate-podclique",
 		"/webhooks/validate-podcliqueset",
 	}, registeredPaths(server.handlers))
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api

#### What this PR does / why we need it:

Implements the GREP-0677 prototype for scale-to-zero component hibernation.

- Preserves explicit `replicas: 0` as idle and rejects positive replica
  counts below `minAvailable`, including through `/scale`.
- Omits idle components from gang membership and availability barriers.
- Wakes every PCSG replica in its own scaled PodGang, without a
  cross-replica `minAvailable` scheduling guarantee.
- Restores waking standalone PodCliques to the highest-index
  current-generation anchor without creating another anchor.
- Retains empty anchor slots and rotates an empty ScaleOut entry's epoch
  when it becomes active; active entries retain their epoch and dependencies.
- Treats a dependency on an explicitly empty PGM entry as satisfied, while
  unknown or unscheduled non-empty dependencies remain blocking.
- Preserves ordered PodGangMap, PodGang, and workload removal, PCSG-member
  scale protection, and the existing gang-termination safeguards.

Standalone wake restores membership and its `MinReplicas` floor. It does
not establish a new joint-scheduling guarantee with running anchor members
or independently waking PCSGs. An already scheduled anchor retains its
history, so dependent SPGs do not wait for the standalone wake.

#### Which issue(s) this PR fixes:

Fixes #677
Related to #676

#### Special notes for your reviewer:

This PR was written in part with the assistance of generative AI.

The wake behavior follows GREP-0677 in PR #686 at
`5f95c019500f6b51a0de9a1aed8731883c58fc1d`, superseding the prototype's
previous additional-anchor wake behavior.

The implementation reuses Grove's existing highest-anchor standalone
distribution, ScaleOut materialization, and LastScheduled dependency
handling. Controller-runtime client documentation and optimistic patch
contracts were consulted; no new scheduler backend abstraction is added.

Startup dependency selection and deduplication are shared by standalone
and PCSG-owned PodCliques. Redundant membership wrappers, scale-in
traversals, and idle branches are removed without dropping the deletion
barriers or health/epoch safeguards. PodCliqueScheduled now refreshes
ObservedGeneration even when its status is unchanged, preserving
LastTransitionTime.

Validation:
- `make validate`
- `make test-unit` across all repository modules, using Kubernetes 1.35.0
  envtest binaries
- Focused controller and startup-dependency tests
- `go test -c -tags=e2e ./e2e/tests` (compilation only)
- `git diff --check`

Real scheduler-backed E2E and actual HPA/KEDA integration were not run for
this revision. Earlier E2E and 1000-pod results do not validate the revised
wake semantics. Volcano/LPX/default-scheduler lifecycle compatibility
remains unverified.

#### Does this PR introduce a API change?

```release-note
Add zero-replica idle support for PodClique and PodCliqueScalingGroup.
Positive replica counts below minAvailable are rejected.
PCSG wake schedules replicas independently; standalone wake restores
membership to the existing anchor.
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
GREP-0677: https://github.com/ai-dynamo/grove/pull/686
```
