### PR TITLE
fix: Recover PodGangMap and Pods when a member is scaled below MinAvailable

### DIFF
--- a/.github/workflows/build-check-test.yaml
+++ b/.github/workflows/build-check-test.yaml
@@ -139,7 +139,8 @@ jobs:
             test_pattern: "^Test_RS"
           - test_name: podgangmap_reconstruct
             test_pattern: "^Test_PGMR"
-          - test_name: upgrade_from_latest_release
+          - test_name: version_upgrade
+            test_pattern: "^Test_VUPG"
             make_target: "run-upgrade-e2e"
     name: E2E - ${{ matrix.test_name }}
     steps:
@@ -162,7 +163,7 @@ jobs:
 
       - name: Run e2e tests - ${{ matrix.test_name }}
         env:
-          GITHUB_TOKEN: ${{ matrix.test_name == 'upgrade_from_latest_release' && secrets.GITHUB_TOKEN || '' }}
+          GITHUB_TOKEN: ${{ matrix.test_name == 'version_upgrade' && secrets.GITHUB_TOKEN || '' }}
         run: |
           make ${{ matrix.make_target || 'run-e2e-full' }} TEST_PATTERN='${{ matrix.test_pattern }}' E2E_CREATE_FLAGS='--dind-memory-mode'
         working-directory: operator
@@ -210,7 +211,7 @@ jobs:
           - test_name: crd_installer
           - test_name: resource_sharing
           - test_name: podgangmap_reconstruct
-          - test_name: upgrade_from_latest_release
+          - test_name: version_upgrade
     name: E2E - ${{ matrix.test_name }}
     steps:
       - name: Skip E2E (no relevant changes)

--- a/operator/e2e/grove/podgangmap/podgangmap.go
+++ b/operator/e2e/grove/podgangmap/podgangmap.go
@@ -149,6 +149,18 @@ func AnchorEpochCheckFn(want string) Check {
 	}
 }
 
+// NoEntriesCheckFn returns a Check that verifies the PodGangMap has no entries. This is the transient
+// state after every entry drains to empty, for example when a PodCliqueScalingGroup is scaled below
+// MinAvailable on an all-PodCliqueScalingGroup PodCliqueSet.
+func NoEntriesCheckFn() Check {
+	return func(pgm *grovecorev1alpha1.PodGangMap) error {
+		if len(pgm.Spec.Entries) != 0 {
+			return fmt.Errorf("expected no entries, found %d", len(pgm.Spec.Entries))
+		}
+		return nil
+	}
+}
+
 // WaitUntilVerified polls the replica's PodGangMap until it satisfies all checks or the timeout
 // elapses. Verification is delegated to Verifier.Verify and runs immediately, then repeats every
 // interval. It returns nil once all checks pass. On timeout or context cancellation it returns an error

--- a/operator/e2e/tests/podgangmap_reconstruct_test.go
+++ b/operator/e2e/tests/podgangmap_reconstruct_test.go
@@ -114,7 +114,7 @@ func Test_PGMR1_ReconstructScaledPCSGAfterPodGangMapDelete(t *testing.T) {
 		t.Fatalf("Pods not all running after PodGangMap reconstruction: %v", err)
 	}
 
-	Logger.Info("PGMR-1 completed successfully")
+	Logger.Info("🎉 PGMR-1 completed successfully!")
 }
 
 // Test_PGMR2_ReconstructScaledStandalonePCLQAfterPodGangMapDelete verifies that a PodGangMap deleted
@@ -174,7 +174,7 @@ func Test_PGMR2_ReconstructScaledStandalonePCLQAfterPodGangMapDelete(t *testing.
 		t.Fatalf("Pods not all running after PodGangMap reconstruction: %v", err)
 	}
 
-	Logger.Info("PGMR-2 completed successfully")
+	Logger.Info("🎉 PGMR-2 completed successfully!")
 }
 
 // Test_PGMR3_ReconstructFreshBootstrapAfterPodGangMapDelete verifies that a PodGangMap deleted with no
@@ -231,7 +231,7 @@ func Test_PGMR3_ReconstructFreshBootstrapAfterPodGangMapDelete(t *testing.T) {
 		t.Fatalf("Pods not all running after PodGangMap reconstruction: %v", err)
 	}
 
-	Logger.Info("PGMR-3 completed successfully")
+	Logger.Info("🎉 PGMR-3 completed successfully!")
 }
 
 // Test_PGMR4_ReconstructAfterScaleInThenPodGangMapDelete verifies that after a PodCliqueScalingGroup is
@@ -292,7 +292,159 @@ func Test_PGMR4_ReconstructAfterScaleInThenPodGangMapDelete(t *testing.T) {
 		t.Fatalf("Pods not all running after PodGangMap reconstruction: %v", err)
 	}
 
-	Logger.Info("PGMR-4 completed successfully")
+	Logger.Info("🎉 PGMR-4 completed successfully!")
+}
+
+// Test_PGMR5_RecoverAfterScalingPCSGBelowMinAvailable verifies that scaling a PodCliqueScalingGroup
+// below MinAvailable, which drains the anchor entry to empty on an all-PCSG PodCliqueSet, does not
+// wedge the PodGangMap. The anchor and ScaleOut entries vanish together while the group is at zero, and
+// both return when the group is scaled back up, so the worker pods schedule again. This is the
+// regression behind an all-PCSG workload that could not scale back from zero.
+// Scenario PGMR-5:
+// 1. Initialize a 4-node Grove cluster
+// 2. Deploy workload WL-PCSG-ONLY (one PCSG worker=1 over worker-ldr+worker-wkr), verify 2 pods
+// 3. Verify the PodGangMap starts with an anchor holding worker index 0 and an empty ScaleOut entry
+// 4. Scale the worker group to 0, below MinAvailable, and verify both entries vanish
+// 5. Scale the worker group back to 1, and verify the anchor holding worker index 0 and the empty
+//    ScaleOut entry are both present again
+// 6. Verify both worker pods are running again
+func Test_PGMR5_RecoverAfterScalingPCSGBelowMinAvailable(t *testing.T) {
+	ctx := t.Context()
+
+	Logger.Info("1. Initialize a 4-node Grove cluster")
+	Logger.Info("2. Deploy workload WL-PCSG-ONLY, and verify 2 newly created pods")
+	tc, cleanup := testctx.PrepareTest(ctx, t, 4,
+		testctx.WithWorkload(&testctx.WorkloadConfig{
+			Name:         "workload-pcsg-only",
+			YAMLPath:     "../yaml/workload-pcsg-only.yaml",
+			Namespace:    "default",
+			ExpectedPods: 2,
+		}),
+	)
+	defer cleanup()
+
+	if _, err := tc.DeployAndVerifyWorkload(); err != nil {
+		t.Fatalf("Failed to deploy workload: %v", err)
+	}
+
+	verifier := podgangmap.NewVerifier(tc.Client, Logger)
+	pcsNsName := types.NamespacedName{Namespace: tc.Namespace, Name: "workload-pcsg-only"}
+
+	Logger.Info("3. Verify the PodGangMap starts with an anchor holding worker index 0 and an empty ScaleOut entry")
+	if err := verifier.Verify(ctx, pcsNsName, 0,
+		podgangmap.AnchorPCSGReplicaIndicesCheckFn("worker", []int32{0}),
+		podgangmap.ScaleOutPCSGReplicaIndicesCheckFn("worker", nil),
+	); err != nil {
+		t.Fatalf("PodGangMap not in expected state at baseline: %v", err)
+	}
+
+	Logger.Info("4. Scale the worker group to 0, below MinAvailable, and verify both entries vanish")
+	tc.ScalePCSGAcrossAllReplicasAndWait("workload-pcsg-only", "worker", 1, 0, 0, 0)
+	if err := podgangmap.WaitUntilVerified(ctx, verifier, pcsNsName, 0, pgmReconstructTimeout, tc.Interval,
+		podgangmap.NoEntriesCheckFn(),
+	); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	Logger.Info("5. Scale the worker group back to 1, and verify the anchor and empty ScaleOut entry are both present")
+	tc.ScalePCSGAcrossAllReplicasAndWait("workload-pcsg-only", "worker", 1, 1, 2, 0)
+	if err := podgangmap.WaitUntilVerified(ctx, verifier, pcsNsName, 0, pgmReconstructTimeout, tc.Interval,
+		podgangmap.AnchorPCSGReplicaIndicesCheckFn("worker", []int32{0}),
+		podgangmap.ScaleOutPCSGReplicaIndicesCheckFn("worker", nil),
+	); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	Logger.Info("6. Verify the anchor PodGang eventually records LastScheduled and LastReady")
+	pgVerifier := podgang.NewVerifier(tc.Client, Logger)
+	if err := podgang.WaitUntilVerified(ctx, pgVerifier, pcsNsName, pgmReconstructTimeout, tc.Interval,
+		podgang.LastScheduledSetCheckFn(true),
+		podgang.LastReadySetCheckFn(true),
+	); err != nil {
+		t.Fatalf("anchor PodGang did not record LastScheduled and LastReady: %v", err)
+	}
+
+	Logger.Info("7. Verify both worker pods are running again")
+	if err := tc.WaitForRunningPods(2); err != nil {
+		t.Fatalf("Pods not all running after scaling the group back up: %v", err)
+	}
+
+	Logger.Info("🎉 PGMR-5 completed successfully!")
+}
+
+// Test_PGMR6_RecoverAfterScalingStandalonePCLQToZero verifies that scaling the only standalone
+// PodClique of a PodCliqueSet to zero drains the anchor entry to empty and, because there is no
+// PodCliqueScalingGroup, leaves the PodGangMap with no entries at all, without wedging it. The
+// PodClique's pods are deleted as it scales to zero, and scaling it back up rebuilds the anchor and
+// recreates the pod.
+// Scenario PGMR-6:
+// 1. Initialize a 4-node Grove cluster
+// 2. Deploy workload WL-PCLQ-ONLY (one standalone PodClique solo=1), verify 1 pod
+// 3. Verify the PodGangMap starts with an anchor holding the solo PodClique count 1
+// 4. Scale solo to 0, and verify the PodGangMap holds no entries and no pods remain
+// 5. Scale solo back to 1, and verify the anchor holds the solo count 1 again
+// 6. Verify the anchor PodGang eventually records LastScheduled and LastReady
+// 7. Verify the pod is running again
+func Test_PGMR6_RecoverAfterScalingStandalonePCLQToZero(t *testing.T) {
+	ctx := t.Context()
+
+	Logger.Info("1. Initialize a 4-node Grove cluster")
+	Logger.Info("2. Deploy workload WL-PCLQ-ONLY, and verify 1 newly created pod")
+	tc, cleanup := testctx.PrepareTest(ctx, t, 4,
+		testctx.WithWorkload(&testctx.WorkloadConfig{
+			Name:         "workload-pclq-only",
+			YAMLPath:     "../yaml/workload-pclq-only.yaml",
+			Namespace:    "default",
+			ExpectedPods: 1,
+		}),
+	)
+	defer cleanup()
+
+	if _, err := tc.DeployAndVerifyWorkload(); err != nil {
+		t.Fatalf("Failed to deploy workload: %v", err)
+	}
+
+	verifier := podgangmap.NewVerifier(tc.Client, Logger)
+	pcsNsName := types.NamespacedName{Namespace: tc.Namespace, Name: "workload-pclq-only"}
+
+	Logger.Info("3. Verify the PodGangMap starts with an anchor holding the solo PodClique count 1")
+	if err := verifier.Verify(ctx, pcsNsName, 0,
+		podgangmap.AnchorStandalonePodCliqueCountCheckFn("solo", 1),
+	); err != nil {
+		t.Fatalf("PodGangMap not in expected state at baseline: %v", err)
+	}
+
+	Logger.Info("4. Scale solo to 0, and verify the PodGangMap holds no entries and no pods remain")
+	tc.ScalePodCliqueAndWait("workload-pclq-only-0-solo", 0, 0, 0)
+	if err := podgangmap.WaitUntilVerified(ctx, verifier, pcsNsName, 0, pgmReconstructTimeout, tc.Interval,
+		podgangmap.NoEntriesCheckFn(),
+	); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	Logger.Info("5. Scale solo back to 1, and verify the anchor holds the solo count 1 again")
+	tc.ScalePodCliqueAndWait("workload-pclq-only-0-solo", 1, 1, 0)
+	if err := podgangmap.WaitUntilVerified(ctx, verifier, pcsNsName, 0, pgmReconstructTimeout, tc.Interval,
+		podgangmap.AnchorStandalonePodCliqueCountCheckFn("solo", 1),
+	); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	Logger.Info("6. Verify the anchor PodGang eventually records LastScheduled and LastReady")
+	pgVerifier := podgang.NewVerifier(tc.Client, Logger)
+	if err := podgang.WaitUntilVerified(ctx, pgVerifier, pcsNsName, pgmReconstructTimeout, tc.Interval,
+		podgang.LastScheduledSetCheckFn(true),
+		podgang.LastReadySetCheckFn(true),
+	); err != nil {
+		t.Fatalf("anchor PodGang did not record LastScheduled and LastReady: %v", err)
+	}
+
+	Logger.Info("7. Verify the pod is running again")
+	if err := tc.WaitForRunningPods(1); err != nil {
+		t.Fatalf("Pod not running after scaling the PodClique back up: %v", err)
+	}
+
+	Logger.Info("🎉 PGMR-6 completed successfully!")
 }
 
 // deletePodGangMap deletes the named PodGangMap, failing the test on error.

