### PR TITLE
fix: use durable health history for gang termination

### DIFF
--- a/operator/api/common/constants/constants.go
+++ b/operator/api/common/constants/constants.go
@@ -118,18 +118,19 @@ const (
 	// ConditionTypePodCliqueScheduled indicates that the PodClique has been successfully scheduled.
 	// This condition is set to true when number of scheduled pods in the PodClique is greater than or equal to PodCliqueSpec.MinAvailable.
 	ConditionTypePodCliqueScheduled = "PodCliqueScheduled"
-	// ConditionTypeHealthyStateObserved is a monotonic signal set after a component reaches a
-	// genuinely scheduled or available state. Gang termination uses it to distinguish a regression
-	// from initial startup.
+	// ConditionTypeHealthyStateObserved records lifecycle history for gang termination,
+	// not current health. Once True, it is never cleared and persists across generations.
+	//
+	// Semantics:
+	//   - PodClique: PodCliqueScheduled was True at least once; readiness is not required.
+	//   - PodCliqueScalingGroup: AvailableReplicas reached MinAvailable at least once,
+	//     based on the readiness of its constituent PodCliques.
 	ConditionTypeHealthyStateObserved = "HealthyStateObserved"
 	// ConditionTypeGangTerminationInProgress indicates that PCS-level gang termination has fired for this
 	// PodCliqueScalingGroup and is still in flight. It is set on the PCSG when the PCS-level handler deletes
-	// the PodCliques of the whole PCS replica, and is cleared when the PCSG's MinAvailableBreached transitions
-	// back to False (recovered). While it is True, further PCS-level gang termination for the PCS replica is
-	// suppressed — at most one fire per breach episode, regardless of how long the workload stays below
-	// MinAvailable. This is a PCS-level-only mechanism: the PCSG-replica-scoped recycle path does not use this
-	// flag and instead breaks its own re-fire loop via WasPCLQEverScheduled, since a freshly recreated
-	// PodClique has never been scheduled and is therefore excluded from the breached set.
+	// the PodCliques of the whole PCS replica, and is cleared only when AvailableReplicas >= MinAvailable.
+	// While True, it suppresses repeated PCS-level firing within the same breach episode. The PCSG-replica
+	// recycle path instead uses WasPCLQEverScheduled, since a recreated PodClique has no scheduling history.
 	// Its only Reason is ConditionReasonGangTerminationActive.
 	ConditionTypeGangTerminationInProgress = "GangTerminationInProgress"
 	// ConditionTopologyLevelsUnavailable indicates that the required topology levels defined on a PodCliqueSet for topology-aware scheduling are no longer available.
@@ -159,8 +160,7 @@ const (
 	ConditionReasonInsufficientAvailablePCSGReplicas = "InsufficientAvailablePodCliqueScalingGroupReplicas"
 	// ConditionReasonSufficientAvailablePCSGReplicas indicates that the number of ready replicas in the PodCliqueScalingGroup is greater than or equal to the PodCliqueScalingGroupSpec.MinAvailable.
 	ConditionReasonSufficientAvailablePCSGReplicas = "SufficientAvailablePodCliqueScalingGroupReplicas"
-	// ConditionReasonHealthyStateObserved is used when a component first reaches a genuinely
-	// scheduled or available state.
+	// ConditionReasonHealthyStateObserved indicates the first observed scheduled or available state.
 	ConditionReasonHealthyStateObserved = "HealthyStateObserved"
 	// ConditionReasonUpdateInProgress indicates that the resource is undergoing rolling update.
 	ConditionReasonUpdateInProgress = "UpdateInProgress"

--- a/operator/api/common/constants/constants.go
+++ b/operator/api/common/constants/constants.go
@@ -118,6 +118,10 @@ const (
 	// ConditionTypePodCliqueScheduled indicates that the PodClique has been successfully scheduled.
 	// This condition is set to true when number of scheduled pods in the PodClique is greater than or equal to PodCliqueSpec.MinAvailable.
 	ConditionTypePodCliqueScheduled = "PodCliqueScheduled"
+	// ConditionTypeHealthyStateObserved is a monotonic signal set after a component reaches a
+	// genuinely scheduled or available state. Gang termination uses it to distinguish a regression
+	// from initial startup.
+	ConditionTypeHealthyStateObserved = "HealthyStateObserved"
 	// ConditionTypeGangTerminationInProgress indicates that PCS-level gang termination has fired for this
 	// PodCliqueScalingGroup and is still in flight. It is set on the PCSG when the PCS-level handler deletes
 	// the PodCliques of the whole PCS replica, and is cleared when the PCSG's MinAvailableBreached transitions
@@ -155,6 +159,9 @@ const (
 	ConditionReasonInsufficientAvailablePCSGReplicas = "InsufficientAvailablePodCliqueScalingGroupReplicas"
 	// ConditionReasonSufficientAvailablePCSGReplicas indicates that the number of ready replicas in the PodCliqueScalingGroup is greater than or equal to the PodCliqueScalingGroupSpec.MinAvailable.
 	ConditionReasonSufficientAvailablePCSGReplicas = "SufficientAvailablePodCliqueScalingGroupReplicas"
+	// ConditionReasonHealthyStateObserved is used when a component first reaches a genuinely
+	// scheduled or available state.
+	ConditionReasonHealthyStateObserved = "HealthyStateObserved"
 	// ConditionReasonUpdateInProgress indicates that the resource is undergoing rolling update.
 	ConditionReasonUpdateInProgress = "UpdateInProgress"
 	// ConditionReasonGangTerminationActive is the (only) Reason paired with

--- a/operator/e2e/yaml/upgrade.yaml
+++ b/operator/e2e/yaml/upgrade.yaml
@@ -6,6 +6,12 @@ spec:
   replicas: 1
   template:
     cliqueStartupType: CliqueStartupTypeExplicit
+    podCliqueScalingGroups:
+      - name: workers
+        cliqueNames:
+          - worker
+        replicas: 1
+        minAvailable: 1
     cliques:
       - name: bootstrap
         spec:

--- a/operator/internal/controller/common/component/utils/podclique.go
+++ b/operator/internal/controller/common/component/utils/podclique.go
@@ -94,30 +94,27 @@ func GroupPCLQsByPCSReplicaIndex(pclqs []grovecorev1alpha1.PodClique) (map[int][
 	return grouped, nil
 }
 
-// WasPCLQEverScheduled reports whether the PodClique has ever reached the
-// PodCliqueScheduled=True state. The signal is persisted explicitly so an initial negative
-// condition cannot be mistaken for a regression based on its transition timestamp.
+// WasPCLQEverScheduled reports whether durable status records PodCliqueScheduled=True.
 func WasPCLQEverScheduled(pclq *grovecorev1alpha1.PodClique) bool {
 	return meta.IsStatusConditionTrue(pclq.Status.Conditions, constants.ConditionTypeHealthyStateObserved)
 }
 
-// WasPCSGEverHealthy reports whether the PodCliqueScalingGroup has ever reached the
-// available state. It uses the same explicit signal as WasPCLQEverScheduled.
+// WasPCSGEverHealthy reports whether durable status records AvailableReplicas >= MinAvailable.
 func WasPCSGEverHealthy(pcsg *grovecorev1alpha1.PodCliqueScalingGroup) bool {
 	return meta.IsStatusConditionTrue(pcsg.Status.Conditions, constants.ConditionTypeHealthyStateObserved)
 }
 
-// MarkHealthyStateObserved records genuine health once and never clears it.
-func MarkHealthyStateObserved(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+// MarkHealthyStateObserved records lifecycle history once. ObservedGeneration is omitted
+// because the signal persists across generations and does not represent current health.
+func MarkHealthyStateObserved(conditions *[]metav1.Condition, message string) {
 	if meta.IsStatusConditionTrue(*conditions, constants.ConditionTypeHealthyStateObserved) {
 		return
 	}
 	meta.SetStatusCondition(conditions, metav1.Condition{
-		Type:               constants.ConditionTypeHealthyStateObserved,
-		Status:             metav1.ConditionTrue,
-		Reason:             constants.ConditionReasonHealthyStateObserved,
-		Message:            message,
-		ObservedGeneration: observedGeneration,
+		Type:    constants.ConditionTypeHealthyStateObserved,
+		Status:  metav1.ConditionTrue,
+		Reason:  constants.ConditionReasonHealthyStateObserved,
+		Message: message,
 	})
 }
 

--- a/operator/internal/controller/common/component/utils/podclique.go
+++ b/operator/internal/controller/common/component/utils/podclique.go
@@ -94,52 +94,31 @@ func GroupPCLQsByPCSReplicaIndex(pclqs []grovecorev1alpha1.PodClique) (map[int][
 	return grouped, nil
 }
 
-// InitialScheduleGrace is the small window after PodClique / PodCliqueScalingGroup creation in
-// which a flipped Status of a status condition is treated as the first-time-set rather than a
-// transition from a different state. WasPCLQEverScheduled / WasPCSGEverHealthy use it to absorb
-// the gap between the apiserver setting CreationTimestamp and the first reconcile that mutates
-// the relevant condition.
-const InitialScheduleGrace = 5 * time.Second
-
 // WasPCLQEverScheduled reports whether the PodClique has ever reached the
-// PodCliqueScheduled=True state since creation. The signal is derived from the
-// PodCliqueScheduled condition: either it is currently True, or it is currently False with a
-// LastTransitionTime sufficiently after CreationTimestamp that the condition must have flipped
-// since creation (i.e. through True). Used to gate gang-termination actions so a workload that
-// has never been healthy is left alone — only regressions get recycled.
-//
-// Limitation: like every status-derived check in the operator, this only sees transitions the
-// operator actually observed and persisted. If the condition flipped while no reconcile ran
-// (e.g. the operator was down), that transition is lost and the PCLQ is treated as
-// never-scheduled. This is a deliberate design trade-off: the gate errs on the side of NOT
-// gang-terminating, and the system stays eventually consistent — once the operator observes a
-// healthy state the gate re-arms and a later regression is recycled normally.
+// PodCliqueScheduled=True state. The signal is persisted explicitly so an initial negative
+// condition cannot be mistaken for a regression based on its transition timestamp.
 func WasPCLQEverScheduled(pclq *grovecorev1alpha1.PodClique) bool {
-	sched := meta.FindStatusCondition(pclq.Status.Conditions, constants.ConditionTypePodCliqueScheduled)
-	if sched == nil {
-		return false
-	}
-	if sched.Status == metav1.ConditionTrue {
-		return true
-	}
-	return sched.LastTransitionTime.After(pclq.CreationTimestamp.Add(InitialScheduleGrace))
+	return meta.IsStatusConditionTrue(pclq.Status.Conditions, constants.ConditionTypeHealthyStateObserved)
 }
 
 // WasPCSGEverHealthy reports whether the PodCliqueScalingGroup has ever reached the
-// MinAvailableBreached=False state since creation. Mirrors WasPCLQEverScheduled but reads the
-// PCSG's own MinAvailableBreached condition (PCSGs have no PodCliqueScheduled equivalent).
-// Used to gate gang-termination so an initial-startup PCSG that has not yet stabilized is left
-// alone — only regressions from a previously-healthy state get recycled.
-// Shares the observed-transitions-only limitation documented on WasPCLQEverScheduled.
+// available state. It uses the same explicit signal as WasPCLQEverScheduled.
 func WasPCSGEverHealthy(pcsg *grovecorev1alpha1.PodCliqueScalingGroup) bool {
-	cond := meta.FindStatusCondition(pcsg.Status.Conditions, constants.ConditionTypeMinAvailableBreached)
-	if cond == nil {
-		return false
+	return meta.IsStatusConditionTrue(pcsg.Status.Conditions, constants.ConditionTypeHealthyStateObserved)
+}
+
+// MarkHealthyStateObserved records genuine health once and never clears it.
+func MarkHealthyStateObserved(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	if meta.IsStatusConditionTrue(*conditions, constants.ConditionTypeHealthyStateObserved) {
+		return
 	}
-	if cond.Status == metav1.ConditionFalse {
-		return true
-	}
-	return cond.LastTransitionTime.After(pcsg.CreationTimestamp.Add(InitialScheduleGrace))
+	meta.SetStatusCondition(conditions, metav1.Condition{
+		Type:               constants.ConditionTypeHealthyStateObserved,
+		Status:             metav1.ConditionTrue,
+		Reason:             constants.ConditionReasonHealthyStateObserved,
+		Message:            message,
+		ObservedGeneration: observedGeneration,
+	})
 }
 
 // GetMinAvailableBreachedPCLQInfo filters PodCliques that have grovecorev1alpha1.ConditionTypeMinAvailableBreached set to true.

--- a/operator/internal/controller/common/component/utils/podclique_test.go
+++ b/operator/internal/controller/common/component/utils/podclique_test.go
@@ -415,57 +415,45 @@ func TestIsLastPCLQUpdateCompleted(t *testing.T) {
 	}
 }
 
-// TestWasPCLQEverScheduled covers the wasScheduled signal used to gate gang-termination
-// actions. The signal is True if PodCliqueScheduled is currently True, or if it is currently
-// False but its LastTransitionTime is sufficiently after the PCLQ's CreationTimestamp (which
-// means the condition must have flipped at least once since creation — i.e. through True).
+// TestWasPCLQEverScheduled covers the durable signal used to gate gang termination.
 func TestWasPCLQEverScheduled(t *testing.T) {
-	created := metav1.Now()
-	wellAfterCreate := metav1.NewTime(created.Add(InitialScheduleGrace + time.Second))
-	withinGraceOfCreate := metav1.NewTime(created.Add(time.Millisecond * 100))
-
 	tests := []struct {
 		name string
 		pclq *grovecorev1alpha1.PodClique
 		want bool
 	}{
 		{
-			name: "no PodCliqueScheduled condition (fresh, before first reconcile) — never scheduled",
-			pclq: &grovecorev1alpha1.PodClique{ObjectMeta: metav1.ObjectMeta{CreationTimestamp: created}},
+			name: "no durable condition",
+			pclq: &grovecorev1alpha1.PodClique{},
 			want: false,
 		},
 		{
-			name: "PodCliqueScheduled=False set near creation — never scheduled",
+			name: "scheduled condition alone does not count",
 			pclq: &grovecorev1alpha1.PodClique{
-				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: created},
-				Status: grovecorev1alpha1.PodCliqueStatus{Conditions: []metav1.Condition{{
-					Type:               constants.ConditionTypePodCliqueScheduled,
-					Status:             metav1.ConditionFalse,
-					LastTransitionTime: withinGraceOfCreate,
-				}}},
-			},
-			want: false,
-		},
-		{
-			name: "PodCliqueScheduled=True now — currently scheduled",
-			pclq: &grovecorev1alpha1.PodClique{
-				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: created},
 				Status: grovecorev1alpha1.PodCliqueStatus{Conditions: []metav1.Condition{{
 					Type:               constants.ConditionTypePodCliqueScheduled,
 					Status:             metav1.ConditionTrue,
-					LastTransitionTime: wellAfterCreate,
+					LastTransitionTime: metav1.Now(),
 				}}},
 			},
-			want: true,
+			want: false,
 		},
 		{
-			name: "PodCliqueScheduled=False but flipped well after create — was scheduled, regressed",
+			name: "durable condition false",
 			pclq: &grovecorev1alpha1.PodClique{
-				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: created},
 				Status: grovecorev1alpha1.PodCliqueStatus{Conditions: []metav1.Condition{{
-					Type:               constants.ConditionTypePodCliqueScheduled,
-					Status:             metav1.ConditionFalse,
-					LastTransitionTime: wellAfterCreate,
+					Type:   constants.ConditionTypeHealthyStateObserved,
+					Status: metav1.ConditionFalse,
+				}}},
+			},
+			want: false,
+		},
+		{
+			name: "durable condition true",
+			pclq: &grovecorev1alpha1.PodClique{
+				Status: grovecorev1alpha1.PodCliqueStatus{Conditions: []metav1.Condition{{
+					Type:   constants.ConditionTypeHealthyStateObserved,
+					Status: metav1.ConditionTrue,
 				}}},
 			},
 			want: true,
@@ -479,55 +467,45 @@ func TestWasPCLQEverScheduled(t *testing.T) {
 	}
 }
 
-// TestWasPCSGEverHealthy covers the PCSG analog: MinAvailableBreached=False at some point
-// since creation means the PCSG was ever in a healthy state.
+// TestWasPCSGEverHealthy covers the PCSG durable-health signal.
 func TestWasPCSGEverHealthy(t *testing.T) {
-	created := metav1.Now()
-	wellAfterCreate := metav1.NewTime(created.Add(InitialScheduleGrace + time.Second))
-	withinGraceOfCreate := metav1.NewTime(created.Add(time.Millisecond * 100))
-
 	tests := []struct {
 		name string
 		pcsg *grovecorev1alpha1.PodCliqueScalingGroup
 		want bool
 	}{
 		{
-			name: "no MinAvailableBreached condition (fresh) — never healthy",
-			pcsg: &grovecorev1alpha1.PodCliqueScalingGroup{ObjectMeta: metav1.ObjectMeta{CreationTimestamp: created}},
+			name: "no durable condition",
+			pcsg: &grovecorev1alpha1.PodCliqueScalingGroup{},
 			want: false,
 		},
 		{
-			name: "MinAvailableBreached=True set near creation — never healthy",
+			name: "non-breached condition alone does not count",
 			pcsg: &grovecorev1alpha1.PodCliqueScalingGroup{
-				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: created},
-				Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{Conditions: []metav1.Condition{{
-					Type:               constants.ConditionTypeMinAvailableBreached,
-					Status:             metav1.ConditionTrue,
-					LastTransitionTime: withinGraceOfCreate,
-				}}},
-			},
-			want: false,
-		},
-		{
-			name: "MinAvailableBreached=False now — currently healthy",
-			pcsg: &grovecorev1alpha1.PodCliqueScalingGroup{
-				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: created},
 				Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{Conditions: []metav1.Condition{{
 					Type:               constants.ConditionTypeMinAvailableBreached,
 					Status:             metav1.ConditionFalse,
-					LastTransitionTime: wellAfterCreate,
+					LastTransitionTime: metav1.Now(),
 				}}},
 			},
-			want: true,
+			want: false,
 		},
 		{
-			name: "MinAvailableBreached=True but flipped well after create — was healthy, regressed",
+			name: "durable condition false",
 			pcsg: &grovecorev1alpha1.PodCliqueScalingGroup{
-				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: created},
 				Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{Conditions: []metav1.Condition{{
-					Type:               constants.ConditionTypeMinAvailableBreached,
-					Status:             metav1.ConditionTrue,
-					LastTransitionTime: wellAfterCreate,
+					Type:   constants.ConditionTypeHealthyStateObserved,
+					Status: metav1.ConditionFalse,
+				}}},
+			},
+			want: false,
+		},
+		{
+			name: "durable condition true",
+			pcsg: &grovecorev1alpha1.PodCliqueScalingGroup{
+				Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{Conditions: []metav1.Condition{{
+					Type:   constants.ConditionTypeHealthyStateObserved,
+					Status: metav1.ConditionTrue,
 				}}},
 			},
 			want: true,
@@ -545,37 +523,39 @@ func TestWasPCSGEverHealthy(t *testing.T) {
 // have MinAvailableBreached=True but were never PodCliqueScheduled=True are excluded from the
 // candidate list — gang-termination must not fire on them.
 func TestGetMinAvailableBreachedPCLQInfoFiltersNeverScheduled(t *testing.T) {
-	created := metav1.Now()
-	wellAfterCreate := metav1.NewTime(created.Add(InitialScheduleGrace + time.Second))
-	withinGraceOfCreate := metav1.NewTime(created.Add(time.Millisecond * 100))
+	pastTransition := metav1.NewTime(time.Now().Add(-time.Hour))
 
 	pclqBreachedNeverScheduled := grovecorev1alpha1.PodClique{
-		ObjectMeta: metav1.ObjectMeta{Name: "never-scheduled", CreationTimestamp: created},
+		ObjectMeta: metav1.ObjectMeta{Name: "never-scheduled"},
 		Status: grovecorev1alpha1.PodCliqueStatus{Conditions: []metav1.Condition{
 			{
 				Type:               constants.ConditionTypePodCliqueScheduled,
 				Status:             metav1.ConditionFalse,
-				LastTransitionTime: withinGraceOfCreate,
+				LastTransitionTime: pastTransition,
 			},
 			{
 				Type:               constants.ConditionTypeMinAvailableBreached,
 				Status:             metav1.ConditionTrue,
-				LastTransitionTime: withinGraceOfCreate,
+				LastTransitionTime: pastTransition,
 			},
 		}},
 	}
 	pclqBreachedAfterHealthy := grovecorev1alpha1.PodClique{
-		ObjectMeta: metav1.ObjectMeta{Name: "regressed", CreationTimestamp: created},
+		ObjectMeta: metav1.ObjectMeta{Name: "regressed"},
 		Status: grovecorev1alpha1.PodCliqueStatus{Conditions: []metav1.Condition{
 			{
 				Type:               constants.ConditionTypePodCliqueScheduled,
 				Status:             metav1.ConditionFalse,
-				LastTransitionTime: wellAfterCreate,
+				LastTransitionTime: pastTransition,
 			},
 			{
 				Type:               constants.ConditionTypeMinAvailableBreached,
 				Status:             metav1.ConditionTrue,
-				LastTransitionTime: wellAfterCreate,
+				LastTransitionTime: pastTransition,
+			},
+			{
+				Type:   constants.ConditionTypeHealthyStateObserved,
+				Status: metav1.ConditionTrue,
 			},
 		}},
 	}

--- a/operator/internal/controller/common/component/utils/podclique_test.go
+++ b/operator/internal/controller/common/component/utils/podclique_test.go
@@ -415,7 +415,6 @@ func TestIsLastPCLQUpdateCompleted(t *testing.T) {
 	}
 }
 
-// TestWasPCLQEverScheduled covers the durable signal used to gate gang termination.
 func TestWasPCLQEverScheduled(t *testing.T) {
 	tests := []struct {
 		name string
@@ -467,7 +466,6 @@ func TestWasPCLQEverScheduled(t *testing.T) {
 	}
 }
 
-// TestWasPCSGEverHealthy covers the PCSG durable-health signal.
 func TestWasPCSGEverHealthy(t *testing.T) {
 	tests := []struct {
 		name string
@@ -523,10 +521,14 @@ func TestWasPCSGEverHealthy(t *testing.T) {
 // have MinAvailableBreached=True but were never PodCliqueScheduled=True are excluded from the
 // candidate list — gang-termination must not fire on them.
 func TestGetMinAvailableBreachedPCLQInfoFiltersNeverScheduled(t *testing.T) {
-	pastTransition := metav1.NewTime(time.Now().Add(-time.Hour))
-
+	now := time.Now()
+	creationTime := metav1.NewTime(now.Add(-2 * time.Hour))
+	pastTransition := metav1.NewTime(now.Add(-time.Hour))
 	pclqBreachedNeverScheduled := grovecorev1alpha1.PodClique{
-		ObjectMeta: metav1.ObjectMeta{Name: "never-scheduled"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "never-scheduled",
+			CreationTimestamp: creationTime,
+		},
 		Status: grovecorev1alpha1.PodCliqueStatus{Conditions: []metav1.Condition{
 			{
 				Type:               constants.ConditionTypePodCliqueScheduled,
@@ -561,8 +563,9 @@ func TestGetMinAvailableBreachedPCLQInfoFiltersNeverScheduled(t *testing.T) {
 	}
 
 	pclqs := []grovecorev1alpha1.PodClique{pclqBreachedNeverScheduled, pclqBreachedAfterHealthy}
-	names, _ := GetMinAvailableBreachedPCLQInfo(pclqs, time.Hour, time.Now())
-	assert.Equal(t, []string{"regressed"}, names, "never-scheduled PCLQ must be filtered out")
+	names, _ := GetMinAvailableBreachedPCLQInfo(pclqs, time.Minute, now)
+	assert.Equal(t, []string{"regressed"}, names,
+		"an upgraded PCLQ without durable health history must be filtered out even when the old timestamp heuristic would pass")
 }
 
 func TestGroupPCLQsByPCSReplicaIndex(t *testing.T) {

--- a/operator/internal/controller/podclique/reconcilestatus.go
+++ b/operator/internal/controller/podclique/reconcilestatus.go
@@ -276,6 +276,13 @@ func mutatePodCliqueScheduledCondition(pclq *grovecorev1alpha1.PodClique) {
 	if k8sutils.HasConditionChanged(pclq.Status.Conditions, newCondition) {
 		meta.SetStatusCondition(&pclq.Status.Conditions, newCondition)
 	}
+	if pclq.Spec.Replicas > 0 && newCondition.Status == metav1.ConditionTrue {
+		componentutils.MarkHealthyStateObserved(
+			&pclq.Status.Conditions,
+			pclq.Generation,
+			"PodClique reached its scheduling threshold",
+		)
+	}
 }
 
 // computePodCliqueScheduledCondition calculates the PodCliqueScheduled condition based on minimum availability requirements

--- a/operator/internal/controller/podclique/reconcilestatus.go
+++ b/operator/internal/controller/podclique/reconcilestatus.go
@@ -276,10 +276,10 @@ func mutatePodCliqueScheduledCondition(pclq *grovecorev1alpha1.PodClique) {
 	if k8sutils.HasConditionChanged(pclq.Status.Conditions, newCondition) {
 		meta.SetStatusCondition(&pclq.Status.Conditions, newCondition)
 	}
+	// The webhook enforces MinAvailable >= 1; Replicas > 0 guards scale-subresource edge paths.
 	if pclq.Spec.Replicas > 0 && newCondition.Status == metav1.ConditionTrue {
 		componentutils.MarkHealthyStateObserved(
 			&pclq.Status.Conditions,
-			pclq.Generation,
 			"PodClique reached its scheduling threshold",
 		)
 	}

--- a/operator/internal/controller/podclique/reconcilestatus_test.go
+++ b/operator/internal/controller/podclique/reconcilestatus_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -586,56 +585,21 @@ func TestReconcileStatusRequeuesOnConflict(t *testing.T) {
 		"a conflicting status patch should requeue after ComponentSyncRetryInterval")
 }
 
-func TestDelayedInitialFailureDoesNotArmGangTermination(t *testing.T) {
-	minAvailable := int32(2)
+func TestMutatePodCliqueScheduledConditionRecordsHealthyState(t *testing.T) {
 	pclq := &grovecorev1alpha1.PodClique{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "worker",
-			CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Hour)),
-		},
 		Spec: grovecorev1alpha1.PodCliqueSpec{
 			Replicas:     2,
-			MinAvailable: &minAvailable,
+			MinAvailable: ptr.To(int32(2)),
+		},
+		Status: grovecorev1alpha1.PodCliqueStatus{
+			ScheduledReplicas: 2,
 		},
 	}
 
 	mutatePodCliqueScheduledCondition(pclq)
-	mutateMinAvailableBreachedCondition(pclq, 0, 0)
-	assert.False(t, componentutils.WasPCLQEverScheduled(pclq), "an initial failure must not create scheduling history")
 
-	candidates, _ := componentutils.GetMinAvailableBreachedPCLQInfo(
-		[]grovecorev1alpha1.PodClique{*pclq},
-		0,
-		time.Now(),
-	)
-	assert.Empty(t, candidates, "an initial failure must not trigger gang termination")
-
-	pclq.Status.ScheduledReplicas = 2
-	pclq.Status.ReadyReplicas = 2
-	mutatePodCliqueScheduledCondition(pclq)
-	mutateMinAvailableBreachedCondition(pclq, 0, 0)
-	require.True(t, componentutils.WasPCLQEverScheduled(pclq), "genuine scheduling must arm regression handling")
-
-	observed := meta.FindStatusCondition(pclq.Status.Conditions, constants.ConditionTypeHealthyStateObserved)
-	require.NotNil(t, observed)
-	observedTransition := observed.LastTransitionTime
-	mutatePodCliqueScheduledCondition(pclq)
-	assert.Equal(t, observedTransition, meta.FindStatusCondition(
-		pclq.Status.Conditions,
-		constants.ConditionTypeHealthyStateObserved,
-	).LastTransitionTime, "the historical signal must be idempotent")
-
-	pclq.Status.ScheduledReplicas = 0
-	pclq.Status.ReadyReplicas = 0
-	mutatePodCliqueScheduledCondition(pclq)
-	mutateMinAvailableBreachedCondition(pclq, 0, 0)
-
-	candidates, _ = componentutils.GetMinAvailableBreachedPCLQInfo(
-		[]grovecorev1alpha1.PodClique{*pclq},
-		0,
-		time.Now(),
-	)
-	assert.Equal(t, []string{pclq.Name}, candidates, "a genuine regression must remain eligible for gang termination")
+	assert.True(t, componentutils.WasPCLQEverScheduled(pclq),
+		"a healthy legacy object must record durable history after upgrade")
 }
 
 // TestMutateSelector verifies the /scale selector is published for standalone PodCliques (with or

--- a/operator/internal/controller/podclique/reconcilestatus_test.go
+++ b/operator/internal/controller/podclique/reconcilestatus_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -583,6 +584,58 @@ func TestReconcileStatusRequeuesOnConflict(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, internalconstants.ComponentSyncRetryInterval, res.RequeueAfter,
 		"a conflicting status patch should requeue after ComponentSyncRetryInterval")
+}
+
+func TestDelayedInitialFailureDoesNotArmGangTermination(t *testing.T) {
+	minAvailable := int32(2)
+	pclq := &grovecorev1alpha1.PodClique{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "worker",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Hour)),
+		},
+		Spec: grovecorev1alpha1.PodCliqueSpec{
+			Replicas:     2,
+			MinAvailable: &minAvailable,
+		},
+	}
+
+	mutatePodCliqueScheduledCondition(pclq)
+	mutateMinAvailableBreachedCondition(pclq, 0, 0)
+	assert.False(t, componentutils.WasPCLQEverScheduled(pclq), "an initial failure must not create scheduling history")
+
+	candidates, _ := componentutils.GetMinAvailableBreachedPCLQInfo(
+		[]grovecorev1alpha1.PodClique{*pclq},
+		0,
+		time.Now(),
+	)
+	assert.Empty(t, candidates, "an initial failure must not trigger gang termination")
+
+	pclq.Status.ScheduledReplicas = 2
+	pclq.Status.ReadyReplicas = 2
+	mutatePodCliqueScheduledCondition(pclq)
+	mutateMinAvailableBreachedCondition(pclq, 0, 0)
+	require.True(t, componentutils.WasPCLQEverScheduled(pclq), "genuine scheduling must arm regression handling")
+
+	observed := meta.FindStatusCondition(pclq.Status.Conditions, constants.ConditionTypeHealthyStateObserved)
+	require.NotNil(t, observed)
+	observedTransition := observed.LastTransitionTime
+	mutatePodCliqueScheduledCondition(pclq)
+	assert.Equal(t, observedTransition, meta.FindStatusCondition(
+		pclq.Status.Conditions,
+		constants.ConditionTypeHealthyStateObserved,
+	).LastTransitionTime, "the historical signal must be idempotent")
+
+	pclq.Status.ScheduledReplicas = 0
+	pclq.Status.ReadyReplicas = 0
+	mutatePodCliqueScheduledCondition(pclq)
+	mutateMinAvailableBreachedCondition(pclq, 0, 0)
+
+	candidates, _ = componentutils.GetMinAvailableBreachedPCLQInfo(
+		[]grovecorev1alpha1.PodClique{*pclq},
+		0,
+		time.Now(),
+	)
+	assert.Equal(t, []string{pclq.Name}, candidates, "a genuine regression must remain eligible for gang termination")
 }
 
 // TestMutateSelector verifies the /scale selector is published for standalone PodCliques (with or

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
@@ -233,6 +233,19 @@ func mutateMinAvailableBreachedCondition(logger logr.Logger, pcsg *grovecorev1al
 			"reason", newCondition.Reason)
 		meta.SetStatusCondition(&pcsg.Status.Conditions, newCondition)
 	}
+	minAvailable := int32(1)
+	if pcsg.Spec.MinAvailable != nil {
+		minAvailable = *pcsg.Spec.MinAvailable
+	}
+	if pcsg.Spec.Replicas > 0 &&
+		newCondition.Status == metav1.ConditionFalse &&
+		pcsg.Status.AvailableReplicas >= minAvailable {
+		componentutils.MarkHealthyStateObserved(
+			&pcsg.Status.Conditions,
+			pcsg.Generation,
+			"PodCliqueScalingGroup reached its availability threshold",
+		)
+	}
 	if newCondition.Status == metav1.ConditionFalse &&
 		meta.IsStatusConditionTrue(pcsg.Status.Conditions, constants.ConditionTypeGangTerminationInProgress) {
 		logger.Info("Clearing GangTerminationInProgress condition — PCSG recovered",

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
@@ -219,10 +219,8 @@ func (r *Reconciler) emitAllScheduledReplicasLostIfNeeded(pcsg *grovecorev1alpha
 
 // mutateMinAvailableBreachedCondition updates the MinAvailableBreached condition based on replica availability.
 //
-// Whenever the computed condition is False (the PCSG is healthy) and the GangTerminationInProgress
-// condition is present, the latter is removed. The flag is only ever set while the PCSG is in
-// breach, so the first False observed with the flag still set is the recovery; clearing it
-// re-arms the next breach episode so a fresh regression can be recycled.
+// Clear GangTerminationInProgress only at the availability threshold; a transient non-breach
+// before recreated children report readiness is not recovery.
 func mutateMinAvailableBreachedCondition(logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup, pclqsPerPCSGReplica map[string][]grovecorev1alpha1.PodClique) {
 	newCondition := computeMinAvailableBreachedCondition(logger, pcsg, pclqsPerPCSGReplica)
 	if k8sutils.HasConditionChanged(pcsg.Status.Conditions, newCondition) {
@@ -233,25 +231,28 @@ func mutateMinAvailableBreachedCondition(logger logr.Logger, pcsg *grovecorev1al
 			"reason", newCondition.Reason)
 		meta.SetStatusCondition(&pcsg.Status.Conditions, newCondition)
 	}
-	minAvailable := int32(1)
-	if pcsg.Spec.MinAvailable != nil {
-		minAvailable = *pcsg.Spec.MinAvailable
-	}
-	if pcsg.Spec.Replicas > 0 &&
+	minAvailable := effectiveMinAvailable(pcsg)
+	hasReachedAvailabilityThreshold := pcsg.Spec.Replicas > 0 &&
 		newCondition.Status == metav1.ConditionFalse &&
-		pcsg.Status.AvailableReplicas >= minAvailable {
+		pcsg.Status.AvailableReplicas >= minAvailable
+	if hasReachedAvailabilityThreshold {
 		componentutils.MarkHealthyStateObserved(
 			&pcsg.Status.Conditions,
-			pcsg.Generation,
 			"PodCliqueScalingGroup reached its availability threshold",
 		)
 	}
-	if newCondition.Status == metav1.ConditionFalse &&
+	if hasReachedAvailabilityThreshold &&
 		meta.IsStatusConditionTrue(pcsg.Status.Conditions, constants.ConditionTypeGangTerminationInProgress) {
-		logger.Info("Clearing GangTerminationInProgress condition — PCSG recovered",
+		logger.Info("Clearing GangTerminationInProgress after PodCliqueScalingGroup recovered",
 			"pcsg", client.ObjectKeyFromObject(pcsg))
 		meta.RemoveStatusCondition(&pcsg.Status.Conditions, constants.ConditionTypeGangTerminationInProgress)
 	}
+}
+
+// effectiveMinAvailable returns the API default for legacy objects persisted before
+// Spec.MinAvailable was defaulted by the CRD schema.
+func effectiveMinAvailable(pcsg *grovecorev1alpha1.PodCliqueScalingGroup) int32 {
+	return ptr.Deref(pcsg.Spec.MinAvailable, 1)
 }
 
 // computeMinAvailableBreachedCondition computes the MinAvailableBreached condition for the
@@ -278,12 +279,10 @@ func computeMinAvailableBreachedCondition(logger logr.Logger, pcsg *grovecorev1a
 	// The apiserver defaults Spec.MinAvailable to 1 (+kubebuilder:default), but objects
 	// persisted under an older CRD schema can still read back nil until their next write —
 	// dereferencing unguarded would crash-loop the operator off a single legacy object.
-	minAvailable := 1
-	if pcsg.Spec.MinAvailable != nil {
-		minAvailable = int(*pcsg.Spec.MinAvailable)
-	} else {
+	if pcsg.Spec.MinAvailable == nil {
 		logger.Info("PCSG has nil Spec.MinAvailable; assuming API default of 1", "pcsg", client.ObjectKeyFromObject(pcsg))
 	}
+	minAvailable := int(effectiveMinAvailable(pcsg))
 	notInBreachReplicas := computeNotInBreachReplicas(logger, pcsg, pclqsPerPCSGReplica)
 	if notInBreachReplicas < minAvailable {
 		return metav1.Condition{
@@ -308,10 +307,8 @@ func computeMinAvailableBreachedCondition(logger logr.Logger, pcsg *grovecorev1a
 //
 // Completeness is required because a partially-created replica (e.g. one whose pc-c was deleted and
 // not yet recreated) has no breached PodClique yet is still not a valid healthy replica. Counting it
-// as not-in-breach would spuriously report the PCSG healthy and would also poison the was-healthy gate,
-// which reads a MinAvailableBreached=False as evidence that the PCSG was once healthy. This mirrors
-// computeReplicaStatus, which likewise treats a replica as unscheduled/unavailable unless all expected
-// PodCliques exist.
+// as not-in-breach would spuriously report the PCSG healthy. This mirrors computeReplicaStatus, which
+// likewise treats a replica as unscheduled/unavailable unless all expected PodCliques exist.
 //
 // Iteration is bounded to expected replica indexes [0, Spec.Replicas) so stale-index children left
 // behind during scale-down neither inflate nor deflate the count.

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus_test.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus_test.go
@@ -152,12 +152,22 @@ func TestComputeMinAvailableBreachedCondition(t *testing.T) {
 		wantReason   string
 	}{
 		{
-			name:     "all replicas healthy, none breached",
-			replicas: 3,
+			name:         "all replicas healthy, none breached",
+			replicas:     3,
+			minAvailable: ptr.To(int32(3)),
 			pclqsMap: map[string][]grovecorev1alpha1.PodClique{
 				"0": healthyPCSGReplica(),
 				"1": healthyPCSGReplica(),
 				"2": healthyPCSGReplica(),
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "SufficientAvailablePodCliqueScalingGroupReplicas",
+		},
+		{
+			name:     "legacy nil MinAvailable defaults to one",
+			replicas: 3,
+			pclqsMap: map[string][]grovecorev1alpha1.PodClique{
+				"0": healthyPCSGReplica(),
 			},
 			wantStatus: metav1.ConditionFalse,
 			wantReason: "SufficientAvailablePodCliqueScalingGroupReplicas",
@@ -230,8 +240,7 @@ func TestComputeMinAvailableBreachedCondition(t *testing.T) {
 		{
 			// Replica 0 is incomplete (its pc-c was deleted and not yet recreated) so it has no
 			// breached PodClique but is not a valid healthy replica; replica 1 is breached.
-			// notInBreach=0 < MinAvailable=1 → in breach. An incomplete replica must not be
-			// mistaken for a healthy one (which would also poison the was-healthy gate).
+			// notInBreach=0 < MinAvailable=1 → in breach.
 			name:         "one replica incomplete, one breached, MinAvailable=1 — in breach",
 			replicas:     2,
 			minAvailable: ptr.To(int32(1)),
@@ -259,14 +268,10 @@ func TestComputeMinAvailableBreachedCondition(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			minAvailable := tt.minAvailable
-			if minAvailable == nil {
-				minAvailable = &tt.replicas
-			}
 			pcsg := &grovecorev1alpha1.PodCliqueScalingGroup{
 				Spec: grovecorev1alpha1.PodCliqueScalingGroupSpec{
 					Replicas:     tt.replicas,
-					MinAvailable: minAvailable,
+					MinAvailable: tt.minAvailable,
 					// Each fixture replica carries exactly one PodClique, so a single clique name
 					// makes healthy/breached replicas "complete" and empty ones "incomplete".
 					CliqueNames: []string{"pc"},
@@ -282,50 +287,38 @@ func TestComputeMinAvailableBreachedCondition(t *testing.T) {
 	}
 }
 
-func TestDelayedInitialFailureDoesNotArmPCSGGangTermination(t *testing.T) {
-	minAvailable := int32(1)
+func TestMutateMinAvailableBreachedConditionRecordsHealthyState(t *testing.T) {
 	pcsg := &grovecorev1alpha1.PodCliqueScalingGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "workers",
-			CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Hour)),
-		},
 		Spec: grovecorev1alpha1.PodCliqueScalingGroupSpec{
 			Replicas:     1,
-			MinAvailable: &minAvailable,
+			MinAvailable: ptr.To(int32(1)),
 			CliqueNames:  []string{"worker"},
+		},
+		Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{
+			Conditions: []metav1.Condition{{
+				Type:   constants.ConditionTypeGangTerminationInProgress,
+				Status: metav1.ConditionTrue,
+				Reason: constants.ConditionReasonGangTerminationActive,
+			}},
 		},
 	}
 
-	// A complete child set can transiently produce MinAvailableBreached=False before the
-	// child PCLQ has reported status. AvailableReplicas is the positive evidence that keeps
-	// this from being mistaken for historical health.
+	// A complete child set can transiently report no breach before readiness is populated.
 	mutateMinAvailableBreachedCondition(logr.Discard(), pcsg, map[string][]grovecorev1alpha1.PodClique{
 		"0": {{}},
 	})
-	assert.False(t, componentutils.WasPCSGEverHealthy(pcsg), "an initial status gap must not create availability history")
+	assert.False(t, componentutils.WasPCSGEverHealthy(pcsg))
+	assert.True(t, meta.IsStatusConditionTrue(
+		pcsg.Status.Conditions,
+		constants.ConditionTypeGangTerminationInProgress,
+	), "a transient status gap must not re-arm gang termination")
 
 	pcsg.Status.AvailableReplicas = 1
 	mutateMinAvailableBreachedCondition(logr.Discard(), pcsg, map[string][]grovecorev1alpha1.PodClique{
 		"0": healthyPCSGReplica(),
 	})
-	require.True(t, componentutils.WasPCSGEverHealthy(pcsg), "genuine availability must arm regression handling")
-
-	observed := meta.FindStatusCondition(pcsg.Status.Conditions, constants.ConditionTypeHealthyStateObserved)
-	require.NotNil(t, observed)
-	observedTransition := observed.LastTransitionTime
-	mutateMinAvailableBreachedCondition(logr.Discard(), pcsg, map[string][]grovecorev1alpha1.PodClique{
-		"0": healthyPCSGReplica(),
-	})
-	assert.Equal(t, observedTransition, meta.FindStatusCondition(
-		pcsg.Status.Conditions,
-		constants.ConditionTypeHealthyStateObserved,
-	).LastTransitionTime, "the historical signal must be idempotent")
-
-	pcsg.Status.AvailableReplicas = 0
-	mutateMinAvailableBreachedCondition(logr.Discard(), pcsg, map[string][]grovecorev1alpha1.PodClique{
-		"0": breachedPCSGReplica(),
-	})
-	assert.True(t, componentutils.WasPCSGEverHealthy(pcsg), "the historical signal must survive regression")
+	assert.True(t, componentutils.WasPCSGEverHealthy(pcsg),
+		"a healthy legacy object must record durable history after upgrade")
 }
 
 // TestEmitAllScheduledReplicasLostIfNeeded covers the only explicit signal users have when a
@@ -1078,10 +1071,6 @@ func assertCondition(t *testing.T, pcsg *grovecorev1alpha1.PodCliqueScalingGroup
 	assert.Equal(t, expectBreached, isBreached, "condition breach status mismatch")
 }
 
-// TestMutateMinAvailableBreachedConditionClearsGangTerminationInProgress pins the second half
-// of the in-progress-flag loop-break design: when MinAvailableBreached transitions from True
-// (or unset) to False, the PCSG status reconciler must also remove the
-// GangTerminationInProgress condition so the next regression can be recycled.
 func TestMutateMinAvailableBreachedConditionClearsGangTerminationInProgress(t *testing.T) {
 	pcsg := &grovecorev1alpha1.PodCliqueScalingGroup{
 		Spec: grovecorev1alpha1.PodCliqueScalingGroupSpec{
@@ -1092,6 +1081,7 @@ func TestMutateMinAvailableBreachedConditionClearsGangTerminationInProgress(t *t
 			CliqueNames: []string{"pc"},
 		},
 		Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{
+			AvailableReplicas: 2,
 			Conditions: []metav1.Condition{
 				{
 					Type:   constants.ConditionTypeMinAvailableBreached,

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus_test.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -279,6 +280,52 @@ func TestComputeMinAvailableBreachedCondition(t *testing.T) {
 			assert.Equal(t, tt.wantReason, condition.Reason)
 		})
 	}
+}
+
+func TestDelayedInitialFailureDoesNotArmPCSGGangTermination(t *testing.T) {
+	minAvailable := int32(1)
+	pcsg := &grovecorev1alpha1.PodCliqueScalingGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "workers",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Hour)),
+		},
+		Spec: grovecorev1alpha1.PodCliqueScalingGroupSpec{
+			Replicas:     1,
+			MinAvailable: &minAvailable,
+			CliqueNames:  []string{"worker"},
+		},
+	}
+
+	// A complete child set can transiently produce MinAvailableBreached=False before the
+	// child PCLQ has reported status. AvailableReplicas is the positive evidence that keeps
+	// this from being mistaken for historical health.
+	mutateMinAvailableBreachedCondition(logr.Discard(), pcsg, map[string][]grovecorev1alpha1.PodClique{
+		"0": {{}},
+	})
+	assert.False(t, componentutils.WasPCSGEverHealthy(pcsg), "an initial status gap must not create availability history")
+
+	pcsg.Status.AvailableReplicas = 1
+	mutateMinAvailableBreachedCondition(logr.Discard(), pcsg, map[string][]grovecorev1alpha1.PodClique{
+		"0": healthyPCSGReplica(),
+	})
+	require.True(t, componentutils.WasPCSGEverHealthy(pcsg), "genuine availability must arm regression handling")
+
+	observed := meta.FindStatusCondition(pcsg.Status.Conditions, constants.ConditionTypeHealthyStateObserved)
+	require.NotNil(t, observed)
+	observedTransition := observed.LastTransitionTime
+	mutateMinAvailableBreachedCondition(logr.Discard(), pcsg, map[string][]grovecorev1alpha1.PodClique{
+		"0": healthyPCSGReplica(),
+	})
+	assert.Equal(t, observedTransition, meta.FindStatusCondition(
+		pcsg.Status.Conditions,
+		constants.ConditionTypeHealthyStateObserved,
+	).LastTransitionTime, "the historical signal must be idempotent")
+
+	pcsg.Status.AvailableReplicas = 0
+	mutateMinAvailableBreachedCondition(logr.Discard(), pcsg, map[string][]grovecorev1alpha1.PodClique{
+		"0": breachedPCSGReplica(),
+	})
+	assert.True(t, componentutils.WasPCSGEverHealthy(pcsg), "the historical signal must survive regression")
 }
 
 // TestEmitAllScheduledReplicasLostIfNeeded covers the only explicit signal users have when a

--- a/operator/internal/controller/podcliqueset/components/podcliquesetreplica/gangterminate.go
+++ b/operator/internal/controller/podcliqueset/components/podcliquesetreplica/gangterminate.go
@@ -171,13 +171,12 @@ func (r _resource) getExistingPCLQsByNames(ctx context.Context, namespace string
 //
 // Two gates run on top of the MinAvailableBreached=True check:
 //
-//  1. WasPCSGEverHealthy — a PCSG without durable evidence of genuine availability is in
-//     initial-startup, not a regression. Gang termination would just churn-loop Pending pods
-//     against a cluster that already cannot schedule them.
+//  1. WasPCSGEverHealthy — without durable availability history, treat the PCSG as starting,
+//     not regressed, to avoid recycling Pending pods on an unschedulable cluster.
 //  2. GangTerminationInProgress=True — a previous fire is already in flight; re-firing while
 //     it's still in flight would also churn-loop. The flag is set by createPCSReplicaDeleteTask
 //     after the DeleteAllOf succeeds, and cleared by the PCSG status reconciler once it
-//     observes MinAvailableBreached=False (recovery).
+//     genuinely recovers to AvailableReplicas >= MinAvailable.
 func getMinAvailableBreachedPCSGInfo(pcsgs []grovecorev1alpha1.PodCliqueScalingGroup, terminationDelay time.Duration, since time.Time) ([]string, time.Duration) {
 	pcsgCandidateNames := make([]string, 0, len(pcsgs))
 	waitForDurations := make([]time.Duration, 0, len(pcsgs))
@@ -211,8 +210,7 @@ func getMinAvailableBreachedPCSGInfo(pcsgs []grovecorev1alpha1.PodCliqueScalingG
 // After the DeleteAllOf succeeds we set GangTerminationInProgress=True on every PCSG in the
 // PCS replica, including PCSGs whose own PodCliques weren't the reason for this fire (their
 // PCLQs are collateral damage of the PCS-replica-wide delete and would otherwise re-trigger
-// the breach loop on the next reconcile). The PCSG status reconciler clears this flag once
-// it observes MinAvailableBreached=False, so a successful recycle naturally re-arms the
+// the breach loop on the next reconcile). Genuine recovery clears the flag and re-arms the
 // next breach episode.
 //
 // Ordering is action-first / flag-second: if the controller crashes between the DeleteAllOf
@@ -254,8 +252,7 @@ func (r _resource) createPCSReplicaDeleteTask(logger logr.Logger, pcs *grovecore
 			logger.Info("Deleted PCS replica PodCliques", "pcsReplicaIndex", pcsReplicaIndex, "reason", reason)
 			r.eventRecorder.Eventf(pcs, corev1.EventTypeNormal, constants.ReasonPodCliqueSetReplicaDeleteSuccessful, "PodCliqueSet replica %d deleted", pcsReplicaIndex)
 
-			// Mark every PCSG in this PCS replica as having a recycle in flight. The status
-			// reconciler clears it once it observes MinAvailableBreached=False (recovery).
+			// Mark every PCSG in this PCS replica as having a recycle in flight.
 			// Flag writes are attempted for ALL PCSGs before returning — a failure on one must
 			// not leave the rest unflagged, or the gate would stay inconsistent across PCSGs
 			// until the task is retried.

--- a/operator/internal/controller/podcliqueset/components/podcliquesetreplica/gangterminate.go
+++ b/operator/internal/controller/podcliqueset/components/podcliquesetreplica/gangterminate.go
@@ -171,9 +171,9 @@ func (r _resource) getExistingPCLQsByNames(ctx context.Context, namespace string
 //
 // Two gates run on top of the MinAvailableBreached=True check:
 //
-//  1. WasPCSGEverHealthy — a PCSG that has never reached MinAvailableBreached=False since
-//     creation is in initial-startup, not a regression. Gang termination would just churn-loop
-//     Pending pods against a cluster that already cannot schedule them.
+//  1. WasPCSGEverHealthy — a PCSG without durable evidence of genuine availability is in
+//     initial-startup, not a regression. Gang termination would just churn-loop Pending pods
+//     against a cluster that already cannot schedule them.
 //  2. GangTerminationInProgress=True — a previous fire is already in flight; re-firing while
 //     it's still in flight would also churn-loop. The flag is set by createPCSReplicaDeleteTask
 //     after the DeleteAllOf succeeds, and cleared by the PCSG status reconciler once it

--- a/operator/internal/controller/podcliqueset/components/podcliquesetreplica/gangterminate_test.go
+++ b/operator/internal/controller/podcliqueset/components/podcliquesetreplica/gangterminate_test.go
@@ -56,6 +56,12 @@ func TestGetMinAvailableBreachedPCSGInfoGangTerminationGate(t *testing.T) {
 		Reason:             apiconstants.ConditionReasonGangTerminationActive,
 		LastTransitionTime: pastTransition,
 	}
+	healthyStateObserved := metav1.Condition{
+		Type:               apiconstants.ConditionTypeHealthyStateObserved,
+		Status:             metav1.ConditionTrue,
+		Reason:             apiconstants.ConditionReasonHealthyStateObserved,
+		LastTransitionTime: pastTransition,
+	}
 
 	tests := []struct {
 		name       string
@@ -67,7 +73,7 @@ func TestGetMinAvailableBreachedPCSGInfoGangTerminationGate(t *testing.T) {
 			pcsg: grovecorev1alpha1.PodCliqueScalingGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pcsg-fresh-breach"},
 				Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{
-					Conditions: []metav1.Condition{breachedTrue},
+					Conditions: []metav1.Condition{breachedTrue, healthyStateObserved},
 				},
 			},
 			wantInList: true,
@@ -77,7 +83,7 @@ func TestGetMinAvailableBreachedPCSGInfoGangTerminationGate(t *testing.T) {
 			pcsg: grovecorev1alpha1.PodCliqueScalingGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pcsg-recycling"},
 				Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{
-					Conditions: []metav1.Condition{breachedTrue, inProgressTrue},
+					Conditions: []metav1.Condition{breachedTrue, healthyStateObserved, inProgressTrue},
 				},
 			},
 			wantInList: false,

--- a/operator/internal/controller/podcliqueset/components/podcliquesetreplica/gangterminate_test.go
+++ b/operator/internal/controller/podcliqueset/components/podcliquesetreplica/gangterminate_test.go
@@ -109,11 +109,11 @@ func TestGetMinAvailableBreachedPCSGInfoGangTerminationGate(t *testing.T) {
 			wantInList: false,
 		},
 		{
-			name: "breached but never healthy (initial startup) — skipped by wasHealthy gate",
+			name: "legacy object already regressed at upgrade is skipped without durable history",
 			pcsg: grovecorev1alpha1.PodCliqueScalingGroup{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "pcsg-initial-startup",
-					CreationTimestamp: metav1.NewTime(now.Add(-2 * time.Second)),
+					Name:              "pcsg-upgrade-regression",
+					CreationTimestamp: metav1.NewTime(now.Add(-2 * time.Hour)),
 				},
 				Status: grovecorev1alpha1.PodCliqueScalingGroupStatus{
 					Conditions: []metav1.Condition{
@@ -121,7 +121,7 @@ func TestGetMinAvailableBreachedPCSGInfoGangTerminationGate(t *testing.T) {
 							Type:               apiconstants.ConditionTypeMinAvailableBreached,
 							Status:             metav1.ConditionTrue,
 							Reason:             apiconstants.ConditionReasonScheduledReplicasBelowMinAvailable,
-							LastTransitionTime: metav1.NewTime(now.Add(-1 * time.Second)),
+							LastTransitionTime: metav1.NewTime(now.Add(-time.Hour)),
 						},
 					},
 				},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Replaces timestamp-based health inference with a durable
`HealthyStateObserved=True` condition. It is recorded when a PCLQ is scheduled
or a PCSG reaches `AvailableReplicas >= MinAvailable`.

This avoids treating a delayed first unhealthy reconcile as a regression.
Existing gang-termination retry behavior remains unchanged; #798 tracks that
separately.

#### Which issue(s) this PR fixes:

Fixes #789

#### Special notes for your reviewer:

`LastScheduled` remains the upgrade fallback for legacy PCLQs. Already-breached
PCSGs and PCLQs without durable history are not backfilled. Tests cover upgrade
migration and transient non-breached status without actual availability.

#### Does this PR introduce a API change?

```release-note
action required: Legacy PCSGs already below MinAvailable during upgrade, and
PCLQs without LastScheduled, remain excluded from automatic gang termination
until they become healthy. PCLQs with LastScheduled remain eligible.
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
GREP-0677 (#686)
```
