### PR TITLE
Coherent Update PreReq PR#2: Enhance PodGangStatus with LastReady and LastScheduled fields.

### DIFF
--- a/docs/api-reference/scheduler-api.md
+++ b/docs/api-reference/scheduler-api.md
@@ -106,6 +106,8 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `phase` _[PodGangPhase](#podgangphase)_ | Phase is the current phase of a PodGang. |  |  |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#condition-v1-meta) array_ | Conditions is a list of conditions that describe the current state of the PodGang. |  |  |
+| `lastScheduled` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#time-v1-meta)_ | LastScheduled is the time at which the Scheduled condition most recently transitioned to True.<br />It is nil until the PodGang is first scheduled and is never reset to nil once set. On a later<br />transition of the Scheduled condition back to True after a regression, it advances to the new time. |  |  |
+| `lastReady` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#time-v1-meta)_ | LastReady is the time at which the Ready condition most recently transitioned to True. It is nil<br />until the PodGang is first ready and is never reset to nil once set. On a later transition of the<br />Ready condition back to True after a regression, it advances to the new time. |  |  |
 | `placementScore` _float_ | PlacementScore is network optimality score for the PodGang. If the choice that the scheduler has made corresponds to the<br />best possible placement of the pods in the PodGang, then the score will be 1.0. Higher the score, better the placement. |  |  |
 
 

--- a/docs/proposals/393-coherent-rolling-updates/README.md
+++ b/docs/proposals/393-coherent-rolling-updates/README.md
@@ -743,16 +743,34 @@ The PodGang component reports two conditions on every `PodGang.Status` to expres
 
 | Condition | Meaning |
 | --- | --- |
-| `PodGangConditionTypeScheduled` | Set to `True` once `MinReplicas` pods of every `PodGroup` have been scheduled onto nodes. Setting `Scheduled=True` also implies `MinReplicas` has been released to 0 on every standalone-PCLQ PodGroup (PCSG-member PodGroups keep their original `MinReplicas` — see stage 2 below). Once set to `True`, this condition remains `True` for the rest of the PodGang's lifetime — placement is a one-time event from the scheduler's perspective. |
-| `PodGangConditionTypeReady` | Set to `True` when, for every `PodGroup`, the count of `Ready` pods (passing readiness probes) is at least the `MinAvailable` of the constituent PCLQ. The floor is read from the PCS spec, not from the live `MinReplicas` value on the PodGroup — a standalone-PCLQ PodGroup with `MinReplicas` released to 0 still needs its constituent PCLQ's `MinAvailable` Ready pods to count as `Ready`. Unlike `Scheduled`, this condition reflects current state — if pods fail readiness, the PodGang component flips it back to `False`. |
+| `PodGangConditionTypeScheduled` | Set to `True` while `MinReplicas` pods of every `PodGroup` are scheduled onto nodes. This condition reflects current state, so if scheduled pods are later evicted, deleted, or preempted and the count for any PodGroup falls below its `MinReplicas`, it flips back to `False`. The first time it transitions to `True`, the PodGang component patches `MinReplicas=0` on every standalone-PCLQ PodGroup (PCSG-member PodGroups keep their original `MinReplicas`, see [Why standalone-PCLQ PodGroups release MinReplicas but PCSG-member PodGroups do not](#why-standalone-pclq-podgroups-release-minreplicas-but-pcsg-member-podgroups-do-not)). |
+| `PodGangConditionTypeReady` | Set to `True` while, for every `PodGroup`, the count of `Ready` pods (passing readiness probes) is at least the `MinAvailable` of the constituent PCLQ. The floor is read from the PCS spec, not from the live `MinReplicas` value on the PodGroup, so a standalone-PCLQ PodGroup with `MinReplicas` released to 0 still needs its constituent PCLQ's `MinAvailable` Ready pods to count as `Ready`. This condition reflects current state, so it flips back to `False` if readiness regresses. |
 
-`Scheduled` is therefore strictly progressive; `Ready` tracks live serving status. The orchestrator's coherent-update advancement reads `Ready=True` only on PodGangs in `InFlightPodGangs` (the current sub-step's PodGangs), so a previously-advanced PodGang flipping `Ready=False` does not block update progression.
+Both conditions reflect current state. To support orchestrator gating and pod-component scheduling-gate-removal that need a stable "ever reached this state" signal, the PodGang component also maintains two timestamps in `PodGang.Status`:
+
+```go
+type PodGangStatus struct {
+    // ... existing fields ...
+    // LastScheduled is the wall-clock time at which the Scheduled condition most
+    // recently transitioned from False (or absent) to True. It is nil until the
+    // first such transition, and is never reset to nil thereafter.
+    LastScheduled *metav1.Time `json:"lastScheduled,omitempty"`
+    // LastReady is the wall-clock time at which the Ready condition most recently
+    // transitioned from False (or absent) to True. It is nil until the first such
+    // transition, and is never reset to nil thereafter.
+    LastReady *metav1.Time `json:"lastReady,omitempty"`
+}
+```
+
+These timestamps are updated on every `False→True` transition of their respective conditions and are never reset. `LastScheduled` gives the pod-component scheduling-gate-removal logic a durable "has been scheduled at least once" signal, and `LastReady` gives the coherent-update orchestrator a durable "has been ready at least once" signal, both of which survive a later regression of the underlying condition.
 
 The lifecycle of a PodGang the PodGang component creates — MPG, TPG, and legacy BPG/SPG alike — proceeds in three stages:
 
 1. **Set on creation.** Each `PodGroup`'s `MinReplicas` is set to the `MinAvailable` value defined in the PCS spec for the constituent PCLQ (standalone-PCLQ PodGroups) or for the member PCLQ (PCSG-member PodGroups). This forces the scheduler to place the whole gang at once before any constituent pod can run, establishing the `MinAvailable` floor for that component.
-2. **Release `MinReplicas` on standalone-PCLQ PodGroups, mark `Scheduled=True`.** Once the scheduler has placed `MinReplicas` pods of every `PodGroup` on nodes, the PodGang component patches `MinReplicas=0` on every **standalone-PCLQ PodGroup** of the PodGang, leaves **PCSG-member PodGroups** at their original `MinReplicas`, then sets `Status.Conditions[Type=Scheduled]=True` with `Reason=PodGangScheduled`. Pod-component scheduling-gate-removal logic uses this condition (see [DependsOn and scheduling order](#dependson-and-scheduling-order)).
-3. **Mark `Ready=True`.** Once every `PodGroup` has at least `MinAvailable` (of the constituent PCLQ) pods passing readiness probes, the PodGang component sets `Status.Conditions[Type=Ready]=True` with `Reason=PodGangReady`. The orchestrator uses this condition (together with the rest of the per-sub-step gate) to advance coherent-update sub-steps — see [Per-sub-step gate](#per-sub-step-gate).
+2. **First placement: release `MinReplicas` on standalone-PCLQ PodGroups, mark `Scheduled=True`, capture `LastScheduled`.** Once the scheduler has placed `MinReplicas` pods of every `PodGroup` on nodes, the PodGang component patches `MinReplicas=0` on every **standalone-PCLQ PodGroup** of the PodGang, leaves **PCSG-member PodGroups** at their original `MinReplicas`, sets `Status.Conditions[Type=Scheduled]=True` with `Reason=PodGangScheduled`, and sets `Status.LastScheduled = metav1.Now()`. Pod-component scheduling-gate-removal logic uses `LastScheduled` (see [DependsOn and scheduling order](#dependson-and-scheduling-order)).
+3. **First readiness: mark `Ready=True`, capture `LastReady`.** Once every `PodGroup` has at least `MinAvailable` (of the constituent PCLQ) pods passing readiness probes, the PodGang component sets `Status.Conditions[Type=Ready]=True` with `Reason=PodGangReady` and sets `Status.LastReady = metav1.Now()`. The orchestrator uses `LastReady` (together with the rest of the per-sub-step gate) to advance coherent-update sub-steps (see [Per-sub-step gate](#per-sub-step-gate)).
+
+After the first `False→True` transition, both conditions become live signals. They can flip back to `False` if placement or readiness regresses, and forward to `True` again on recovery. `LastScheduled` and `LastReady` advance on every fresh `False→True` transition.
 
 ##### Why standalone-PCLQ PodGroups release MinReplicas but PCSG-member PodGroups do not
 

--- a/operator/e2e/grove/podgang/podgang.go
+++ b/operator/e2e/grove/podgang/podgang.go
@@ -1,0 +1,140 @@
+//go:build e2e
+
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podgang
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	commonapi "github.com/ai-dynamo/grove/operator/api/common"
+	"github.com/ai-dynamo/grove/operator/e2e/log"
+	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Verifier provides capabilities to verify PodGang resources.
+type Verifier struct {
+	cl     client.Client
+	logger *log.Logger
+}
+
+// Check verifies a single PodGang. It returns nil if the PodGang passes the check
+// or an error why the check failed.
+type Check func(*groveschedulerv1alpha1.PodGang) error
+
+// NewVerifier creates a Verifier for PodGang resources bound to the given client.
+func NewVerifier(cl client.Client, logger *log.Logger) *Verifier {
+	return &Verifier{
+		cl:     cl,
+		logger: logger,
+	}
+}
+
+// List returns the PodGangs for the given PodCliqueSet name.
+func (v *Verifier) List(ctx context.Context, pcsNsName types.NamespacedName) ([]groveschedulerv1alpha1.PodGang, error) {
+	pgList := &groveschedulerv1alpha1.PodGangList{}
+	if err := v.cl.List(ctx, pgList,
+		client.InNamespace(pcsNsName.Namespace),
+		client.MatchingLabels(commonapi.GetDefaultLabelsForPodCliqueSetManagedResources(pcsNsName.Name))); err != nil {
+		return nil, err
+	}
+	return pgList.Items, nil
+}
+
+// Verify lists the PodGang(s) for the given PodCliqueSet namespace/name and applies the given
+// check to each of the PodGang. It returns an error if one of the below conditions is met:
+//  1. An error while listing PodGang resources.
+//  2. No PodGang is found
+//  3. Check fails for a PodGang (returns on the first failure).
+//
+// If there are no errors then it will return nil signaling that the verification has succeeded.
+func (v *Verifier) Verify(ctx context.Context, pcsNsName types.NamespacedName, check ...Check) error {
+	podGangs, err := v.List(ctx, pcsNsName)
+	if err != nil {
+		return err
+	}
+	if len(podGangs) == 0 {
+		return fmt.Errorf("no PodGang(s) found for PodCliqueSet %v", pcsNsName)
+	}
+	for i := range podGangs {
+		pg := &podGangs[i]
+		for _, c := range check {
+			if err := c(pg); err != nil {
+				return fmt.Errorf("check failed for PodGang %v: %w", client.ObjectKeyFromObject(pg), err)
+			}
+		}
+	}
+	return nil
+}
+
+// ConditionStatusCheckFn returns a Check that verifies the PodGang has the given condition type set
+// to the wanted status.
+func ConditionStatusCheckFn(condType groveschedulerv1alpha1.PodGangConditionType, want metav1.ConditionStatus) Check {
+	return func(pg *groveschedulerv1alpha1.PodGang) error {
+		cond := meta.FindStatusCondition(pg.Status.Conditions, string(condType))
+		if cond == nil {
+			return fmt.Errorf("condition %s not found", condType)
+		}
+		if cond.Status != want {
+			return fmt.Errorf("condition %s = %s, want %s", condType, cond.Status, want)
+		}
+		return nil
+	}
+}
+
+// LastScheduledSetCheckFn returns a Check that verifies whether Status.LastScheduled is set.
+func LastScheduledSetCheckFn(want bool) Check {
+	return func(pg *groveschedulerv1alpha1.PodGang) error {
+		if got := pg.Status.LastScheduled != nil; got != want {
+			return fmt.Errorf("LastScheduled set = %t, want %t", got, want)
+		}
+		return nil
+	}
+}
+
+// LastReadySetCheckFn returns a Check that verifies whether Status.LastReady is set.
+func LastReadySetCheckFn(want bool) Check {
+	return func(pg *groveschedulerv1alpha1.PodGang) error {
+		if got := pg.Status.LastReady != nil; got != want {
+			return fmt.Errorf("LastReady set = %t, want %t", got, want)
+		}
+		return nil
+	}
+}
+
+// WaitUntilVerified polls the named PodCliqueSet's PodGangs until every one satisfies all checks or
+// the timeout elapses. Verification is delegated to Verifier.Verify and runs immediately, then
+// repeats every interval. It returns nil once all checks pass. On timeout or context cancellation it
+// returns an error that joins the poll outcome with the last verification failure, so the message
+// names both why polling stopped and which check was not satisfied.
+func WaitUntilVerified(ctx context.Context, v *Verifier, pcsNsName types.NamespacedName, timeout, interval time.Duration, checks ...Check) error {
+	var lastErr error
+	pollErr := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+		lastErr = v.Verify(ctx, pcsNsName, checks...)
+		return lastErr == nil, nil
+	})
+	if pollErr == nil {
+		return nil
+	}
+	return fmt.Errorf("PodGangs for PodCliqueSet %v not verified within %s: %w", pcsNsName, timeout, errors.Join(pollErr, lastErr))
+}

--- a/operator/e2e/tests/gang_scheduling_test.go
+++ b/operator/e2e/tests/gang_scheduling_test.go
@@ -20,7 +20,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ai-dynamo/grove/operator/e2e/grove/podgang"
 	"github.com/ai-dynamo/grove/operator/e2e/testctx"
+	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // Test_GS1_GangSchedulingWithFullReplicas tests gang-scheduling behavior with insufficient resources
@@ -61,12 +65,37 @@ func Test_GS1_GangSchedulingWithFullReplicas(t *testing.T) {
 		t.Fatalf("Failed to verify all pods have Unschedulable events: %v", err)
 	}
 
-	Logger.Info("4. Uncordon the node and verify all pods get scheduled")
+	verifier := podgang.NewVerifier(tc.Client, Logger)
+	pcsNsName := types.NamespacedName{Namespace: tc.Namespace, Name: "workload1"}
+
+	Logger.Info("4. While pods are pending, verify PodGang conditions Initialized=True, Scheduled=False, Ready=False with timestamps unset")
+	if err := podgang.WaitUntilVerified(ctx, verifier, pcsNsName, tc.Timeout, tc.Interval,
+		podgang.ConditionStatusCheckFn(groveschedulerv1alpha1.PodGangConditionTypeInitialized, metav1.ConditionTrue),
+		podgang.ConditionStatusCheckFn(groveschedulerv1alpha1.PodGangConditionTypeScheduled, metav1.ConditionFalse),
+		podgang.ConditionStatusCheckFn(groveschedulerv1alpha1.PodGangConditionTypeReady, metav1.ConditionFalse),
+		podgang.LastScheduledSetCheckFn(false),
+		podgang.LastReadySetCheckFn(false),
+	); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	Logger.Info("5. Uncordon the node and verify all pods get scheduled")
 	tc.UncordonNodesAndWaitForPods([]string{workerNodeToCordon}, expectedPods)
 
 	// Verify that each pod is scheduled on a unique node, worker nodes have 150m memory
 	// and workload pods requests 80m memory, so only 1 should fit per node
+	Logger.Info("6. Verify that each pod is scheduled on a unique node")
 	tc.ListPodsAndAssertDistinctNodes()
+
+	Logger.Info("7. Once scheduled, verify PodGang conditions Scheduled=True, Ready=True with timestamps set")
+	if err := podgang.WaitUntilVerified(ctx, verifier, pcsNsName, tc.Timeout, tc.Interval,
+		podgang.ConditionStatusCheckFn(groveschedulerv1alpha1.PodGangConditionTypeScheduled, metav1.ConditionTrue),
+		podgang.ConditionStatusCheckFn(groveschedulerv1alpha1.PodGangConditionTypeReady, metav1.ConditionTrue),
+		podgang.LastScheduledSetCheckFn(true),
+		podgang.LastReadySetCheckFn(true),
+	); err != nil {
+		t.Fatalf("%v", err)
+	}
 
 	Logger.Info("🎉 Gang-scheduling With Full Replicas test completed successfully!")
 }

--- a/operator/internal/controller/podclique/register.go
+++ b/operator/internal/controller/podclique/register.go
@@ -147,24 +147,23 @@ func hasPodStatusChanged(updateEvent event.UpdateEvent) bool {
 	if !oldOk || !newOk {
 		return false
 	}
-	return hasReadyConditionChanged(oldPod.Status.Conditions, newPod.Status.Conditions) ||
+	return hasConditionStatusChanged(oldPod.Status.Conditions, newPod.Status.Conditions, corev1.PodReady) ||
+		hasConditionStatusChanged(oldPod.Status.Conditions, newPod.Status.Conditions, corev1.PodScheduled) ||
 		hasLastTerminationStateChanged(oldPod.Status.InitContainerStatuses, newPod.Status.InitContainerStatuses) ||
 		hasLastTerminationStateChanged(oldPod.Status.ContainerStatuses, newPod.Status.ContainerStatuses) ||
 		hasStartedAndReadyChangedForAnyContainer(oldPod.Status.ContainerStatuses, newPod.Status.ContainerStatuses)
 }
 
-// hasReadyConditionChanged checks if the Pod's Ready condition status has transitioned
-func hasReadyConditionChanged(oldPodConditions, newPodConditions []corev1.PodCondition) bool {
-	getReadyCondition := func(podConditions []corev1.PodCondition) (corev1.PodCondition, bool) {
-		return lo.Find(podConditions, func(condition corev1.PodCondition) bool {
-			return condition.Type == corev1.PodReady
+// hasConditionStatusChanged reports whether the given Pod condition transitioned into or out of the
+// True state between the old and new conditions. A missing condition counts as not True.
+func hasConditionStatusChanged(oldPodConditions, newPodConditions []corev1.PodCondition, condType corev1.PodConditionType) bool {
+	isTrue := func(podConditions []corev1.PodCondition) bool {
+		cond, ok := lo.Find(podConditions, func(condition corev1.PodCondition) bool {
+			return condition.Type == condType
 		})
+		return ok && cond.Status == corev1.ConditionTrue
 	}
-	oldPodReadyCondition, oldOk := getReadyCondition(oldPodConditions)
-	newPodReadyCondition, newOk := getReadyCondition(newPodConditions)
-	oldPodReady := oldOk && oldPodReadyCondition.Status == corev1.ConditionTrue
-	newPodReady := newOk && newPodReadyCondition.Status == corev1.ConditionTrue
-	return oldPodReady != newPodReady
+	return isTrue(oldPodConditions) != isTrue(newPodConditions)
 }
 
 // hasLastTerminationStateChanged detects changes in container termination states with non-zero exit codes

--- a/operator/internal/controller/podclique/register_test.go
+++ b/operator/internal/controller/podclique/register_test.go
@@ -75,6 +75,82 @@ func TestPodPredicate_Delete(t *testing.T) {
 	})
 }
 
+// TestPodPredicateUpdate verifies the pod predicate's Update path. A managed pod whose Scheduled or
+// Ready condition transitions must enqueue a reconcile so PodClique.Status.ScheduledReplicas and
+// ReadyReplicas stay current. Updates with no relevant status change, a spec change, or an
+// unmanaged pod must not enqueue.
+func TestPodPredicateUpdate(t *testing.T) {
+	const ns, pclqName, podName = "default", "pclq-1", "pclq-1-0"
+	r := &Reconciler{expectationsStore: expect.NewExpectationsStore()}
+	pred, ok := r.podPredicate().(predicate.Funcs)
+	require.True(t, ok, "predicate must be predicate.Funcs")
+
+	managedPod := func(conds ...corev1.PodCondition) *corev1.Pod {
+		b := testutils.NewPodBuilder(podName, ns).
+			WithOwner(pclqName).
+			WithLabels(map[string]string{common.LabelManagedByKey: common.LabelManagedByValue})
+		for _, c := range conds {
+			b = b.WithCondition(c)
+		}
+		return b.Build()
+	}
+	scheduled := corev1.PodCondition{Type: corev1.PodScheduled, Status: corev1.ConditionTrue}
+	notScheduled := corev1.PodCondition{Type: corev1.PodScheduled, Status: corev1.ConditionFalse}
+	ready := corev1.PodCondition{Type: corev1.PodReady, Status: corev1.ConditionTrue}
+	notReady := corev1.PodCondition{Type: corev1.PodReady, Status: corev1.ConditionFalse}
+
+	tests := []struct {
+		name     string
+		oldPod   *corev1.Pod
+		newPod   *corev1.Pod
+		wantFire bool
+	}{
+		{
+			name:     "Scheduled False to True enqueues",
+			oldPod:   managedPod(notScheduled),
+			newPod:   managedPod(scheduled),
+			wantFire: true,
+		},
+		{
+			name:     "Scheduled condition appears as True enqueues",
+			oldPod:   managedPod(),
+			newPod:   managedPod(scheduled),
+			wantFire: true,
+		},
+		{
+			name:     "Ready False to True enqueues",
+			oldPod:   managedPod(scheduled, notReady),
+			newPod:   managedPod(scheduled, ready),
+			wantFire: true,
+		},
+		{
+			name:     "no relevant status change does not enqueue",
+			oldPod:   managedPod(scheduled, ready),
+			newPod:   managedPod(scheduled, ready),
+			wantFire: false,
+		},
+		{
+			name:     "unmanaged pod does not enqueue",
+			oldPod:   testutils.NewPodBuilder(podName, ns).WithCondition(notScheduled).Build(),
+			newPod:   testutils.NewPodBuilder(podName, ns).WithCondition(scheduled).Build(),
+			wantFire: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantFire, pred.UpdateFunc(event.UpdateEvent{ObjectOld: tt.oldPod, ObjectNew: tt.newPod}))
+		})
+	}
+
+	t.Run("spec change does not enqueue even with a Scheduled transition", func(t *testing.T) {
+		oldPod := managedPod(notScheduled)
+		newPod := managedPod(scheduled)
+		newPod.Generation = oldPod.Generation + 1
+		assert.False(t, pred.UpdateFunc(event.UpdateEvent{ObjectOld: oldPod, ObjectNew: newPod}))
+	})
+}
+
 // TestPodCliqueSetPredicateCurrentlyUpdatingReplicaChanges verifies that the PodCliqueSet
 // watch predicate enqueues PodClique reconciles when the replica currently being rolled out
 // changes.

--- a/operator/internal/controller/podcliqueset/components/podgang/podgang.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/podgang.go
@@ -52,6 +52,7 @@ const (
 	errCodeSetControllerReference  grovecorev1alpha1.ErrorCode = "ERR_SET_CONTROLLER_REFERENCE"
 	errCodeCreateOrPatchPodGang    grovecorev1alpha1.ErrorCode = "ERR_CREATE_OR_PATCH_PODGANG"
 	errCodeResolveTopologyLevels   grovecorev1alpha1.ErrorCode = "ERR_RESOLVE_TOPOLOGY_LEVELS"
+	errCodeUpdatePodGangStatus     grovecorev1alpha1.ErrorCode = "ERR_UPDATE_PODGANG_STATUS"
 )
 
 type _resource struct {

--- a/operator/internal/controller/podcliqueset/components/podgang/podgang.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/podgang.go
@@ -34,7 +34,6 @@ import (
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -260,17 +259,4 @@ func (r _resource) getSchedulerNameForPCS(pcs *grovecorev1alpha1.PodCliqueSet) s
 		}
 	}
 	return r.schedRegistry.GetDefault().Name()
-}
-
-// setOrUpdateInitializedCondition sets or updates the PodGangInitialized condition on the PodGang status.
-func setOrUpdateInitializedCondition(pg *groveschedulerv1alpha1.PodGang, status metav1.ConditionStatus, reason, message string) {
-	condition := metav1.Condition{
-		Type:               string(groveschedulerv1alpha1.PodGangConditionTypeInitialized),
-		Status:             status,
-		ObservedGeneration: pg.Generation,
-		LastTransitionTime: metav1.Now(),
-		Reason:             reason,
-		Message:            message,
-	}
-	meta.SetStatusCondition(&pg.Status.Conditions, condition)
 }

--- a/operator/internal/controller/podcliqueset/components/podgang/podgang_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/podgang_test.go
@@ -39,7 +39,7 @@ func TestSetInitializedCondition(t *testing.T) {
 	pg := &groveschedulerv1alpha1.PodGang{
 		ObjectMeta: metav1.ObjectMeta{Name: "pg-1", Namespace: "default", Generation: 1},
 	}
-	setOrUpdateInitializedCondition(pg, metav1.ConditionFalse, "PodsPending", "waiting")
+	setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeInitialized, metav1.ConditionFalse, "PodsPending", "waiting")
 	require.Len(t, pg.Status.Conditions, 1)
 	assert.Equal(t, string(groveschedulerv1alpha1.PodGangConditionTypeInitialized), pg.Status.Conditions[0].Type)
 	assert.Equal(t, metav1.ConditionFalse, pg.Status.Conditions[0].Status)
@@ -47,7 +47,7 @@ func TestSetInitializedCondition(t *testing.T) {
 	assert.Equal(t, "waiting", pg.Status.Conditions[0].Message)
 
 	// Update existing condition to ready
-	setOrUpdateInitializedCondition(pg, metav1.ConditionTrue, "Ready", "all ready")
+	setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeInitialized, metav1.ConditionTrue, "Ready", "all ready")
 	require.Len(t, pg.Status.Conditions, 1)
 	assert.Equal(t, metav1.ConditionTrue, pg.Status.Conditions[0].Status)
 	assert.Equal(t, "Ready", pg.Status.Conditions[0].Reason)

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
@@ -446,9 +446,10 @@ func (r _resource) deleteExcessPodGangs(ctx context.Context, ss *syncState) erro
 	return nil
 }
 
-// createOrUpdatePodGangs creates or updates all expected PodGangs.
-// PodGangs are created with empty podReferences, Initialized=False.
-// Once all pods are created, PodReferences are populated and the PodGang is marked as Initialized=True.
+// createOrUpdatePodGangs creates or updates all expected PodGangs. PodGangs are created with empty
+// podReferences and Initialized set to False. Once all pods are created the PodReferences are
+// populated and the PodGang is marked Initialized True. The Scheduled and Ready conditions are
+// reconciled from live pod observation on every pass.
 func (r _resource) createOrUpdatePodGangs(ctx context.Context, ss *syncState) syncFlowResult {
 	result := syncFlowResult{}
 	for _, expectedPG := range ss.expectedPodGangs {
@@ -464,16 +465,18 @@ func (r _resource) createOrUpdatePodGangs(ctx context.Context, ss *syncState) sy
 			result.recordPodGangCreation(expectedPG.fqn)
 		}
 
-		// Verify all pods are created before proceeding
-		if err := r.verifyAllPodsCreated(ss, expectedPG); err != nil {
+		// verifyAllPodsCreated reports whether every constituent pod has been created and associated.
+		// Its result gates only the Initialized latch. The Scheduled and Ready conditions are live and
+		// are reconciled on every pass regardless, so a regression is reflected instead of frozen.
+		allPodsCreatedErr := r.verifyAllPodsCreated(ss, expectedPG)
+		if allPodsCreatedErr != nil {
 			ss.logger.Info("Not all pods are created or associated to the PodGang yet", "PodGangName", expectedPG.fqn)
-			result.recordError(err)
-			continue
+			result.recordError(allPodsCreatedErr)
 		}
 
-		// Reconcile the PodGang status conditions (Initialized, Scheduled, Ready) and their
-		// timestamps from live pod observation.
-		if err := r.reconcilePodGangStatus(ctx, ss, expectedPG); err != nil {
+		// Reconcile the PodGang Scheduled and Ready conditions and their timestamps from live pod
+		// observation. Initialized is set to True only once all pods are created, and is never reset.
+		if err := r.reconcilePodGangStatus(ctx, ss, expectedPG, allPodsCreatedErr == nil); err != nil {
 			ss.logger.Error(err, "failed to reconcile PodGang status", "PodGangName", expectedPG.fqn)
 			result.recordError(err)
 			continue
@@ -483,14 +486,14 @@ func (r _resource) createOrUpdatePodGangs(ctx context.Context, ss *syncState) sy
 	return result
 }
 
-// reconcilePodGangStatus reads the live PodGang and reconciles its Initialized, Scheduled and
-// Ready conditions from live pod observation, advancing LastScheduled and LastReady on each fresh
-// transition to True. It is called after verifyAllPodsCreated passes, so Initialized is set to
-// True here. It does not write Phase, which the backend scheduler owns. The patch takes an
-// optimistic lock so a write built from a stale cached PodGang is rejected with a conflict rather
-// than reverting a concurrent scheduler update, in which case a requeue is signalled. It emits at
-// most one status-subresource patch per call, skipping the patch when the status is unchanged.
-func (r _resource) reconcilePodGangStatus(ctx context.Context, ss *syncState, pgi *podGangInfo) error {
+// reconcilePodGangStatus reconciles the PodGang status from live pods.
+//   - Scheduled and Ready track current pod state on every call and advance LastScheduled and
+//     LastReady on each fresh transition to True.
+//   - Initialized is a one-way latch set to True when allPodsCreated is true and never reset.
+//   - The patch is optimistically locked so a write from a stale cache is rejected as a conflict
+//     and signals a requeue.
+//   - At most one status patch is emitted per call, and it is skipped when the status is unchanged.
+func (r _resource) reconcilePodGangStatus(ctx context.Context, ss *syncState, pgi *podGangInfo, allPodsCreated bool) error {
 	pg, err := componentutils.GetPodGang(ctx, r.client, pgi.fqn, ss.pcs.Namespace)
 	if err != nil {
 		return err
@@ -502,8 +505,10 @@ func (r _resource) reconcilePodGangStatus(ctx context.Context, ss *syncState, pg
 	minReplicasScheduled := r.arePodGangMinReplicasScheduled(ss, pgi)
 	minReplicasReady := r.arePodGangMinReplicasReady(ss, pgi)
 
-	setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeInitialized, metav1.ConditionTrue,
-		groveschedulerv1alpha1.ConditionReasonPodGangPodsCreated, "PodGang is fully initialized")
+	if allPodsCreated {
+		setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeInitialized, metav1.ConditionTrue,
+			groveschedulerv1alpha1.ConditionReasonPodGangPodsCreated, "PodGang is fully initialized")
+	}
 	setScheduledCondition(pg, minReplicasScheduled, now)
 	setReadyCondition(pg, minReplicasReady, now)
 
@@ -519,22 +524,6 @@ func (r _resource) reconcilePodGangStatus(ctx context.Context, ss *syncState, pg
 			fmt.Sprintf("failed to patch status for PodGang %s", pgi.fqn))
 	}
 	return nil
-}
-
-// setScheduledCondition sets the Scheduled condition from the live scheduled count and advances
-// LastScheduled when the condition transitions to True. LastScheduled is never reset once set.
-func setScheduledCondition(pg *groveschedulerv1alpha1.PodGang, minReplicasScheduled bool, now metav1.Time) {
-	status := metav1.ConditionFalse
-	reason := groveschedulerv1alpha1.ConditionReasonPodGangNotReady
-	message := "one or more PodGroups have fewer scheduled pods than MinReplicas"
-	if minReplicasScheduled {
-		status = metav1.ConditionTrue
-		reason = groveschedulerv1alpha1.ConditionReasonPodGangScheduled
-		message = "MinReplicas pods of every PodGroup are scheduled"
-	}
-	if setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeScheduled, status, reason, message) && minReplicasScheduled {
-		pg.Status.LastScheduled = &now
-	}
 }
 
 // arePodGangMinReplicasScheduled returns true if, for every constituent PodClique, at least
@@ -557,38 +546,6 @@ func (r _resource) arePodGangMinReplicasScheduled(ss *syncState, pgi *podGangInf
 	return true
 }
 
-// setPodGangCondition sets the given condition via meta.SetStatusCondition and returns whether the
-// condition's status changed, that is whether this call was a transition rather than an idempotent
-// re-assertion of the same status. A nil prior condition counts as a transition.
-func setPodGangCondition(pg *groveschedulerv1alpha1.PodGang, condType groveschedulerv1alpha1.PodGangConditionType, status metav1.ConditionStatus, reason, message string) bool {
-	prior := meta.FindStatusCondition(pg.Status.Conditions, string(condType))
-	changed := prior == nil || prior.Status != status
-	meta.SetStatusCondition(&pg.Status.Conditions, metav1.Condition{
-		Type:               string(condType),
-		Status:             status,
-		ObservedGeneration: pg.Generation,
-		Reason:             reason,
-		Message:            message,
-	})
-	return changed
-}
-
-// setReadyCondition sets the Ready condition from the live ready count and advances LastReady when
-// the condition transitions to True. LastReady is never reset once set.
-func setReadyCondition(pg *groveschedulerv1alpha1.PodGang, minReplicasReady bool, now metav1.Time) {
-	status := metav1.ConditionFalse
-	reason := groveschedulerv1alpha1.ConditionReasonPodGangNotReady
-	message := "one or more PodGroups have fewer ready pods than MinReplicas"
-	if minReplicasReady {
-		status = metav1.ConditionTrue
-		reason = groveschedulerv1alpha1.ConditionReasonPodGangReady
-		message = "MinReplicas pods of every PodGroup are ready"
-	}
-	if setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeReady, status, reason, message) && minReplicasReady {
-		pg.Status.LastReady = &now
-	}
-}
-
 // arePodGangMinReplicasReady returns true if, for every constituent PodClique, at least
 // MinReplicas pods associated to this PodGang are Ready. Only pods named in the PodClique's
 // associatedPodNames are counted, so a PodClique whose pods are spread across more than one
@@ -609,6 +566,54 @@ func (r _resource) arePodGangMinReplicasReady(ss *syncState, pgi *podGangInfo) b
 	return true
 }
 
+// setPodGangCondition sets the given condition via meta.SetStatusCondition and returns whether the
+// condition's status changed, that is whether this call was a transition rather than an idempotent
+// re-assertion of the same status. A nil prior condition counts as a transition.
+func setPodGangCondition(pg *groveschedulerv1alpha1.PodGang, condType groveschedulerv1alpha1.PodGangConditionType, status metav1.ConditionStatus, reason, message string) bool {
+	prior := meta.FindStatusCondition(pg.Status.Conditions, string(condType))
+	changed := prior == nil || prior.Status != status
+	meta.SetStatusCondition(&pg.Status.Conditions, metav1.Condition{
+		Type:               string(condType),
+		Status:             status,
+		ObservedGeneration: pg.Generation,
+		Reason:             reason,
+		Message:            message,
+	})
+	return changed
+}
+
+// setScheduledCondition sets the Scheduled condition from the live scheduled count and advances
+// LastScheduled when the condition transitions to True. LastScheduled is never reset once set.
+func setScheduledCondition(pg *groveschedulerv1alpha1.PodGang, minReplicasScheduled bool, now metav1.Time) {
+	status := metav1.ConditionFalse
+	reason := groveschedulerv1alpha1.ConditionReasonPodGangNotReady
+	message := "one or more PodGroups have fewer scheduled pods than MinReplicas"
+	if minReplicasScheduled {
+		status = metav1.ConditionTrue
+		reason = groveschedulerv1alpha1.ConditionReasonPodGangScheduled
+		message = "MinReplicas pods of every PodGroup are scheduled"
+	}
+	if setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeScheduled, status, reason, message) && minReplicasScheduled {
+		pg.Status.LastScheduled = &now
+	}
+}
+
+// setReadyCondition sets the Ready condition from the live ready count and advances LastReady when
+// the condition transitions to True. LastReady is never reset once set.
+func setReadyCondition(pg *groveschedulerv1alpha1.PodGang, minReplicasReady bool, now metav1.Time) {
+	status := metav1.ConditionFalse
+	reason := groveschedulerv1alpha1.ConditionReasonPodGangNotReady
+	message := "one or more PodGroups have fewer ready pods than MinReplicas"
+	if minReplicasReady {
+		status = metav1.ConditionTrue
+		reason = groveschedulerv1alpha1.ConditionReasonPodGangReady
+		message = "MinReplicas pods of every PodGroup are ready"
+	}
+	if setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeReady, status, reason, message) && minReplicasReady {
+		pg.Status.LastReady = &now
+	}
+}
+
 // patchPodGangInitializedStatus patches the Initialized condition with the given status.
 func (r _resource) patchPodGangInitializedStatus(ctx context.Context, ss *syncState, podGangName string, status metav1.ConditionStatus, reason, message string) error {
 	// Create a PodGang object with only the status we want to patch
@@ -618,7 +623,7 @@ func (r _resource) patchPodGangInitializedStatus(ctx context.Context, ss *syncSt
 			Namespace: ss.pcs.Namespace,
 		},
 	}
-	setOrUpdateInitializedCondition(statusPatch, status, reason, message)
+	setPodGangCondition(statusPatch, groveschedulerv1alpha1.PodGangConditionTypeInitialized, status, reason, message)
 	// One could argue why not use Status.Phase to also denote Initialized condition. For now the argument is that
 	// current set of phases (Pending, Starting, Running) is influenced by the status of constituent Pods w.r.t their
 	// scheduling state, whereas initialized condition is denoting if a PodGang is ready to be scheduled

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
@@ -593,7 +593,8 @@ func setScheduledCondition(pg *groveschedulerv1alpha1.PodGang, minReplicasSchedu
 		reason = groveschedulerv1alpha1.ConditionReasonPodGangScheduled
 		message = "MinReplicas pods of every PodGroup are scheduled"
 	}
-	if setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeScheduled, status, reason, message) && minReplicasScheduled {
+	mutated := setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeScheduled, status, reason, message)
+	if mutated && minReplicasScheduled {
 		pg.Status.LastScheduled = &now
 	}
 }
