### PR TITLE
fix: avoid PodGang churn when PodGangMap is reconstructed

### DIFF
--- a/.github/workflows/build-check-test.yaml
+++ b/.github/workflows/build-check-test.yaml
@@ -137,6 +137,8 @@ jobs:
             test_pattern: "^Test_CRD_Installer"
           - test_name: resource_sharing
             test_pattern: "^Test_RS"
+          - test_name: podgangmap_reconstruct
+            test_pattern: "^Test_PGMR"
           - test_name: upgrade_from_latest_release
             make_target: "run-upgrade-e2e"
     name: E2E - ${{ matrix.test_name }}
@@ -207,6 +209,7 @@ jobs:
           - test_name: auto_mnnvl
           - test_name: crd_installer
           - test_name: resource_sharing
+          - test_name: podgangmap_reconstruct
           - test_name: upgrade_from_latest_release
     name: E2E - ${{ matrix.test_name }}
     steps:

--- a/operator/e2e/grove/podgang/podgang.go
+++ b/operator/e2e/grove/podgang/podgang.go
@@ -61,6 +61,15 @@ func (v *Verifier) List(ctx context.Context, pcsNsName types.NamespacedName) ([]
 	return pgList.Items, nil
 }
 
+// Get returns the named PodGang.
+func (v *Verifier) Get(ctx context.Context, namespace, name string) (*groveschedulerv1alpha1.PodGang, error) {
+	pg := &groveschedulerv1alpha1.PodGang{}
+	if err := v.cl.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, pg); err != nil {
+		return nil, err
+	}
+	return pg, nil
+}
+
 // Verify lists the PodGang(s) for the given PodCliqueSet namespace/name and applies the given
 // check to each of the PodGang. It returns an error if one of the below conditions is met:
 //  1. An error while listing PodGang resources.
@@ -85,6 +94,34 @@ func (v *Verifier) Verify(ctx context.Context, pcsNsName types.NamespacedName, c
 		}
 	}
 	return nil
+}
+
+// VerifyByName gets the named PodGang and applies each check to it. It returns an error if the PodGang
+// cannot be fetched or a check fails (returns on the first failure).
+func (v *Verifier) VerifyByName(ctx context.Context, namespace, name string, check ...Check) error {
+	pg, err := v.Get(ctx, namespace, name)
+	if err != nil {
+		return err
+	}
+	for _, c := range check {
+		if err := c(pg); err != nil {
+			return fmt.Errorf("check failed for PodGang %s/%s: %w", namespace, name, err)
+		}
+	}
+	return nil
+}
+
+// SameUIDCheckFn returns a Check that verifies the PodGang still carries the given UID. A PodGang that
+// was deleted and recreated gets a new UID, so an unchanged UID proves the same object survived.
+// UID comparison is used rather than watching for delete events, because the recreation happens within
+// a very short window and watch events observed over such a short interval are unreliable.
+func SameUIDCheckFn(want types.UID) Check {
+	return func(pg *groveschedulerv1alpha1.PodGang) error {
+		if pg.UID != want {
+			return fmt.Errorf("UID = %s, want %s (PodGang was recreated)", pg.UID, want)
+		}
+		return nil
+	}
 }
 
 // ConditionStatusCheckFn returns a Check that verifies the PodGang has the given condition type set

--- a/operator/e2e/grove/podgangmap/podgangmap.go
+++ b/operator/e2e/grove/podgangmap/podgangmap.go
@@ -1,0 +1,190 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+
+package podgangmap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	commonapi "github.com/ai-dynamo/grove/operator/api/common"
+	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/ai-dynamo/grove/operator/e2e/log"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Verifier provides capabilities to verify PodGangMap resources.
+type Verifier struct {
+	cl     client.Client
+	logger *log.Logger
+}
+
+// Check verifies a single PodGangMap. It returns nil if the PodGangMap passes the check or an error
+// why the check failed.
+type Check func(*grovecorev1alpha1.PodGangMap) error
+
+// NewVerifier creates a Verifier for PodGangMap resources bound to the given client.
+func NewVerifier(cl client.Client, logger *log.Logger) *Verifier {
+	return &Verifier{
+		cl:     cl,
+		logger: logger,
+	}
+}
+
+// Get returns the PodGangMap for the given PodCliqueSet replica index. One PodGangMap exists per
+// PodCliqueSet replica, named <pcs-name>-<pcs-replica-index>.
+func (v *Verifier) Get(ctx context.Context, pcsNsName types.NamespacedName, pcsReplicaIndex int) (*grovecorev1alpha1.PodGangMap, error) {
+	name := commonapi.GeneratePodGangMapName(commonapi.ResourceNameReplica{Name: pcsNsName.Name, Replica: pcsReplicaIndex})
+	pgm := &grovecorev1alpha1.PodGangMap{}
+	if err := v.cl.Get(ctx, types.NamespacedName{Namespace: pcsNsName.Namespace, Name: name}, pgm); err != nil {
+		return nil, err
+	}
+	return pgm, nil
+}
+
+// Verify gets the PodGangMap for the given PodCliqueSet replica index and applies each check to it. It
+// returns an error if the PodGangMap cannot be fetched or a check fails (returns on the first failure).
+func (v *Verifier) Verify(ctx context.Context, pcsNsName types.NamespacedName, pcsReplicaIndex int, check ...Check) error {
+	pgm, err := v.Get(ctx, pcsNsName, pcsReplicaIndex)
+	if err != nil {
+		return err
+	}
+	for _, c := range check {
+		if err := c(pgm); err != nil {
+			return fmt.Errorf("check failed for PodGangMap %v: %w", client.ObjectKeyFromObject(pgm), err)
+		}
+	}
+	return nil
+}
+
+// AnchorPCSGReplicaIndicesCheckFn returns a Check that verifies the anchor entry carries the wanted
+// replica indices for the given PodCliqueScalingGroup.
+// NOTE: it selects the single anchor entry. After a coherent update a PodGangMap has more than one
+// anchor entry, and selecting the right one is left to the coherent update tests.
+func AnchorPCSGReplicaIndicesCheckFn(pcsgName string, want []int32) Check {
+	return func(pgm *grovecorev1alpha1.PodGangMap) error {
+		entry, err := singleEntryByRole(pgm, grovecorev1alpha1.PodGangEntryRoleAnchor)
+		if err != nil {
+			return err
+		}
+		return assertPCSGReplicaIndices(entry, pcsgName, want)
+	}
+}
+
+// ScaleOutPCSGReplicaIndicesCheckFn returns a Check that verifies the ScaleOut entry carries the wanted
+// replica indices for the given PodCliqueScalingGroup.
+func ScaleOutPCSGReplicaIndicesCheckFn(pcsgName string, want []int32) Check {
+	return func(pgm *grovecorev1alpha1.PodGangMap) error {
+		entry, err := singleEntryByRole(pgm, grovecorev1alpha1.PodGangEntryRoleScaleOut)
+		if err != nil {
+			return err
+		}
+		return assertPCSGReplicaIndices(entry, pcsgName, want)
+	}
+}
+
+// AnchorStandalonePodCliqueCountCheckFn returns a Check that verifies the anchor entry carries the
+// wanted pod count for the given standalone PodClique.
+func AnchorStandalonePodCliqueCountCheckFn(cliqueName string, want int32) Check {
+	return func(pgm *grovecorev1alpha1.PodGangMap) error {
+		entry, err := singleEntryByRole(pgm, grovecorev1alpha1.PodGangEntryRoleAnchor)
+		if err != nil {
+			return err
+		}
+		if got := entry.PodCliques[cliqueName]; got != want {
+			return fmt.Errorf("anchor PodClique %q count = %d, want %d", cliqueName, got, want)
+		}
+		return nil
+	}
+}
+
+// ScaleOutEpochCheckFn returns a Check that verifies the ScaleOut entry carries the wanted epoch. It is
+// used to confirm a rebuilt PodGangMap reuses the epoch of the existing scale-out PodGang rather than
+// minting a new one, so the scale-out PodGang keeps its name.
+func ScaleOutEpochCheckFn(want string) Check {
+	return func(pgm *grovecorev1alpha1.PodGangMap) error {
+		entry, err := singleEntryByRole(pgm, grovecorev1alpha1.PodGangEntryRoleScaleOut)
+		if err != nil {
+			return err
+		}
+		if entry.Epoch != want {
+			return fmt.Errorf("ScaleOut epoch = %q, want %q", entry.Epoch, want)
+		}
+		return nil
+	}
+}
+
+// AnchorEpochCheckFn returns a Check that verifies the anchor entry carries the wanted epoch. It is used
+// to confirm a rebuilt PodGangMap reuses the epoch of the existing anchor PodGang rather than minting a
+// new one, so the anchor PodGang keeps its name.
+func AnchorEpochCheckFn(want string) Check {
+	return func(pgm *grovecorev1alpha1.PodGangMap) error {
+		entry, err := singleEntryByRole(pgm, grovecorev1alpha1.PodGangEntryRoleAnchor)
+		if err != nil {
+			return err
+		}
+		if entry.Epoch != want {
+			return fmt.Errorf("anchor epoch = %q, want %q", entry.Epoch, want)
+		}
+		return nil
+	}
+}
+
+// WaitUntilVerified polls the replica's PodGangMap until it satisfies all checks or the timeout
+// elapses. Verification is delegated to Verifier.Verify and runs immediately, then repeats every
+// interval. It returns nil once all checks pass. On timeout or context cancellation it returns an error
+// that joins the poll outcome with the last verification failure.
+func WaitUntilVerified(ctx context.Context, v *Verifier, pcsNsName types.NamespacedName, pcsReplicaIndex int, timeout, interval time.Duration, checks ...Check) error {
+	var lastErr error
+	pollErr := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+		lastErr = v.Verify(ctx, pcsNsName, pcsReplicaIndex, checks...)
+		return lastErr == nil, nil
+	})
+	if pollErr == nil {
+		return nil
+	}
+	return fmt.Errorf("PodGangMap for PodCliqueSet %v replica %d not verified within %s: %w", pcsNsName, pcsReplicaIndex, timeout, errors.Join(pollErr, lastErr))
+}
+
+// singleEntryByRole returns the entry with the given role, or an error unless there is exactly one.
+func singleEntryByRole(pgm *grovecorev1alpha1.PodGangMap, role grovecorev1alpha1.PodGangEntryRole) (grovecorev1alpha1.PodGangEntry, error) {
+	var found []grovecorev1alpha1.PodGangEntry
+	for i := range pgm.Spec.Entries {
+		if pgm.Spec.Entries[i].Role == role {
+			found = append(found, pgm.Spec.Entries[i])
+		}
+	}
+	if len(found) != 1 {
+		return grovecorev1alpha1.PodGangEntry{}, fmt.Errorf("expected exactly one %s entry, found %d", role, len(found))
+	}
+	return found[0], nil
+}
+
+// assertPCSGReplicaIndices reports whether the entry carries exactly the wanted replica indices for the
+// given PodCliqueScalingGroup.
+func assertPCSGReplicaIndices(entry grovecorev1alpha1.PodGangEntry, pcsgName string, want []int32) error {
+	got := entry.PCSGReplicaIndices[pcsgName]
+	if !slices.Equal(got, want) {
+		return fmt.Errorf("%s PodCliqueScalingGroup %q replica indices = %v, want %v", entry.Role, pcsgName, got, want)
+	}
+	return nil
+}

--- a/operator/e2e/grove/workload/workload.go
+++ b/operator/e2e/grove/workload/workload.go
@@ -53,7 +53,12 @@ func NewWorkloadManager(k8s *k8sclient.Client, logger *log.Logger) *WorkloadMana
 
 // ScalePCS scales a PodCliqueSet to the specified replica count.
 func (wm *WorkloadManager) ScalePCS(ctx context.Context, namespace, name string, replicas int) error {
-	return wm.resources.ScaleCRD(ctx, gvk.PodCliqueSet, namespace, name, replicas)
+	return wm.resources.ScaleResource(ctx, gvk.PodCliqueSet, namespace, name, replicas)
+}
+
+// ScalePodClique scales a standalone PodClique to the specified replica count.
+func (wm *WorkloadManager) ScalePodClique(ctx context.Context, namespace, name string, replicas int) error {
+	return wm.resources.ScaleResource(ctx, gvk.PodClique, namespace, name, replicas)
 }
 
 // ScalePCSG scales a PodCliqueScalingGroup to the specified replica count.
@@ -64,7 +69,7 @@ func (wm *WorkloadManager) ScalePCSG(ctx context.Context, namespace, name string
 		return fmt.Errorf("failed to find PodCliqueScalingGroup %s: %w", name, err)
 	}
 
-	return wm.resources.ScaleCRD(ctx, gvk.PodCliqueScalingGroup, namespace, name, replicas)
+	return wm.resources.ScaleResource(ctx, gvk.PodCliqueScalingGroup, namespace, name, replicas)
 }
 
 // TriggerPCSReconcile bumps a benchmark annotation on a PodCliqueSet without touching its

--- a/operator/e2e/k8s/resources/resources.go
+++ b/operator/e2e/k8s/resources/resources.go
@@ -18,14 +18,15 @@ package resources
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
 	"github.com/ai-dynamo/grove/operator/e2e/log"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -95,27 +96,21 @@ func (rm *ResourceManager) ApplyYAMLData(ctx context.Context, yamlData []byte, n
 	return appliedResources, nil
 }
 