--- a/operator/e2e/tests/upgrade/upgrade.go
+++ b/operator/e2e/tests/upgrade/upgrade.go
@@ -32,60 +32,85 @@ const (
 	defaultPollTimeout = 5 * time.Minute
 	// defaultPollInterval is the interval for most polling conditions
 	defaultPollInterval = 5 * time.Second
+	// pgmRecoverTimeout bounds the wait for a PodGangMap to drain to empty and then rebuild its anchor
+	// as a PodCliqueScalingGroup is scaled below MinAvailable and back. Recovery runs on the next
+	// reconcile, so a long wait here signals a real defect.
+	pgmRecoverTimeout = 1 * time.Minute
+
+	// groveReleaseName is the Helm release name used for both the install and the upgrade.
+	groveReleaseName = "grove"
+	// groveNamespace is the namespace the Grove operator runs in.
+	groveNamespace = "grove-system"
+	// groveReleasedChartRef is the OCI reference of the published Grove chart used for the install.
+	groveReleasedChartRef = "oci://ghcr.io/ai-dynamo/grove/grove-charts"
 )
 
-// testConfig holds configuration for upgrade test setup.
-type testConfig struct {
-	// Required - initial version installed
+// upgradeTest describes an upgrade scenario. The harness installs fromVersion, runs preUpgrade,
+// upgrades to the operator built from the current checkout, then runs postUpgrade. preUpgrade owns
+// workload setup and any assertions on the fromVersion operator. postUpgrade holds the assertions on
+// the upgraded operator. preUpgrade may be nil.
+type upgradeTest struct {
+	// fromVersion is the released Grove version to install first. The harness never defaults it, so
+	// each test states the version it exercises.
 	fromVersion string
-
-	// Required - workload that will be installed before and verified after an upgrade.
-	workload *testctx.WorkloadConfig
+	// nodeWorkerCount is the number of worker nodes the cluster is prepared with.
+	nodeWorkerCount int
+	// prepareOpts are passed to PrepareTest, so a test declares its workload with WithWorkload.
+	prepareOpts []testctx.TestOption
+	// preUpgrade runs against the fromVersion operator, before the upgrade. It is optional.
+	preUpgrade func(t *testing.T, tc *testctx.TestContext)
+	// postUpgrade runs against the upgraded operator, after the upgrade.
+	postUpgrade func(t *testing.T, tc *testctx.TestContext)
 }
 
-// setupTest initializes an upgrade test with the given configuration.
-// It handles:
-// 1. Cluster preparation
-// 2. TestContext creation with standard parameters
-// 3. Workload deployment and pod verification
-// 4. Installation of the given version
-//
-// Returns:
-//   - tc: TestContext for the test
-func setupTest(t *testing.T, cfg testConfig) *testctx.TestContext {
+// runUpgradeTest installs the fromVersion Grove operator, runs preUpgrade, upgrades to the operator
+// built from the current checkout, then runs postUpgrade.
+func runUpgradeTest(t *testing.T, cfg upgradeTest) {
 	t.Helper()
 
 	if testing.Short() {
 		t.Skip("upgrade E2E test is disabled by -short")
 	}
-
-	if cfg.fromVersion == "" {
-		t.Fatalf("TestConfig.FromVersion is required")
-	}
-
-	if cfg.workload == nil {
-		t.Fatalf("TestConfig.Workload is required")
-	}
+	cfg.validate(t)
 
 	testctx.Logger.Infof("preparing test cluster")
+	tc, cleanup := testctx.PrepareTest(t.Context(), t, cfg.nodeWorkerCount, cfg.prepareOpts...)
+	defer cleanup()
 
-	tc, cleanup := testctx.PrepareTest(
-		t.Context(),
-		t,
-		1,
-		testctx.WithWorkload(cfg.workload),
-	)
-	t.Cleanup(cleanup)
+	installReleasedGrove(t, tc, cfg.fromVersion)
+	if cfg.preUpgrade != nil {
+		cfg.preUpgrade(t, tc)
+	}
+	upgradeGrove(t, tc)
+	cfg.postUpgrade(t, tc)
+}
 
-	testctx.Logger.Infof("testing Grove upgrade from %s to the current checkout", cfg.fromVersion)
-	testctx.Logger.Info("installing released Grove operator")
+// validate fails the test when the upgradeTest is not fully specified.
+func (cfg upgradeTest) validate(t *testing.T) {
+	t.Helper()
+	if cfg.fromVersion == "" {
+		t.Fatalf("upgradeTest.fromVersion is required")
+	}
+	if cfg.nodeWorkerCount <= 0 {
+		t.Fatalf("upgradeTest.nodeWorkerCount must be greater than zero")
+	}
+	if cfg.postUpgrade == nil {
+		t.Fatalf("upgradeTest.postUpgrade is required")
+	}
+}
 
+// installReleasedGrove installs the given released Grove version from the published OCI chart and waits
+// for the operator to become ready.
+func installReleasedGrove(t *testing.T, tc *testctx.TestContext, version string) {
+	t.Helper()
+
+	testctx.Logger.Infof("installing released Grove operator %s", version)
 	_, err := setup.InstallHelmChart(&setup.HelmInstallConfig{
 		RestConfig:      tc.Client.RestConfig,
-		ReleaseName:     "grove",
-		Namespace:       "grove-system",
-		ChartRef:        "oci://ghcr.io/ai-dynamo/grove/grove-charts",
-		ChartVersion:    cfg.fromVersion,
+		ReleaseName:     groveReleaseName,
+		Namespace:       groveNamespace,
+		ChartRef:        groveReleasedChartRef,
+		ChartVersion:    version,
 		CreateNamespace: true,
 		Wait:            true,
 		Timeout:         defaultPollTimeout,
@@ -95,18 +120,8 @@ func setupTest(t *testing.T, cfg testConfig) *testctx.TestContext {
 	require.NoError(t, err, "install released Grove chart")
 
 	podsManager := pods.NewPodManager(tc.Client, testctx.Logger)
-	err = podsManager.WaitForReadyInNamespace(t.Context(), "grove-system", 1, defaultPollTimeout, defaultPollInterval)
-	require.NoError(t, err, "waiting for Grove to become ready")
-
-	testctx.Logger.Info("applying workload before upgrade")
-
-	_, err = tc.DeployAndVerifyWorkload()
-	require.NoError(t, err, "applying workload")
-
-	err = podsManager.WaitForReadyInNamespace(t.Context(), cfg.workload.Namespace, 2, defaultPollTimeout, defaultPollInterval)
-	require.NoError(t, err, "waiting for workload to become ready")
-
-	return tc
+	require.NoError(t, podsManager.WaitForReadyInNamespace(t.Context(), groveNamespace, 1, defaultPollTimeout, defaultPollInterval),
+		"waiting for Grove to become ready")
 }
 
 // upgradeGrove handles the upgrade of Grove to the current codebase.

--- a/operator/e2e/tests/upgrade/upgrade.go
+++ b/operator/e2e/tests/upgrade/upgrade.go
@@ -75,9 +75,14 @@ func runUpgradeTest(t *testing.T, cfg upgradeTest) {
 
 	testctx.Logger.Infof("preparing test cluster")
 	tc, cleanup := testctx.PrepareTest(t.Context(), t, cfg.nodeWorkerCount, cfg.prepareOpts...)
-	defer cleanup()
 
 	installReleasedGrove(t, tc, cfg.fromVersion)
+	// The upgrade tests share one cluster, so uninstall Grove after the test to free the release name
+	// for the next one. This defer is registered before cleanup so it runs last, after cleanup has
+	// deleted the workload while the operator is still up to process finalizers.
+	defer uninstallGrove(t, tc)
+	defer cleanup()
+
 	if cfg.preUpgrade != nil {
 		cfg.preUpgrade(t, tc)
 	}
@@ -122,6 +127,18 @@ func installReleasedGrove(t *testing.T, tc *testctx.TestContext, version string)
 	podsManager := pods.NewPodManager(tc.Client, testctx.Logger)
 	require.NoError(t, podsManager.WaitForReadyInNamespace(t.Context(), groveNamespace, 1, defaultPollTimeout, defaultPollInterval),
 		"waiting for Grove to become ready")
+}
+
+// uninstallGrove removes the Grove release so the shared cluster is clean for the next upgrade test.
+func uninstallGrove(t *testing.T, tc *testctx.TestContext) {
+	t.Helper()
+	require.NoError(t, setup.UninstallHelmChart(&setup.HelmInstallConfig{
+		RestConfig:     tc.Client.RestConfig,
+		ReleaseName:    groveReleaseName,
+		Namespace:      groveNamespace,
+		Timeout:        defaultPollTimeout,
+		HelmLoggerFunc: testctx.Logger.Infof,
+	}), "uninstall Grove chart")
 }
 
 // upgradeGrove handles the upgrade of Grove to the current codebase.

--- a/operator/e2e/tests/upgrade/upgrade_test.go
+++ b/operator/e2e/tests/upgrade/upgrade_test.go
@@ -52,11 +52,6 @@ const (
 	upgradePCSGWorkloadNamespace = "default"
 )
 
-// TestUpgradeFromLatestGitHubRelease verifies that a workload's pods created with the latest released
-// version of Grove are not recreated during an upgrade to the operator built from the current
-// checkout.
-//
-// The initial version of Grove to install can be controlled with GROVE_UPGRADE_FROM_VERSION.
 // podSurvivalUpgrade holds the state shared between the pre-upgrade and post-upgrade steps of the pod
 // survival test. The pod list is captured before the upgrade and asserted against afterwards.
 type podSurvivalUpgrade struct {
@@ -82,12 +77,12 @@ func (s *podSurvivalUpgrade) verifyPodsSurvive(t *testing.T, tc *testctx.TestCon
 	verifyPodUIDsUnchanged(t, tc, s.podsBeforeUpgrade)
 }
 
-// TestUpgradeFromLatestGitHubRelease verifies that a workload's pods created with the latest released
+// Test_VUPG1_UpgradeFromLatestGitHubRelease verifies that a workload's pods created with the latest released
 // version of Grove are not recreated during an upgrade to the operator built from the current
 // checkout.
 //
 // The initial version of Grove to install can be controlled with GROVE_UPGRADE_FROM_VERSION.
-func TestUpgradeFromLatestGitHubRelease(t *testing.T) {
+func Test_VUPG1_UpgradeFromLatestGitHubRelease(t *testing.T) {
 	fromVersion := os.Getenv("GROVE_UPGRADE_FROM_VERSION")
 	if fromVersion == "" {
 		fromVersion = latestGitHubRelease(t)
@@ -112,12 +107,12 @@ func TestUpgradeFromLatestGitHubRelease(t *testing.T) {
 	})
 }
 
-// TestUpgradeFromAlpha11RecoversPodGangMapAfterScaleBelowMinAvailable verifies that after migrating a
+// Test_VUPG2_RecoverPodGangMapAfterScaleBelowMinAvailable verifies that after migrating a
 // legacy workload from v0.1.0-alpha.11 to the epoch-based PodGang scheme, scaling a
 // PodCliqueScalingGroup below MinAvailable drains its PodGangMap to empty without wedging, and scaling
 // it back up rebuilds the anchor and reschedules the pods. This exercises the fix for issues #808 and
 // #809 through the real migration path.
-func TestUpgradeFromAlpha11RecoversPodGangMapAfterScaleBelowMinAvailable(t *testing.T) {
+func Test_VUPG2_RecoverPodGangMapAfterScaleBelowMinAvailable(t *testing.T) {
 	runUpgradeTest(t, upgradeTest{
 		fromVersion:     "v0.1.0-alpha.11",
 		nodeWorkerCount: 4,

--- a/operator/e2e/tests/upgrade/upgrade_test.go
+++ b/operator/e2e/tests/upgrade/upgrade_test.go
@@ -26,20 +26,65 @@
 package upgrade
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
 
+	apiconstants "github.com/ai-dynamo/grove/operator/api/common/constants"
+	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/ai-dynamo/grove/operator/e2e/grove/podgangmap"
 	"github.com/ai-dynamo/grove/operator/e2e/k8s/pods"
 	"github.com/ai-dynamo/grove/operator/e2e/testctx"
 	"github.com/google/go-github/v86/github"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-// TestUpgradeFromGitHubRelease verifies that a workload's pods created with
-// the latest released version of Grove will not be recreated during an upgrade
-// to the latest code built from the current checkout.
+const (
+	// upgradePCSGWorkloadName is the name of the all-PodCliqueScalingGroup workload used by the
+	// migration recovery test.
+	upgradePCSGWorkloadName = "upgrade-pcsg-only"
+	// upgradePCSGWorkloadNamespace is the namespace of that workload.
+	upgradePCSGWorkloadNamespace = "default"
+)
+
+// TestUpgradeFromLatestGitHubRelease verifies that a workload's pods created with the latest released
+// version of Grove are not recreated during an upgrade to the operator built from the current
+// checkout.
+//
+// The initial version of Grove to install can be controlled with GROVE_UPGRADE_FROM_VERSION.
+// podSurvivalUpgrade holds the state shared between the pre-upgrade and post-upgrade steps of the pod
+// survival test. The pod list is captured before the upgrade and asserted against afterwards.
+type podSurvivalUpgrade struct {
+	fromVersion       string
+	workload          *testctx.WorkloadConfig
+	podsBeforeUpgrade *corev1.PodList
+}
+
+// deployWorkload deploys the workload on the fromVersion operator and captures its pods.
+func (s *podSurvivalUpgrade) deployWorkload(t *testing.T, tc *testctx.TestContext) {
+	_, err := tc.DeployAndVerifyWorkload()
+	require.NoError(t, err, "applying workload")
+	s.podsBeforeUpgrade, err = tc.ListPods()
+	require.NoError(t, err, "listing workload pods")
+}
+
+// verifyPodsSurvive scales the workload, then asserts the pre-upgrade pods were not recreated and the
+// init containers were updated.
+func (s *podSurvivalUpgrade) verifyPodsSurvive(t *testing.T, tc *testctx.TestContext) {
+	tc.ScalePCSAndWait(s.workload.Name, 2, 4, 0)
+	initContainerImage := fmt.Sprintf("ghcr.io/ai-dynamo/grove/grove-initc:%s", s.fromVersion)
+	verifyInitContainerUpdate(t, tc, s.podsBeforeUpgrade, initContainerImage)
+	verifyPodUIDsUnchanged(t, tc, s.podsBeforeUpgrade)
+}
+
+// TestUpgradeFromLatestGitHubRelease verifies that a workload's pods created with the latest released
+// version of Grove are not recreated during an upgrade to the operator built from the current
+// checkout.
 //
 // The initial version of Grove to install can be controlled with GROVE_UPGRADE_FROM_VERSION.
 func TestUpgradeFromLatestGitHubRelease(t *testing.T) {
@@ -48,29 +93,94 @@ func TestUpgradeFromLatestGitHubRelease(t *testing.T) {
 		fromVersion = latestGitHubRelease(t)
 	}
 
-	workload := &testctx.WorkloadConfig{
-		Name:         "upgrade-survivor",
-		YAMLPath:     "../../yaml/upgrade.yaml",
-		Namespace:    "default",
-		ExpectedPods: 2,
+	s := &podSurvivalUpgrade{
+		fromVersion: fromVersion,
+		workload: &testctx.WorkloadConfig{
+			Name:         "upgrade-survivor",
+			YAMLPath:     "../../yaml/upgrade.yaml",
+			Namespace:    "default",
+			ExpectedPods: 2,
+		},
 	}
 
-	tc := setupTest(t, testConfig{
-		fromVersion: fromVersion,
-		workload:    workload,
+	runUpgradeTest(t, upgradeTest{
+		fromVersion:     s.fromVersion,
+		nodeWorkerCount: 1,
+		prepareOpts:     []testctx.TestOption{testctx.WithWorkload(s.workload)},
+		preUpgrade:      s.deployWorkload,
+		postUpgrade:     s.verifyPodsSurvive,
 	})
+}
 
-	podsList, err := tc.ListPods()
-	require.NoError(t, err, "listing workload pods")
+// TestUpgradeFromAlpha11RecoversPodGangMapAfterScaleBelowMinAvailable verifies that after migrating a
+// legacy workload from v0.1.0-alpha.11 to the epoch-based PodGang scheme, scaling a
+// PodCliqueScalingGroup below MinAvailable drains its PodGangMap to empty without wedging, and scaling
+// it back up rebuilds the anchor and reschedules the pods. This exercises the fix for issues #808 and
+// #809 through the real migration path.
+func TestUpgradeFromAlpha11RecoversPodGangMapAfterScaleBelowMinAvailable(t *testing.T) {
+	runUpgradeTest(t, upgradeTest{
+		fromVersion:     "v0.1.0-alpha.11",
+		nodeWorkerCount: 4,
+		prepareOpts: []testctx.TestOption{testctx.WithWorkload(&testctx.WorkloadConfig{
+			Name:         upgradePCSGWorkloadName,
+			YAMLPath:     "../../yaml/upgrade-pcsg-only.yaml",
+			Namespace:    upgradePCSGWorkloadNamespace,
+			ExpectedPods: 2,
+		})},
+		preUpgrade:  deployWorkloadOnFromVersion,
+		postUpgrade: verifyPodGangMapRecoversAfterScaleBelowMinAvailable,
+	})
+}
 
-	upgradeGrove(t, tc)
+// deployWorkloadOnFromVersion deploys the configured workload on the fromVersion operator.
+func deployWorkloadOnFromVersion(t *testing.T, tc *testctx.TestContext) {
+	_, err := tc.DeployAndVerifyWorkload()
+	require.NoError(t, err, "applying workload on the fromVersion operator")
+}
 
-	tc.ScalePCSAndWait(workload.Name, 2, 4, 0)
+// verifyPodGangMapRecoversAfterScaleBelowMinAvailable waits for the migration to complete, checks the
+// migrated PodGangMap, scales the worker group below MinAvailable to zero so the anchor drains away,
+// then scales it back up and checks the anchor is rebuilt and the pods run.
+func verifyPodGangMapRecoversAfterScaleBelowMinAvailable(t *testing.T, tc *testctx.TestContext) {
+	verifier := podgangmap.NewVerifier(tc.Client, testctx.Logger)
+	pcsNsName := types.NamespacedName{Namespace: upgradePCSGWorkloadNamespace, Name: upgradePCSGWorkloadName}
 
-	initContainerImage := fmt.Sprintf("ghcr.io/ai-dynamo/grove/grove-initc:%s", fromVersion)
-	verifyInitContainerUpdate(t, tc, podsList, initContainerImage)
+	testctx.Logger.Info("waiting for the legacy workload to finish migrating to the epoch-based scheme")
+	waitForMigrationComplete(t, tc, pcsNsName)
 
-	verifyPodUIDsUnchanged(t, tc, podsList)
+	testctx.Logger.Info("verifying the migrated PodGangMap has an anchor holding worker index 0")
+	require.NoError(t, podgangmap.WaitUntilVerified(t.Context(), verifier, pcsNsName, 0, pgmRecoverTimeout, defaultPollInterval,
+		podgangmap.AnchorPCSGReplicaIndicesCheckFn("worker", []int32{0}),
+	), "migrated PodGangMap not in expected state")
+
+	testctx.Logger.Info("scaling the worker group to 0 and verifying the PodGangMap holds no entries")
+	tc.ScalePCSGAcrossAllReplicasAndWait(upgradePCSGWorkloadName, "worker", 1, 0, 0, 0)
+	require.NoError(t, podgangmap.WaitUntilVerified(t.Context(), verifier, pcsNsName, 0, pgmRecoverTimeout, defaultPollInterval,
+		podgangmap.NoEntriesCheckFn(),
+	))
+
+	testctx.Logger.Info("scaling the worker group back to 1 and verifying the anchor is rebuilt")
+	tc.ScalePCSGAcrossAllReplicasAndWait(upgradePCSGWorkloadName, "worker", 1, 1, 2, 0)
+	require.NoError(t, podgangmap.WaitUntilVerified(t.Context(), verifier, pcsNsName, 0, pgmRecoverTimeout, defaultPollInterval,
+		podgangmap.AnchorPCSGReplicaIndicesCheckFn("worker", []int32{0}),
+	))
+
+	require.NoError(t, tc.WaitForRunningPods(2), "pods not running after scaling the group back up")
+}
+
+// waitForMigrationComplete polls the PodCliqueSet until the PodGangMigrationInProgress condition is
+// cleared, which the operator does once every replica has migrated to the epoch-based PodGang scheme.
+func waitForMigrationComplete(t *testing.T, tc *testctx.TestContext, pcsNsName types.NamespacedName) {
+	t.Helper()
+	err := wait.PollUntilContextTimeout(t.Context(), defaultPollInterval, defaultPollTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			pcs := &grovev1alpha1.PodCliqueSet{}
+			if err := tc.Client.Get(ctx, pcsNsName, pcs); err != nil {
+				return false, err
+			}
+			return meta.FindStatusCondition(pcs.Status.Conditions, apiconstants.ConditionTypePodGangMigrationInProgress) == nil, nil
+		})
+	require.NoError(t, err, "migration did not complete: PodGangMigrationInProgress condition still present")
 }
 
 // verifyInitContainerUpdate verifies that workload pods receive the new init container images after an upgrade.

--- a/operator/e2e/yaml/upgrade-pcsg-only.yaml
+++ b/operator/e2e/yaml/upgrade-pcsg-only.yaml
@@ -1,0 +1,37 @@
+# Workload for the upgrade migration test. It has a single PodCliqueScalingGroup and no standalone
+# PodClique, so scaling the group below MinAvailable drains the anchor entry to empty. It uses the
+# default scheduler and a pullable image, since the upgrade test cluster runs without Kai.
+---
+apiVersion: grove.io/v1alpha1
+kind: PodCliqueSet
+metadata:
+  name: upgrade-pcsg-only
+spec:
+  replicas: 1
+  template:
+    podCliqueScalingGroups:
+      - name: worker
+        replicas: 1
+        minAvailable: 1
+        cliqueNames:
+          - worker-ldr
+          - worker-wkr
+    cliques:
+      - name: worker-ldr
+        spec:
+          roleName: worker-ldr
+          replicas: 1
+          minAvailable: 1
+          podSpec:
+            containers:
+              - name: worker-ldr
+                image: registry.k8s.io/pause:3.10
+      - name: worker-wkr
+        spec:
+          roleName: worker-wkr
+          replicas: 1
+          minAvailable: 1
+          podSpec:
+            containers:
+              - name: worker-wkr
+                image: registry.k8s.io/pause:3.10

--- a/operator/e2e/yaml/workload-pclq-only.yaml
+++ b/operator/e2e/yaml/workload-pclq-only.yaml
@@ -1,0 +1,45 @@
+# Workload: single standalone PodClique with no PodCliqueScalingGroup.
+# Scaling the sole PodClique below MinAvailable drains the anchor entry to empty, and because there is
+# no PodCliqueScalingGroup there is no ScaleOut entry, so the PodGangMap holds no entries at all.
+---
+apiVersion: grove.io/v1alpha1
+kind: PodCliqueSet
+metadata:
+  name: workload-pclq-only
+  labels:
+    app: workload-pclq-only
+spec:
+  replicas: 1
+  template:
+    cliques:
+      - name: solo
+        labels:
+          kai.scheduler/queue: test
+        spec:
+          roleName: solo
+          replicas: 1
+          minAvailable: 1
+          podSpec:
+            terminationGracePeriodSeconds: 5
+            schedulerName: kai-scheduler
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node_role.e2e.grove.nvidia.com
+                          operator: In
+                          values:
+                            - agent
+            tolerations:
+              - key: node_role.e2e.grove.nvidia.com
+                operator: Equal
+                value: agent
+                effect: NoSchedule
+            containers:
+              - name: solo
+                image: registry:5001/busybox:latest
+                command: ["sleep", "infinity"]
+                resources:
+                  requests:
+                    memory: 80Mi

--- a/operator/e2e/yaml/workload-pcsg-only.yaml
+++ b/operator/e2e/yaml/workload-pcsg-only.yaml
@@ -1,0 +1,83 @@
+# Workload: PCSG-only worker group with no standalone PodClique.
+# Mirrors a multi-node worker DGD (one PodCliqueScalingGroup spanning a leader and a worker clique)
+# so scaling the group below MinAvailable drains the anchor entry to empty.
+---
+apiVersion: grove.io/v1alpha1
+kind: PodCliqueSet
+metadata:
+  name: workload-pcsg-only
+  labels:
+    app: workload-pcsg-only
+spec:
+  replicas: 1
+  template:
+    podCliqueScalingGroups:
+      - name: worker
+        replicas: 1
+        minAvailable: 1
+        cliqueNames:
+          - worker-ldr
+          - worker-wkr
+    cliques:
+      - name: worker-ldr
+        labels:
+          kai.scheduler/queue: test
+        spec:
+          roleName: worker-ldr
+          replicas: 1
+          minAvailable: 1
+          podSpec:
+            terminationGracePeriodSeconds: 5
+            schedulerName: kai-scheduler
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node_role.e2e.grove.nvidia.com
+                          operator: In
+                          values:
+                            - agent
+            tolerations:
+              - key: node_role.e2e.grove.nvidia.com
+                operator: Equal
+                value: agent
+                effect: NoSchedule
+            containers:
+              - name: worker-ldr
+                image: registry:5001/busybox:latest
+                command: ["sleep", "infinity"]
+                resources:
+                  requests:
+                    memory: 80Mi
+      - name: worker-wkr
+        labels:
+          kai.scheduler/queue: test
+        spec:
+          roleName: worker-wkr
+          replicas: 1
+          minAvailable: 1
+          podSpec:
+            terminationGracePeriodSeconds: 5
+            schedulerName: kai-scheduler
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node_role.e2e.grove.nvidia.com
+                          operator: In
+                          values:
+                            - agent
+            tolerations:
+              - key: node_role.e2e.grove.nvidia.com
+                operator: Equal
+                value: agent
+                effect: NoSchedule
+            containers:
+              - name: worker-wkr
+                image: registry:5001/busybox:latest
+                command: ["sleep", "infinity"]
+                resources:
+                  requests:
+                    memory: 80Mi

--- a/operator/internal/controller/podclique/components/pod/standalonepclqdistribution.go
+++ b/operator/internal/controller/podclique/components/pod/standalonepclqdistribution.go
@@ -42,7 +42,11 @@ import (
 // grove.io/podgang label, then reconciles per PodGang against the PodGangMap counts.
 func (r _resource) reconcileStandalonePCLQDistribution(ctx context.Context, logger logr.Logger, ss *syncSnapshot) error {
 	desiredCountByPodGang := buildDesiredCountByPodGang(ss)
-	if len(desiredCountByPodGang) == 0 {
+	// An empty desired count means the PodGangMap carries no anchor entry for this PodClique. When the
+	// PodClique still wants replicas this is a transient state, the PodGangMap has not authored or
+	// absorbed the anchor entry yet, so requeue and wait. When the PodClique is scaled to zero the empty
+	// desired count is correct, so fall through and let the delta computation delete the excess pods.
+	if len(desiredCountByPodGang) == 0 && ss.pclq.Spec.Replicas > 0 {
 		return groveerr.New(groveerr.ErrCodeRequeueAfter, component.OperationSync,
 			fmt.Sprintf("PodGangMap has no anchor entry for standalone PodClique %v yet, re-queueing", client.ObjectKeyFromObject(ss.pclq)))
 	}

--- a/operator/internal/controller/podclique/components/pod/standalonepclqdistribution_test.go
+++ b/operator/internal/controller/podclique/components/pod/standalonepclqdistribution_test.go
@@ -285,6 +285,13 @@ func TestReconcileStandalonePCLQDistributionEarlyReturn(t *testing.T) {
 			ss:   &syncSnapshot{pcs: pcs(), pcsReplicaIndex: testPCSReplicaIndex, pclq: pclqWithReplicas(1), cliqueName: testCliqueName, pgm: pgmWithEntries()},
 		},
 		{
+			name: "requeues when the PodGangMap carries no count for the clique but the clique wants replicas",
+			ss: &syncSnapshot{
+				pcs: pcs(), pcsReplicaIndex: testPCSReplicaIndex, pclq: pclqWithReplicas(1), cliqueName: testCliqueName,
+				pgm: pgmWithEntries(anchorEntryWithCliques(testAnchor0Epoch, 0, map[string]int32{"other-clique": 1})),
+			},
+		},
+		{
 			name: "requeues after repairing a labelless pod",
 			ss: &syncSnapshot{
 				pcs: pcs(), pcsReplicaIndex: testPCSReplicaIndex, pclq: pclqWithReplicas(1), cliqueName: testCliqueName,
@@ -370,6 +377,24 @@ func TestReconcileStandalonePCLQDistributionCreateAndDelete(t *testing.T) {
 
 		pods := listPodsForPodGang(t, cl, anchor0)
 		assert.Len(t, pods, 1)
+	})
+
+	t.Run("scaled to zero deletes all pods when the PodGangMap has no anchor entry", func(t *testing.T) {
+		pclq := newPCLQ(0)
+		live := []*corev1.Pod{nonTerminatingPodInPodGang("pod-a", anchor0, ""), nonTerminatingPodInPodGang("pod-b", anchor0, "")}
+		cl := testutils.NewTestClientBuilder().WithObjects(pclq, live[0], live[1]).Build()
+		r := _resource{client: cl, scheme: cl.Scheme(), schedRegistry: registry, eventRecorder: record.NewFakeRecorder(64), expectationsStore: expect.NewExpectationsStore()}
+		ss := &syncSnapshot{
+			pcs: testPCS, pclq: pclq, pcsReplicaIndex: testPCSReplicaIndex, cliqueName: testCliqueName,
+			pgm:              pgmWithEntries(),
+			existingPCLQPods: live,
+		}
+
+		err := r.reconcileStandalonePCLQDistribution(context.Background(), logr.Discard(), ss)
+		require.NoError(t, err)
+
+		pods := listPodsForPodGang(t, cl, anchor0)
+		assert.Empty(t, pods)
 	})
 
 	t.Run("propagates a pod deletion failure", func(t *testing.T) {

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow.go
@@ -495,8 +495,8 @@ func (r _resource) reconcilePodGangStatus(ctx context.Context, ss *syncState, pg
 		setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeInitialized, metav1.ConditionTrue,
 			groveschedulerv1alpha1.ConditionReasonPodGangPodsCreated, "PodGang is fully initialized")
 	}
-	setScheduledCondition(pg, minReplicasScheduled, now)
-	setReadyCondition(pg, minReplicasReady, now)
+	setScheduledCondition(pg, originalStatus, minReplicasScheduled, now)
+	setReadyCondition(pg, originalStatus, minReplicasReady, now)
 
 	if equality.Semantic.DeepEqual(*originalStatus, pg.Status) {
 		return nil
@@ -552,12 +552,8 @@ func (r _resource) arePodGangMinReplicasReady(ss *syncState, pgi *podGangInfo) b
 	return true
 }
 
-// setPodGangCondition sets the given condition via meta.SetStatusCondition and returns whether the
-// condition's status changed, that is whether this call was a transition rather than an idempotent
-// re-assertion of the same status. A nil prior condition counts as a transition.
-func setPodGangCondition(pg *groveschedulerv1alpha1.PodGang, condType groveschedulerv1alpha1.PodGangConditionType, status metav1.ConditionStatus, reason, message string) bool {
-	prior := meta.FindStatusCondition(pg.Status.Conditions, string(condType))
-	changed := prior == nil || prior.Status != status
+// setPodGangCondition sets the given condition via meta.SetStatusCondition.
+func setPodGangCondition(pg *groveschedulerv1alpha1.PodGang, condType groveschedulerv1alpha1.PodGangConditionType, status metav1.ConditionStatus, reason, message string) {
 	meta.SetStatusCondition(&pg.Status.Conditions, metav1.Condition{
 		Type:               string(condType),
 		Status:             status,
@@ -565,12 +561,14 @@ func setPodGangCondition(pg *groveschedulerv1alpha1.PodGang, condType grovesched
 		Reason:             reason,
 		Message:            message,
 	})
-	return changed
 }
 
 // setScheduledCondition sets the Scheduled condition from the live scheduled count and advances
-// LastScheduled when the condition transitions to True. LastScheduled is never reset once set.
-func setScheduledCondition(pg *groveschedulerv1alpha1.PodGang, minReplicasScheduled bool, now metav1.Time) {
+// LastScheduled to now. LastScheduled advances when the condition transitions to True in this
+// reconcile, and is backfilled when the condition is already True but LastScheduled is unset, which
+// covers a PodGang whose transition to scheduled was not observed. LastScheduled is never reset to nil
+// once set.
+func setScheduledCondition(pg *groveschedulerv1alpha1.PodGang, originalStatus *groveschedulerv1alpha1.PodGangStatus, minReplicasScheduled bool, now metav1.Time) {
 	status := metav1.ConditionFalse
 	reason := groveschedulerv1alpha1.ConditionReasonPodGangNotReady
 	message := "one or more PodGroups have fewer scheduled pods than MinReplicas"
@@ -579,15 +577,21 @@ func setScheduledCondition(pg *groveschedulerv1alpha1.PodGang, minReplicasSchedu
 		reason = groveschedulerv1alpha1.ConditionReasonPodGangScheduled
 		message = "MinReplicas pods of every PodGroup are scheduled"
 	}
-	mutated := setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeScheduled, status, reason, message)
-	if mutated && minReplicasScheduled {
+	setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeScheduled, status, reason, message)
+
+	scheduledBefore := meta.IsStatusConditionTrue(originalStatus.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeScheduled))
+	freshlyScheduled := minReplicasScheduled && !scheduledBefore
+	needsBackfill := minReplicasScheduled && pg.Status.LastScheduled == nil
+	if freshlyScheduled || needsBackfill {
 		pg.Status.LastScheduled = &now
 	}
 }
 
-// setReadyCondition sets the Ready condition from the live ready count and advances LastReady when
-// the condition transitions to True. LastReady is never reset once set.
-func setReadyCondition(pg *groveschedulerv1alpha1.PodGang, minReplicasReady bool, now metav1.Time) {
+// setReadyCondition sets the Ready condition from the live ready count and advances LastReady to now.
+// LastReady advances when the condition transitions to True in this reconcile, and is backfilled when
+// the condition is already True but LastReady is unset, which covers a PodGang whose transition to
+// ready was not observed. LastReady is never reset to nil once set.
+func setReadyCondition(pg *groveschedulerv1alpha1.PodGang, originalStatus *groveschedulerv1alpha1.PodGangStatus, minReplicasReady bool, now metav1.Time) {
 	status := metav1.ConditionFalse
 	reason := groveschedulerv1alpha1.ConditionReasonPodGangNotReady
 	message := "one or more PodGroups have fewer ready pods than MinReplicas"
@@ -596,8 +600,12 @@ func setReadyCondition(pg *groveschedulerv1alpha1.PodGang, minReplicasReady bool
 		reason = groveschedulerv1alpha1.ConditionReasonPodGangReady
 		message = "MinReplicas pods of every PodGroup are ready"
 	}
-	mutated := setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeReady, status, reason, message)
-	if mutated && minReplicasReady {
+	setPodGangCondition(pg, groveschedulerv1alpha1.PodGangConditionTypeReady, status, reason, message)
+
+	readyBefore := meta.IsStatusConditionTrue(originalStatus.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeReady))
+	freshlyReady := minReplicasReady && !readyBefore
+	needsBackfill := minReplicasReady && pg.Status.LastReady == nil
+	if freshlyReady || needsBackfill {
 		pg.Status.LastReady = &now
 	}
 }

--- a/operator/internal/controller/podcliqueset/components/podgang/syncflow_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgang/syncflow_test.go
@@ -306,8 +306,8 @@ func TestCreateOrUpdatePodGangs(t *testing.T) {
 		// have regressed so verifyAllPodsCreated fails, but the live Scheduled and Ready conditions must
 		// still be reconciled to False. LastScheduled and LastReady are never cleared.
 		existingPG := makeExistingPodGang(pgName, true)
-		setScheduledCondition(existingPG, true, metav1.Now())
-		setReadyCondition(existingPG, true, metav1.Now())
+		setScheduledCondition(existingPG, &groveschedulerv1alpha1.PodGangStatus{}, true, metav1.Now())
+		setReadyCondition(existingPG, &groveschedulerv1alpha1.PodGangStatus{}, true, metav1.Now())
 
 		pclq := makePCLQ(pclqName, 2)
 		cl := testutils.NewTestClientBuilder().
@@ -1635,159 +1635,168 @@ func TestArePodGangMinReplicasReady(t *testing.T) {
 	}
 }
 
-// TestSetPodGangCondition verifies setPodGangCondition sets the condition and reports whether the
-// status changed, treating a nil prior condition and any status flip as a transition and an
-// unchanged status as not a transition.
-func TestSetPodGangCondition(t *testing.T) {
-	const condType = groveschedulerv1alpha1.PodGangConditionTypeScheduled
-	tests := []struct {
-		name        string
-		priorStatus *metav1.ConditionStatus
-		newStatus   metav1.ConditionStatus
-		wantChanged bool
-	}{
-		{
-			name:        "no prior condition is a transition",
-			priorStatus: nil,
-			newStatus:   metav1.ConditionTrue,
-			wantChanged: true,
-		},
-		{
-			name:        "status flip False to True is a transition",
-			priorStatus: ptr.To(metav1.ConditionFalse),
-			newStatus:   metav1.ConditionTrue,
-			wantChanged: true,
-		},
-		{
-			name:        "status flip True to False is a transition",
-			priorStatus: ptr.To(metav1.ConditionTrue),
-			newStatus:   metav1.ConditionFalse,
-			wantChanged: true,
-		},
-		{
-			name:        "same status is not a transition",
-			priorStatus: ptr.To(metav1.ConditionTrue),
-			newStatus:   metav1.ConditionTrue,
-			wantChanged: false,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			pg := &groveschedulerv1alpha1.PodGang{}
-			if tc.priorStatus != nil {
-				setPodGangCondition(pg, condType, *tc.priorStatus, "PriorReason", "prior")
-			}
-			actualChanged := setPodGangCondition(pg, condType, tc.newStatus, "NewReason", "new")
-			assert.Equal(t, tc.wantChanged, actualChanged)
-			assert.True(t, meta.IsStatusConditionPresentAndEqual(pg.Status.Conditions, string(condType), tc.newStatus))
-		})
-	}
-}
-
-// TestSetScheduledCondition verifies setScheduledCondition sets the Scheduled condition and advances
-// LastScheduled on each fresh transition to True, never clearing it on a transition to False and
-// never re-stamping on an idempotent True.
+// TestSetScheduledCondition verifies setScheduledCondition sets the Scheduled condition from the live
+// scheduled count and stamps LastScheduled on a fresh transition to True, leaves it unchanged while the
+// PodGang stays scheduled, advances it when the PodGang is scheduled again after going unscheduled, and
+// backfills it when the condition is already True but LastScheduled was never set.
 func TestSetScheduledCondition(t *testing.T) {
-	earlier := metav1.NewTime(time.Now())
-	later := metav1.NewTime(earlier.Add(time.Minute))
-	type step struct {
-		scheduled bool
-		now       metav1.Time
+	schedCond := func(status metav1.ConditionStatus) []metav1.Condition {
+		return []metav1.Condition{{Type: string(groveschedulerv1alpha1.PodGangConditionTypeScheduled), Status: status}}
 	}
+	earlier := metav1.NewTime(time.Now().Add(-time.Hour))
+	now := metav1.NewTime(time.Now())
+
 	tests := []struct {
-		name              string
-		steps             []step
-		wantConditionTrue bool
-		wantLastScheduled *metav1.Time
+		name                 string
+		originalStatus       groveschedulerv1alpha1.PodGangStatus
+		currentLastScheduled *metav1.Time
+		minReplicasScheduled bool
+		wantConditionTrue    bool
+		wantSet              bool
+		wantAdvanced         bool
 	}{
 		{
-			name:              "transition to True stamps LastScheduled",
-			steps:             []step{{true, earlier}},
-			wantConditionTrue: true,
-			wantLastScheduled: &earlier,
+			name:                 "not scheduled before or now - stays nil",
+			originalStatus:       groveschedulerv1alpha1.PodGangStatus{Conditions: schedCond(metav1.ConditionFalse)},
+			minReplicasScheduled: false,
+			wantConditionTrue:    false,
+			wantSet:              false,
 		},
 		{
-			name:              "idempotent True does not re-stamp LastScheduled",
-			steps:             []step{{true, earlier}, {true, later}},
-			wantConditionTrue: true,
-			wantLastScheduled: &earlier,
+			name:                 "transitions to scheduled this reconcile - sets LastScheduled",
+			originalStatus:       groveschedulerv1alpha1.PodGangStatus{Conditions: schedCond(metav1.ConditionFalse)},
+			minReplicasScheduled: true,
+			wantConditionTrue:    true,
+			wantSet:              true,
+			wantAdvanced:         true,
 		},
 		{
-			name:              "transition to False does not clear LastScheduled",
-			steps:             []step{{true, earlier}, {false, later}},
-			wantConditionTrue: false,
-			wantLastScheduled: &earlier,
+			name:                 "stays scheduled - does not change existing LastScheduled",
+			originalStatus:       groveschedulerv1alpha1.PodGangStatus{Conditions: schedCond(metav1.ConditionTrue)},
+			currentLastScheduled: &earlier,
+			minReplicasScheduled: true,
+			wantConditionTrue:    true,
+			wantSet:              true,
+			wantAdvanced:         false,
 		},
 		{
-			name:              "re-transition to True advances LastScheduled",
-			steps:             []step{{true, earlier}, {false, earlier}, {true, later}},
-			wantConditionTrue: true,
-			wantLastScheduled: &later,
+			name:                 "scheduled again after previously going unscheduled - advances LastScheduled",
+			originalStatus:       groveschedulerv1alpha1.PodGangStatus{Conditions: schedCond(metav1.ConditionFalse)},
+			currentLastScheduled: &earlier,
+			minReplicasScheduled: true,
+			wantConditionTrue:    true,
+			wantSet:              true,
+			wantAdvanced:         true,
+		},
+		{
+			name:                 "already scheduled with no LastScheduled - backfills on upgrade",
+			originalStatus:       groveschedulerv1alpha1.PodGangStatus{Conditions: schedCond(metav1.ConditionTrue)},
+			minReplicasScheduled: true,
+			wantConditionTrue:    true,
+			wantSet:              true,
+			wantAdvanced:         true,
 		},
 	}
+
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			pg := &groveschedulerv1alpha1.PodGang{}
-			for _, s := range tc.steps {
-				setScheduledCondition(pg, s.scheduled, s.now)
+			pg := &groveschedulerv1alpha1.PodGang{Status: groveschedulerv1alpha1.PodGangStatus{LastScheduled: tc.currentLastScheduled}}
+			setScheduledCondition(pg, &tc.originalStatus, tc.minReplicasScheduled, now)
+			assert.Equal(t, tc.wantConditionTrue, meta.IsStatusConditionTrue(pg.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeScheduled)))
+			actual := pg.Status.LastScheduled
+			if !tc.wantSet {
+				assert.Nil(t, actual)
+				return
 			}
-			actualConditionTrue := meta.IsStatusConditionTrue(pg.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeScheduled))
-			assert.Equal(t, tc.wantConditionTrue, actualConditionTrue)
-			assert.Equal(t, tc.wantLastScheduled, pg.Status.LastScheduled)
+			require.NotNil(t, actual)
+			if tc.wantAdvanced {
+				assert.Equal(t, now, *actual, "LastScheduled should advance to now")
+			} else {
+				assert.Equal(t, earlier, *actual, "LastScheduled should be unchanged")
+			}
 		})
 	}
 }
 
-// TestSetReadyCondition verifies setReadyCondition sets the Ready condition and advances LastReady
-// on each fresh transition to True, never clearing it on a transition to False and never
-// re-stamping on an idempotent True.
+// TestSetReadyCondition verifies setReadyCondition sets the Ready condition from the live ready count
+// and stamps LastReady on a fresh transition to True, leaves it unchanged while the PodGang stays
+// ready, advances it when the PodGang is ready again after going not-ready, and backfills it when the
+// condition is already True but LastReady was never set.
 func TestSetReadyCondition(t *testing.T) {
-	earlier := metav1.NewTime(time.Now())
-	later := metav1.NewTime(earlier.Add(time.Minute))
-	type step struct {
-		ready bool
-		now   metav1.Time
+	readyCond := func(status metav1.ConditionStatus) []metav1.Condition {
+		return []metav1.Condition{{Type: string(groveschedulerv1alpha1.PodGangConditionTypeReady), Status: status}}
 	}
+	earlier := metav1.NewTime(time.Now().Add(-time.Hour))
+	now := metav1.NewTime(time.Now())
+
 	tests := []struct {
 		name              string
-		steps             []step
+		originalStatus    groveschedulerv1alpha1.PodGangStatus
+		currentLastReady  *metav1.Time
+		minReplicasReady  bool
 		wantConditionTrue bool
-		wantLastReady     *metav1.Time
+		wantSet           bool
+		wantAdvanced      bool
 	}{
 		{
-			name:              "transition to True stamps LastReady",
-			steps:             []step{{true, earlier}},
-			wantConditionTrue: true,
-			wantLastReady:     &earlier,
-		},
-		{
-			name:              "idempotent True does not re-stamp LastReady",
-			steps:             []step{{true, earlier}, {true, later}},
-			wantConditionTrue: true,
-			wantLastReady:     &earlier,
-		},
-		{
-			name:              "transition to False does not clear LastReady",
-			steps:             []step{{true, earlier}, {false, later}},
+			name:              "not ready before or now - stays nil",
+			originalStatus:    groveschedulerv1alpha1.PodGangStatus{Conditions: readyCond(metav1.ConditionFalse)},
+			minReplicasReady:  false,
 			wantConditionTrue: false,
-			wantLastReady:     &earlier,
+			wantSet:           false,
 		},
 		{
-			name:              "re-transition to True advances LastReady",
-			steps:             []step{{true, earlier}, {false, earlier}, {true, later}},
+			name:              "transitions to ready this reconcile - sets LastReady",
+			originalStatus:    groveschedulerv1alpha1.PodGangStatus{Conditions: readyCond(metav1.ConditionFalse)},
+			minReplicasReady:  true,
 			wantConditionTrue: true,
-			wantLastReady:     &later,
+			wantSet:           true,
+			wantAdvanced:      true,
+		},
+		{
+			name:              "stays ready - does not change existing LastReady",
+			originalStatus:    groveschedulerv1alpha1.PodGangStatus{Conditions: readyCond(metav1.ConditionTrue)},
+			currentLastReady:  &earlier,
+			minReplicasReady:  true,
+			wantConditionTrue: true,
+			wantSet:           true,
+			wantAdvanced:      false,
+		},
+		{
+			name:              "ready again after previously going not-ready - advances LastReady",
+			originalStatus:    groveschedulerv1alpha1.PodGangStatus{Conditions: readyCond(metav1.ConditionFalse)},
+			currentLastReady:  &earlier,
+			minReplicasReady:  true,
+			wantConditionTrue: true,
+			wantSet:           true,
+			wantAdvanced:      true,
+		},
+		{
+			name:              "already ready with no LastReady - backfills on upgrade",
+			originalStatus:    groveschedulerv1alpha1.PodGangStatus{Conditions: readyCond(metav1.ConditionTrue)},
+			minReplicasReady:  true,
+			wantConditionTrue: true,
+			wantSet:           true,
+			wantAdvanced:      true,
 		},
 	}
+
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			pg := &groveschedulerv1alpha1.PodGang{}
-			for _, s := range tc.steps {
-				setReadyCondition(pg, s.ready, s.now)
+			pg := &groveschedulerv1alpha1.PodGang{Status: groveschedulerv1alpha1.PodGangStatus{LastReady: tc.currentLastReady}}
+			setReadyCondition(pg, &tc.originalStatus, tc.minReplicasReady, now)
+			assert.Equal(t, tc.wantConditionTrue, meta.IsStatusConditionTrue(pg.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeReady)))
+			actual := pg.Status.LastReady
+			if !tc.wantSet {
+				assert.Nil(t, actual)
+				return
 			}
-			actualConditionTrue := meta.IsStatusConditionTrue(pg.Status.Conditions, string(groveschedulerv1alpha1.PodGangConditionTypeReady))
-			assert.Equal(t, tc.wantConditionTrue, actualConditionTrue)
-			assert.Equal(t, tc.wantLastReady, pg.Status.LastReady)
+			require.NotNil(t, actual)
+			if tc.wantAdvanced {
+				assert.Equal(t, now, *actual, "LastReady should advance to now")
+			} else {
+				assert.Equal(t, earlier, *actual, "LastReady should be unchanged")
+			}
 		})
 	}
 }
@@ -1865,8 +1874,8 @@ func TestReconcilePodGangStatus(t *testing.T) {
 		seeded := existingPodGang()
 		setPodGangCondition(seeded, groveschedulerv1alpha1.PodGangConditionTypeInitialized, metav1.ConditionTrue,
 			groveschedulerv1alpha1.ConditionReasonPodGangPodsCreated, "PodGang is fully initialized")
-		setScheduledCondition(seeded, true, metav1.Now())
-		setReadyCondition(seeded, true, metav1.Now())
+		setScheduledCondition(seeded, &groveschedulerv1alpha1.PodGangStatus{}, true, metav1.Now())
+		setReadyCondition(seeded, &groveschedulerv1alpha1.PodGangStatus{}, true, metav1.Now())
 
 		cl := testutils.NewTestClientBuilder().
 			WithObjects(pcs, seeded).

--- a/operator/internal/controller/podcliqueset/components/podgangmap/podgangmap.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/podgangmap.go
@@ -45,7 +45,6 @@ const (
 	errCodeGroupPCSGsByReplica     grovecorev1alpha1.ErrorCode = "ERR_GROUP_PCSGS_BY_REPLICA"
 	errCodeListPodGangs            grovecorev1alpha1.ErrorCode = "ERR_LIST_PODGANGS"
 	errCodeGroupPodGangsByReplica  grovecorev1alpha1.ErrorCode = "ERR_GROUP_PODGANGS_BY_REPLICA"
-	errCodePodGangMapNoEntries     grovecorev1alpha1.ErrorCode = "ERR_PODGANGMAP_NO_ENTRIES"
 )
 
 type _resource struct {

--- a/operator/internal/controller/podcliqueset/components/podgangmap/podgangmap_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/podgangmap_test.go
@@ -25,7 +25,6 @@ import (
 	grovecorev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	groveclientscheme "github.com/ai-dynamo/grove/operator/internal/client"
 	componentutils "github.com/ai-dynamo/grove/operator/internal/controller/common/component/utils"
-	groveerr "github.com/ai-dynamo/grove/operator/internal/errors"
 	testutils "github.com/ai-dynamo/grove/operator/test/utils"
 
 	groveschedulerv1alpha1 "github.com/ai-dynamo/grove/scheduler/api/core/v1alpha1"
@@ -206,22 +205,27 @@ func TestSyncIgnoresLegacyPodGangsWithoutEpochLabelWhenPodGangMapIsMissing(t *te
 	assert.Equal(t, "1000", anchor.Epoch)
 }
 
-func TestSyncErrorsWhenPodGangMapHasNoEntries(t *testing.T) {
+func TestSyncRebuildsAnchorWhenPodGangMapHasNoEntries(t *testing.T) {
 	pcs := testutils.NewPodCliqueSetBuilder("pcs", "default", "uid").
 		WithReplicas(1).
 		WithStandaloneCliqueReplicas("clq-a", 1).
 		WithPodCliqueSetGenerationHash(ptr.To("hash1")).
 		Build()
 
-	// A PodGangMap that exists but has no entries can only come from a coding error, since a live
-	// PodGangMap always has an anchor entry. The sync fails with a hard error.
+	// A PodGangMap can end up with no entries when every entry drained to empty. The sync rebuilds it
+	// from the spec instead of failing, so the replica recovers.
 	emptyPGM := testutils.NewPodGangMapBuilder("pcs", "default", types.UID("uid"), 0).Build()
 
 	cl := testutils.CreateDefaultFakeClient([]client.Object{pcs, emptyPGM})
 	operator := New(cl, groveclientscheme.Scheme, clocktesting.NewFakeClock(time.Unix(0, 1000)))
 
 	err := operator.Sync(context.Background(), logr.Discard(), pcs)
-	testutils.AssertGroveError(t, &groveerr.GroveError{Code: errCodePodGangMapNoEntries, Operation: "Sync"}, err)
+	require.NoError(t, err)
+
+	pgm := getPodGangMap(t, cl, "pcs-0")
+	anchor := testutils.EntryByRole(pgm.Spec.Entries, grovecorev1alpha1.PodGangEntryRoleAnchor)
+	assert.Equal(t, "1000", anchor.Epoch)
+	assert.Equal(t, int32(1), anchor.PodCliques["clq-a"])
 }
 
 func TestSyncDeletesOrphanedPodGangMaps(t *testing.T) {

--- a/operator/internal/controller/podcliqueset/components/podgangmap/steadystate.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/steadystate.go
@@ -136,9 +136,11 @@ func buildBootstrapTailEntry(pcs *grovecorev1alpha1.PodCliqueSet, epoch, anchorE
 }
 
 // reconcileEntries authors the desired PodGangMap entries for a PCS replica and returns them for create
-// or patch. When no PodGangMap exists it starts from a fresh set of bootstrap entries, reusing the epoch
-// the replica's existing PodGangs carry. When one exists it starts from that PodGangMap's entries,
-// advancing them to the current generation hash unless a coherent update is in progress.
+// or patch. When no PodGangMap exists, or one exists with no entries, it starts from a fresh set of
+// bootstrap entries, reusing the epoch the replica's existing PodGangs carry. An entry-less PodGangMap
+// is bootstrapped the same way so a replica whose entries were all drained recovers instead of staying
+// empty. When a PodGangMap with entries exists it starts from those entries, advancing them to the
+// current generation hash unless a coherent update is in progress.
 //
 // Each entry keeps its identity (epoch, role, DependsOn, anchor index) and its already-placed replica
 // indices. Placement is not recomputed from the template. A template Replicas change does not reach an
@@ -167,7 +169,7 @@ func reconcileEntries(clk clock.Clock,
 		entries       []grovecorev1alpha1.PodGangEntry
 		scaleOutEpoch string
 	)
-	if pgm == nil {
+	if pgm == nil || len(pgm.Spec.Entries) == 0 {
 		entries, scaleOutEpoch = buildBootstrapEntries(clk, pcs, existingPodGangs)
 	} else {
 		// Deep-copy the existing entries so mutations here do not alias the snapshot's PodGangMap.
@@ -339,17 +341,30 @@ func drainPriority(entry grovecorev1alpha1.PodGangEntry) int {
 	}
 }
 
-// removeEmptyEntries drops entries that carry no pods and no replica indices. A ScaleOut entry for
-// the CURRENT generation hash is exempt, it is pre-created empty and kept as the PodGangMap-owned
-// scale-out epoch that steady-state scale-outs attach to, so it must persist even when it carries
-// nothing. A ScaleOut entry for an OLD generation hash is not exempt, once drained it is a remnant of
-// a superseded generation and is removed like any other empty entry.
+// removeEmptyEntries drops entries that carry no pods and no replica indices. A ScaleOut entry of the
+// current generation is kept even when empty, but only while a current-generation anchor entry
+// survives. A ScaleOut entry depends on its generation's anchor, so once the last current-generation
+// anchor drains to empty it is removed and its ScaleOut entry is removed with it. A ScaleOut entry of
+// an older generation is never kept when empty.
 func removeEmptyEntries(entries []grovecorev1alpha1.PodGangEntry, currentGenerationHash string) []grovecorev1alpha1.PodGangEntry {
+	keepCurrentGenerationScaleOut := hasNonEmptyCurrentGenerationAnchor(entries, currentGenerationHash)
 	return slices.DeleteFunc(entries, func(entry grovecorev1alpha1.PodGangEntry) bool {
-		if entry.Role == grovecorev1alpha1.PodGangEntryRoleScaleOut && entry.PodCliqueSetGenerationHash == currentGenerationHash {
+		if keepCurrentGenerationScaleOut &&
+			entry.Role == grovecorev1alpha1.PodGangEntryRoleScaleOut &&
+			entry.PodCliqueSetGenerationHash == currentGenerationHash {
 			return false
 		}
 		return isPodGangEntryEmpty(entry)
+	})
+}
+
+// hasNonEmptyCurrentGenerationAnchor reports whether entries contains a current-generation anchor
+// entry that carries at least one pod or replica index, meaning it will survive empty-entry removal.
+func hasNonEmptyCurrentGenerationAnchor(entries []grovecorev1alpha1.PodGangEntry, currentGenerationHash string) bool {
+	return slices.ContainsFunc(entries, func(entry grovecorev1alpha1.PodGangEntry) bool {
+		return entry.Role == grovecorev1alpha1.PodGangEntryRoleAnchor &&
+			entry.PodCliqueSetGenerationHash == currentGenerationHash &&
+			!isPodGangEntryEmpty(entry)
 	})
 }
 

--- a/operator/internal/controller/podcliqueset/components/podgangmap/steadystate_test.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/steadystate_test.go
@@ -431,6 +431,73 @@ func TestReconcileStandaloneCliqueCountAcrossAnchors(t *testing.T) {
 	}
 }
 
+// TestRemoveEmptyEntries verifies removeEmptyEntries keeps a current-generation empty ScaleOut entry
+// only while a current-generation anchor survives, drops the ScaleOut once its anchor drains to empty
+// and is removed, and never keeps an empty ScaleOut of an older generation.
+func TestRemoveEmptyEntries(t *testing.T) {
+	olderGenerationScaleOut := testutils.NewPodGangEntryBuilder("hash0", "099").
+		WithRole(grovecorev1alpha1.PodGangEntryRoleScaleOut).
+		WithDependsOn("098").
+		Build()
+	tests := []struct {
+		name      string
+		entries   []grovecorev1alpha1.PodGangEntry
+		wantRoles []grovecorev1alpha1.PodGangEntryRole
+	}{
+		{
+			name: "non-empty anchor keeps the empty current-generation ScaleOut",
+			entries: []grovecorev1alpha1.PodGangEntry{
+				anchorEntry(nil, map[string][]int32{testPCSGName: {0, 1}}),
+				scaleOutEntry(nil),
+			},
+			wantRoles: []grovecorev1alpha1.PodGangEntryRole{
+				grovecorev1alpha1.PodGangEntryRoleAnchor,
+				grovecorev1alpha1.PodGangEntryRoleScaleOut,
+			},
+		},
+		{
+			name: "empty anchor is removed and its empty ScaleOut is removed with it",
+			entries: []grovecorev1alpha1.PodGangEntry{
+				anchorEntry(nil, map[string][]int32{testPCSGName: {}}),
+				scaleOutEntry(nil),
+			},
+			wantRoles: []grovecorev1alpha1.PodGangEntryRole{},
+		},
+		{
+			name: "empty tail is removed while a non-empty anchor and its ScaleOut remain",
+			entries: []grovecorev1alpha1.PodGangEntry{
+				anchorEntry(nil, map[string][]int32{testPCSGName: {0, 1}}),
+				tailEntry(map[string][]int32{testPCSGName: {}}),
+				scaleOutEntry(nil),
+			},
+			wantRoles: []grovecorev1alpha1.PodGangEntryRole{
+				grovecorev1alpha1.PodGangEntryRoleAnchor,
+				grovecorev1alpha1.PodGangEntryRoleScaleOut,
+			},
+		},
+		{
+			name: "empty ScaleOut of an older generation is removed even when a current anchor survives",
+			entries: []grovecorev1alpha1.PodGangEntry{
+				anchorEntry(nil, map[string][]int32{testPCSGName: {0, 1}}),
+				olderGenerationScaleOut,
+			},
+			wantRoles: []grovecorev1alpha1.PodGangEntryRole{
+				grovecorev1alpha1.PodGangEntryRoleAnchor,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			retained := removeEmptyEntries(tc.entries, testGenHash)
+			actualRoles := make([]grovecorev1alpha1.PodGangEntryRole, 0, len(retained))
+			for _, entry := range retained {
+				actualRoles = append(actualRoles, entry.Role)
+			}
+			assert.Equal(t, tc.wantRoles, actualRoles)
+		})
+	}
+}
+
 // podGangWithEpochRole builds a PodGang carrying the grove.io/epoch and grove.io/podgang-role labels.
 func podGangWithEpochRole(name, epoch string, role grovecorev1alpha1.PodGangEntryRole) *groveschedulerv1alpha1.PodGang {
 	return testutils.NewPodGangBuilder(name, testNamespace).

--- a/operator/internal/controller/podcliqueset/components/podgangmap/syncflow.go
+++ b/operator/internal/controller/podcliqueset/components/podgangmap/syncflow.go
@@ -170,21 +170,13 @@ func (r _resource) getExistingPodGangsByReplica(ctx context.Context, pcs *grovec
 // PCS replica scale-in. Each replica is in one of three states.
 //  1. No PodGangMap. Its entries are authored from the PCS spec, reusing the epoch its existing
 //     PodGangs carry so a rebuilt PodGangMap does not strand pods.
-//  2. A PodGangMap with no entries. A live PodGangMap always has an anchor entry, so this can only
-//     come from a coding error. The reconcile fails with a hard error.
+//  2. A PodGangMap with no entries. This happens when every entry drained to empty. It is authored
+//     the same way as a missing PodGangMap so the replica recovers instead of staying empty.
 //  3. A PodGangMap with entries. reconcileEntries re-authors them, advancing an under-update replica
 //     to the current generation hash first.
 func (r _resource) runSyncFlow(ctx context.Context, syncSnap *syncSnapshot) error {
 	for pcsReplicaIndex := range int(syncSnap.pcs.Spec.Replicas) {
-		pgm, pgmExists := syncSnap.existingPGMByReplica[pcsReplicaIndex]
-
-		if pgmExists && len(pgm.Spec.Entries) == 0 {
-			return groveerr.New(
-				errCodePodGangMapNoEntries,
-				component.OperationSync,
-				fmt.Sprintf("PodGangMap %s for replica %d of PodCliqueSet %v has no entries, this is not expected. A live PodGangMap at least has an anchor entry", pgm.Name, pcsReplicaIndex, client.ObjectKeyFromObject(syncSnap.pcs)),
-			)
-		}
+		pgm := syncSnap.existingPGMByReplica[pcsReplicaIndex]
 
 		entries, err := reconcileEntries(r.clk,
 			syncSnap.pcs, pcsReplicaIndex,


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api
-->

/kind bug

#### What this PR does / why we need it:

Scaling a PodCliqueScalingGroup or a standalone PodClique to zero is allowed. It sets the MinAvailableBreached condition.
When a member is scaled to zero, its anchor PodGangMap entry loses its indices and becomes empty, and the entry is
removed.

On a PodCliqueSet that has only PodCliqueScalingGroups, or only standalone PodCliques, this leaves the PodGangMap with no anchor entry. Two problems follow:

 - All standalone: the PodGangMap ends up with no entries. Every reconcile then fails with `ERR_PODGANGMAP_NO_ENTRIES`, and pods are not created when the member is scaled back up (#808).
  - All PodCliqueScalingGroup: the worker pods stay on a ScaleOut entry that depends on an anchor epoch that no longer exists, so they stay SchedulingGated (#809).

This PR makes the workload recover on its own. Scaling a member to zero drains the PodGangMap without leaving it in a broken state, and scaling back up rebuilds the PodGangMap and reschedules the pods.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #808 
Fixes #809 

#### Special notes for your reviewer:

- Scaling below MinAvailable is supported. It sets MinAvailableBreached. This PR makes the PodGangMap handle that state instead of rejecting the scale.
- The upgrade e2e test uses the `e2e,e2eupgrade` build tags and runs with `make run-upgrade-e2e`. It also moves the existing upgrade test onto a small shared harness that installs a from-version, runs a pre-upgrade step, upgrades to the current checkout, and runs a post-upgrade step.

#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
NONE
```