@@ -609,7 +610,8 @@ func setReadyCondition(pg *groveschedulerv1alpha1.PodGang, minReplicasReady bool
 		reason = groveschedulerv1alpha1.ConditionReasonPodGangReady
 		message = "MinReplicas pods of every PodGroup are ready"
 	}
-	if setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeReady, status, reason, message) && minReplicasReady {
+	mutated := setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeReady, status, reason, message)
+	if mutated && minReplicasReady {
 		pg.Status.LastReady = &now
 	}
 }

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
@@ -32,7 +33,9 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -468,17 +471,142 @@ func (r _resource) createOrUpdatePodGangs(ctx context.Context, ss *syncState) sy
 			continue
 		}
 
-		// Update status to set Initialized=True (idempotent - no need to check current state)
-		if !ss.isPodGangInitialized(expectedPG.fqn) {
-			if err := r.patchPodGangInitializedStatus(ctx, ss, expectedPG.fqn, metav1.ConditionTrue, groveschedulerv1alpha1.ConditionReasonPodGangPodsCreated, "PodGang is fully initialized"); err != nil {
-				ss.logger.Error(err, "failed to update Initialized condition in PodGang status", "PodGangName", expectedPG.fqn)
-				result.recordError(err)
-				continue
-			}
+		// Reconcile the PodGang status conditions (Initialized, Scheduled, Ready) and their
+		// timestamps from live pod observation.
+		if err := r.reconcilePodGangStatus(ctx, ss, expectedPG); err != nil {
+			ss.logger.Error(err, "failed to reconcile PodGang status", "PodGangName", expectedPG.fqn)
+			result.recordError(err)
+			continue
 		}
 	}
 
 	return result
