### PR TITLE
fix: preserve live replicas when rebuilding PodGangMaps

### DIFF
--- a/operator/internal/controller/podcliqueset/components/podgangmap/podgangmap_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/podgangmap_test.go
@@ -74,6 +74,51 @@ func TestSyncBootstrapsPodGangMapForFreshReplica(t *testing.T) {
 	assert.Equal(t, []string{anchor.Epoch}, scaleOut.DependsOn)
 }
 
+func TestSyncReconcilesBootstrapEntriesWithLivePCSG(t *testing.T) {
+	pcs := testutils.NewPodCliqueSetBuilder("pcs", "default", "uid").
+		WithReplicas(1).
+		WithScalingGroupConfig("sg", []string{"c"}, 1, 1).
+		WithPodCliqueSetGenerationHash(ptr.To("hash1")).
+		Build()
+	pcsg := testutils.NewPodCliqueScalingGroupBuilder("pcs-0-sg", "default", "pcs", 0).
+		WithReplicas(2).
+		Build()
+
+	cl := testutils.CreateDefaultFakeClient([]client.Object{pcs, pcsg})
+	operator := New(cl, groveclientscheme.Scheme, clocktesting.NewFakeClock(time.Unix(0, 1000)))
+
+	err := operator.Sync(context.Background(), logr.Discard(), pcs)
+	require.NoError(t, err)
+
+	pgm := getPodGangMap(t, cl, "pcs-0")
+	anchor := testutils.EntryByRole(pgm.Spec.Entries, grovecorev1alpha1.PodGangEntryRoleAnchor)
+	assert.Equal(t, []int32{0}, anchor.PCSGReplicaIndices["sg"])
+
+	scaleOut := testutils.EntryByRole(pgm.Spec.Entries, grovecorev1alpha1.PodGangEntryRoleScaleOut)
+	assert.Equal(t, []int32{1}, scaleOut.PCSGReplicaIndices["sg"])
+}
+
+func TestSyncReconcilesBootstrapEntriesWithLiveStandalonePodClique(t *testing.T) {
+	pcs := testutils.NewPodCliqueSetBuilder("pcs", "default", "uid").
+		WithReplicas(1).
+		WithStandaloneCliqueReplicas("clq-a", 1).
+		WithPodCliqueSetGenerationHash(ptr.To("hash1")).
+		Build()
+	pclq := testutils.NewPodCliqueBuilder("pcs", types.UID("uid"), "clq-a", "default", 0).
+		WithReplicas(4).
+		Build()
+
+	cl := testutils.CreateDefaultFakeClient([]client.Object{pcs, pclq})
+	operator := New(cl, groveclientscheme.Scheme, clocktesting.NewFakeClock(time.Unix(0, 1000)))
+
+	err := operator.Sync(context.Background(), logr.Discard(), pcs)
+	require.NoError(t, err)
+
+	pgm := getPodGangMap(t, cl, "pcs-0")
+	anchor := testutils.EntryByRole(pgm.Spec.Entries, grovecorev1alpha1.PodGangEntryRoleAnchor)
+	assert.Equal(t, int32(4), anchor.PodCliques["clq-a"])
+}
+
 func TestSyncReusesEpochFromExistingPodGangsWhenPodGangMapIsMissing(t *testing.T) {
 	pcs := testutils.NewPodCliqueSetBuilder("pcs", "default", "uid").
 		WithReplicas(1).

--- a/operator/internal/controller/podcliqueset/components/podgangmap/steadystate.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/steadystate.go
@@ -135,8 +135,8 @@ func buildBootstrapTailEntry(pcs *grovecorev1alpha1.PodCliqueSet, epoch, anchorE
 	return entry, true
 }
 
-// reconcileEntries re-authors the entries of a PCS replica whose PodGangMap already has entries. It runs
-// in steady state (no update in progress) and while a RollingRecreate is in progress.
+// reconcileEntries authors the desired entries for one PCS replica, bootstrapping them when the
+// PodGangMap does not exist and re-authoring them otherwise.
 //
 // Each entry keeps its identity (epoch, role, DependsOn, anchor index) and its already-placed replica
 // indices. Placement is not recomputed from the template. A template Replicas change does not reach an
@@ -147,17 +147,28 @@ func buildBootstrapTailEntry(pcs *grovecorev1alpha1.PodCliqueSet, epoch, anchorE
 // Spec.Replicas. A scale-out appends new indices to the ScaleOut entry. A scale-in drains indices in
 // role order ScaleOut, Tail, Anchor. Each standalone PodClique pod count on the anchor is set from its
 // live Spec.Replicas. A ScaleOut entry is ensured (even if empty) and empty entries are dropped.
-func reconcileEntries(pcs *grovecorev1alpha1.PodCliqueSet,
-	entries []grovecorev1alpha1.PodGangEntry,
-	standalonePCLQs []grovecorev1alpha1.PodClique,
-	pcsgs []grovecorev1alpha1.PodCliqueScalingGroup,
+func reconcileEntries(clk clock.Clock,
+	pcs *grovecorev1alpha1.PodCliqueSet,
 	pcsReplicaIndex int,
-	scaleOutEpoch string) ([]grovecorev1alpha1.PodGangEntry, error) {
+	pgm grovecorev1alpha1.PodGangMap,
+	existingPodGangs []groveschedulerv1alpha1.PodGang,
+	standalonePCLQs []grovecorev1alpha1.PodClique,
+	pcsgs []grovecorev1alpha1.PodCliqueScalingGroup) ([]grovecorev1alpha1.PodGangEntry, error) {
+	var entries []grovecorev1alpha1.PodGangEntry
+	if len(pgm.Spec.Entries) == 0 {
+		entries = buildBootstrapEntries(pcs, clk, existingPodGangs)
+	} else {
+		entries = clonePodGangEntries(pgm.Spec.Entries)
+		if shouldAdvanceEntriesGenerationHash(pcs, entries) {
+			advanceEntriesGenerationHash(entries, *pcs.Status.CurrentGenerationHash)
+		}
+	}
+
 	refreshStandalonePodCliqueCounts(entries, pcs, standalonePCLQs, pcsReplicaIndex)
 	if err := reconcilePCSGReplicaIndices(entries, pcs, pcsgs, pcsReplicaIndex); err != nil {
 		return nil, err
 	}
-	entries = ensureScaleOutEntry(entries, pcs, scaleOutEpoch, nil)
+	entries = ensureScaleOutEntry(entries, pcs, strconv.FormatInt(clk.Now().UnixNano(), 10), nil)
 	return removeEmptyEntries(entries, *pcs.Status.CurrentGenerationHash), nil
 }
 

--- a/operator/internal/controller/podcliqueset/components/podgangmap/steadystate_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/steadystate_test.go
@@ -15,7 +15,6 @@
 package podgangmap
 
 import (
-	"strconv"
 	"testing"
 	"time"
 
@@ -287,8 +286,6 @@ func TestEpochByRoleFromPodGangs(t *testing.T) {
 }
 
 func TestSyncEntries(t *testing.T) {
-	scaleOutEpoch := strconv.FormatInt(time.Unix(0, 5000).UnixNano(), 10)
-
 	tests := []struct {
 		name            string
 		pcs             *grovecorev1alpha1.PodCliqueSet
@@ -385,7 +382,9 @@ func TestSyncEntries(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, err := reconcileEntries(tt.pcs, tt.existingEntries, tt.standalonePCLQs, tt.pcsgs, 0, scaleOutEpoch)
+			pgm := grovecorev1alpha1.PodGangMap{Spec: grovecorev1alpha1.PodGangMapSpec{Entries: tt.existingEntries}}
+			actual, err := reconcileEntries(clocktesting.NewFakeClock(time.Unix(0, 5000)),
+				tt.pcs, 0, pgm, nil, tt.standalonePCLQs, tt.pcsgs)
 			require.NoError(t, err)
 			tt.assertResult(t, actual)
 		})

--- a/operator/internal/controller/podcliqueset/components/podgangmap/syncflow.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/syncflow.go
@@ -168,8 +168,8 @@ func (r _resource) getExistingPodGangsByReplica(ctx context.Context, pcs *grovec
 
 // runSyncFlow reconciles the PodGangMap for every PCS replica, then deletes PodGangMaps orphaned by a
 // PCS replica scale-in. Each replica is in one of three states.
-//  1. No PodGangMap. Its entries are authored from the PCS spec, reusing the epoch its existing
-//     PodGangs carry so a rebuilt PodGangMap does not strand pods.
+//  1. No PodGangMap. Bootstrap entries are authored from the PCS spec, reusing the epoch its existing
+//     PodGangs carry, then reconciled with live child replicas before the PodGangMap is created.
 //  2. A PodGangMap with no entries. A live PodGangMap always has an anchor entry, so this can only
 //     come from a coding error. The reconcile fails with a hard error.
 //  3. A PodGangMap with entries. reconcileEntries re-authors them, advancing an under-update replica
@@ -198,14 +198,14 @@ func (r _resource) runSyncFlow(ctx context.Context, syncSnap *syncSnapshot) erro
 			if shouldAdvanceEntriesGenerationHash(syncSnap.pcs, entries) {
 				advanceEntriesGenerationHash(entries, *syncSnap.pcs.Status.CurrentGenerationHash)
 			}
-			scaleOutEpoch := strconv.FormatInt(r.clk.Now().UnixNano(), 10)
-			entries, err = reconcileEntries(syncSnap.pcs, entries,
-				syncSnap.existingStandalonePCLQsByReplica[pcsReplicaIndex],
-				syncSnap.existingPCSGsByReplica[pcsReplicaIndex],
-				pcsReplicaIndex, scaleOutEpoch)
-			if err != nil {
-				return err
-			}
+		}
+		scaleOutEpoch := strconv.FormatInt(r.clk.Now().UnixNano(), 10)
+		entries, err = reconcileEntries(syncSnap.pcs, entries,
+			syncSnap.existingStandalonePCLQsByReplica[pcsReplicaIndex],
+			syncSnap.existingPCSGsByReplica[pcsReplicaIndex],
+			pcsReplicaIndex, scaleOutEpoch)
+		if err != nil {
+			return err
 		}
 		pgmName := apicommon.GeneratePodGangMapName(apicommon.ResourceNameReplica{Name: syncSnap.pcs.Name, Replica: pcsReplicaIndex})
 		if err = r.createOrPatchPodGangMap(ctx, syncSnap.pcs, pgmName, pcsReplicaIndex, entries); err != nil {

--- a/operator/internal/controller/podcliqueset/components/podgangmap/syncflow.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/syncflow.go
@@ -186,24 +186,10 @@ func (r _resource) runSyncFlow(ctx context.Context, syncSnap *syncSnapshot) erro
 			)
 		}
 
-		var (
-			entries []grovecorev1alpha1.PodGangEntry
-			err     error
-		)
-		if !pgmExists {
-			entries = buildBootstrapEntries(syncSnap.pcs, r.clk, syncSnap.existingPodGangsByReplica[pcsReplicaIndex])
-		} else {
-			// Deep-copy the existing entries so mutations here do not alias the snapshot's PodGangMap.
-			entries = clonePodGangEntries(pgm.Spec.Entries)
-			if shouldAdvanceEntriesGenerationHash(syncSnap.pcs, entries) {
-				advanceEntriesGenerationHash(entries, *syncSnap.pcs.Status.CurrentGenerationHash)
-			}
-		}
-		scaleOutEpoch := strconv.FormatInt(r.clk.Now().UnixNano(), 10)
-		entries, err = reconcileEntries(syncSnap.pcs, entries,
+		entries, err := reconcileEntries(r.clk, syncSnap.pcs, pcsReplicaIndex, pgm,
+			syncSnap.existingPodGangsByReplica[pcsReplicaIndex],
 			syncSnap.existingStandalonePCLQsByReplica[pcsReplicaIndex],
-			syncSnap.existingPCSGsByReplica[pcsReplicaIndex],
-			pcsReplicaIndex, scaleOutEpoch)
+			syncSnap.existingPCSGsByReplica[pcsReplicaIndex])
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

PodGangMap-only deletion normally self-heals on a subsequent reconcile. However, bootstrap reconstruction can temporarily omit externally scaled live replicas, causing ScaleOut PodGangs to be unnecessarily deleted and recreated.

This change reconciles bootstrap entries with live PodClique and PodCliqueScalingGroup replica counts before creating the PodGangMap, making recovery correct in the first reconcile and avoiding transient PodGang churn.

Includes focused unit tests and Kind verification.

#### Which issue(s) this PR fixes:

Issue: #796

#### Special notes for your reviewer:

This is recovery-path hardening. Running Pods were not disrupted during verification. Recovery after deletion of the live child resource itself remains out of scope.

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