-// ScaleCRD patches the replicas field of a custom resource identified by GVK.
-func (rm *ResourceManager) ScaleCRD(ctx context.Context, gvk schema.GroupVersionKind, namespace, name string, replicas int) error {
-	scalePatch := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"replicas": replicas,
-		},
-	}
-	patchBytes, err := json.Marshal(scalePatch)
-	if err != nil {
-		return fmt.Errorf("failed to marshal scale patch: %w", err)
-	}
-
+// ScaleResource scales a custom resource identified by GVK through its Scale subresource.
+// This is the same path that any autoscaler like HPA, KEDA etc. will take.
+func (rm *ResourceManager) ScaleResource(ctx context.Context, gvk schema.GroupVersionKind, namespace, name string, replicas int) error {
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(gvk)
 	obj.SetName(name)
 	obj.SetNamespace(namespace)
 
-	if err := rm.cl.Patch(ctx, obj, client.RawPatch(types.MergePatchType, patchBytes)); err != nil {
-		return fmt.Errorf("failed to scale %s %s: %w", gvk.Kind, name, err)
+	scale := &autoscalingv1.Scale{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec:       autoscalingv1.ScaleSpec{Replicas: int32(replicas)},
 	}
-
+	if err := rm.cl.SubResource("scale").Update(ctx, obj, client.WithSubResourceBody(scale)); err != nil {
+		return fmt.Errorf("failed to scale resource %s %s/%s: %w", gvk.Kind, namespace, name, err)
+	}
 	return nil
 }
 

--- a/operator/e2e/testctx/context.go
+++ b/operator/e2e/testctx/context.go
@@ -279,6 +279,11 @@ func (tc *TestContext) ScalePCS(name string, replicas int) error {
 	return tc.newWorkloadManager().ScalePCS(tc.Ctx, tc.Namespace, name, replicas)
 }
 
+// ScalePodClique scales a standalone PodClique to the specified replica count.
+func (tc *TestContext) ScalePodClique(name string, replicas int) error {
+	return tc.newWorkloadManager().ScalePodClique(tc.Ctx, tc.Namespace, name, replicas)
+}
+
 // ScalePCSG scales a PodCliqueScalingGroup to the specified replica count.
 func (tc *TestContext) ScalePCSG(name string, replicas int) error {
 	return tc.newWorkloadManager().ScalePCSG(tc.Ctx, tc.Namespace, name, replicas, tc.Timeout, tc.Interval)
@@ -406,6 +411,21 @@ func (tc *TestContext) ScalePCSAndWait(pcsName string, replicas int32, expectedT
 	totalPods, runningPods, pendingPods, err := tc.WaitForPodConditions(expectedTotalPods, expectedPending)
 	if err != nil {
 		tc.T.Fatalf("Failed to wait for expected pod conditions after PCS scaling: %v. Final state: total=%d, running=%d, pending=%d (expected: total=%d, pending=%d)",
+			err, totalPods, runningPods, pendingPods, expectedTotalPods, expectedPending)
+	}
+}
+
+// ScalePodCliqueAndWait scales a standalone PodClique and waits for the expected pod conditions.
+func (tc *TestContext) ScalePodCliqueAndWait(pclqName string, replicas int32, expectedTotalPods, expectedPending int) {
+	tc.T.Helper()
+
+	if err := tc.ScalePodClique(pclqName, int(replicas)); err != nil {
+		tc.T.Fatalf("Failed to scale PodClique %s: %v", pclqName, err)
+	}
+
+	totalPods, runningPods, pendingPods, err := tc.WaitForPodConditions(expectedTotalPods, expectedPending)
+	if err != nil {
+		tc.T.Fatalf("Failed to wait for expected pod conditions after PodClique scaling: %v. Final state: total=%d, running=%d, pending=%d (expected: total=%d, pending=%d)",
 			err, totalPods, runningPods, pendingPods, expectedTotalPods, expectedPending)
 	}
 }

--- a/operator/e2e/tests/podgangmap_reconstruct_test.go
+++ b/operator/e2e/tests/podgangmap_reconstruct_test.go
@@ -21,7 +21,9 @@ import (
 	"testing"
 	"time"
 
+	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/ai-dynamo/grove/operator/e2e/grove/podgang"
 	"github.com/ai-dynamo/grove/operator/e2e/grove/podgangmap"
 	"github.com/ai-dynamo/grove/operator/e2e/testctx"
 
@@ -43,7 +45,7 @@ const pgmReconstructTimeout = 1 * time.Minute
 // 4. Delete the PodGangMap for replica 0
 // 5. Verify the recreated PodGangMap has anchor sg-x indices [0,1], scale-out sg-x index [2] with the
 //    same epoch, and the standalone pc-a count 2
-// 6. Verify all 14 pods remain running, so the scaled-out replica is not stranded
+// 6. Verify the scaled-out PodGang was not recreated (stable UID) and all 14 pods remain running
 func Test_PGMR1_ReconstructScaledPCSGAfterPodGangMapDelete(t *testing.T) {
 	ctx := t.Context()
 
@@ -79,6 +81,16 @@ func Test_PGMR1_ReconstructScaledPCSGAfterPodGangMapDelete(t *testing.T) {
 	}
 	scaleOutEpoch := scaleOutEpochOf(t, ctx, verifier, pcsNsName)
 
+	// Capture the scaled-out PodGang's UID so a delete-and-recreate can be detected after reconstruction.
+	pgVerifier := podgang.NewVerifier(tc.Client, Logger)
+	scaleOutPodGangName := apicommon.GenerateNonAnchorPodGangName(
+		apicommon.ResourceNameReplica{Name: "workload1", Replica: 0}, scaleOutEpoch, "sg-x", 2)
+	scaleOutPodGang, err := pgVerifier.Get(ctx, tc.Namespace, scaleOutPodGangName)
+	if err != nil {
+		t.Fatalf("Failed to get scaled-out PodGang %s: %v", scaleOutPodGangName, err)
+	}
+	uidBefore := scaleOutPodGang.UID
+
 	Logger.Info("4. Delete the PodGangMap for replica 0")
 	deletePodGangMap(t, tc, "workload1-0")
 
@@ -92,7 +104,12 @@ func Test_PGMR1_ReconstructScaledPCSGAfterPodGangMapDelete(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	Logger.Info("6. Verify all 14 pods remain running, so the scaled-out replica is not stranded")
+	Logger.Info("6. Verify the scaled-out PodGang was not churned and all 14 pods remain running")
+	// Reconstruction reflects the scaled counts up front, so the scaled-out PodGang is never dropped
+	// and recreated. A stable UID proves it is the same object.
+	if err := pgVerifier.VerifyByName(ctx, tc.Namespace, scaleOutPodGangName, podgang.SameUIDCheckFn(uidBefore)); err != nil {
+		t.Fatalf("scaled-out PodGang %s churned: %v", scaleOutPodGangName, err)
+	}
 	if err := tc.WaitForRunningPods(14); err != nil {
 		t.Fatalf("Pods not all running after PodGangMap reconstruction: %v", err)
 	}

--- a/operator/e2e/tests/podgangmap_reconstruct_test.go
+++ b/operator/e2e/tests/podgangmap_reconstruct_test.go
@@ -1,0 +1,319 @@
+// Copyright 2026 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/ai-dynamo/grove/operator/e2e/grove/podgangmap"
+	"github.com/ai-dynamo/grove/operator/e2e/testctx"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// pgmReconstructTimeout bounds the wait for a deleted PodGangMap to be reconstructed. Reconstruction
+// runs on the next reconcile and is near-instant, so a long wait here signals a real defect.
+const pgmReconstructTimeout = 1 * time.Minute
+
+// Test_PGMR1_ReconstructScaledPCSGAfterPodGangMapDelete verifies that a PodGangMap deleted after a
+// PodCliqueScalingGroup was scaled beyond its template is reconstructed from the live scaled replicas,
+// reuses the scale-out epoch so the scaled-out PodGang keeps its name, and leaves running pods intact.
+// Scenario PGMR-1:
+// 1. Initialize a 14-node Grove cluster
+// 2. Deploy workload WL1 (standalone pc-a=2, PCSG sg-x=2 over pc-b+pc-c), verify 10 pods
+// 3. Scale sg-x from 2 to 3, verify 14 pods, and capture the scale-out entry epoch
+// 4. Delete the PodGangMap for replica 0
+// 5. Verify the recreated PodGangMap has anchor sg-x indices [0,1], scale-out sg-x index [2] with the
+//    same epoch, and the standalone pc-a count 2
+// 6. Verify all 14 pods remain running, so the scaled-out replica is not stranded
+func Test_PGMR1_ReconstructScaledPCSGAfterPodGangMapDelete(t *testing.T) {
+	ctx := t.Context()
+
+	Logger.Info("1. Initialize a 14-node Grove cluster")
+	Logger.Info("2. Deploy workload WL1, and verify 10 newly created pods")
+	tc, cleanup := testctx.PrepareTest(ctx, t, 14,
+		testctx.WithWorkload(&testctx.WorkloadConfig{
+			Name:         "workload1",
+			YAMLPath:     "../yaml/workload1.yaml",
+			Namespace:    "default",
+			ExpectedPods: 10,
+		}),
+	)
+	defer cleanup()
+
+	if _, err := tc.DeployAndVerifyWorkload(); err != nil {
+		t.Fatalf("Failed to deploy workload: %v", err)
+	}
+
+	verifier := podgangmap.NewVerifier(tc.Client, Logger)
+	pcsNsName := types.NamespacedName{Namespace: tc.Namespace, Name: "workload1"}
+
+	Logger.Info("3. Scale sg-x from 2 to 3, verify 14 pods, and capture the scale-out entry epoch")
+	// Per PCSG replica sg-x holds pc-b(1)+pc-c(3)=4 pods. With pc-a(2) the totals are 2+4*2=10 at 2
+	// replicas and 2+4*3=14 at 3 replicas.
+	tc.ScalePCSGAcrossAllReplicasAndWait("workload1", "sg-x", 1, 3, 14, 0)
+
+	if err := verifier.Verify(ctx, pcsNsName, 0,
+		podgangmap.AnchorPCSGReplicaIndicesCheckFn("sg-x", []int32{0, 1}),
+		podgangmap.ScaleOutPCSGReplicaIndicesCheckFn("sg-x", []int32{2}),
+	); err != nil {
+		t.Fatalf("PodGangMap not in expected state after scale-out: %v", err)
+	}
+	scaleOutEpoch := scaleOutEpochOf(t, ctx, verifier, pcsNsName)
+
+	Logger.Info("4. Delete the PodGangMap for replica 0")
+	deletePodGangMap(t, tc, "workload1-0")
+
+	Logger.Info("5. Verify the recreated PodGangMap reflects the live scaled replicas and reuses the epoch")
+	if err := podgangmap.WaitUntilVerified(ctx, verifier, pcsNsName, 0, pgmReconstructTimeout, tc.Interval,
+		podgangmap.AnchorPCSGReplicaIndicesCheckFn("sg-x", []int32{0, 1}),
+		podgangmap.ScaleOutPCSGReplicaIndicesCheckFn("sg-x", []int32{2}),
+		podgangmap.ScaleOutEpochCheckFn(scaleOutEpoch),
+		podgangmap.AnchorStandalonePodCliqueCountCheckFn("pc-a", 2),
+	); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	Logger.Info("6. Verify all 14 pods remain running, so the scaled-out replica is not stranded")
+	if err := tc.WaitForRunningPods(14); err != nil {
+		t.Fatalf("Pods not all running after PodGangMap reconstruction: %v", err)
+	}
+
+	Logger.Info("PGMR-1 completed successfully")
+}
+
+// Test_PGMR2_ReconstructScaledStandalonePCLQAfterPodGangMapDelete verifies that a PodGangMap deleted
+// after a standalone PodClique was scaled beyond its template is reconstructed from the live scaled
+// replicas, not the stale template count.
+// Scenario PGMR-2:
+// 1. Initialize a 14-node Grove cluster
+// 2. Deploy workload WL1, verify 10 pods
+// 3. Scale standalone pc-a from 2 to 4, verify 12 pods, and assert the anchor count is 4
+// 4. Delete the PodGangMap for replica 0
+// 5. Verify the recreated PodGangMap has the anchor pc-a count 4
+// 6. Verify all 12 pods remain running
+func Test_PGMR2_ReconstructScaledStandalonePCLQAfterPodGangMapDelete(t *testing.T) {
+	ctx := t.Context()
+
+	Logger.Info("1. Initialize a 14-node Grove cluster")
+	Logger.Info("2. Deploy workload WL1, and verify 10 newly created pods")
+	tc, cleanup := testctx.PrepareTest(ctx, t, 14,
+		testctx.WithWorkload(&testctx.WorkloadConfig{
+			Name:         "workload1",
+			YAMLPath:     "../yaml/workload1.yaml",
+			Namespace:    "default",
+			ExpectedPods: 10,
+		}),
+	)
+	defer cleanup()
+
+	if _, err := tc.DeployAndVerifyWorkload(); err != nil {
+		t.Fatalf("Failed to deploy workload: %v", err)
+	}
+
+	verifier := podgangmap.NewVerifier(tc.Client, Logger)
+	pcsNsName := types.NamespacedName{Namespace: tc.Namespace, Name: "workload1"}
+
+	Logger.Info("3. Scale standalone pc-a from 2 to 4, verify 12 pods")
+	// pc-a is standalone. Scaling it 2 to 4 adds 2 pods to the 10-pod baseline.
+	tc.ScalePodCliqueAndWait("workload1-0-pc-a", 4, 12, 0)
+
+	if err := verifier.Verify(ctx, pcsNsName, 0,
+		podgangmap.AnchorStandalonePodCliqueCountCheckFn("pc-a", 4),
+	); err != nil {
+		t.Fatalf("PodGangMap not in expected state after scale-out: %v", err)
+	}
+
+	Logger.Info("4. Delete the PodGangMap for replica 0")
+	deletePodGangMap(t, tc, "workload1-0")
+
+	Logger.Info("5. Verify the recreated PodGangMap has the anchor pc-a count 4")
+	if err := podgangmap.WaitUntilVerified(ctx, verifier, pcsNsName, 0, pgmReconstructTimeout, tc.Interval,
+		podgangmap.AnchorStandalonePodCliqueCountCheckFn("pc-a", 4),
+	); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	Logger.Info("6. Verify all 12 pods remain running")
+	if err := tc.WaitForRunningPods(12); err != nil {
+		t.Fatalf("Pods not all running after PodGangMap reconstruction: %v", err)
+	}
+
+	Logger.Info("PGMR-2 completed successfully")
+}
+
+// Test_PGMR3_ReconstructFreshBootstrapAfterPodGangMapDelete verifies that a PodGangMap deleted with no
+// prior scaling is reconstructed to the same template shape, reusing the anchor epoch from the live
+// anchor PodGang so pods are not stranded.
+// Scenario PGMR-3:
+// 1. Initialize a 14-node Grove cluster
+// 2. Deploy workload WL1, verify 10 pods
+// 3. Capture the anchor epoch
+// 4. Delete the PodGangMap for replica 0
+// 5. Verify the recreated PodGangMap has anchor sg-x indices [0,1], pc-a count 2, an empty scale-out,
+//    and the anchor epoch is reused
+// 6. Verify all 10 pods remain running
+func Test_PGMR3_ReconstructFreshBootstrapAfterPodGangMapDelete(t *testing.T) {
+	ctx := t.Context()
+
+	Logger.Info("1. Initialize a 14-node Grove cluster")
+	Logger.Info("2. Deploy workload WL1, and verify 10 newly created pods")
+	tc, cleanup := testctx.PrepareTest(ctx, t, 14,
+		testctx.WithWorkload(&testctx.WorkloadConfig{
+			Name:         "workload1",
+			YAMLPath:     "../yaml/workload1.yaml",
+			Namespace:    "default",
+			ExpectedPods: 10,
+		}),
+	)
+	defer cleanup()
+
+	if _, err := tc.DeployAndVerifyWorkload(); err != nil {
+		t.Fatalf("Failed to deploy workload: %v", err)
+	}
+
+	verifier := podgangmap.NewVerifier(tc.Client, Logger)
+	pcsNsName := types.NamespacedName{Namespace: tc.Namespace, Name: "workload1"}
+
+	Logger.Info("3. Capture the anchor epoch")
+	anchorEpoch := anchorEpochOf(t, ctx, verifier, pcsNsName)
+
+	Logger.Info("4. Delete the PodGangMap for replica 0")
+	deletePodGangMap(t, tc, "workload1-0")
+
+	Logger.Info("5. Verify the recreated PodGangMap matches the template shape and reuses the anchor epoch")
+	if err := podgangmap.WaitUntilVerified(ctx, verifier, pcsNsName, 0, pgmReconstructTimeout, tc.Interval,
+		podgangmap.AnchorPCSGReplicaIndicesCheckFn("sg-x", []int32{0, 1}),
+		podgangmap.AnchorStandalonePodCliqueCountCheckFn("pc-a", 2),
+		podgangmap.ScaleOutPCSGReplicaIndicesCheckFn("sg-x", nil),
+		podgangmap.AnchorEpochCheckFn(anchorEpoch),
+	); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	Logger.Info("6. Verify all 10 pods remain running")
+	if err := tc.WaitForRunningPods(10); err != nil {
+		t.Fatalf("Pods not all running after PodGangMap reconstruction: %v", err)
+	}
+
+	Logger.Info("PGMR-3 completed successfully")
+}
+
+// Test_PGMR4_ReconstructAfterScaleInThenPodGangMapDelete verifies that after a PodCliqueScalingGroup is
+// scaled out and then scaled back in, a deleted PodGangMap is reconstructed without the drained index.
+// Scenario PGMR-4:
+// 1. Initialize a 14-node Grove cluster
+// 2. Deploy workload WL1, verify 10 pods
+// 3. Scale sg-x 2 to 3 (14 pods), then 3 to 2 (10 pods), and assert the scale-out entry drained
+// 4. Delete the PodGangMap for replica 0
+// 5. Verify the recreated PodGangMap has anchor sg-x indices [0,1] and an empty scale-out
+// 6. Verify all 10 pods remain running
+func Test_PGMR4_ReconstructAfterScaleInThenPodGangMapDelete(t *testing.T) {
+	ctx := t.Context()
+
+	Logger.Info("1. Initialize a 14-node Grove cluster")
+	Logger.Info("2. Deploy workload WL1, and verify 10 newly created pods")
+	tc, cleanup := testctx.PrepareTest(ctx, t, 14,
+		testctx.WithWorkload(&testctx.WorkloadConfig{
+			Name:         "workload1",
+			YAMLPath:     "../yaml/workload1.yaml",
+			Namespace:    "default",
+			ExpectedPods: 10,
+		}),
+	)
+	defer cleanup()
+
+	if _, err := tc.DeployAndVerifyWorkload(); err != nil {
+		t.Fatalf("Failed to deploy workload: %v", err)
+	}
+
+	verifier := podgangmap.NewVerifier(tc.Client, Logger)
+	pcsNsName := types.NamespacedName{Namespace: tc.Namespace, Name: "workload1"}
+
+	Logger.Info("3. Scale sg-x 2 to 3 then 3 to 2, and assert the scale-out entry drained")
+	tc.ScalePCSGAcrossAllReplicasAndWait("workload1", "sg-x", 1, 3, 14, 0)
+	tc.ScalePCSGAcrossAllReplicasAndWait("workload1", "sg-x", 1, 2, 10, 0)
+
+	if err := verifier.Verify(ctx, pcsNsName, 0,
+		podgangmap.AnchorPCSGReplicaIndicesCheckFn("sg-x", []int32{0, 1}),
+		podgangmap.ScaleOutPCSGReplicaIndicesCheckFn("sg-x", nil),
+	); err != nil {
+		t.Fatalf("PodGangMap not in expected state after scale-in: %v", err)
+	}
+
+	Logger.Info("4. Delete the PodGangMap for replica 0")
+	deletePodGangMap(t, tc, "workload1-0")
+
+	Logger.Info("5. Verify the recreated PodGangMap has anchor sg-x indices [0,1] and an empty scale-out")
+	if err := podgangmap.WaitUntilVerified(ctx, verifier, pcsNsName, 0, pgmReconstructTimeout, tc.Interval,
+		podgangmap.AnchorPCSGReplicaIndicesCheckFn("sg-x", []int32{0, 1}),
+		podgangmap.ScaleOutPCSGReplicaIndicesCheckFn("sg-x", nil),
+	); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	Logger.Info("6. Verify all 10 pods remain running")
+	if err := tc.WaitForRunningPods(10); err != nil {
+		t.Fatalf("Pods not all running after PodGangMap reconstruction: %v", err)
+	}
+
+	Logger.Info("PGMR-4 completed successfully")
+}
+
+// deletePodGangMap deletes the named PodGangMap, failing the test on error.
+func deletePodGangMap(t *testing.T, tc *testctx.TestContext, name string) {
+	t.Helper()
+	pgm := &grovev1alpha1.PodGangMap{ObjectMeta: metav1.ObjectMeta{Namespace: tc.Namespace, Name: name}}
+	if err := tc.Client.Delete(tc.Ctx, pgm); err != nil {
+		t.Fatalf("Failed to delete PodGangMap %s: %v", name, err)
+	}
+}
+
+// scaleOutEpochOf returns the epoch of replica 0's single ScaleOut entry.
+func scaleOutEpochOf(t *testing.T, ctx context.Context, v *podgangmap.Verifier, pcsNsName types.NamespacedName) string {
+	t.Helper()
+	return epochOfRole(t, ctx, v, pcsNsName, grovev1alpha1.PodGangEntryRoleScaleOut)
+}
+
+// anchorEpochOf returns the epoch of replica 0's single anchor entry.
+func anchorEpochOf(t *testing.T, ctx context.Context, v *podgangmap.Verifier, pcsNsName types.NamespacedName) string {
+	t.Helper()
+	return epochOfRole(t, ctx, v, pcsNsName, grovev1alpha1.PodGangEntryRoleAnchor)
+}
+
+// epochOfRole returns the epoch of replica 0's single entry with the given role.
+func epochOfRole(t *testing.T, ctx context.Context, v *podgangmap.Verifier, pcsNsName types.NamespacedName, role grovev1alpha1.PodGangEntryRole) string {
+	t.Helper()
+	pgm, err := v.Get(ctx, pcsNsName, 0)
+	if err != nil {
+		t.Fatalf("Failed to get PodGangMap: %v", err)
+	}
+	var epochs []string
+	for i := range pgm.Spec.Entries {
+		if pgm.Spec.Entries[i].Role == role {
+			epochs = append(epochs, pgm.Spec.Entries[i].Epoch)
+		}
+	}
+	if len(epochs) != 1 {
+		t.Fatalf("expected exactly one %s entry, found %d", role, len(epochs))
+	}
+	return epochs[0]
+}

--- a/operator/e2e/tests/resource_sharing_test.go
+++ b/operator/e2e/tests/resource_sharing_test.go
@@ -26,11 +26,9 @@ import (
 
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
-	"github.com/ai-dynamo/grove/operator/e2e/grove/gvk"
 	"github.com/ai-dynamo/grove/operator/e2e/grove/workload"
 	k8sutils "github.com/ai-dynamo/grove/operator/e2e/k8s"
 	"github.com/ai-dynamo/grove/operator/e2e/k8s/pods"
-	"github.com/ai-dynamo/grove/operator/e2e/k8s/resources"
 	"github.com/ai-dynamo/grove/operator/e2e/testctx"
 	v1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
@@ -385,7 +383,7 @@ func Test_RS1_HierarchicalResourceSharing(t *testing.T) {
 	// --- PCLQ scale-out/in (single PCS replica) ---
 
 	Logger.Info("10. Scale standalone PCLQ worker-a from 1 to 2")
-	if err := scalePodClique(tc, "rs-test-0-worker-a", 2); err != nil {
+	if err := tc.ScalePodClique("rs-test-0-worker-a", 2); err != nil {
 		t.Fatalf("Failed to scale PCLQ: %v", err)
 	}
 	verifyRCState(t, tc, rcLabelSelector, 15, pclqScaleOutRCNames())
@@ -408,7 +406,7 @@ func Test_RS1_HierarchicalResourceSharing(t *testing.T) {
 	Logger.Info("   Verified 15 RCs and 5 pods (per-pod refs) after PCLQ scale-out")
 
 	Logger.Info("11. Scale standalone PCLQ worker-a from 2 to 1")
-	if err := scalePodClique(tc, "rs-test-0-worker-a", 1); err != nil {
+	if err := tc.ScalePodClique("rs-test-0-worker-a", 1); err != nil {
 		t.Fatalf("Failed to scale PCLQ: %v", err)
 	}
 	verifyRCState(t, tc, rcLabelSelector, 14, pcsgScaleOutRCNames())
@@ -453,12 +451,6 @@ func Test_RS1_HierarchicalResourceSharing(t *testing.T) {
 	Logger.Info("   Verified all ResourceClaims garbage-collected after PCS deletion")
 
 	Logger.Info("Hierarchical resource sharing e2e test completed successfully!")
-}
-
-// scalePodClique scales a PodClique using the resource manager.
-func scalePodClique(tc *testctx.TestContext, name string, replicas int) error {
-	rm := resources.NewResourceManager(tc.Client, Logger)
-	return rm.ScaleCRD(tc.Ctx, gvk.PodClique, tc.Namespace, name, replicas)
 }
 
 // verifyRCState waits for the expected RC count and verifies exact RC names.

--- a/operator/internal/controller/common/component/utils/podclique.go
+++ b/operator/internal/controller/common/component/utils/podclique.go
@@ -175,13 +175,14 @@ func GetMinAvailableBreachedPCLQInfo(pclqs []grovecorev1alpha1.PodClique, termin
 }
 
 // GetPodCliquesWithParentPCS retrieves PodClique objects that are not part of any PodCliqueScalingGroup for the given PodCliqueSet.
-func GetPodCliquesWithParentPCS(ctx context.Context, cl client.Client, pcsObjKey client.ObjectKey) ([]grovecorev1alpha1.PodClique, error) {
+// GetPodCliquesWithParentPCS retrieves PodClique objects that are not part of any PodCliqueScalingGroup for the given PodCliqueSet.
+func GetPodCliquesWithParentPCS(ctx context.Context, cl client.Client, pcsObjMeta metav1.ObjectMeta) ([]grovecorev1alpha1.PodClique, error) {
 	pclqList := &grovecorev1alpha1.PodCliqueList{}
 	err := cl.List(ctx,
 		pclqList,
-		client.InNamespace(pcsObjKey.Namespace),
+		client.InNamespace(pcsObjMeta.Namespace),
 		client.MatchingLabels(lo.Assign(
-			apicommon.GetDefaultLabelsForPodCliqueSetManagedResources(pcsObjKey.Name),
+			apicommon.GetDefaultLabelsForPodCliqueSetManagedResources(pcsObjMeta.Name),
 			map[string]string{
 				apicommon.LabelComponentKey: apicommon.LabelComponentNamePodCliqueSetPodClique,
 			},
@@ -190,7 +191,11 @@ func GetPodCliquesWithParentPCS(ctx context.Context, cl client.Client, pcsObjKey
 	if err != nil {
 		return nil, err
 	}
-	return pclqList.Items, nil
+	// Exclude PodCliques controlled by an older PodCliqueSet of the same name, so a recreated
+	// PodCliqueSet does not ingest a deleted one's leftover children.
+	return lo.Filter(pclqList.Items, func(pclq grovecorev1alpha1.PodClique, _ int) bool {
+		return metav1.IsControlledBy(&pclq, &pcsObjMeta)
+	}), nil
 }
 
 // groupPCLQsByLabel groups PodCliques by the value of the specified label key

--- a/operator/internal/controller/common/component/utils/podcliquescalinggroup.go
+++ b/operator/internal/controller/common/component/utils/podcliquescalinggroup.go
@@ -24,6 +24,7 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 
 	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -42,12 +43,16 @@ func FindScalingGroupConfigForClique(scalingGroupConfigs []grovecorev1alpha1.Pod
 }
 
 // GetPCSGsForPCS fetches all PodCliqueScalingGroups for a PodCliqueSet.
-func GetPCSGsForPCS(ctx context.Context, cl client.Client, pcsObjKey client.ObjectKey) ([]grovecorev1alpha1.PodCliqueScalingGroup, error) {
-	pcsgList, err := doGetPCSGsForPCS(ctx, cl, pcsObjKey, nil)
+func GetPCSGsForPCS(ctx context.Context, cl client.Client, pcsObjMeta metav1.ObjectMeta) ([]grovecorev1alpha1.PodCliqueScalingGroup, error) {
+	pcsgList, err := doGetPCSGsForPCS(ctx, cl, client.ObjectKey{Namespace: pcsObjMeta.Namespace, Name: pcsObjMeta.Name}, nil)
 	if err != nil {
 		return nil, err
 	}
-	return pcsgList.Items, nil
+	// Exclude PodCliqueScalingGroups controlled by an older PodCliqueSet of the same name, so a
+	// recreated PodCliqueSet does not ingest a deleted one's leftover children.
+	return lo.Filter(pcsgList.Items, func(pcsg grovecorev1alpha1.PodCliqueScalingGroup, _ int) bool {
+		return metav1.IsControlledBy(&pcsg, &pcsObjMeta)
+	}), nil
 }
 
 // doGetPCSGsForPCS is a helper function that fetches PodCliqueScalingGroups with optional additional label filtering

--- a/operator/internal/controller/common/component/utils/podgang.go
+++ b/operator/internal/controller/common/component/utils/podgang.go
@@ -52,5 +52,9 @@ func GetExistingPodGangs(ctx context.Context, cl client.Client, pcsObjectMeta me
 		client.MatchingLabels(GetPodGangSelectorLabels(pcsObjectMeta))); err != nil {
 		return nil, err
 	}
-	return podGangs.Items, nil
+	// Exclude PodGangs controlled by an older PodCliqueSet of the same name. A recreated PodCliqueSet
+	// reuses the name, so a name-label match can return a deleted PodCliqueSet's leftover children.
+	return lo.Filter(podGangs.Items, func(podGang groveschedulerv1alpha1.PodGang, _ int) bool {
+		return metav1.IsControlledBy(&podGang, &pcsObjectMeta)
+	}), nil
 }

--- a/operator/internal/controller/common/component/utils/podgang_test.go
+++ b/operator/internal/controller/common/component/utils/podgang_test.go
@@ -19,12 +19,15 @@ import (
 	"testing"
 
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
+	"github.com/ai-dynamo/grove/operator/api/common/constants"
+	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -149,20 +152,19 @@ func TestGetExistingPodGangs(t *testing.T) {
 
 	pcsName := "test-pcs"
 	namespace := "default"
+	const pcsUID = types.UID("pcs-uid")
 	pcsObjectMeta := metav1.ObjectMeta{
 		Name:      pcsName,
 		Namespace: namespace,
+		UID:       pcsUID,
 	}
 	matchingLabels := GetPodGangSelectorLabels(pcsObjectMeta)
 
 	t.Run("returns matching podgangs", func(t *testing.T) {
-		managed := &groveschedulerv1alpha1.PodGang{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pg-1",
-				Namespace: namespace,
-				Labels:    matchingLabels,
-			},
-		}
+		managed := testutils.NewPodGangBuilder("pg-1", namespace).
+			WithLabels(matchingLabels).
+			WithOwnerReference(constants.KindPodCliqueSet, pcsName, pcsUID).
+			Build()
 		cl := fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithObjects(managed).
@@ -176,20 +178,14 @@ func TestGetExistingPodGangs(t *testing.T) {
 	})
 
 	t.Run("returns multiple matching podgangs", func(t *testing.T) {
-		pg1 := &groveschedulerv1alpha1.PodGang{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pg-1",
-				Namespace: namespace,
-				Labels:    matchingLabels,
-			},
-		}
-		pg2 := &groveschedulerv1alpha1.PodGang{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pg-2",
-				Namespace: namespace,
-				Labels:    matchingLabels,
-			},
-		}
+		pg1 := testutils.NewPodGangBuilder("pg-1", namespace).
+			WithLabels(matchingLabels).
+			WithOwnerReference(constants.KindPodCliqueSet, pcsName, pcsUID).
+			Build()
+		pg2 := testutils.NewPodGangBuilder("pg-2", namespace).
+			WithLabels(matchingLabels).
+			WithOwnerReference(constants.KindPodCliqueSet, pcsName, pcsUID).
+			Build()
 		cl := fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithObjects(pg1, pg2).
@@ -202,13 +198,10 @@ func TestGetExistingPodGangs(t *testing.T) {
 	})
 
 	t.Run("excludes podgangs belonging to a different PodCliqueSet", func(t *testing.T) {
-		ownedPG := &groveschedulerv1alpha1.PodGang{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pg-owned",
-				Namespace: namespace,
-				Labels:    matchingLabels,
-			},
-		}
+		ownedPG := testutils.NewPodGangBuilder("pg-owned", namespace).
+			WithLabels(matchingLabels).
+			WithOwnerReference(constants.KindPodCliqueSet, pcsName, pcsUID).
+			Build()
 		otherLabels := GetPodGangSelectorLabels(metav1.ObjectMeta{Name: "other-pcs"})
 		otherPG := &groveschedulerv1alpha1.PodGang{
 			ObjectMeta: metav1.ObjectMeta{
@@ -227,6 +220,30 @@ func TestGetExistingPodGangs(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, result, 1)
 		assert.Equal(t, "pg-owned", result[0].Name)
+	})
+
+	t.Run("excludes podgangs controlled by a same-named PodCliqueSet of a different UID", func(t *testing.T) {
+		// A PodCliqueSet deleted and recreated with the same name reuses the name labels, so a
+		// leftover PodGang from the old instance still matches. It is controlled by the old UID and
+		// must be excluded so its stale counts and epochs do not enter the new PodGangMap.
+		currentPG := testutils.NewPodGangBuilder("pg-current", namespace).
+			WithLabels(matchingLabels).
+			WithOwnerReference(constants.KindPodCliqueSet, pcsName, pcsUID).
+			Build()
+		stalePG := testutils.NewPodGangBuilder("pg-stale", namespace).
+			WithLabels(matchingLabels).
+			WithOwnerReference(constants.KindPodCliqueSet, pcsName, types.UID("old-pcs-uid")).
+			Build()
+		cl := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(currentPG, stalePG).
+			Build()
+
+		result, err := GetExistingPodGangs(t.Context(), cl, pcsObjectMeta, namespace)
+
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, "pg-current", result[0].Name)
 	})
 
 	t.Run("excludes podgangs without managed-by label", func(t *testing.T) {

--- a/operator/internal/controller/common/component/utils/podgangmap.go
+++ b/operator/internal/controller/common/component/utils/podgangmap.go
@@ -52,8 +52,8 @@ func ListPodGangMapsForPCS(ctx context.Context, cl client.Client, pcsObjectKey c
 
 // PodGangMapByPCSReplicaIndex groups PodGangMaps by their PCS replica index.
 // A PodCliqueSetReplicaIndex label that is missing or not a valid integer is a contract violation and returns an error.
-func PodGangMapByPCSReplicaIndex(pgms []grovecorev1alpha1.PodGangMap) (map[int]grovecorev1alpha1.PodGangMap, error) {
-	pgmByReplicaIndex := make(map[int]grovecorev1alpha1.PodGangMap, len(pgms))
+func PodGangMapByPCSReplicaIndex(pgms []grovecorev1alpha1.PodGangMap) (map[int]*grovecorev1alpha1.PodGangMap, error) {
+	pgmByReplicaIndex := make(map[int]*grovecorev1alpha1.PodGangMap, len(pgms))
 	for i := range pgms {
 		labelValue, ok := pgms[i].Labels[apicommon.LabelPodCliqueSetReplicaIndex]
 		if !ok {
@@ -63,7 +63,7 @@ func PodGangMapByPCSReplicaIndex(pgms []grovecorev1alpha1.PodGangMap) (map[int]g
 		if err != nil {
 			return nil, fmt.Errorf("%s label on PodGangMap %s is not a valid integer: %q", apicommon.LabelPodCliqueSetReplicaIndex, pgms[i].Name, labelValue)
 		}
-		pgmByReplicaIndex[pcsReplicaIndex] = pgms[i]
+		pgmByReplicaIndex[pcsReplicaIndex] = &pgms[i]
 	}
 	return pgmByReplicaIndex, nil
 }

--- a/operator/internal/controller/common/component/utils/podgangmap.go
+++ b/operator/internal/controller/common/component/utils/podgangmap.go
@@ -23,6 +23,7 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 
 	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -37,17 +38,21 @@ func GetPodGangMap(ctx context.Context, cl client.Client, pcsObjectKey client.Ob
 }
 
 // ListPodGangMapsForPCS fetches all PodGangMaps owned by a PodCliqueSet.
-func ListPodGangMapsForPCS(ctx context.Context, cl client.Client, pcsObjectKey client.ObjectKey) ([]grovecorev1alpha1.PodGangMap, error) {
+func ListPodGangMapsForPCS(ctx context.Context, cl client.Client, pcsObjMeta metav1.ObjectMeta) ([]grovecorev1alpha1.PodGangMap, error) {
 	pgmList := &grovecorev1alpha1.PodGangMapList{}
 	if err := cl.List(ctx, pgmList,
-		client.InNamespace(pcsObjectKey.Namespace),
+		client.InNamespace(pcsObjMeta.Namespace),
 		client.MatchingLabels(lo.Assign(
-			apicommon.GetDefaultLabelsForPodCliqueSetManagedResources(pcsObjectKey.Name),
+			apicommon.GetDefaultLabelsForPodCliqueSetManagedResources(pcsObjMeta.Name),
 			map[string]string{apicommon.LabelComponentKey: apicommon.LabelComponentNamePodGangMap},
 		))); err != nil {
 		return nil, err
 	}
-	return pgmList.Items, nil
+	// Exclude PodGangMaps controlled by an older PodCliqueSet of the same name, so a recreated
+	// PodCliqueSet does not pick up a deleted one's stale PodGangMap.
+	return lo.Filter(pgmList.Items, func(pgm grovecorev1alpha1.PodGangMap, _ int) bool {
+		return metav1.IsControlledBy(&pgm, &pcsObjMeta)
+	}), nil
 }
 
 // PodGangMapByPCSReplicaIndex groups PodGangMaps by their PCS replica index.

--- a/operator/internal/controller/common/component/utils/podgangmap_test.go
+++ b/operator/internal/controller/common/component/utils/podgangmap_test.go
@@ -121,7 +121,7 @@ func pgmNames(pgms []grovecorev1alpha1.PodGangMap) []string {
 	return names
 }
 
-func indicesOf(byIndex map[int]grovecorev1alpha1.PodGangMap) []int {
+func indicesOf(byIndex map[int]*grovecorev1alpha1.PodGangMap) []int {
 	idx := make([]int, 0, len(byIndex))
 	for i := range byIndex {
 		idx = append(idx, i)

--- a/operator/internal/controller/common/component/utils/podgangmap_test.go
+++ b/operator/internal/controller/common/component/utils/podgangmap_test.go
@@ -57,12 +57,15 @@ func TestListPodGangMapsForPCS(t *testing.T) {
 
 	pgm0 := testutils.NewPodGangMapBuilder(pcsName, namespace, pcsUID, 0).Build()
 	pgm1 := testutils.NewPodGangMapBuilder(pcsName, namespace, pcsUID, 1).Build()
-	// A PodGangMap owned by a different PodCliqueSet must not be returned.
+	// A PodGangMap owned by a PodCliqueSet of a different name must not be returned.
 	otherPGM := testutils.NewPodGangMapBuilder("other-pcs", namespace, types.UID("other-uid"), 0).Build()
+	// A PodGangMap of the same name but controlled by an older PodCliqueSet UID must not be returned,
+	// modelling a same-name recreation before garbage collection removed the old PodGangMap.
+	stalePGM := testutils.NewPodGangMapBuilder(pcsName, namespace, types.UID("old-uid"), 2).Build()
 
-	fakeClient := testutils.CreateDefaultFakeClient([]client.Object{pgm0, pgm1, otherPGM})
+	fakeClient := testutils.CreateDefaultFakeClient([]client.Object{pgm0, pgm1, otherPGM, stalePGM})
 
-	actual, err := ListPodGangMapsForPCS(context.Background(), fakeClient, client.ObjectKey{Namespace: namespace, Name: pcsName})
+	actual, err := ListPodGangMapsForPCS(context.Background(), fakeClient, metav1.ObjectMeta{Namespace: namespace, Name: pcsName, UID: pcsUID})
 	require.NoError(t, err)
 
 	assert.ElementsMatch(t, []string{pgm0.Name, pgm1.Name}, pgmNames(actual))

--- a/operator/internal/controller/podcliquescalinggroup/reconcilespec_test.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilespec_test.go
@@ -236,7 +236,7 @@ func TestInitOrResetUpdate(t *testing.T) {
 			setupPCSG: func(pcsUID types.UID) *grovecorev1alpha1.PodCliqueScalingGroup {
 				pcsg := testutils.NewPodCliqueScalingGroupBuilder(testPCSGName, testNamespacePCSG, testPCSNamePCSG, 0).
 					WithReplicas(2).
-					WithOwnerReference("PodCliqueSet", testPCSNamePCSG, string(pcsUID)).
+					WithOwnerReference("PodCliqueSet", testPCSNamePCSG, pcsUID).
 					Build()
 				pcsg.Status.UpdatedReplicas = 3 // should be reset to 0
 				return pcsg
@@ -255,7 +255,7 @@ func TestInitOrResetUpdate(t *testing.T) {
 			setupPCSG: func(pcsUID types.UID) *grovecorev1alpha1.PodCliqueScalingGroup {
 				pcsg := testutils.NewPodCliqueScalingGroupBuilder(testPCSGName, testNamespacePCSG, testPCSNamePCSG, 0).
 					WithReplicas(2).
-					WithOwnerReference("PodCliqueSet", testPCSNamePCSG, string(pcsUID)).
+					WithOwnerReference("PodCliqueSet", testPCSNamePCSG, pcsUID).
 					Build()
 				pcsg.Status.UpdatedReplicas = 2 // should be reset to 0
 				return pcsg
@@ -277,7 +277,7 @@ func TestInitOrResetUpdate(t *testing.T) {
 			setupPCSG: func(pcsUID types.UID) *grovecorev1alpha1.PodCliqueScalingGroup {
 				pcsg := testutils.NewPodCliqueScalingGroupBuilder(testPCSGName, testNamespacePCSG, testPCSNamePCSG, 0).
 					WithReplicas(2).
-					WithOwnerReference("PodCliqueSet", testPCSNamePCSG, string(pcsUID)).
+					WithOwnerReference("PodCliqueSet", testPCSNamePCSG, pcsUID).
 					Build()
 				pcsg.Status.UpdatedReplicas = 5 // should be reset to 0
 				return pcsg
@@ -301,7 +301,7 @@ func TestInitOrResetUpdate(t *testing.T) {
 
 				pcsg := testutils.NewPodCliqueScalingGroupBuilder(testPCSGName, testNamespacePCSG, testPCSNamePCSG, 0).
 					WithReplicas(2).
-					WithOwnerReference("PodCliqueSet", testPCSNamePCSG, string(pcsUID)).
+					WithOwnerReference("PodCliqueSet", testPCSNamePCSG, pcsUID).
 					Build()
 				// Simulate an existing update in progress
 				pcsg.Status.UpdateProgress = &grovecorev1alpha1.PodCliqueScalingGroupUpdateProgress{
@@ -331,7 +331,7 @@ func TestInitOrResetUpdate(t *testing.T) {
 
 				pcsg := testutils.NewPodCliqueScalingGroupBuilder(testPCSGName, testNamespacePCSG, testPCSNamePCSG, 0).
 					WithReplicas(2).
-					WithOwnerReference("PodCliqueSet", testPCSNamePCSG, string(pcsUID)).
+					WithOwnerReference("PodCliqueSet", testPCSNamePCSG, pcsUID).
 					Build()
 				// Simulate an existing update that was completed
 				pcsg.Status.UpdateProgress = &grovecorev1alpha1.PodCliqueScalingGroupUpdateProgress{

--- a/operator/internal/controller/podcliqueset/components/podgang/podgang.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/podgang.go
@@ -205,10 +205,9 @@ func emptyPodGang(objKey client.ObjectKey) *groveschedulerv1alpha1.PodGang {
 
 func (r _resource) buildLabels(pcs *grovecorev1alpha1.PodCliqueSet, pgi *podGangInfo, schedulerName string) map[string]string {
 	pgLabels := map[string]string{
-		apicommon.LabelComponentKey:               apicommon.LabelComponentNamePodGang,
-		apicommon.LabelPodCliqueSetReplicaIndex:   strconv.Itoa(pgi.pcsReplicaIndex),
-		apicommon.LabelSchedulerName:              schedulerName,
-		apicommon.LabelPodCliqueSetGenerationHash: *pcs.Status.CurrentGenerationHash,
+		apicommon.LabelComponentKey:             apicommon.LabelComponentNamePodGang,
+		apicommon.LabelPodCliqueSetReplicaIndex: strconv.Itoa(pgi.pcsReplicaIndex),
+		apicommon.LabelSchedulerName:            schedulerName,
 	}
 	return lo.Assign(
 		apicommon.GetDefaultLabelsForPodCliqueSetManagedResources(pcs.Name),

--- a/operator/internal/controller/podcliqueset/components/podgang/podgang_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/podgang_test.go
@@ -57,7 +57,7 @@ func TestSetInitializedCondition(t *testing.T) {
 // PCS owns the non-grove.io key namespace exclusively (additions and removals on the PCS propagate);
 // grove.io/-prefixed keys are operator-managed and persist independent of PCS state. The operator
 // also stamps a fixed set of managed labels (managed-by, part-of, component, replica-index,
-// scheduler-name, generation-hash) plus any entry-derived extra labels (epoch, role).
+// scheduler-name) plus any entry-derived extra labels (epoch, role, generation-hash).
 func TestBuildResource(t *testing.T) {
 	const (
 		pcsName              = "test-pcs"
@@ -70,12 +70,11 @@ func TestBuildResource(t *testing.T) {
 	// (not derived from buildLabels) so the test independently pins the expected label set.
 	operatorLabels := func(schedulerName string, replicaIndex string) map[string]string {
 		return map[string]string{
-			apicommon.LabelManagedByKey:               apicommon.LabelManagedByValue,
-			apicommon.LabelPartOfKey:                  pcsName,
-			apicommon.LabelComponentKey:               apicommon.LabelComponentNamePodGang,
-			apicommon.LabelPodCliqueSetReplicaIndex:   replicaIndex,
-			apicommon.LabelSchedulerName:              schedulerName,
-			apicommon.LabelPodCliqueSetGenerationHash: generationHash,
+			apicommon.LabelManagedByKey:             apicommon.LabelManagedByValue,
+			apicommon.LabelPartOfKey:                pcsName,
+			apicommon.LabelComponentKey:             apicommon.LabelComponentNamePodGang,
+			apicommon.LabelPodCliqueSetReplicaIndex: replicaIndex,
+			apicommon.LabelSchedulerName:            schedulerName,
 		}
 	}
 	expectedDefaultLabels := operatorLabels(defaultSchedulerName, "0")
@@ -204,14 +203,36 @@ func TestBuildResource(t *testing.T) {
 			name:            "replica index and entry-derived extra labels are stamped",
 			pgiReplicaIndex: 2,
 			pgiExtraLabels: map[string]string{
-				apicommon.LabelEpoch:       "1000",
-				apicommon.LabelPodGangRole: "Anchor",
+				apicommon.LabelEpoch:                      "1000",
+				apicommon.LabelPodGangRole:                "Anchor",
+				apicommon.LabelPodCliqueSetGenerationHash: generationHash,
 			},
 			expectedLabels: lo.Assign(
 				operatorLabels(defaultSchedulerName, "2"),
 				map[string]string{
-					apicommon.LabelEpoch:       "1000",
-					apicommon.LabelPodGangRole: "Anchor",
+					apicommon.LabelEpoch:                      "1000",
+					apicommon.LabelPodGangRole:                "Anchor",
+					apicommon.LabelPodCliqueSetGenerationHash: generationHash,
+				},
+			),
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			// The PCS is at generationHash, but the entry belongs to an earlier generation. The PodGang
+			// must carry the entry's generation hash, not the current PodCliqueSet generation hash.
+			name:            "generation hash comes from the entry, not the current PodCliqueSet",
+			pgiReplicaIndex: 0,
+			pgiExtraLabels: map[string]string{
+				apicommon.LabelEpoch:                      "1000",
+				apicommon.LabelPodGangRole:                "Anchor",
+				apicommon.LabelPodCliqueSetGenerationHash: "earlier-hash",
+			},
+			expectedLabels: lo.Assign(
+				operatorLabels(defaultSchedulerName, "0"),
+				map[string]string{
+					apicommon.LabelEpoch:                      "1000",
+					apicommon.LabelPodGangRole:                "Anchor",
+					apicommon.LabelPodCliqueSetGenerationHash: "earlier-hash",
 				},
 			),
 			expectedAnnotations: map[string]string{},

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
@@ -209,12 +209,15 @@ func (r _resource) buildPodGangInfosFromEntry(ss *syncState, pcsReplicaIndex int
 	return r.buildNonAnchorPodGangInfos(ss, pcsReplicaIndex, pgEntry)
 }
 
-// buildAdditionalLabelsFromPodGangEntry returns the epoch and role labels stamped on a PodGang
-// materialized from the given entry.
+// buildAdditionalLabelsFromPodGangEntry returns the epoch, role and generation hash labels stamped on a
+// PodGang materialized from the given entry. The generation hash comes from the entry, so a PodGang
+// carries the generation it belongs to. During a coherent update this can differ from the current
+// PodCliqueSet generation hash.
 func buildAdditionalLabelsFromPodGangEntry(pgEntry grovecorev1alpha1.PodGangEntry) map[string]string {
 	return map[string]string{
-		apicommon.LabelEpoch:       pgEntry.Epoch,
-		apicommon.LabelPodGangRole: string(pgEntry.Role),
+		apicommon.LabelEpoch:                      pgEntry.Epoch,
+		apicommon.LabelPodGangRole:                string(pgEntry.Role),
+		apicommon.LabelPodCliqueSetGenerationHash: pgEntry.PodCliqueSetGenerationHash,
 	}
 }
 

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow_test.go
@@ -1904,6 +1904,25 @@ func TestReconcilePodGangStatus(t *testing.T) {
 	})
 }
 
+// TestBuildAdditionalLabelsFromPodGangEntry pins that a PodGang materialized from an entry carries the
+// entry's generation hash, epoch and role.
+func TestBuildAdditionalLabelsFromPodGangEntry(t *testing.T) {
+	entry := grovecorev1alpha1.PodGangEntry{
+		Epoch:                      "1500",
+		Role:                       grovecorev1alpha1.PodGangEntryRoleAnchor,
+		PodCliqueSetGenerationHash: "hash-1",
+	}
+
+	actual := buildAdditionalLabelsFromPodGangEntry(entry)
+
+	expected := map[string]string{
+		apicommon.LabelEpoch:                      "1500",
+		apicommon.LabelPodGangRole:                string(grovecorev1alpha1.PodGangEntryRoleAnchor),
+		apicommon.LabelPodCliqueSetGenerationHash: "hash-1",
+	}
+	assert.Equal(t, expected, actual)
+}
+
 func podNames(pods []v1.Pod) []string {
 	return lo.Map(pods, func(pod v1.Pod, _ int) string { return pod.Name })
 }

--- a/operator/internal/controller/podcliqueset/components/podgangmap/podgangmap_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/podgangmap_test.go
@@ -82,7 +82,7 @@ func TestSyncReusesEpochFromExistingPodGangsWhenPodGangMapIsMissing(t *testing.T
 		Build()
 
 	// The PodGangMap for replica 0 is gone, but its anchor PodGang still carries the epoch its pods use.
-	anchorPodGang := podGangForReplica(t, "pcs-0-1500", "pcs", 0, "1500", grovecorev1alpha1.PodGangEntryRoleAnchor)
+	anchorPodGang := podGangForReplica(t, "pcs-0-1500", 0, "1500", grovecorev1alpha1.PodGangEntryRoleAnchor)
 
 	cl := testutils.CreateDefaultFakeClient([]client.Object{pcs, anchorPodGang})
 	// A clock at 9999 would assign a different epoch, so reusing 1500 proves the epoch came from the PodGang.
@@ -94,6 +94,88 @@ func TestSyncReusesEpochFromExistingPodGangsWhenPodGangMapIsMissing(t *testing.T
 	pgm := getPodGangMap(t, cl, "pcs-0")
 	anchor := testutils.EntryByRole(pgm.Spec.Entries, grovecorev1alpha1.PodGangEntryRoleAnchor)
 	assert.Equal(t, "1500", anchor.Epoch)
+}
+
+func TestSyncReconstructsScaledOutPCSGWhenPodGangMapIsMissing(t *testing.T) {
+	// A PCSG scaled out to 2 while its PodGangMap was deleted. Reconstruction must reflect the live
+	// PCSG replica count, not the template count of 1, so the scaled-out replica keeps a PodGang.
+	pcs := testutils.NewPodCliqueSetBuilder("pcs", "default", "uid").
+		WithReplicas(1).
+		WithScalingGroupConfig("sg", []string{"c"}, 1, 1).
+		WithPodCliqueSetGenerationHash(ptr.To("hash1")).
+		Build()
+	pcsg := testutils.NewPodCliqueScalingGroupBuilder("pcs-0-sg", "default", "pcs", 0).
+		WithReplicas(2).
+		Build()
+	// The PodGangMap is gone, but the anchor and scale-out PodGangs still carry their epochs.
+	anchorPodGang := podGangForReplica(t, "pcs-0-1500", 0, "1500", grovecorev1alpha1.PodGangEntryRoleAnchor)
+	scaleOutPodGang := podGangForReplica(t, "pcs-0-1502-sg-1", 0, "1502", grovecorev1alpha1.PodGangEntryRoleScaleOut)
+
+	cl := testutils.CreateDefaultFakeClient([]client.Object{pcs, pcsg, anchorPodGang, scaleOutPodGang})
+	operator := New(cl, groveclientscheme.Scheme, clocktesting.NewFakeClock(time.Unix(0, 9999)))
+
+	err := operator.Sync(context.Background(), logr.Discard(), pcs)
+	require.NoError(t, err)
+
+	pgm := getPodGangMap(t, cl, "pcs-0")
+	anchor := testutils.EntryByRole(pgm.Spec.Entries, grovecorev1alpha1.PodGangEntryRoleAnchor)
+	assert.Equal(t, []int32{0}, anchor.PCSGReplicaIndices["sg"])
+	scaleOut := testutils.EntryByRole(pgm.Spec.Entries, grovecorev1alpha1.PodGangEntryRoleScaleOut)
+	assert.Equal(t, []int32{1}, scaleOut.PCSGReplicaIndices["sg"])
+	// The scale-out epoch is reused from the existing scale-out PodGang, not minted from the clock.
+	assert.Equal(t, "1502", scaleOut.Epoch)
+}
+
+func TestSyncReconstructsScaledOutPCSGWithoutExistingScaleOutPodGang(t *testing.T) {
+	// A PCSG scaled out to 2 while its PodGangMap was deleted, and the scale-out PodGang was never
+	// materialized (only the anchor exists). Reconstruction must still place index 1 in the ScaleOut
+	// entry. This exercises the ordering that ensures the ScaleOut entry exists before the PCSG index
+	// diff runs, so the scaled-out index has a place to land.
+	pcs := testutils.NewPodCliqueSetBuilder("pcs", "default", "uid").
+		WithReplicas(1).
+		WithScalingGroupConfig("sg", []string{"c"}, 1, 1).
+		WithPodCliqueSetGenerationHash(ptr.To("hash1")).
+		Build()
+	pcsg := testutils.NewPodCliqueScalingGroupBuilder("pcs-0-sg", "default", "pcs", 0).
+		WithReplicas(2).
+		Build()
+	anchorPodGang := podGangForReplica(t, "pcs-0-1500", 0, "1500", grovecorev1alpha1.PodGangEntryRoleAnchor)
+
+	cl := testutils.CreateDefaultFakeClient([]client.Object{pcs, pcsg, anchorPodGang})
+	operator := New(cl, groveclientscheme.Scheme, clocktesting.NewFakeClock(time.Unix(0, 9999)))
+
+	err := operator.Sync(context.Background(), logr.Discard(), pcs)
+	require.NoError(t, err)
+
+	pgm := getPodGangMap(t, cl, "pcs-0")
+	anchor := testutils.EntryByRole(pgm.Spec.Entries, grovecorev1alpha1.PodGangEntryRoleAnchor)
+	assert.Equal(t, []int32{0}, anchor.PCSGReplicaIndices["sg"])
+	scaleOut := testutils.EntryByRole(pgm.Spec.Entries, grovecorev1alpha1.PodGangEntryRoleScaleOut)
+	assert.Equal(t, []int32{1}, scaleOut.PCSGReplicaIndices["sg"])
+}
+
+func TestSyncReconstructsScaledStandalonePCLQWhenPodGangMapIsMissing(t *testing.T) {
+	// A standalone PodClique scaled to 4 while its PodGangMap was deleted. Reconstruction must reflect
+	// the live PodClique replica count, not the template count of 1.
+	pcs := testutils.NewPodCliqueSetBuilder("pcs", "default", "uid").
+		WithReplicas(1).
+		WithStandaloneCliqueReplicas("clq-a", 1).
+		WithPodCliqueSetGenerationHash(ptr.To("hash1")).
+		Build()
+	pclq := testutils.NewPodCliqueBuilder("pcs", types.UID("uid"), "clq-a", "default", 0).
+		WithReplicas(4).
+		Build()
+	anchorPodGang := podGangForReplica(t, "pcs-0-1500", 0, "1500", grovecorev1alpha1.PodGangEntryRoleAnchor)
+
+	cl := testutils.CreateDefaultFakeClient([]client.Object{pcs, pclq, anchorPodGang})
+	operator := New(cl, groveclientscheme.Scheme, clocktesting.NewFakeClock(time.Unix(0, 9999)))
+
+	err := operator.Sync(context.Background(), logr.Discard(), pcs)
+	require.NoError(t, err)
+
+	pgm := getPodGangMap(t, cl, "pcs-0")
+	anchor := testutils.EntryByRole(pgm.Spec.Entries, grovecorev1alpha1.PodGangEntryRoleAnchor)
+	assert.Equal(t, int32(4), anchor.PodCliques["clq-a"])
 }
 
 func TestSyncIgnoresLegacyPodGangsWithoutEpochLabelWhenPodGangMapIsMissing(t *testing.T) {
@@ -230,17 +312,19 @@ func oldHashPodGangMap(pcsName, namespace string, replicaIndex int) *grovecorev1
 // podGangForReplica builds a PodGang for a PCS replica carrying the labels the PodGangMap component
 // selects, groups, and reads epochs on: the PodGang selector labels, the replica index, the epoch, and
 // the role.
-func podGangForReplica(t *testing.T, name, pcsName string, replicaIndex int, epoch string, role grovecorev1alpha1.PodGangEntryRole) *groveschedulerv1alpha1.PodGang {
+//
+//nolint:unparam // replicaIndex is a genuine label dimension; current tests only need replica 0.
+func podGangForReplica(t *testing.T, name string, replicaIndex int, epoch string, role grovecorev1alpha1.PodGangEntryRole) *groveschedulerv1alpha1.PodGang {
 	t.Helper()
 	labels := lo.Assign(
-		componentutils.GetPodGangSelectorLabels(metav1.ObjectMeta{Name: pcsName}),
+		componentutils.GetPodGangSelectorLabels(metav1.ObjectMeta{Name: testPCSName}),
 		map[string]string{
 			apicommon.LabelPodCliqueSetReplicaIndex: strconv.Itoa(replicaIndex),
 			apicommon.LabelEpoch:                    epoch,
 			apicommon.LabelPodGangRole:              string(role),
 		},
 	)
-	return testutils.NewPodGangBuilder(name, "default").WithLabels(labels).Build()
+	return testutils.NewPodGangBuilder(name, testNamespace).WithLabels(labels).Build()
 }
 
 func getPodGangMap(t *testing.T, cl client.Client, name string) *grovecorev1alpha1.PodGangMap {

--- a/operator/internal/controller/podcliqueset/components/podgangmap/podgangmap_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/podgangmap_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	apicommon "github.com/ai-dynamo/grove/operator/api/common"
+	"github.com/ai-dynamo/grove/operator/api/common/constants"
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	groveclientscheme "github.com/ai-dynamo/grove/operator/internal/client"
 	componentutils "github.com/ai-dynamo/grove/operator/internal/controller/common/component/utils"
@@ -106,6 +107,7 @@ func TestSyncReconstructsScaledOutPCSGWhenPodGangMapIsMissing(t *testing.T) {
 		Build()
 	pcsg := testutils.NewPodCliqueScalingGroupBuilder("pcs-0-sg", "default", "pcs", 0).
 		WithReplicas(2).
+		WithOwnerReference(constants.KindPodCliqueSet, testPCSName, testPCSUID).
 		Build()
 	// The PodGangMap is gone, but the anchor and scale-out PodGangs still carry their epochs.
 	anchorPodGang := podGangForReplica(t, "pcs-0-1500", 0, "1500", grovecorev1alpha1.PodGangEntryRoleAnchor)
@@ -138,6 +140,7 @@ func TestSyncReconstructsScaledOutPCSGWithoutExistingScaleOutPodGang(t *testing.
 		Build()
 	pcsg := testutils.NewPodCliqueScalingGroupBuilder("pcs-0-sg", "default", "pcs", 0).
 		WithReplicas(2).
+		WithOwnerReference(constants.KindPodCliqueSet, testPCSName, testPCSUID).
 		Build()
 	anchorPodGang := podGangForReplica(t, "pcs-0-1500", 0, "1500", grovecorev1alpha1.PodGangEntryRoleAnchor)
 
@@ -324,7 +327,10 @@ func podGangForReplica(t *testing.T, name string, replicaIndex int, epoch string
 			apicommon.LabelPodGangRole:              string(role),
 		},
 	)
-	return testutils.NewPodGangBuilder(name, testNamespace).WithLabels(labels).Build()
+	return testutils.NewPodGangBuilder(name, testNamespace).
+		WithLabels(labels).
+		WithOwnerReference(constants.KindPodCliqueSet, testPCSName, testPCSUID).
+		Build()
 }
 
 func getPodGangMap(t *testing.T, cl client.Client, name string) *grovecorev1alpha1.PodGangMap {

--- a/operator/internal/controller/podcliqueset/components/podgangmap/steadystate.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/steadystate.go
@@ -31,11 +31,11 @@ import (
 
 // buildBootstrapEntries builds the initial PodGangMap entries for a PCS replica from the PCS spec. It
 // produces an anchor entry with every standalone PodClique and each PodCliqueScalingGroup's
-// MinAvailable replicas, a Tail entry for PodCliqueScalingGroup replicas above MinAvailable, and, when
-// the PodCliqueSet has a PodCliqueScalingGroup, an empty ScaleOut entry that later scale-outs attach
-// to. Each entry reuses the epoch its existing PodGangs carry. It assigns a new epoch for a role that
-// has no existing PodGang, or for every role when there is no anchor PodGang to reuse.
-func buildBootstrapEntries(pcs *grovecorev1alpha1.PodCliqueSet, clk clock.Clock, existingPodGangs []groveschedulerv1alpha1.PodGang) []grovecorev1alpha1.PodGangEntry {
+// MinAvailable replicas, and a Tail entry for PodCliqueScalingGroup replicas above MinAvailable. Each
+// entry reuses the epoch its existing PodGangs carry. It assigns a new epoch for a role that has no
+// existing PodGang, or for every role when there is no anchor PodGang to reuse. It returns the entries
+// and the scale-out epoch, which the caller uses to author the ScaleOut entry.
+func buildBootstrapEntries(clk clock.Clock, pcs *grovecorev1alpha1.PodCliqueSet, existingPodGangs []groveschedulerv1alpha1.PodGang) ([]grovecorev1alpha1.PodGangEntry, string) {
 	epochByRole := epochByRoleFromPodGangs(existingPodGangs)
 	now := clk.Now().UnixNano()
 
@@ -55,9 +55,8 @@ func buildBootstrapEntries(pcs *grovecorev1alpha1.PodCliqueSet, clk clock.Clock,
 	if tailEntry, ok := buildBootstrapTailEntry(pcs, strconv.FormatInt(tailEpoch, 10), strconv.FormatInt(anchorEpoch, 10)); ok {
 		entries = append(entries, tailEntry)
 	}
-	entries = ensureScaleOutEntry(entries, pcs, strconv.FormatInt(scaleOutEpoch, 10), nil)
 
-	return entries
+	return entries, strconv.FormatInt(scaleOutEpoch, 10)
 }
 
 // epochByRoleFromPodGangs returns the epoch each role's PodGangs carry, keyed by role, from the
@@ -135,8 +134,10 @@ func buildBootstrapTailEntry(pcs *grovecorev1alpha1.PodCliqueSet, epoch, anchorE
 	return entry, true
 }
 
-// reconcileEntries re-authors the entries of a PCS replica whose PodGangMap already has entries. It runs
-// in steady state (no update in progress) and while a RollingRecreate is in progress.
+// reconcileEntries authors the desired PodGangMap entries for a PCS replica and returns them for create
+// or patch. When no PodGangMap exists it starts from a fresh set of bootstrap entries, reusing the epoch
+// the replica's existing PodGangs carry. When one exists it starts from that PodGangMap's entries,
+// advancing them to the current generation hash unless a coherent update is in progress.
 //
 // Each entry keeps its identity (epoch, role, DependsOn, anchor index) and its already-placed replica
 // indices. Placement is not recomputed from the template. A template Replicas change does not reach an
@@ -146,18 +147,40 @@ func buildBootstrapTailEntry(pcs *grovecorev1alpha1.PodCliqueSet, epoch, anchorE
 // For each PodCliqueScalingGroup the count of its placed indices is diffed against its live
 // Spec.Replicas. A scale-out appends new indices to the ScaleOut entry. A scale-in drains indices in
 // role order ScaleOut, Tail, Anchor. Each standalone PodClique pod count on the anchor is set from its
-// live Spec.Replicas. A ScaleOut entry is ensured (even if empty) and empty entries are dropped.
-func reconcileEntries(pcs *grovecorev1alpha1.PodCliqueSet,
-	entries []grovecorev1alpha1.PodGangEntry,
-	standalonePCLQs []grovecorev1alpha1.PodClique,
-	pcsgs []grovecorev1alpha1.PodCliqueScalingGroup,
+// live Spec.Replicas. A ScaleOut entry is ensured before the diff so scale-out indices have a place to
+// land, and empty entries are dropped afterward.
+//
+// NOTE: this reconstructs a single-anchor PodGangMap. After a coherent update the steady-state
+// PodGangMap has more than one anchor entry and more than one tail entry, with a single ScaleOut entry.
+// buildBootstrapEntries produces a single anchor, and each entry's anchor index and DependsOn are held
+// only on the PodGangMap and are not recoverable from the live PodGangs. Reconstructing a multi-anchor
+// PodGangMap is deferred to the coherent update engine.
+func reconcileEntries(clk clock.Clock,
+	pcs *grovecorev1alpha1.PodCliqueSet,
 	pcsReplicaIndex int,
-	scaleOutEpoch string) ([]grovecorev1alpha1.PodGangEntry, error) {
+	pgm *grovecorev1alpha1.PodGangMap,
+	existingPodGangs []groveschedulerv1alpha1.PodGang,
+	standalonePCLQs []grovecorev1alpha1.PodClique,
+	pcsgs []grovecorev1alpha1.PodCliqueScalingGroup) ([]grovecorev1alpha1.PodGangEntry, error) {
+	var (
+		entries       []grovecorev1alpha1.PodGangEntry
+		scaleOutEpoch string
+	)
+	if pgm == nil {
+		entries, scaleOutEpoch = buildBootstrapEntries(clk, pcs, existingPodGangs)
+	} else {
+		// Deep-copy the existing entries so mutations here do not alias the snapshot's PodGangMap.
+		entries = clonePodGangEntries(pgm.Spec.Entries)
+		if shouldAdvanceEntriesGenerationHash(pcs, entries) {
+			advanceEntriesGenerationHash(entries, *pcs.Status.CurrentGenerationHash)
+		}
+	}
+
 	refreshStandalonePodCliqueCounts(entries, pcs, standalonePCLQs, pcsReplicaIndex)
+	entries = ensureScaleOutEntry(clk, entries, pcs, scaleOutEpoch)
 	if err := reconcilePCSGReplicaIndices(entries, pcs, pcsgs, pcsReplicaIndex); err != nil {
 		return nil, err
 	}
-	entries = ensureScaleOutEntry(entries, pcs, scaleOutEpoch, nil)
 	return removeEmptyEntries(entries, *pcs.Status.CurrentGenerationHash), nil
 }
 
@@ -300,12 +323,12 @@ func removeEmptyEntries(entries []grovecorev1alpha1.PodGangEntry, currentGenerat
 	})
 }
 
-// ensureScaleOutEntry appends a ScaleOut entry to entries when the PodCliqueSet has any
-// PodCliqueScalingGroup and no ScaleOut entry is present. The entry carries scaleOutIndices (empty
-// when nothing has scaled out) and depends on the current-generation anchor, the AnchorIndex 0
-// anchor. When a ScaleOut entry already exists, entries are returned unchanged. The AnchorIndex 0
-// anchor of the current generation is always present in entries when this is called.
-func ensureScaleOutEntry(entries []grovecorev1alpha1.PodGangEntry, pcs *grovecorev1alpha1.PodCliqueSet, scaleOutEpoch string, scaleOutIndices map[string][]int32) []grovecorev1alpha1.PodGangEntry {
+// ensureScaleOutEntry appends an empty ScaleOut entry to entries when the PodCliqueSet has any
+// PodCliqueScalingGroup and no current-generation ScaleOut entry is present. The entry depends on the
+// AnchorIndex 0 anchor of the current generation, which is always present in entries when this is
+// called. It uses scaleOutEpoch when set, and a freshly minted epoch otherwise. When a current-generation
+// ScaleOut entry already exists, entries are returned unchanged.
+func ensureScaleOutEntry(clk clock.Clock, entries []grovecorev1alpha1.PodGangEntry, pcs *grovecorev1alpha1.PodCliqueSet, scaleOutEpoch string) []grovecorev1alpha1.PodGangEntry {
 	if len(pcs.Spec.Template.PodCliqueScalingGroupConfigs) == 0 {
 		return entries
 	}
@@ -319,18 +342,10 @@ func ensureScaleOutEntry(entries []grovecorev1alpha1.PodGangEntry, pcs *grovecor
 			anchorEpoch = entry.Epoch
 		}
 	}
+	if scaleOutEpoch == "" {
+		scaleOutEpoch = strconv.FormatInt(clk.Now().UnixNano(), 10)
+	}
 	scaleOut := newPodGangEntry(scaleOutEpoch, currentHash, []string{anchorEpoch})
 	scaleOut.Role = grovecorev1alpha1.PodGangEntryRoleScaleOut
-	if len(scaleOutIndices) > 0 {
-		sortIndicesPerPCSG(scaleOutIndices)
-		scaleOut.PCSGReplicaIndices = scaleOutIndices
-	}
 	return append(entries, scaleOut)
-}
-
-// sortIndicesPerPCSG sorts each PodCliqueScalingGroup's index slice ascending for deterministic output.
-func sortIndicesPerPCSG(indicesByPCSG map[string][]int32) {
-	for name := range indicesByPCSG {
-		slices.Sort(indicesByPCSG[name])
-	}
 }

--- a/operator/internal/controller/podcliqueset/components/podgangmap/steadystate_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/steadystate_test.go
@@ -33,6 +33,7 @@ import (
 const (
 	testNamespace = "default"
 	testPCSName   = "pcs"
+	testPCSUID    = "uid"
 	testGenHash   = "hash1"
 	testPCSGName  = "sg"
 )

--- a/operator/internal/controller/podcliqueset/components/podgangmap/steadystate_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/steadystate_test.go
@@ -15,7 +15,6 @@
 package podgangmap
 
 import (
-	"strconv"
 	"testing"
 	"time"
 
@@ -66,17 +65,11 @@ func TestBuildBootstrapEntries(t *testing.T) {
 				WithScalingGroupConfig(testPCSGName, []string{"c"}, 2, 2).
 				WithPodCliqueSetGenerationHash(ptr.To(testGenHash)).
 				Build(),
-			expectedRoles: []grovecorev1alpha1.PodGangEntryRole{
-				grovecorev1alpha1.PodGangEntryRoleAnchor,
-				grovecorev1alpha1.PodGangEntryRoleScaleOut,
-			},
+			expectedRoles: []grovecorev1alpha1.PodGangEntryRole{grovecorev1alpha1.PodGangEntryRoleAnchor},
 			assertEntries: func(t *testing.T, entries []grovecorev1alpha1.PodGangEntry) {
 				anchor := testutils.EntryByRole(entries, grovecorev1alpha1.PodGangEntryRoleAnchor)
 				assert.Empty(t, anchor.PodCliques)
 				assert.Equal(t, []int32{0, 1}, anchor.PCSGReplicaIndices[testPCSGName])
-				scaleOut := testutils.EntryByRole(entries, grovecorev1alpha1.PodGangEntryRoleScaleOut)
-				assert.Empty(t, scaleOut.PCSGReplicaIndices[testPCSGName])
-				assert.Equal(t, []string{anchor.Epoch}, scaleOut.DependsOn)
 			},
 		},
 		{
@@ -88,7 +81,6 @@ func TestBuildBootstrapEntries(t *testing.T) {
 			expectedRoles: []grovecorev1alpha1.PodGangEntryRole{
 				grovecorev1alpha1.PodGangEntryRoleAnchor,
 				grovecorev1alpha1.PodGangEntryRoleTail,
-				grovecorev1alpha1.PodGangEntryRoleScaleOut,
 			},
 			assertEntries: func(t *testing.T, entries []grovecorev1alpha1.PodGangEntry) {
 				anchor := testutils.EntryByRole(entries, grovecorev1alpha1.PodGangEntryRoleAnchor)
@@ -109,7 +101,6 @@ func TestBuildBootstrapEntries(t *testing.T) {
 			expectedRoles: []grovecorev1alpha1.PodGangEntryRole{
 				grovecorev1alpha1.PodGangEntryRoleAnchor,
 				grovecorev1alpha1.PodGangEntryRoleTail,
-				grovecorev1alpha1.PodGangEntryRoleScaleOut,
 			},
 			assertEntries: func(t *testing.T, entries []grovecorev1alpha1.PodGangEntry) {
 				anchor := testutils.EntryByRole(entries, grovecorev1alpha1.PodGangEntryRoleAnchor)
@@ -147,7 +138,6 @@ func TestBuildBootstrapEntries(t *testing.T) {
 			expectedRoles: []grovecorev1alpha1.PodGangEntryRole{
 				grovecorev1alpha1.PodGangEntryRoleAnchor,
 				grovecorev1alpha1.PodGangEntryRoleTail,
-				grovecorev1alpha1.PodGangEntryRoleScaleOut,
 			},
 			assertEntries: func(t *testing.T, entries []grovecorev1alpha1.PodGangEntry) {
 				anchor := testutils.EntryByRole(entries, grovecorev1alpha1.PodGangEntryRoleAnchor)
@@ -168,7 +158,6 @@ func TestBuildBootstrapEntries(t *testing.T) {
 			expectedRoles: []grovecorev1alpha1.PodGangEntryRole{
 				grovecorev1alpha1.PodGangEntryRoleAnchor,
 				grovecorev1alpha1.PodGangEntryRoleTail,
-				grovecorev1alpha1.PodGangEntryRoleScaleOut,
 			},
 			assertEntries: func(t *testing.T, entries []grovecorev1alpha1.PodGangEntry) {
 				anchor := testutils.EntryByRole(entries, grovecorev1alpha1.PodGangEntryRoleAnchor)
@@ -191,11 +180,10 @@ func TestBuildBootstrapEntries(t *testing.T) {
 			expectedRoles: []grovecorev1alpha1.PodGangEntryRole{
 				grovecorev1alpha1.PodGangEntryRoleAnchor,
 				grovecorev1alpha1.PodGangEntryRoleTail,
-				grovecorev1alpha1.PodGangEntryRoleScaleOut,
 			},
 			assertEntries: func(t *testing.T, entries []grovecorev1alpha1.PodGangEntry) {
 				// No anchor PodGang to reuse, so all epochs are assigned from the clock and the orphan
-				// tail epoch is ignored. anchor < tail < scaleOut holds.
+				// tail epoch is ignored. anchor < tail holds.
 				anchor := testutils.EntryByRole(entries, grovecorev1alpha1.PodGangEntryRoleAnchor)
 				tail := testutils.EntryByRole(entries, grovecorev1alpha1.PodGangEntryRoleTail)
 				assert.NotEqual(t, "600", tail.Epoch)
@@ -222,7 +210,7 @@ func TestBuildBootstrapEntries(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			clk := clocktesting.NewFakeClock(time.Unix(0, 1000))
-			actual := buildBootstrapEntries(tt.pcs, clk, tt.existingPodGangs)
+			actual, _ := buildBootstrapEntries(clk, tt.pcs, tt.existingPodGangs)
 			assert.Equal(t, tt.expectedRoles, testutils.RolesOf(actual))
 			tt.assertEntries(t, actual)
 		})
@@ -287,8 +275,6 @@ func TestEpochByRoleFromPodGangs(t *testing.T) {
 }
 
 func TestSyncEntries(t *testing.T) {
-	scaleOutEpoch := strconv.FormatInt(time.Unix(0, 5000).UnixNano(), 10)
-
 	tests := []struct {
 		name            string
 		pcs             *grovecorev1alpha1.PodCliqueSet
@@ -385,7 +371,9 @@ func TestSyncEntries(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, err := reconcileEntries(tt.pcs, tt.existingEntries, tt.standalonePCLQs, tt.pcsgs, 0, scaleOutEpoch)
+			clk := clocktesting.NewFakeClock(time.Unix(0, 5000))
+			pgm := &grovecorev1alpha1.PodGangMap{Spec: grovecorev1alpha1.PodGangMapSpec{Entries: tt.existingEntries}}
+			actual, err := reconcileEntries(clk, tt.pcs, 0, pgm, nil, tt.standalonePCLQs, tt.pcsgs)
 			require.NoError(t, err)
 			tt.assertResult(t, actual)
 		})

--- a/operator/internal/controller/podcliqueset/components/podgangmap/syncflow.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/syncflow.go
@@ -111,7 +111,7 @@ func (r _resource) getExistingPCSGsByReplica(ctx context.Context, pcs *grovecore
 
 // getExistingPGMByReplica fetches all PodGangMaps for the PCS and groups them by PCS replica index.
 func (r _resource) getExistingPGMByReplica(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet) (map[int]*grovecorev1alpha1.PodGangMap, error) {
-	existingPGMs, err := componentutils.ListPodGangMapsForPCS(ctx, r.client, client.ObjectKeyFromObject(pcs))
+	existingPGMs, err := componentutils.ListPodGangMapsForPCS(ctx, r.client, pcs.ObjectMeta)
 	if err != nil {
 		return nil, groveerr.WrapError(err,
 			errCodeListPodGangMaps,

--- a/operator/internal/controller/podcliqueset/components/podgangmap/syncflow.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/syncflow.go
@@ -69,7 +69,7 @@ func (r _resource) takeSnapshot(ctx context.Context, logger logr.Logger, pcs *gr
 
 // getExistingStandalonePCLQsByReplica fetches all standalone PodCliques for the PCS and groups them by PCS replica index.
 func (r _resource) getExistingStandalonePCLQsByReplica(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet) (map[int][]grovecorev1alpha1.PodClique, error) {
-	existingStandalonePCLQs, err := componentutils.GetPodCliquesWithParentPCS(ctx, r.client, client.ObjectKeyFromObject(pcs))
+	existingStandalonePCLQs, err := componentutils.GetPodCliquesWithParentPCS(ctx, r.client, pcs.ObjectMeta)
 	if err != nil {
 		return nil, groveerr.WrapError(err,
 			errCodeListPCLQs,
@@ -90,7 +90,7 @@ func (r _resource) getExistingStandalonePCLQsByReplica(ctx context.Context, pcs 
 
 // getExistingPCSGsByReplica fetches all PodCliqueScalingGroups for the PCS and groups them by PCS replica index.
 func (r _resource) getExistingPCSGsByReplica(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet) (map[int][]grovecorev1alpha1.PodCliqueScalingGroup, error) {
-	existingPCSGs, err := componentutils.GetPCSGsForPCS(ctx, r.client, client.ObjectKeyFromObject(pcs))
+	existingPCSGs, err := componentutils.GetPCSGsForPCS(ctx, r.client, pcs.ObjectMeta)
 	if err != nil {
 		return nil, groveerr.WrapError(err,
 			errCodeListPCSGs,

--- a/operator/internal/controller/podcliqueset/components/podgangmap/syncflow.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/syncflow.go
@@ -38,7 +38,7 @@ type syncSnapshot struct {
 	pcs                              *grovecorev1alpha1.PodCliqueSet
 	existingStandalonePCLQsByReplica map[int][]grovecorev1alpha1.PodClique
 	existingPCSGsByReplica           map[int][]grovecorev1alpha1.PodCliqueScalingGroup
-	existingPGMByReplica             map[int]grovecorev1alpha1.PodGangMap
+	existingPGMByReplica             map[int]*grovecorev1alpha1.PodGangMap
 	existingPodGangsByReplica        map[int][]groveschedulerv1alpha1.PodGang
 }
 
@@ -110,7 +110,7 @@ func (r _resource) getExistingPCSGsByReplica(ctx context.Context, pcs *grovecore
 }
 
 // getExistingPGMByReplica fetches all PodGangMaps for the PCS and groups them by PCS replica index.
-func (r _resource) getExistingPGMByReplica(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet) (map[int]grovecorev1alpha1.PodGangMap, error) {
+func (r _resource) getExistingPGMByReplica(ctx context.Context, pcs *grovecorev1alpha1.PodCliqueSet) (map[int]*grovecorev1alpha1.PodGangMap, error) {
 	existingPGMs, err := componentutils.ListPodGangMapsForPCS(ctx, r.client, client.ObjectKeyFromObject(pcs))
 	if err != nil {
 		return nil, groveerr.WrapError(err,
@@ -186,27 +186,16 @@ func (r _resource) runSyncFlow(ctx context.Context, syncSnap *syncSnapshot) erro
 			)
 		}
 
-		var (
-			entries []grovecorev1alpha1.PodGangEntry
-			err     error
-		)
-		if !pgmExists {
-			entries = buildBootstrapEntries(syncSnap.pcs, r.clk, syncSnap.existingPodGangsByReplica[pcsReplicaIndex])
-		} else {
-			// Deep-copy the existing entries so mutations here do not alias the snapshot's PodGangMap.
-			entries = clonePodGangEntries(pgm.Spec.Entries)
-			if shouldAdvanceEntriesGenerationHash(syncSnap.pcs, entries) {
-				advanceEntriesGenerationHash(entries, *syncSnap.pcs.Status.CurrentGenerationHash)
-			}
-			scaleOutEpoch := strconv.FormatInt(r.clk.Now().UnixNano(), 10)
-			entries, err = reconcileEntries(syncSnap.pcs, entries,
-				syncSnap.existingStandalonePCLQsByReplica[pcsReplicaIndex],
-				syncSnap.existingPCSGsByReplica[pcsReplicaIndex],
-				pcsReplicaIndex, scaleOutEpoch)
-			if err != nil {
-				return err
-			}
+		entries, err := reconcileEntries(r.clk,
+			syncSnap.pcs, pcsReplicaIndex,
+			pgm,
+			syncSnap.existingPodGangsByReplica[pcsReplicaIndex],
+			syncSnap.existingStandalonePCLQsByReplica[pcsReplicaIndex],
+			syncSnap.existingPCSGsByReplica[pcsReplicaIndex])
+		if err != nil {
+			return err
 		}
+
 		pgmName := apicommon.GeneratePodGangMapName(apicommon.ResourceNameReplica{Name: syncSnap.pcs.Name, Replica: pcsReplicaIndex})
 		if err = r.createOrPatchPodGangMap(ctx, syncSnap.pcs, pgmName, pcsReplicaIndex, entries); err != nil {
 			return err
@@ -239,7 +228,7 @@ func (r _resource) deleteOrphanedPodGangMaps(ctx context.Context, syncSnap *sync
 		if pcsReplicaIndex < int(syncSnap.pcs.Spec.Replicas) {
 			continue
 		}
-		if err := r.client.Delete(ctx, &pgm); err != nil {
+		if err := r.client.Delete(ctx, pgm); err != nil {
 			return groveerr.WrapError(err,
 				errCodeDeletePodGangMaps,
 				component.OperationSync,

--- a/operator/internal/controller/podcliqueset/reconcilestatus.go
+++ b/operator/internal/controller/podcliqueset/reconcilestatus.go
@@ -144,7 +144,7 @@ func (r *Reconciler) computeAvailableAndUpdatedReplicas(ctx context.Context, log
 	// Fetch all PCSGs for this PCS, then drop any stray PCSGs (not part of the spec) using O(1)
 	// set lookup. slices.DeleteFunc compacts in-place; safe here because the slice came from a
 	// fresh fetch and isn't aliased.
-	pcsgs, err := componentutils.GetPCSGsForPCS(ctx, r.client, pcsObjectKey)
+	pcsgs, err := componentutils.GetPCSGsForPCS(ctx, r.client, pcs.ObjectMeta)
 	if err != nil {
 		return stats, err
 	}
@@ -154,7 +154,7 @@ func (r *Reconciler) computeAvailableAndUpdatedReplicas(ctx context.Context, log
 	})
 
 	// Fetch all standalone PodCliques for this PCS and drop strays the same way.
-	standalonePCLQs, err := componentutils.GetPodCliquesWithParentPCS(ctx, r.client, pcsObjectKey)
+	standalonePCLQs, err := componentutils.GetPodCliquesWithParentPCS(ctx, r.client, pcs.ObjectMeta)
 	if err != nil {
 		return stats, err
 	}

--- a/operator/internal/controller/podcliqueset/reconcilestatus_test.go
+++ b/operator/internal/controller/podcliqueset/reconcilestatus_test.go
@@ -66,13 +66,15 @@ func TestComputePCSAvailableReplicas(t *testing.T) {
 				return []client.Object{
 					// Healthy PCSGs
 					testutils.NewPodCliqueScalingGroupBuilder("test-pcs-0-compute", testNamespace, testPCSName, 0).
+						WithOwnerReference(apicommonconstants.KindPodCliqueSet, testPCSName, pcsUID).
 						WithOptions(testutils.WithPCSGAvailableReplicas(1)).Build(),
 					testutils.NewPodCliqueScalingGroupBuilder("test-pcs-1-compute", testNamespace, testPCSName, 1).
+						WithOwnerReference(apicommonconstants.KindPodCliqueSet, testPCSName, pcsUID).
 						WithOptions(testutils.WithPCSGAvailableReplicas(1)).Build(),
 					// Healthy standalone PodCliques
-					testutils.NewPodCliqueBuilder(testPCSName, uuid.NewUUID(), "worker", testNamespace, 0).
+					testutils.NewPodCliqueBuilder(testPCSName, pcsUID, "worker", testNamespace, 0).
 						WithOptions(testutils.WithPCLQReplicaReadyStatus(1), testutils.WithPCLQCurrentPCSGenerationHash(pcsGenerationHash)).Build(),
-					testutils.NewPodCliqueBuilder(testPCSName, uuid.NewUUID(), "worker", testNamespace, 1).
+					testutils.NewPodCliqueBuilder(testPCSName, pcsUID, "worker", testNamespace, 1).
 						WithOptions(testutils.WithPCLQReplicaReadyStatus(1), testutils.WithPCLQCurrentPCSGenerationHash(pcsGenerationHash)).Build(),
 				}
 			},
@@ -90,12 +92,14 @@ func TestComputePCSAvailableReplicas(t *testing.T) {
 			childResources: func() []client.Object {
 				return []client.Object{
 					testutils.NewPodCliqueScalingGroupBuilder("test-pcs-0-compute", testNamespace, testPCSName, 0).
+						WithOwnerReference(apicommonconstants.KindPodCliqueSet, testPCSName, pcsUID).
 						WithOptions(testutils.WithPCSGAvailableReplicas(1)).Build(),
 					testutils.NewPodCliqueScalingGroupBuilder("test-pcs-1-compute", testNamespace, testPCSName, 1).
+						WithOwnerReference(apicommonconstants.KindPodCliqueSet, testPCSName, pcsUID).
 						WithOptions(testutils.WithPCSGMinAvailableBreached()).Build(),
-					testutils.NewPodCliqueBuilder(testPCSName, uuid.NewUUID(), "worker", testNamespace, 0).
+					testutils.NewPodCliqueBuilder(testPCSName, pcsUID, "worker", testNamespace, 0).
 						WithOptions(testutils.WithPCLQReplicaReadyStatus(1), testutils.WithPCLQCurrentPCSGenerationHash(pcsGenerationHash)).Build(),
-					testutils.NewPodCliqueBuilder(testPCSName, uuid.NewUUID(), "worker", testNamespace, 1).
+					testutils.NewPodCliqueBuilder(testPCSName, pcsUID, "worker", testNamespace, 1).
 						WithOptions(testutils.WithPCLQTerminating(), testutils.WithPCLQCurrentPCSGenerationHash(pcsGenerationHash)).Build(),
 				}
 			},
@@ -113,9 +117,9 @@ func TestComputePCSAvailableReplicas(t *testing.T) {
 			childResources: func() []client.Object {
 				// Missing PCSG, extra standalone PodClique
 				return []client.Object{
-					testutils.NewPodCliqueBuilder(testPCSName, uuid.NewUUID(), "test-pcs-0-worker", testNamespace, 0).
+					testutils.NewPodCliqueBuilder(testPCSName, pcsUID, "test-pcs-0-worker", testNamespace, 0).
 						WithOptions(testutils.WithPCLQAvailable(), testutils.WithPCLQCurrentPCSGenerationHash(pcsGenerationHash)).Build(),
-					testutils.NewPodCliqueBuilder(testPCSName, uuid.NewUUID(), "test-pcs-0-extra", testNamespace, 0).
+					testutils.NewPodCliqueBuilder(testPCSName, pcsUID, "test-pcs-0-extra", testNamespace, 0).
 						WithOptions(testutils.WithPCLQAvailable(), testutils.WithPCLQCurrentPCSGenerationHash(pcsGenerationHash)).Build(),
 				}
 			},
@@ -143,13 +147,13 @@ func TestComputePCSAvailableReplicas(t *testing.T) {
 			},
 			childResources: func() []client.Object {
 				return []client.Object{
-					testutils.NewPodCliqueBuilder(testPCSName, uuid.NewUUID(), "worker", testNamespace, 0).
+					testutils.NewPodCliqueBuilder(testPCSName, pcsUID, "worker", testNamespace, 0).
 						WithOptions(testutils.WithPCLQReplicaReadyStatus(1), testutils.WithPCLQCurrentPCSGenerationHash(pcsGenerationHash)).Build(),
-					testutils.NewPodCliqueBuilder(testPCSName, uuid.NewUUID(), "monitor", testNamespace, 0).
+					testutils.NewPodCliqueBuilder(testPCSName, pcsUID, "monitor", testNamespace, 0).
 						WithOptions(testutils.WithPCLQReplicaReadyStatus(1), testutils.WithPCLQCurrentPCSGenerationHash(pcsGenerationHash)).Build(),
-					testutils.NewPodCliqueBuilder(testPCSName, uuid.NewUUID(), "worker", testNamespace, 1).
+					testutils.NewPodCliqueBuilder(testPCSName, pcsUID, "worker", testNamespace, 1).
 						WithOptions(testutils.WithPCLQReplicaReadyStatus(1), testutils.WithPCLQCurrentPCSGenerationHash(pcsGenerationHash)).Build(),
-					testutils.NewPodCliqueBuilder(testPCSName, uuid.NewUUID(), "monitor", testNamespace, 1).
+					testutils.NewPodCliqueBuilder(testPCSName, pcsUID, "monitor", testNamespace, 1).
 						WithOptions(testutils.WithPCLQReplicaReadyStatus(1), testutils.WithPCLQCurrentPCSGenerationHash(pcsGenerationHash)).Build(),
 				}
 			},
@@ -168,12 +172,16 @@ func TestComputePCSAvailableReplicas(t *testing.T) {
 			childResources: func() []client.Object {
 				return []client.Object{
 					testutils.NewPodCliqueScalingGroupBuilder("test-pcs-0-compute", testNamespace, testPCSName, 0).
+						WithOwnerReference(apicommonconstants.KindPodCliqueSet, testPCSName, pcsUID).
 						WithOptions(testutils.WithPCSGAvailableReplicas(1)).Build(),
 					testutils.NewPodCliqueScalingGroupBuilder("test-pcs-0-storage", testNamespace, testPCSName, 0).
+						WithOwnerReference(apicommonconstants.KindPodCliqueSet, testPCSName, pcsUID).
 						WithOptions(testutils.WithPCSGAvailableReplicas(1)).Build(),
 					testutils.NewPodCliqueScalingGroupBuilder("test-pcs-1-compute", testNamespace, testPCSName, 1).
+						WithOwnerReference(apicommonconstants.KindPodCliqueSet, testPCSName, pcsUID).
 						WithOptions(testutils.WithPCSGAvailableReplicas(1)).Build(),
 					testutils.NewPodCliqueScalingGroupBuilder("test-pcs-1-storage", testNamespace, testPCSName, 1).
+						WithOwnerReference(apicommonconstants.KindPodCliqueSet, testPCSName, pcsUID).
 						WithOptions(testutils.WithPCSGAvailableReplicas(1)).Build(),
 				}
 			},
@@ -190,7 +198,7 @@ func TestComputePCSAvailableReplicas(t *testing.T) {
 			},
 			childResources: func() []client.Object {
 				return []client.Object{
-					testutils.NewPodCliqueBuilder(testPCSName, uuid.NewUUID(), "test-pcs-0-worker", testNamespace, 0).
+					testutils.NewPodCliqueBuilder(testPCSName, pcsUID, "test-pcs-0-worker", testNamespace, 0).
 						WithOptions(testutils.WithPCLQTerminating(), testutils.WithPCLQCurrentPCSGenerationHash(pcsGenerationHash)).Build(),
 				}
 			},
@@ -208,6 +216,7 @@ func TestComputePCSAvailableReplicas(t *testing.T) {
 			childResources: func() []client.Object {
 				return []client.Object{
 					testutils.NewPodCliqueScalingGroupBuilder("test-pcs-0-compute", testNamespace, testPCSName, 0).
+						WithOwnerReference(apicommonconstants.KindPodCliqueSet, testPCSName, pcsUID).
 						WithOptions(testutils.WithPCSGUnknownCondition()).Build(),
 				}
 			},
@@ -224,7 +233,7 @@ func TestComputePCSAvailableReplicas(t *testing.T) {
 			},
 			childResources: func() []client.Object {
 				return []client.Object{
-					testutils.NewPodCliqueBuilder(testPCSName, uuid.NewUUID(), "test-pcs-0-worker", testNamespace, 0).
+					testutils.NewPodCliqueBuilder(testPCSName, pcsUID, "test-pcs-0-worker", testNamespace, 0).
 						WithOptions(testutils.WithPCLQNoConditions()).Build(),
 				}
 			},
@@ -254,9 +263,10 @@ func TestComputePCSAvailableReplicas(t *testing.T) {
 			},
 			childResources: func() []client.Object {
 				return []client.Object{
-					testutils.NewPodCliqueBuilder(testPCSName, uuid.NewUUID(), "worker", testNamespace, 0).
+					testutils.NewPodCliqueBuilder(testPCSName, pcsUID, "worker", testNamespace, 0).
 						WithOptions(testutils.WithPCLQReplicaReadyStatus(1), testutils.WithPCLQCurrentPCSGenerationHash(pcsGenerationHash)).Build(),
 					testutils.NewPodCliqueScalingGroupBuilder("test-pcs-0-unexpected", testNamespace, testPCSName, 0).
+						WithOwnerReference(apicommonconstants.KindPodCliqueSet, testPCSName, pcsUID).
 						WithOptions(testutils.WithPCSGAvailableReplicas(1)).Build(),
 				}
 			},
@@ -685,13 +695,13 @@ func TestComputePCSUpdateProgressCounts(t *testing.T) {
 	makePCSG := func(replicaIndex int, hash string) *grovecorev1alpha1.PodCliqueScalingGroup {
 		return testutils.NewPodCliqueScalingGroupBuilder(
 			pcsgName(replicaIndex), testNamespace, testPCSName, replicaIndex,
-		).WithOptions(testutils.WithPCSGCurrentPCSGenerationHash(hash)).Build()
+		).WithOwnerReference(apicommonconstants.KindPodCliqueSet, testPCSName, pcsUID).WithOptions(testutils.WithPCSGCurrentPCSGenerationHash(hash)).Build()
 	}
 	// makePCSGNoHash builds a PCSG with no CurrentPodCliqueSetGenerationHash (not yet updated).
 	makePCSGNoHash := func(replicaIndex int) *grovecorev1alpha1.PodCliqueScalingGroup {
 		return testutils.NewPodCliqueScalingGroupBuilder(
 			pcsgName(replicaIndex), testNamespace, testPCSName, replicaIndex,
-		).Build()
+		).WithOwnerReference(apicommonconstants.KindPodCliqueSet, testPCSName, pcsUID).Build()
 	}
 
 	testCases := []struct {
@@ -812,8 +822,10 @@ func TestPCSMutateReplicasWritesUpdateProgressCounts(t *testing.T) {
 		pcs := b.Build()
 		children := []client.Object{
 			testutils.NewPodCliqueScalingGroupBuilder(pcsgName(0), testNamespace, testPCSName, 0).
+				WithOwnerReference(apicommonconstants.KindPodCliqueSet, testPCSName, pcsUID).
 				WithOptions(testutils.WithPCSGCurrentPCSGenerationHash(pcsHash)).Build(),
 			testutils.NewPodCliqueScalingGroupBuilder(pcsgName(1), testNamespace, testPCSName, 1).
+				WithOwnerReference(apicommonconstants.KindPodCliqueSet, testPCSName, pcsUID).
 				WithOptions(testutils.WithPCSGCurrentPCSGenerationHash(pcsHash)).Build(),
 			markStandalonePCLQConverged(t, pcs, testutils.NewPodCliqueBuilder(testPCSName, pcsUID, "worker", testNamespace, 0).Build(), pcsHash),
 			markStandalonePCLQConverged(t, pcs, testutils.NewPodCliqueBuilder(testPCSName, pcsUID, "worker", testNamespace, 1).Build(), pcsHash),

--- a/operator/internal/podgangmigrator/gate.go
+++ b/operator/internal/podgangmigrator/gate.go
@@ -71,7 +71,7 @@ func SetMigrationGateForLegacyPodCliqueSets(ctx context.Context, cl client.Clien
 			logger.V(4).Info("PodGang migration gate already set on PodCliqueSet", "podCliqueSet", client.ObjectKeyFromObject(pcs))
 			continue
 		}
-		pgms, err := componentutils.ListPodGangMapsForPCS(ctx, cl, client.ObjectKeyFromObject(pcs))
+		pgms, err := componentutils.ListPodGangMapsForPCS(ctx, cl, pcs.ObjectMeta)
 		if err != nil {
 			return fmt.Errorf("failed to list PodGangMaps for PodCliqueSet %v: %w", client.ObjectKeyFromObject(pcs), err)
 		}

--- a/operator/test/utils/pclq.go
+++ b/operator/test/utils/pclq.go
@@ -104,12 +104,13 @@ func (b *PodCliqueBuilder) WithAutoScaleMaxReplicas(maximum int32) *PodCliqueBui
 	return b
 }
 
-// WithOwnerReference sets the owner reference for the PodClique from individual values.
+// WithOwnerReference sets a controller owner reference for the PodClique from individual values.
 func (b *PodCliqueBuilder) WithOwnerReference(kind, name string, uid types.UID) *PodCliqueBuilder {
 	ownerRef := metav1.OwnerReference{
-		Kind: kind,
-		Name: name,
-		UID:  types.UID("test-uid"),
+		Kind:       kind,
+		Name:       name,
+		UID:        types.UID("test-uid"),
+		Controller: ptr.To(true),
 	}
 	if uid != "" {
 		ownerRef.UID = uid

--- a/operator/test/utils/pcsg.go
+++ b/operator/test/utils/pcsg.go
@@ -81,15 +81,16 @@ func (b *PodCliqueScalingGroupBuilder) WithLabels(labels map[string]string) *Pod
 	return b
 }
 
-// WithOwnerReference adds an owner reference to the PodCliqueScalingGroup.
-func (b *PodCliqueScalingGroupBuilder) WithOwnerReference(kind, name, uid string) *PodCliqueScalingGroupBuilder {
+// WithOwnerReference sets a controller owner reference on the PodCliqueScalingGroup.
+func (b *PodCliqueScalingGroupBuilder) WithOwnerReference(kind, name string, uid types.UID) *PodCliqueScalingGroupBuilder {
 	ownerRef := metav1.OwnerReference{
-		Kind: kind,
-		Name: name,
-		UID:  types.UID("test-uid"),
+		Kind:       kind,
+		Name:       name,
+		UID:        types.UID("test-uid"),
+		Controller: ptr.To(true),
 	}
 	if uid != "" {
-		ownerRef.UID = types.UID(uid)
+		ownerRef.UID = uid
 	}
 	b.pcsg.OwnerReferences = append(b.pcsg.OwnerReferences, ownerRef)
 	return b

--- a/operator/test/utils/podgang.go
+++ b/operator/test/utils/podgang.go
@@ -21,6 +21,8 @@ import (
 
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 )
 
 // PodGangBuilder is a builder for PodGang objects (scheduler API).
@@ -93,6 +95,19 @@ func (b *PodGangBuilder) WithLabels(labels map[string]string) *PodGangBuilder {
 func (b *PodGangBuilder) WithDeletionTimestamp() *PodGangBuilder {
 	now := metav1.NewTime(time.Now())
 	b.pg.DeletionTimestamp = &now
+	return b
+}
+
+// WithOwnerReference sets a controller owner reference of the given kind, name and uid on the
+// PodGang. It lets a test model a PodGang owned by a specific controller instance, so ownership by
+// UID (not just name) can be exercised.
+func (b *PodGangBuilder) WithOwnerReference(kind, name string, uid types.UID) *PodGangBuilder {
+	b.pg.OwnerReferences = append(b.pg.OwnerReferences, metav1.OwnerReference{
+		Kind:       kind,
+		Name:       name,
+		UID:        uid,
+		Controller: ptr.To(true),
+	})
 	return b
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a PodGangMap is missing, its entries are bootstrapped from the PodCliqueSet template and the epochs of existing PodGangs, but the live child replica counts were ignored. A PodClique or PodCliqueScalingGroup scaled externally beyond its template (for example by an HPA or DGD through the `/scale` subresource) holds the
scaled count only on its own spec. So a rebuilt PodGangMap briefly omitted the scaled-out entries until a later reconcile repaired them from the live children, churning the scaled-out PodGang in the meantime.

This PR authors the entries through a single `reconcileEntries` path that bootstraps from the template when no PodGangMap exists and otherwise starts from the existing entries, then converges both against the live child replicas before the PodGangMap is written. The ScaleOut entry is ensured before the replica-index diff so a reconstructed scale-out index has a place to land, and the scale-out epoch is adopted from the existing PodGangs so the scale-out PodGang keeps its name. The reconstruction therefore reflects the scaled counts up front and avoids
the churn.

It also makes a PodGang carry the generation hash of the PodGangMap entry it is materialized from, rather than the PodCliqueSet's current generation hash, so a PodGang is labelled with the generation it belongs to. This matters during a coherent update when entries span more than one generation.

#### Which issue(s) this PR fixes:

Fixes #796

#### Special notes for your reviewer:

This supersedes #800.

The change is limited to PodGangMap reconstruction. Recovery of the externally scaled count after deleting the child PodClique or PodCliqueScalingGroup resource itself is out of scope, since the scaled count lives only on the child's spec and is not recoverable once the resource is gone.

Reconstruction of a PodGangMap deleted during a coherent update (multiple anchor entries across generations, with per-entry anchor index and DependsOn that are held only on the PodGangMap) is also out of scope and deferred to a later PR which introduces the core coherent update engine.

**Additional change (refactoring)**
e2e scale helpers now scale through the resource's `/scale` subresource, the same path an external autoscaler uses. New PodGangMap reconstruction e2e tests cover the scaled PodCliqueScalingGroup, scaled standalone PodClique, fresh bootstrap, and scale-in cases.

Verified with:
- `go test ./internal/controller/podcliqueset/... ./internal/controller/common/component/utils/ -count=1`
- `make --directory=operator run-e2e TEST_PATTERN=Test_PGMR` (all 4 pass on a live k3d + KAI cluster)

#### Does this PR introduce a API change?

```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```