+}
+
+// reconcilePodGangStatus reads the live PodGang and reconciles its Initialized, Scheduled and
+// Ready conditions from live pod observation, advancing LastScheduled and LastReady on each fresh
+// transition to True. It is called after verifyAllPodsCreated passes, so Initialized is set to
+// True here. It does not write Phase, which the backend scheduler owns. The patch takes an
+// optimistic lock so a write built from a stale cached PodGang is rejected with a conflict rather
+// than reverting a concurrent scheduler update, in which case a requeue is signalled. It emits at
+// most one status-subresource patch per call, skipping the patch when the status is unchanged.
+func (r _resource) reconcilePodGangStatus(ctx context.Context, ss *syncState, pgi *podGangInfo) error {
+	pg, err := componentutils.GetPodGang(ctx, r.client, pgi.fqn, ss.pcs.Namespace)
+	if err != nil {
+		return err
+	}
+	patch := client.MergeFromWithOptions(pg.DeepCopy(), client.MergeFromWithOptimisticLock{})
+	originalStatus := pg.Status.DeepCopy()
+	now := metav1.Now()
+
+	minReplicasScheduled := r.arePodGangMinReplicasScheduled(ss, pgi)
+	minReplicasReady := r.arePodGangMinReplicasReady(ss, pgi)
+
+	setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeInitialized, metav1.ConditionTrue,
+		groveschedulerv1alpha1.ConditionReasonPodGangPodsCreated, "PodGang is fully initialized")
+	setScheduledCondition(pg, minReplicasScheduled, now)
+	setReadyCondition(pg, minReplicasReady, now)
+
+	if equality.Semantic.DeepEqual(*originalStatus, pg.Status) {
+		return nil
+	}
+	if err = r.client.Status().Patch(ctx, pg, patch); err != nil {
+		if apierrors.IsConflict(err) {
+			return groveerr.New(groveerr.ErrCodeRequeueAfter, component.OperationSync,
+				fmt.Sprintf("conflict patching PodGang %s status from a stale cache, re-queueing", pgi.fqn))
+		}
+		return groveerr.WrapError(err, errCodeUpdatePodGangStatus, component.OperationSync,
+			fmt.Sprintf("failed to patch status for PodGang %s", pgi.fqn))
+	}
+	return nil
+}
+
+// setScheduledCondition sets the Scheduled condition from the live scheduled count and advances
+// LastScheduled when the condition transitions to True. LastScheduled is never reset once set.
+func setScheduledCondition(pg *groveschedulerv1alpha1.PodGang, minReplicasScheduled bool, now metav1.Time) {
+	status := metav1.ConditionFalse
+	reason := groveschedulerv1alpha1.ConditionReasonPodGangNotReady
+	message := "one or more PodGroups have fewer scheduled pods than MinReplicas"
+	if minReplicasScheduled {
+		status = metav1.ConditionTrue
+		reason = groveschedulerv1alpha1.ConditionReasonPodGangScheduled
+		message = "MinReplicas pods of every PodGroup are scheduled"
+	}
+	if setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeScheduled, status, reason, message) && minReplicasScheduled {
+		pg.Status.LastScheduled = &now
+	}
+}
+
+// arePodGangMinReplicasScheduled returns true if, for every constituent PodClique, at least
+// MinReplicas pods associated to this PodGang have been scheduled. Only pods named in the
+// PodClique's associatedPodNames are counted, so a PodClique whose pods are spread across more
+// than one PodGang is evaluated per PodGang.
+func (r _resource) arePodGangMinReplicasScheduled(ss *syncState, pgi *podGangInfo) bool {
+	for _, pclq := range pgi.pclqs {
+		pods := ss.existingPCLQPods[pclq.fqn]
+		var scheduledCount int32
+		for i := range pods {
+			if slices.Contains(pclq.associatedPodNames, pods[i].Name) && k8sutils.IsPodScheduled(&pods[i]) {
+				scheduledCount++
+			}
+		}
+		if scheduledCount < pclq.minAvailable {
+			return false
+		}
+	}
+	return true
+}
+
+// setPodGangCondition sets the given condition via meta.SetStatusCondition and returns whether the
+// condition's status changed, that is whether this call was a transition rather than an idempotent
+// re-assertion of the same status. A nil prior condition counts as a transition.
+func setPodGangCondition(pg *groveschedulerv1alpha1.PodGang, condType groveschedulerv1alpha1.PodGangConditionType, status metav1.ConditionStatus, reason, message string) bool {
+	prior := meta.FindStatusCondition(pg.Status.Conditions, string(condType))
+	changed := prior == nil || prior.Status != status
+	meta.SetStatusCondition(&pg.Status.Conditions, metav1.Condition{
+		Type:               string(condType),
+		Status:             status,
+		ObservedGeneration: pg.Generation,
+		Reason:             reason,
+		Message:            message,
+	})
+	return changed
+}
+
+// setReadyCondition sets the Ready condition from the live ready count and advances LastReady when
+// the condition transitions to True. LastReady is never reset once set.
+func setReadyCondition(pg *groveschedulerv1alpha1.PodGang, minReplicasReady bool, now metav1.Time) {
+	status := metav1.ConditionFalse
+	reason := groveschedulerv1alpha1.ConditionReasonPodGangNotReady
+	message := "one or more PodGroups have fewer ready pods than MinReplicas"
+	if minReplicasReady {
+		status = metav1.ConditionTrue
+		reason = groveschedulerv1alpha1.ConditionReasonPodGangReady
+		message = "MinReplicas pods of every PodGroup are ready"
+	}
+	if setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeReady, status, reason, message) && minReplicasReady {
+		pg.Status.LastReady = &now
+	}
+}
+
+// arePodGangMinReplicasReady returns true if, for every constituent PodClique, at least
+// MinReplicas pods associated to this PodGang are Ready. Only pods named in the PodClique's
+// associatedPodNames are counted, so a PodClique whose pods are spread across more than one
+// PodGang is evaluated per PodGang.
+func (r _resource) arePodGangMinReplicasReady(ss *syncState, pgi *podGangInfo) bool {
+	for _, pclq := range pgi.pclqs {
+		pods := ss.existingPCLQPods[pclq.fqn]
+		var readyCount int32
+		for i := range pods {
+			if slices.Contains(pclq.associatedPodNames, pods[i].Name) && k8sutils.IsPodReady(&pods[i]) {
+				readyCount++
+			}
+		}
+		if readyCount < pclq.minAvailable {
+			return false
+		}
+	}
+	return true
 }
 
 // patchPodGangInitializedStatus patches the Initialized condition with the given status.
@@ -639,11 +767,6 @@ func (ss *syncState) getExcessPodGangNames() []string {
 		}
 	}
 	return excessPodGangNames
-}
-
-func (ss *syncState) isPodGangInitialized(podGangName string) bool {
-	foundPG, ok := ss.existingPodGangByName[podGangName]
-	return ok && k8sutils.IsConditionTrue(foundPG.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeInitialized))
 }
 
 // initializeAssignedAndUnassignedPodsForPCS categorizes pods by PodGang assignment.

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow_test.go
@@ -288,7 +288,7 @@ func TestCreateOrUpdatePodGangs(t *testing.T) {
 			},
 		}
 		if initialized {
-			setOrUpdateInitializedCondition(pg, metav1.ConditionTrue, groveschedulerv1alpha1.ConditionReasonPodGangPodsCreated, "PodGang is fully initialized")
+			setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeInitialized, metav1.ConditionTrue, groveschedulerv1alpha1.ConditionReasonPodGangPodsCreated, "PodGang is fully initialized")
 		}
 		return pg
 	}
@@ -345,6 +345,51 @@ func TestCreateOrUpdatePodGangs(t *testing.T) {
 		pgAfter := &groveschedulerv1alpha1.PodGang{}
 		require.NoError(t, cl.Get(ctx, client.ObjectKey{Namespace: ns, Name: pgName}, pgAfter))
 		assert.False(t, isInitializedInCluster(t, cl, pgName))
+	})
+
+	t.Run("existing PodGang was Scheduled and Ready, pods regress - flips Scheduled and Ready to False, keeps timestamps", func(t *testing.T) {
+		ctx := t.Context()
+		// The PodGang was previously Scheduled and Ready with timestamps stamped. In this pass its pods
+		// have regressed so verifyAllPodsCreated fails, but the live Scheduled and Ready conditions must
+		// still be reconciled to False. LastScheduled and LastReady are never cleared.
+		existingPG := makeExistingPodGang(pgName, true)
+		setScheduledCondition(existingPG, true, metav1.Now())
+		setReadyCondition(existingPG, true, metav1.Now())
+
+		pclq := makePCLQ(pclqName, 2)
+		cl := testutils.NewTestClientBuilder().
+			WithObjects(pcs, existingPG).
+			WithStatusSubresource(&groveschedulerv1alpha1.PodGang{}).
+			Build()
+		r := newResource(cl)
+		pgi := anchorPodGangInfo()
+		ss := &syncState{
+			pcs:                   pcs,
+			logger:                ctrllogger.FromContext(ctx),
+			expectedPodGangs:      []*podGangInfo{pgi},
+			existingPodGangByName: map[string]groveschedulerv1alpha1.PodGang{pgName: *existingPG},
+			existingPCLQByName:    componentutils.PodCliqueByName([]grovecorev1alpha1.PodClique{pclq}),
+			existingPCLQPods:      map[string][]v1.Pod{},
+		}
+
+		// Read the seeded timestamps back from the client so they carry the same store-truncated
+		// precision as the values asserted on after reconcile.
+		initial := &groveschedulerv1alpha1.PodGang{}
+		require.NoError(t, cl.Get(ctx, client.ObjectKey{Namespace: ns, Name: pgName}, initial))
+		wantLastScheduled := initial.Status.LastScheduled
+		wantLastReady := initial.Status.LastReady
+
+		result := r.createOrUpdatePodGangs(ctx, ss)
+
+		require.True(t, result.hasErrors(), "verifyAllPodsCreated must record a requeue error")
+		testutils.AssertGroveError(t, &groveerr.GroveError{Code: groveerr.ErrCodeRequeueAfter, Operation: component.OperationSync}, result.errs[0])
+		patched := &groveschedulerv1alpha1.PodGang{}
+		require.NoError(t, cl.Get(ctx, client.ObjectKey{Namespace: ns, Name: pgName}, patched))
+		assert.False(t, meta.IsStatusConditionTrue(patched.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeScheduled)), "Scheduled must flip to False on regression")
+		assert.False(t, meta.IsStatusConditionTrue(patched.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeReady)), "Ready must flip to False on regression")
+		assert.True(t, isInitializedInCluster(t, cl, pgName), "Initialized is a latch and must remain True")
+		assert.Equal(t, wantLastScheduled, patched.Status.LastScheduled, "LastScheduled must not be cleared")
+		assert.Equal(t, wantLastReady, patched.Status.LastReady, "LastReady must not be cleared")
 	})
 
 	t.Run("new PodGang, pods ready - creates PodGang, records creation, sets Initialized=True", func(t *testing.T) {
@@ -1728,8 +1773,9 @@ func TestSetReadyCondition(t *testing.T) {
 }
 
 // TestReconcilePodGangStatus verifies reconcilePodGangStatus patches the live PodGang's Scheduled
-// and Ready conditions from live pod observation, skips the patch when the status is already
-// current, requeues on a conflicting patch, and surfaces a non-conflict patch failure as an error.
+// and Ready conditions from live pod observation on every call, sets the Initialized latch only
+// when allPodsCreated is true, skips the patch when the status is already current, requeues on a
+// conflicting patch, and surfaces a non-conflict patch failure as an error.
 func TestReconcilePodGangStatus(t *testing.T) {
 	const (
 		ns       = "default"
@@ -1759,22 +1805,40 @@ func TestReconcilePodGangStatus(t *testing.T) {
 		}
 	}
 
-	t.Run("patches Scheduled and Ready True and stamps timestamps when pods are ready", func(t *testing.T) {
+	t.Run("allPodsCreated true - sets Initialized and patches Scheduled and Ready True with timestamps", func(t *testing.T) {
 		cl := testutils.NewTestClientBuilder().
 			WithObjects(pcs, existingPodGang()).
 			WithStatusSubresource(&groveschedulerv1alpha1.PodGang{}).
 			Build()
 		r := newResource(cl)
 
-		err := r.reconcilePodGangStatus(t.Context(), readyState(), pgi)
+		err := r.reconcilePodGangStatus(t.Context(), readyState(), pgi, true)
 
 		require.NoError(t, err)
 		patched := &groveschedulerv1alpha1.PodGang{}
 		require.NoError(t, cl.Get(t.Context(), client.ObjectKey{Namespace: ns, Name: pgName}, patched))
+		assert.True(t, meta.IsStatusConditionTrue(patched.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeInitialized)))
 		assert.True(t, meta.IsStatusConditionTrue(patched.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeScheduled)))
 		assert.True(t, meta.IsStatusConditionTrue(patched.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeReady)))
 		assert.NotNil(t, patched.Status.LastScheduled)
 		assert.NotNil(t, patched.Status.LastReady)
+	})
+
+	t.Run("allPodsCreated false - does not set Initialized but still reconciles Scheduled and Ready", func(t *testing.T) {
+		cl := testutils.NewTestClientBuilder().
+			WithObjects(pcs, existingPodGang()).
+			WithStatusSubresource(&groveschedulerv1alpha1.PodGang{}).
+			Build()
+		r := newResource(cl)
+
+		err := r.reconcilePodGangStatus(t.Context(), readyState(), pgi, false)
+
+		require.NoError(t, err)
+		patched := &groveschedulerv1alpha1.PodGang{}
+		require.NoError(t, cl.Get(t.Context(), client.ObjectKey{Namespace: ns, Name: pgName}, patched))
+		assert.Nil(t, meta.FindStatusCondition(patched.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeInitialized)), "Initialized must not be set when allPodsCreated is false")
+		assert.True(t, meta.IsStatusConditionTrue(patched.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeScheduled)))
+		assert.True(t, meta.IsStatusConditionTrue(patched.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeReady)))
 	})
 
 	t.Run("does not patch when status is already current", func(t *testing.T) {
@@ -1799,7 +1863,7 @@ func TestReconcilePodGangStatus(t *testing.T) {
 		require.NoError(t, cl.Get(t.Context(), client.ObjectKey{Namespace: ns, Name: pgName}, initial))
 		wantLastScheduled := initial.Status.LastScheduled
 
-		err := r.reconcilePodGangStatus(t.Context(), readyState(), pgi)
+		err := r.reconcilePodGangStatus(t.Context(), readyState(), pgi, true)
 
 		// The recorded StatusPatch error fails the test if a patch is issued. A nil error therefore
 		// proves the DeepEqual guard skipped the patch because the status was already current.
@@ -1820,7 +1884,7 @@ func TestReconcilePodGangStatus(t *testing.T) {
 			Build()
 		r := newResource(cl)
 
-		err := r.reconcilePodGangStatus(t.Context(), readyState(), pgi)
+		err := r.reconcilePodGangStatus(t.Context(), readyState(), pgi, true)
 
 		testutils.AssertGroveError(t, &groveerr.GroveError{Code: groveerr.ErrCodeRequeueAfter, Operation: component.OperationSync}, err)
 	})
@@ -1834,7 +1898,7 @@ func TestReconcilePodGangStatus(t *testing.T) {
 			Build()
 		r := newResource(cl)
 
-		err := r.reconcilePodGangStatus(t.Context(), readyState(), pgi)
+		err := r.reconcilePodGangStatus(t.Context(), readyState(), pgi, true)
 
 		testutils.AssertGroveError(t, &groveerr.GroveError{Code: errCodeUpdatePodGangStatus, Cause: internalErr, Operation: component.OperationSync}, err)
 	})

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow_test.go
@@ -16,7 +16,9 @@ package podgang
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
@@ -34,7 +36,9 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1025,77 +1029,6 @@ func TestComputeExpectedPodGangsWithTopologyConstraints(t *testing.T) {
 	}
 }
 
-func assertPodGangLevelConstraint(t *testing.T, pg *podGangInfo, expected expectedPodGangTopologyConstraints) {
-	t.Helper()
-	if expected.topologyPackConstraint == nil {
-		assert.Nil(t, pg.topologyConstraint)
-		return
-	}
-	assertPackConstraint(t, pg.topologyConstraint, *expected.topologyPackConstraint)
-}
-
-func assertPCLQConstraints(t *testing.T, pg *podGangInfo, expected expectedPodGangTopologyConstraints) {
-	t.Helper()
-	for _, pclq := range pg.pclqs {
-		want, exists := expected.pclqPackConstraints[pclq.fqn]
-		if !exists {
-			assert.Nil(t, pclq.topologyConstraint, "PCLQ %s should have no topology constraint", pclq.fqn)
-			continue
-		}
-		assertPackConstraint(t, pclq.topologyConstraint, want)
-	}
-}
-
-func assertPCSGConstraints(t *testing.T, pg *podGangInfo, expected expectedPodGangTopologyConstraints) {
-	t.Helper()
-	for pcsgFQN, want := range expected.pcsgPackConstraints {
-		actualPCSGTC, found := lo.Find(pg.pcsgTopologyConstraints, func(pcsgTC groveschedulerv1alpha1.TopologyConstraintGroupConfig) bool {
-			return pcsgTC.Name == pcsgFQN
-		})
-		assert.True(t, found, "expected PCSG topology constraint for %s not found", pcsgFQN)
-		assertPackConstraint(t, actualPCSGTC.TopologyConstraint, want)
-	}
-	for _, actualPCSGTC := range pg.pcsgTopologyConstraints {
-		if _, exists := expected.pcsgPackConstraints[actualPCSGTC.Name]; !exists {
-			t.Errorf("unexpected PCSG topology constraint for %s found in PodGang %s", actualPCSGTC.Name, pg.fqn)
-		}
-	}
-}
-
-func mustNotHaveAnyTopologyConstraints(t *testing.T, podGangs []*podGangInfo) {
-	for _, pg := range podGangs {
-		assert.Nil(t, pg.topologyConstraint)
-		for _, pclq := range pg.pclqs {
-			assert.Nil(t, pclq.topologyConstraint)
-		}
-		assert.Nil(t, pg.pcsgTopologyConstraints)
-	}
-}
-
-// assertPackConstraint checks both required and preferred keys of a TopologyConstraint. An empty
-// expected key asserts the corresponding side is nil; a non-empty key asserts the value matches.
-func assertPackConstraint(t *testing.T, got *groveschedulerv1alpha1.TopologyConstraint, want expectedTopologyPackConstraint) {
-	t.Helper()
-	if want.requiredKey == "" && want.preferredKey == "" {
-		assert.Nil(t, got)
-		return
-	}
-	require.NotNil(t, got)
-	require.NotNil(t, got.PackConstraint)
-	if want.requiredKey == "" {
-		assert.Nil(t, got.PackConstraint.Required, "expected no required key")
-	} else {
-		require.NotNil(t, got.PackConstraint.Required)
-		assert.Equal(t, want.requiredKey, *got.PackConstraint.Required)
-	}
-	if want.preferredKey == "" {
-		assert.Nil(t, got.PackConstraint.Preferred, "expected no preferred key")
-	} else {
-		require.NotNil(t, got.PackConstraint.Preferred)
-		assert.Equal(t, want.preferredKey, *got.PackConstraint.Preferred)
-	}
-}
-
 // TestResolveTopologyLevels verifies that resolveTopologyLevels resolves cluster topology levels from
 // the PodCliqueSet's effective topologyName, and returns nil (no error) when there is no constraint,
 // no resolvable topologyName, or the referenced ClusterTopologyBinding does not exist. The caller
@@ -1195,29 +1128,6 @@ func TestResolveTopologyLevels(t *testing.T) {
 			assert.Equal(t, test.wantTopologyLevels, actual)
 		})
 	}
-}
-
-// nonAnchorPodGangNames returns the non-anchor PodGang names for the given epoch and PCSG replica
-// indices, iterating PCSG configs in order for deterministic output.
-func nonAnchorPodGangNames(rnr apicommon.ResourceNameReplica, epoch string, pcsgConfigs []grovecorev1alpha1.PodCliqueScalingGroupConfig, indicesByPCSG map[string][]int32) []string {
-	var names []string
-	for _, pcsgConfig := range pcsgConfigs {
-		for _, idx := range indicesByPCSG[pcsgConfig.Name] {
-			names = append(names, apicommon.GenerateNonAnchorPodGangName(rnr, epoch, pcsgConfig.Name, idx))
-		}
-	}
-	return names
-}
-
-// podGangNamesByRole groups the materialized PodGang names by the role recorded on their
-// grove.io/podgang-role label.
-func podGangNamesByRole(podGangs []*podGangInfo) map[grovecorev1alpha1.PodGangEntryRole][]string {
-	byRole := make(map[grovecorev1alpha1.PodGangEntryRole][]string)
-	for _, pg := range podGangs {
-		role := grovecorev1alpha1.PodGangEntryRole(pg.extraLabels[apicommon.LabelPodGangRole])
-		byRole[role] = append(byRole[role], pg.fqn)
-	}
-	return byRole
 }
 
 // TestComputeExpectedPodGangs verifies that the materializer turns the PodGangMap entries of each PCS
@@ -1440,13 +1350,6 @@ func TestComputeExpectedPodGangs(t *testing.T) {
 	}
 }
 
-func makeClusterTopologyBindingWithLevels(name string, levels []grovecorev1alpha1.TopologyLevel) *grovecorev1alpha1.ClusterTopologyBinding {
-	return &grovecorev1alpha1.ClusterTopologyBinding{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-		Spec:       grovecorev1alpha1.ClusterTopologyBindingSpec{Levels: levels},
-	}
-}
-
 // TestGetExistingPCLQsForPCS verifies that getExistingPCLQsForPCS returns exactly the PodCliques
 // selected by the PodCliqueSet managed-resource labels, regardless of whether the PodClique is owned
 // directly by the PCS (standalone) or by a PodCliqueScalingGroup.
@@ -1559,6 +1462,505 @@ func TestInitializeAssignedAndUnassignedPodsForPCS(t *testing.T) {
 	assert.ElementsMatch(t, []string{"unassigned-0"}, podNames(ss.unassignedPodsByPCLQ[pclqName]))
 }
 
+// TestArePodGangMinReplicasScheduled verifies arePodGangMinReplicasScheduled counts only pods that
+// are associated to the PodGang (named in associatedPodNames) and scheduled, and requires every
+// constituent PodClique to meet MinReplicas.
+func TestArePodGangMinReplicasScheduled(t *testing.T) {
+	tests := []struct {
+		name         string
+		existingPods map[string][]v1.Pod
+		podGang      *podGangInfo
+		want         bool
+	}{
+		{
+			name:         "all associated pods scheduled meets MinReplicas",
+			existingPods: map[string][]v1.Pod{"pclq-a": {scheduledTestPod("a1"), scheduledTestPod("a2")}},
+			podGang:      &podGangInfo{fqn: "pg-1", pclqs: []pclqInfo{{fqn: "pclq-a", minAvailable: 2, associatedPodNames: []string{"a1", "a2"}}}},
+			want:         true,
+		},
+		{
+			name:         "fewer scheduled pods than MinReplicas",
+			existingPods: map[string][]v1.Pod{"pclq-a": {scheduledTestPod("a1"), unscheduledTestPod("a2")}},
+			podGang:      &podGangInfo{fqn: "pg-1", pclqs: []pclqInfo{{fqn: "pclq-a", minAvailable: 2, associatedPodNames: []string{"a1", "a2"}}}},
+			want:         false,
+		},
+		{
+			name:         "scheduled pod not in associatedPodNames is not counted",
+			existingPods: map[string][]v1.Pod{"pclq-a": {scheduledTestPod("a1"), scheduledTestPod("a2")}},
+			podGang:      &podGangInfo{fqn: "pg-1", pclqs: []pclqInfo{{fqn: "pclq-a", minAvailable: 2, associatedPodNames: []string{"a1"}}}},
+			want:         false,
+		},
+		{
+			name: "one PodClique below MinReplicas fails the whole PodGang",
+			existingPods: map[string][]v1.Pod{
+				"pclq-a": {scheduledTestPod("a1"), scheduledTestPod("a2")},
+				"pclq-b": {scheduledTestPod("b1")},
+			},
+			podGang: &podGangInfo{fqn: "pg-1", pclqs: []pclqInfo{
+				{fqn: "pclq-a", minAvailable: 2, associatedPodNames: []string{"a1", "a2"}},
+				{fqn: "pclq-b", minAvailable: 2, associatedPodNames: []string{"b1"}},
+			}},
+			want: false,
+		},
+		{
+			name:         "more scheduled pods than MinReplicas still meets it",
+			existingPods: map[string][]v1.Pod{"pclq-a": {scheduledTestPod("a1"), scheduledTestPod("a2"), scheduledTestPod("a3")}},
+			podGang:      &podGangInfo{fqn: "pg-1", pclqs: []pclqInfo{{fqn: "pclq-a", minAvailable: 2, associatedPodNames: []string{"a1", "a2", "a3"}}}},
+			want:         true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ss := &syncState{existingPCLQPods: tc.existingPods}
+			r := &_resource{}
+			actual := r.arePodGangMinReplicasScheduled(ss, tc.podGang)
+			assert.Equal(t, tc.want, actual)
+		})
+	}
+}
+
+// TestArePodGangMinReplicasReady verifies arePodGangMinReplicasReady counts only pods that are
+// associated to the PodGang (named in associatedPodNames) and ready, and requires every
+// constituent PodClique to meet MinReplicas. A scheduled-but-not-ready pod does not count.
+func TestArePodGangMinReplicasReady(t *testing.T) {
+	tests := []struct {
+		name         string
+		existingPods map[string][]v1.Pod
+		podGang      *podGangInfo
+		want         bool
+	}{
+		{
+			name:         "all associated pods ready meets MinReplicas",
+			existingPods: map[string][]v1.Pod{"pclq-a": {readyTestPod("a1"), readyTestPod("a2")}},
+			podGang:      &podGangInfo{fqn: "pg-1", pclqs: []pclqInfo{{fqn: "pclq-a", minAvailable: 2, associatedPodNames: []string{"a1", "a2"}}}},
+			want:         true,
+		},
+		{
+			name:         "scheduled but not ready does not meet MinReplicas",
+			existingPods: map[string][]v1.Pod{"pclq-a": {scheduledTestPod("a1"), scheduledTestPod("a2")}},
+			podGang:      &podGangInfo{fqn: "pg-1", pclqs: []pclqInfo{{fqn: "pclq-a", minAvailable: 2, associatedPodNames: []string{"a1", "a2"}}}},
+			want:         false,
+		},
+		{
+			name:         "ready pod not in associatedPodNames is not counted",
+			existingPods: map[string][]v1.Pod{"pclq-a": {readyTestPod("a1"), readyTestPod("a2")}},
+			podGang:      &podGangInfo{fqn: "pg-1", pclqs: []pclqInfo{{fqn: "pclq-a", minAvailable: 2, associatedPodNames: []string{"a1"}}}},
+			want:         false,
+		},
+		{
+			name: "one PodClique below MinReplicas fails the whole PodGang",
+			existingPods: map[string][]v1.Pod{
+				"pclq-a": {readyTestPod("a1"), readyTestPod("a2")},
+				"pclq-b": {readyTestPod("b1")},
+			},
+			podGang: &podGangInfo{fqn: "pg-1", pclqs: []pclqInfo{
+				{fqn: "pclq-a", minAvailable: 2, associatedPodNames: []string{"a1", "a2"}},
+				{fqn: "pclq-b", minAvailable: 2, associatedPodNames: []string{"b1"}},
+			}},
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ss := &syncState{existingPCLQPods: tc.existingPods}
+			r := &_resource{}
+			actual := r.arePodGangMinReplicasReady(ss, tc.podGang)
+			assert.Equal(t, tc.want, actual)
+		})
+	}
+}
+
+// TestSetPodGangCondition verifies setPodGangCondition sets the condition and reports whether the
+// status changed, treating a nil prior condition and any status flip as a transition and an
+// unchanged status as not a transition.
+func TestSetPodGangCondition(t *testing.T) {
+	const condType = groveschedulerv1alpha1.PodGangConditionTypeScheduled
+	tests := []struct {
+		name        string
+		priorStatus *metav1.ConditionStatus
+		newStatus   metav1.ConditionStatus
+		wantChanged bool
+	}{
+		{
+			name:        "no prior condition is a transition",
+			priorStatus: nil,
+			newStatus:   metav1.ConditionTrue,
+			wantChanged: true,
+		},
+		{
+			name:        "status flip False to True is a transition",
+			priorStatus: ptr.To(metav1.ConditionFalse),
+			newStatus:   metav1.ConditionTrue,
+			wantChanged: true,
+		},
+		{
+			name:        "status flip True to False is a transition",
+			priorStatus: ptr.To(metav1.ConditionTrue),
+			newStatus:   metav1.ConditionFalse,
+			wantChanged: true,
+		},
+		{
+			name:        "same status is not a transition",
+			priorStatus: ptr.To(metav1.ConditionTrue),
+			newStatus:   metav1.ConditionTrue,
+			wantChanged: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pg := &groveschedulerv1alpha1.PodGang{}
+			if tc.priorStatus != nil {
+				setPodGangCondition(pg, condType, *tc.priorStatus, "PriorReason", "prior")
+			}
+			actualChanged := setPodGangCondition(pg, condType, tc.newStatus, "NewReason", "new")
+			assert.Equal(t, tc.wantChanged, actualChanged)
+			assert.True(t, meta.IsStatusConditionPresentAndEqual(pg.Status.Conditions, string(condType), tc.newStatus))
+		})
+	}
+}
+
+// TestSetScheduledCondition verifies setScheduledCondition sets the Scheduled condition and advances
+// LastScheduled on each fresh transition to True, never clearing it on a transition to False and
+// never re-stamping on an idempotent True.
+func TestSetScheduledCondition(t *testing.T) {
+	earlier := metav1.NewTime(time.Now())
+	later := metav1.NewTime(earlier.Add(time.Minute))
+	type step struct {
+		scheduled bool
+		now       metav1.Time
+	}
+	tests := []struct {
+		name              string
+		steps             []step
+		wantConditionTrue bool
+		wantLastScheduled *metav1.Time
+	}{
+		{
+			name:              "transition to True stamps LastScheduled",
+			steps:             []step{{true, earlier}},
+			wantConditionTrue: true,
+			wantLastScheduled: &earlier,
+		},
+		{
+			name:              "idempotent True does not re-stamp LastScheduled",
+			steps:             []step{{true, earlier}, {true, later}},
+			wantConditionTrue: true,
+			wantLastScheduled: &earlier,
+		},
+		{
+			name:              "transition to False does not clear LastScheduled",
+			steps:             []step{{true, earlier}, {false, later}},
+			wantConditionTrue: false,
+			wantLastScheduled: &earlier,
+		},
+		{
+			name:              "re-transition to True advances LastScheduled",
+			steps:             []step{{true, earlier}, {false, earlier}, {true, later}},
+			wantConditionTrue: true,
+			wantLastScheduled: &later,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pg := &groveschedulerv1alpha1.PodGang{}
+			for _, s := range tc.steps {
+				setScheduledCondition(pg, s.scheduled, s.now)
+			}
+			actualConditionTrue := meta.IsStatusConditionTrue(pg.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeScheduled))
+			assert.Equal(t, tc.wantConditionTrue, actualConditionTrue)
+			assert.Equal(t, tc.wantLastScheduled, pg.Status.LastScheduled)
+		})
+	}
+}
+
+// TestSetReadyCondition verifies setReadyCondition sets the Ready condition and advances LastReady
+// on each fresh transition to True, never clearing it on a transition to False and never
+// re-stamping on an idempotent True.
+func TestSetReadyCondition(t *testing.T) {
+	earlier := metav1.NewTime(time.Now())
+	later := metav1.NewTime(earlier.Add(time.Minute))
+	type step struct {
+		ready bool
+		now   metav1.Time
+	}
+	tests := []struct {
+		name              string
+		steps             []step
+		wantConditionTrue bool
+		wantLastReady     *metav1.Time
+	}{
+		{
+			name:              "transition to True stamps LastReady",
+			steps:             []step{{true, earlier}},
+			wantConditionTrue: true,
+			wantLastReady:     &earlier,
+		},
+		{
+			name:              "idempotent True does not re-stamp LastReady",
+			steps:             []step{{true, earlier}, {true, later}},
+			wantConditionTrue: true,
+			wantLastReady:     &earlier,
+		},
+		{
+			name:              "transition to False does not clear LastReady",
+			steps:             []step{{true, earlier}, {false, later}},
+			wantConditionTrue: false,
+			wantLastReady:     &earlier,
+		},
+		{
+			name:              "re-transition to True advances LastReady",
+			steps:             []step{{true, earlier}, {false, earlier}, {true, later}},
+			wantConditionTrue: true,
+			wantLastReady:     &later,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pg := &groveschedulerv1alpha1.PodGang{}
+			for _, s := range tc.steps {
+				setReadyCondition(pg, s.ready, s.now)
+			}
+			actualConditionTrue := meta.IsStatusConditionTrue(pg.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeReady))
+			assert.Equal(t, tc.wantConditionTrue, actualConditionTrue)
+			assert.Equal(t, tc.wantLastReady, pg.Status.LastReady)
+		})
+	}
+}
+
+// TestReconcilePodGangStatus verifies reconcilePodGangStatus patches the live PodGang's Scheduled
+// and Ready conditions from live pod observation, skips the patch when the status is already
+// current, requeues on a conflicting patch, and surfaces a non-conflict patch failure as an error.
+func TestReconcilePodGangStatus(t *testing.T) {
+	const (
+		ns       = "default"
+		pgName   = "test-pcs-0-1000"
+		pclqName = "test-pcs-0-worker"
+	)
+	pcs := testutils.NewPodCliqueSetBuilder("test-pcs", ns, "uid").Build()
+	newResource := func(cl client.Client) *_resource {
+		return &_resource{
+			client:        cl,
+			scheme:        groveclientscheme.Scheme,
+			eventRecorder: record.NewFakeRecorder(10),
+			schedRegistry: defaultFakeSchedulerRegistry,
+		}
+	}
+	pgi := &podGangInfo{fqn: pgName, pcsReplicaIndex: 0, pclqs: []pclqInfo{
+		{fqn: pclqName, replicas: 2, minAvailable: 2, associatedPodNames: []string{"worker-0", "worker-1"}},
+	}}
+	existingPodGang := func() *groveschedulerv1alpha1.PodGang {
+		return &groveschedulerv1alpha1.PodGang{ObjectMeta: metav1.ObjectMeta{Name: pgName, Namespace: ns}}
+	}
+	readyState := func() *syncState {
+		return &syncState{
+			pcs:              pcs,
+			logger:           ctrllogger.FromContext(t.Context()),
+			existingPCLQPods: map[string][]v1.Pod{pclqName: {readyTestPod("worker-0"), readyTestPod("worker-1")}},
+		}
+	}
+
+	t.Run("patches Scheduled and Ready True and stamps timestamps when pods are ready", func(t *testing.T) {
+		cl := testutils.NewTestClientBuilder().
+			WithObjects(pcs, existingPodGang()).
+			WithStatusSubresource(&groveschedulerv1alpha1.PodGang{}).
+			Build()
+		r := newResource(cl)
+
+		err := r.reconcilePodGangStatus(t.Context(), readyState(), pgi)
+
+		require.NoError(t, err)
+		patched := &groveschedulerv1alpha1.PodGang{}
+		require.NoError(t, cl.Get(t.Context(), client.ObjectKey{Namespace: ns, Name: pgName}, patched))
+		assert.True(t, meta.IsStatusConditionTrue(patched.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeScheduled)))
+		assert.True(t, meta.IsStatusConditionTrue(patched.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeReady)))
+		assert.NotNil(t, patched.Status.LastScheduled)
+		assert.NotNil(t, patched.Status.LastReady)
+	})
+
+	t.Run("does not patch when status is already current", func(t *testing.T) {
+		seeded := existingPodGang()
+		setPodGangCondition(seeded, groveschedulerv1alpha1.PodGangConditionTypeInitialized, metav1.ConditionTrue,
+			groveschedulerv1alpha1.ConditionReasonPodGangPodsCreated, "PodGang is fully initialized")
+		setScheduledCondition(seeded, true, metav1.Now())
+		setReadyCondition(seeded, true, metav1.Now())
+
+		cl := testutils.NewTestClientBuilder().
+			WithObjects(pcs, seeded).
+			WithStatusSubresource(&groveschedulerv1alpha1.PodGang{}).
+			RecordErrorForObjects(testutils.ClientMethodStatusPatch,
+				apierrors.NewInternalError(errors.New("patch must not be called when status is unchanged")),
+				client.ObjectKey{Namespace: ns, Name: pgName}).
+			Build()
+		r := newResource(cl)
+
+		// Read the seeded LastScheduled back from the client so it carries the same store-truncated
+		// precision as the value asserted on after reconcile.
+		initial := &groveschedulerv1alpha1.PodGang{}
+		require.NoError(t, cl.Get(t.Context(), client.ObjectKey{Namespace: ns, Name: pgName}, initial))
+		wantLastScheduled := initial.Status.LastScheduled
+
+		err := r.reconcilePodGangStatus(t.Context(), readyState(), pgi)
+
+		// The recorded StatusPatch error fails the test if a patch is issued. A nil error therefore
+		// proves the DeepEqual guard skipped the patch because the status was already current.
+		require.NoError(t, err, "an already-current status must not trigger a patch")
+		patched := &groveschedulerv1alpha1.PodGang{}
+		require.NoError(t, cl.Get(t.Context(), client.ObjectKey{Namespace: ns, Name: pgName}, patched))
+		assert.Equal(t, wantLastScheduled, patched.Status.LastScheduled, "LastScheduled must be unchanged")
+	})
+
+	t.Run("requeues instead of erroring on a status patch conflict", func(t *testing.T) {
+		conflict := apierrors.NewConflict(
+			schema.GroupResource{Group: groveschedulerv1alpha1.SchemeGroupVersion.Group, Resource: "podgangs"},
+			pgName, errors.New("object was modified"))
+		cl := testutils.NewTestClientBuilder().
+			WithObjects(pcs, existingPodGang()).
+			WithStatusSubresource(&groveschedulerv1alpha1.PodGang{}).
+			RecordErrorForObjects(testutils.ClientMethodStatusPatch, conflict, client.ObjectKey{Namespace: ns, Name: pgName}).
+			Build()
+		r := newResource(cl)
+
+		err := r.reconcilePodGangStatus(t.Context(), readyState(), pgi)
+
+		testutils.AssertGroveError(t, &groveerr.GroveError{Code: groveerr.ErrCodeRequeueAfter, Operation: component.OperationSync}, err)
+	})
+
+	t.Run("returns error on a non-conflict status patch failure", func(t *testing.T) {
+		internalErr := apierrors.NewInternalError(errors.New("apiserver boom"))
+		cl := testutils.NewTestClientBuilder().
+			WithObjects(pcs, existingPodGang()).
+			WithStatusSubresource(&groveschedulerv1alpha1.PodGang{}).
+			RecordErrorForObjects(testutils.ClientMethodStatusPatch, internalErr, client.ObjectKey{Namespace: ns, Name: pgName}).
+			Build()
+		r := newResource(cl)
+
+		err := r.reconcilePodGangStatus(t.Context(), readyState(), pgi)
+
+		testutils.AssertGroveError(t, &groveerr.GroveError{Code: errCodeUpdatePodGangStatus, Cause: internalErr, Operation: component.OperationSync}, err)
+	})
+}
+
 func podNames(pods []v1.Pod) []string {
 	return lo.Map(pods, func(pod v1.Pod, _ int) string { return pod.Name })
+}
+
+// scheduledTestPod returns a Pod with the PodScheduled condition True.
+func scheduledTestPod(name string) v1.Pod {
+	return *testutils.NewPodBuilder(name, "default").
+		WithCondition(v1.PodCondition{Type: v1.PodScheduled, Status: v1.ConditionTrue}).
+		Build()
+}
+
+// readyTestPod returns a Pod with both the PodScheduled and PodReady conditions True.
+func readyTestPod(name string) v1.Pod {
+	return *testutils.NewPodBuilder(name, "default").
+		WithCondition(v1.PodCondition{Type: v1.PodScheduled, Status: v1.ConditionTrue}).
+		WithCondition(v1.PodCondition{Type: v1.PodReady, Status: v1.ConditionTrue}).
+		Build()
+}
+
+// unscheduledTestPod returns a Pod with no scheduling or readiness conditions.
+func unscheduledTestPod(name string) v1.Pod {
+	return *testutils.NewPodBuilder(name, "default").Build()
+}
+
+func assertPodGangLevelConstraint(t *testing.T, pg *podGangInfo, expected expectedPodGangTopologyConstraints) {
+	t.Helper()
+	if expected.topologyPackConstraint == nil {
+		assert.Nil(t, pg.topologyConstraint)
+		return
+	}
+	assertPackConstraint(t, pg.topologyConstraint, *expected.topologyPackConstraint)
+}
+
+func assertPCLQConstraints(t *testing.T, pg *podGangInfo, expected expectedPodGangTopologyConstraints) {
+	t.Helper()
+	for _, pclq := range pg.pclqs {
+		want, exists := expected.pclqPackConstraints[pclq.fqn]
+		if !exists {
+			assert.Nil(t, pclq.topologyConstraint, "PCLQ %s should have no topology constraint", pclq.fqn)
+			continue
+		}
+		assertPackConstraint(t, pclq.topologyConstraint, want)
+	}
+}
+
+func assertPCSGConstraints(t *testing.T, pg *podGangInfo, expected expectedPodGangTopologyConstraints) {
+	t.Helper()
+	for pcsgFQN, want := range expected.pcsgPackConstraints {
+		actualPCSGTC, found := lo.Find(pg.pcsgTopologyConstraints, func(pcsgTC groveschedulerv1alpha1.TopologyConstraintGroupConfig) bool {
+			return pcsgTC.Name == pcsgFQN
+		})
+		assert.True(t, found, "expected PCSG topology constraint for %s not found", pcsgFQN)
+		assertPackConstraint(t, actualPCSGTC.TopologyConstraint, want)
+	}
+	for _, actualPCSGTC := range pg.pcsgTopologyConstraints {
+		if _, exists := expected.pcsgPackConstraints[actualPCSGTC.Name]; !exists {
+			t.Errorf("unexpected PCSG topology constraint for %s found in PodGang %s", actualPCSGTC.Name, pg.fqn)
+		}
+	}
+}
+
+func mustNotHaveAnyTopologyConstraints(t *testing.T, podGangs []*podGangInfo) {
+	for _, pg := range podGangs {
+		assert.Nil(t, pg.topologyConstraint)
+		for _, pclq := range pg.pclqs {
+			assert.Nil(t, pclq.topologyConstraint)
+		}
+		assert.Nil(t, pg.pcsgTopologyConstraints)
+	}
+}
+
+// assertPackConstraint checks both required and preferred keys of a TopologyConstraint. An empty
+// expected key asserts the corresponding side is nil; a non-empty key asserts the value matches.
+func assertPackConstraint(t *testing.T, got *groveschedulerv1alpha1.TopologyConstraint, want expectedTopologyPackConstraint) {
+	t.Helper()
+	if want.requiredKey == "" && want.preferredKey == "" {
+		assert.Nil(t, got)
+		return
+	}
+	require.NotNil(t, got)
+	require.NotNil(t, got.PackConstraint)
+	if want.requiredKey == "" {
+		assert.Nil(t, got.PackConstraint.Required, "expected no required key")
+	} else {
+		require.NotNil(t, got.PackConstraint.Required)
+		assert.Equal(t, want.requiredKey, *got.PackConstraint.Required)
+	}
+	if want.preferredKey == "" {
+		assert.Nil(t, got.PackConstraint.Preferred, "expected no preferred key")
+	} else {
+		require.NotNil(t, got.PackConstraint.Preferred)
+		assert.Equal(t, want.preferredKey, *got.PackConstraint.Preferred)
+	}
+}
+
+// nonAnchorPodGangNames returns the non-anchor PodGang names for the given epoch and PCSG replica
+// indices, iterating PCSG configs in order for deterministic output.
+func nonAnchorPodGangNames(rnr apicommon.ResourceNameReplica, epoch string, pcsgConfigs []grovecorev1alpha1.PodCliqueScalingGroupConfig, indicesByPCSG map[string][]int32) []string {
+	var names []string
+	for _, pcsgConfig := range pcsgConfigs {
+		for _, idx := range indicesByPCSG[pcsgConfig.Name] {
+			names = append(names, apicommon.GenerateNonAnchorPodGangName(rnr, epoch, pcsgConfig.Name, idx))
+		}
+	}
+	return names
+}
+
+// podGangNamesByRole groups the materialized PodGang names by the role recorded on their
+// grove.io/podgang-role label.
+func podGangNamesByRole(podGangs []*podGangInfo) map[grovecorev1alpha1.PodGangEntryRole][]string {
+	byRole := make(map[grovecorev1alpha1.PodGangEntryRole][]string)
+	for _, pg := range podGangs {
+		role := grovecorev1alpha1.PodGangEntryRole(pg.extraLabels[apicommon.LabelPodGangRole])
+		byRole[role] = append(byRole[role], pg.fqn)
+	}
+	return byRole
+}
+
+func makeClusterTopologyBindingWithLevels(name string, levels []grovecorev1alpha1.TopologyLevel) *grovecorev1alpha1.ClusterTopologyBinding {
+	return &grovecorev1alpha1.ClusterTopologyBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       grovecorev1alpha1.ClusterTopologyBindingSpec{Levels: levels},
+	}
 }

--- a/operator/internal/controller/podcliqueset/register.go
+++ b/operator/internal/controller/podcliqueset/register.go
@@ -212,6 +212,7 @@ func hasStatusChanged(updateEvent event.UpdateEvent) bool {
 // hasAnyStatusReplicasChanged checks if any replica count fields have changed.
 func hasAnyStatusReplicasChanged(oldPCLQStatus, newPCLQStatus grovecorev1alpha1.PodCliqueStatus) bool {
 	return oldPCLQStatus.Replicas != newPCLQStatus.Replicas ||
+		oldPCLQStatus.ScheduledReplicas != newPCLQStatus.ScheduledReplicas ||
 		oldPCLQStatus.ReadyReplicas != newPCLQStatus.ReadyReplicas ||
 		oldPCLQStatus.ScheduleGatedReplicas != newPCLQStatus.ScheduleGatedReplicas ||
 		oldPCLQStatus.UpdatedReplicas != newPCLQStatus.UpdatedReplicas

--- a/operator/internal/controller/podcliqueset/register_test.go
+++ b/operator/internal/controller/podcliqueset/register_test.go
@@ -206,6 +206,86 @@ func TestPodCliquePredicateStatusChangesAffectingUpdatedAccounting(t *testing.T)
 	}
 }
 
+// TestPodCliquePredicateStatusReplicaChanges asserts that the PodClique predicate enqueues the
+// PodCliqueSet when any replica-count status field changes. ScheduledReplicas is included so a
+// change in scheduled pods wakes the PodCliqueSet reconciler to advance the PodGang Scheduled
+// condition and LastScheduled.
+func TestPodCliquePredicateStatusReplicaChanges(t *testing.T) {
+	pred, ok := podCliquePredicate().(predicate.Funcs)
+	require.True(t, ok, "predicate must be predicate.Funcs")
+
+	tests := []struct {
+		name   string
+		mutate func(*grovecorev1alpha1.PodClique)
+	}{
+		{
+			name:   "replicas changes",
+			mutate: func(pclq *grovecorev1alpha1.PodClique) { pclq.Status.Replicas = 1 },
+		},
+		{
+			name:   "scheduled replicas changes",
+			mutate: func(pclq *grovecorev1alpha1.PodClique) { pclq.Status.ScheduledReplicas = 1 },
+		},
+		{
+			name:   "ready replicas changes",
+			mutate: func(pclq *grovecorev1alpha1.PodClique) { pclq.Status.ReadyReplicas = 1 },
+		},
+		{
+			name:   "schedule gated replicas changes",
+			mutate: func(pclq *grovecorev1alpha1.PodClique) { pclq.Status.ScheduleGatedReplicas = 1 },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldPCLQ := testutils.NewPodCliqueBuilder("pcs", uuid.NewUUID(), "worker", "default", 0).Build()
+			newPCLQ := oldPCLQ.DeepCopy()
+			tt.mutate(newPCLQ)
+
+			assert.True(t, pred.UpdateFunc(event.UpdateEvent{ObjectOld: oldPCLQ, ObjectNew: newPCLQ}))
+		})
+	}
+}
+
+// TestPodCliquePredicateNoRelevantChange asserts that the PodClique predicate does not enqueue the
+// PodCliqueSet when nothing changes or when only a status field that does not feed PodCliqueSet
+// reconciliation changes.
+func TestPodCliquePredicateNoRelevantChange(t *testing.T) {
+	pred, ok := podCliquePredicate().(predicate.Funcs)
+	require.True(t, ok, "predicate must be predicate.Funcs")
+
+	tests := []struct {
+		name   string
+		mutate func(*grovecorev1alpha1.PodClique)
+	}{
+		{
+			name:   "no change",
+			mutate: func(*grovecorev1alpha1.PodClique) {},
+		},
+		{
+			name:   "observed generation changes",
+			mutate: func(pclq *grovecorev1alpha1.PodClique) { pclq.Status.ObservedGeneration = ptr.To(int64(2)) },
+		},
+		{
+			name: "last errors change",
+			mutate: func(pclq *grovecorev1alpha1.PodClique) {
+				pclq.Status.LastErrors = []grovecorev1alpha1.LastError{{Code: grovecorev1alpha1.ErrorCode("ERR"), Description: "boom"}}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldPCLQ := testutils.NewPodCliqueBuilder("pcs", uuid.NewUUID(), "worker", "default", 0).Build()
+			oldPCLQ.Status.ObservedGeneration = ptr.To(int64(1))
+			newPCLQ := oldPCLQ.DeepCopy()
+			tt.mutate(newPCLQ)
+
+			assert.False(t, pred.UpdateFunc(event.UpdateEvent{ObjectOld: oldPCLQ, ObjectNew: newPCLQ}))
+		})
+	}
+}
+
 // TestPodCliqueScalingGroupPredicateStatusChangesAffectingUpdatedAccounting asserts
 // that the PodCliqueScalingGroup predicate enqueues on status changes relevant to
 // rolling-update accounting (generation hash, updated replicas, update progress).

--- a/scheduler/api/core/v1alpha1/crds/scheduler.grove.io_podgangs.yaml
+++ b/scheduler/api/core/v1alpha1/crds/scheduler.grove.io_podgangs.yaml
@@ -286,6 +286,20 @@ spec:
                   - type
                   type: object
                 type: array
+              lastReady:
+                description: |-
+                  LastReady is the time at which the Ready condition most recently transitioned to True. It is nil
+                  until the PodGang is first ready and is never reset to nil once set. On a later transition of the
+                  Ready condition back to True after a regression, it advances to the new time.
+                format: date-time
+                type: string
+              lastScheduled:
+                description: |-
+                  LastScheduled is the time at which the Scheduled condition most recently transitioned to True.
+                  It is nil until the PodGang is first scheduled and is never reset to nil once set. On a later
+                  transition of the Scheduled condition back to True after a regression, it advances to the new time.
+                format: date-time
+                type: string
               phase:
                 description: Phase is the current phase of a PodGang.
                 type: string

--- a/scheduler/api/core/v1alpha1/podgang.go
+++ b/scheduler/api/core/v1alpha1/podgang.go
@@ -189,16 +189,20 @@ type PodGangStatus struct {
 	// Phase is the current phase of a PodGang.
 	Phase PodGangPhase `json:"phase"`
 	// Conditions is a list of conditions that describe the current state of the PodGang.
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 	// LastScheduled is the time at which the Scheduled condition most recently transitioned to True.
 	// It is nil until the PodGang is first scheduled and is never reset to nil once set. On a later
 	// transition of the Scheduled condition back to True after a regression, it advances to the new time.
+	// +optional
 	LastScheduled *metav1.Time `json:"lastScheduled,omitempty"`
 	// LastReady is the time at which the Ready condition most recently transitioned to True. It is nil
 	// until the PodGang is first ready and is never reset to nil once set. On a later transition of the
 	// Ready condition back to True after a regression, it advances to the new time.
+	// +optional
 	LastReady *metav1.Time `json:"lastReady,omitempty"`
 	// PlacementScore is network optimality score for the PodGang. If the choice that the scheduler has made corresponds to the
 	// best possible placement of the pods in the PodGang, then the score will be 1.0. Higher the score, better the placement.
+	// +optional
 	PlacementScore *float64 `json:"placementScore,omitempty"`
 }

--- a/scheduler/api/core/v1alpha1/podgang.go
+++ b/scheduler/api/core/v1alpha1/podgang.go
@@ -176,6 +176,12 @@ const (
 	ConditionReasonPodGangPodsCreationPending = "PodGangPodsCreationPending"
 	// ConditionReasonPodGangPodsCreated indicates that all constituent Pods for a PodGang have been created.
 	ConditionReasonPodGangPodsCreated = "PodGangPodsCreated"
+	// ConditionReasonPodGangScheduled indicates that MinReplicas pods of every PodGroup have been scheduled.
+	ConditionReasonPodGangScheduled = "PodGangScheduled"
+	// ConditionReasonPodGangReady indicates that MinReplicas pods of every PodGroup are ready.
+	ConditionReasonPodGangReady = "PodGangReady"
+	// ConditionReasonPodGangNotReady indicates that one or more PodGroups have fewer scheduled or ready pods than required.
+	ConditionReasonPodGangNotReady = "PodGangNotReady"
 )
 
 // PodGangStatus defines the status of a PodGang.
@@ -184,6 +190,14 @@ type PodGangStatus struct {
 	Phase PodGangPhase `json:"phase"`
 	// Conditions is a list of conditions that describe the current state of the PodGang.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+	// LastScheduled is the time at which the Scheduled condition most recently transitioned to True.
+	// It is nil until the PodGang is first scheduled and is never reset to nil once set. On a later
+	// transition of the Scheduled condition back to True after a regression, it advances to the new time.
+	LastScheduled *metav1.Time `json:"lastScheduled,omitempty"`
+	// LastReady is the time at which the Ready condition most recently transitioned to True. It is nil
+	// until the PodGang is first ready and is never reset to nil once set. On a later transition of the
+	// Ready condition back to True after a regression, it advances to the new time.
+	LastReady *metav1.Time `json:"lastReady,omitempty"`
 	// PlacementScore is network optimality score for the PodGang. If the choice that the scheduler has made corresponds to the
 	// best possible placement of the pods in the PodGang, then the score will be 1.0. Higher the score, better the placement.
 	PlacementScore *float64 `json:"placementScore,omitempty"`

--- a/scheduler/api/core/v1alpha1/zz_generated.deepcopy.go
+++ b/scheduler/api/core/v1alpha1/zz_generated.deepcopy.go
@@ -153,6 +153,14 @@ func (in *PodGangStatus) DeepCopyInto(out *PodGangStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.LastScheduled != nil {
+		in, out := &in.LastScheduled, &out.LastScheduled
+		*out = (*in).DeepCopy()
+	}
+	if in.LastReady != nil {
+		in, out := &in.LastReady, &out.LastReady
+		*out = (*in).DeepCopy()
+	}
 	if in.PlacementScore != nil {
 		in, out := &in.PlacementScore, &out.PlacementScore
 		*out = new(float64)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api
-->
/kind feature
/kind api

#### What this PR does / why we need it:
Currently PodGang component only sets `Initialized` condition on the `PodGang` resource.  The `Scheduled` and `Ready` condition types were defined in the scheduler API but never set by the operator. This PR enhances the component to set all three conditions and adds two durable timestamp fields namely `LastScheduled` and `LastReady` to PodGangStatus.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #791

#### Special notes for your reviewer:

#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Introduces `LastScheduled` and `LastReady` timestamp fields to `PodGangStatus`. Two additional conditions - `Scheduled` and `Ready` conditions are set on a PodGang resource. The timestamps are changed when the Scheduled and Ready conditions transitions to True (never cleared once set).
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
