### PR TITLE
fix: ClusterTopologyBinding CRD short name prevented upgrades

### DIFF
--- a/operator/api/core/v1alpha1/clustertopologybinding.go
+++ b/operator/api/core/v1alpha1/clustertopologybinding.go
@@ -22,7 +22,7 @@ import (
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster,shortName=ct
+// +kubebuilder:resource:scope=Cluster,shortName=ctb
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Domains",type=string,JSONPath=`.spec.levels[*].domain`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`

--- a/operator/api/core/v1alpha1/crds/grove.io_clustertopologybindings.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_clustertopologybindings.yaml
@@ -12,7 +12,7 @@ spec:
     listKind: ClusterTopologyBindingList
     plural: clustertopologybindings
     shortNames:
-    - ct
+    - ctb
     singular: clustertopologybinding
   scope: Cluster
   versions:

--- a/operator/charts/templates/clusterrole.yaml
+++ b/operator/charts/templates/clusterrole.yaml
@@ -251,6 +251,7 @@ rules:
   - podcliquesets.grove.io
   - podcliques.grove.io
   - podcliquescalinggroups.grove.io
+  - clustertopologies.grove.io
   - clustertopologybindings.grove.io
   - podgangmaps.grove.io
   - podgangs.scheduler.grove.io
@@ -259,4 +260,11 @@ rules:
   - create
   - update
   - patch
+  - delete
+- apiGroups:
+  - grove.io
+  resources:
+  - clustertopologies
+  verbs:
+  - list
 {{- end }}

--- a/operator/internal/crdinstaller/installer.go
+++ b/operator/internal/crdinstaller/installer.go
@@ -21,16 +21,29 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
 
-const fieldManager = "grove-crd-installer"
+const (
+	fieldManager                 = "grove-crd-installer"
+	legacyClusterTopologyCRDName = "clustertopologies.grove.io"
+	legacyClusterTopologyGroup   = "grove.io"
+	legacyClusterTopologyVersion = "v1alpha1"
+	legacyClusterTopologyKind    = "ClusterTopology"
+)
 
 // InstallCRDs applies the given CRD YAML definitions via server-side apply and
 // logs each applied name. It returns an error if any CRD fails to apply.
 func InstallCRDs(ctx context.Context, cl client.Client, log logr.Logger, crds []string) error {
+	if err := deleteEmptyLegacyClusterTopologyCRD(ctx, cl, log); err != nil {
+		return err
+	}
+
 	for _, crdYAML := range crds {
 		name, err := applyCRD(ctx, cl, []byte(crdYAML))
 		if err != nil {
@@ -38,6 +51,40 @@ func InstallCRDs(ctx context.Context, cl client.Client, log logr.Logger, crds []
 		}
 		log.Info("CRD applied", "name", name)
 	}
+	return nil
+}
+
+// deleteEmptyLegacyClusterTopologyCRD removes the unused ClusterTopology CRD
+// when it has no instances. It retains the CRD when resources exist.
+func deleteEmptyLegacyClusterTopologyCRD(ctx context.Context, cl client.Client, log logr.Logger) error {
+	legacyCRD := &apiextensionsv1.CustomResourceDefinition{}
+	if err := cl.Get(ctx, client.ObjectKey{Name: legacyClusterTopologyCRDName}, legacyCRD); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("get legacy ClusterTopology CRD: %w", err)
+	}
+
+	legacyTopologies := &unstructured.UnstructuredList{}
+	legacyTopologies.SetGroupVersionKind(schema.GroupVersion{
+		Group:   legacyClusterTopologyGroup,
+		Version: legacyClusterTopologyVersion,
+	}.WithKind(legacyClusterTopologyKind + "List"))
+	if err := cl.List(ctx, legacyTopologies); err != nil {
+		return fmt.Errorf("list legacy ClusterTopology resources: %w", err)
+	}
+	if len(legacyTopologies.Items) != 0 {
+		log.Info("Legacy ClusterTopology CRD retained because resources still exist",
+			"name", legacyClusterTopologyCRDName,
+			"resourceCount", len(legacyTopologies.Items),
+		)
+		return nil
+	}
+
+	if err := cl.Delete(ctx, legacyCRD); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete empty legacy ClusterTopology CRD: %w", err)
+	}
+	log.Info("Deleted empty legacy ClusterTopology CRD", "name", legacyClusterTopologyCRDName)
 	return nil
 }
 

--- a/operator/internal/crdinstaller/installer_test.go
+++ b/operator/internal/crdinstaller/installer_test.go
@@ -217,3 +217,26 @@ func TestInstallCRDs_ReturnsErrorOnInvalidYAML(t *testing.T) {
 	err := crdinstaller.InstallCRDs(ctx, cl, logr.Discard(), []string{"not: valid: yaml: [[["})
 	assert.Error(t, err)
 }
+
+// TestInstallCRDs_ClusterTopologyBindingShortName verifies that the ClusterTopologyBinding CRD
+// has the correct shortName "ctb" and not "ct" (which would conflict with the old ClusterTopology CRD).
+//
+// Flow:
+//  1. Call InstallCRDs with the ClusterTopologyBinding CRD.
+//  2. Fetch the CRD from the cluster.
+//  3. Assert that spec.names.shortNames contains "ctb" and not "ct".
+func TestInstallCRDs_ClusterTopologyBindingShortName(t *testing.T) {
+	cl := buildFakeClient()
+	ctx := context.Background()
+
+	err := crdinstaller.InstallCRDs(ctx, cl, logr.Discard(), []string{operatorcrds.ClusterTopologyCRD()})
+	require.NoError(t, err)
+
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	err = cl.Get(ctx, client.ObjectKey{Name: "clustertopologybindings.grove.io"}, crd)
+	require.NoError(t, err, "ClusterTopologyBinding CRD should exist")
+
+	shortNames := crd.Spec.Names.ShortNames
+	assert.Contains(t, shortNames, "ctb", "ClusterTopologyBinding should have shortName 'ctb'")
+	assert.NotContains(t, shortNames, "ct", "ClusterTopologyBinding should NOT have shortName 'ct' (conflicts with old ClusterTopology)")
+}

--- a/operator/internal/crdinstaller/installer_test.go
+++ b/operator/internal/crdinstaller/installer_test.go
@@ -26,17 +26,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 // buildFakeClient creates a fake client with apiextensionsv1 scheme registered.
-func buildFakeClient() client.Client {
+func buildFakeClient(objects ...client.Object) client.Client {
 	scheme := runtime.NewScheme()
 	_ = apiextensionsv1.AddToScheme(scheme)
-	return fake.NewClientBuilder().WithScheme(scheme).Build()
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
 }
 
 // minimalCRDYAML returns a minimal valid CRD yaml for testing.
@@ -239,4 +241,31 @@ func TestInstallCRDs_ClusterTopologyBindingShortName(t *testing.T) {
 	shortNames := crd.Spec.Names.ShortNames
 	assert.Contains(t, shortNames, "ctb", "ClusterTopologyBinding should have shortName 'ctb'")
 	assert.NotContains(t, shortNames, "ct", "ClusterTopologyBinding should NOT have shortName 'ct' (conflicts with old ClusterTopology)")
+}
+
+func TestInstallCRDs_DeletesEmptyLegacyClusterTopologyCRD(t *testing.T) {
+	legacyCRD := &apiextensionsv1.CustomResourceDefinition{}
+	legacyCRD.Name = "clustertopologies.grove.io"
+	cl := buildFakeClient(legacyCRD)
+
+	err := crdinstaller.InstallCRDs(context.Background(), cl, logr.Discard(), nil)
+	require.NoError(t, err)
+
+	err = cl.Get(context.Background(), client.ObjectKey{Name: legacyCRD.Name}, &apiextensionsv1.CustomResourceDefinition{})
+	assert.True(t, apierrors.IsNotFound(err))
+}
+
+func TestInstallCRDs_RetainsLegacyClusterTopologyCRDWithResources(t *testing.T) {
+	legacyCRD := &apiextensionsv1.CustomResourceDefinition{}
+	legacyCRD.Name = "clustertopologies.grove.io"
+	legacyTopology := &unstructured.Unstructured{}
+	legacyTopology.SetGroupVersionKind(schema.GroupVersion{Group: "grove.io", Version: "v1alpha1"}.WithKind("ClusterTopology"))
+	legacyTopology.SetName("existing-topology")
+	cl := buildFakeClient(legacyCRD, legacyTopology)
+
+	err := crdinstaller.InstallCRDs(context.Background(), cl, logr.Discard(), nil)
+	require.NoError(t, err)
+
+	err = cl.Get(context.Background(), client.ObjectKey{Name: legacyCRD.Name}, &apiextensionsv1.CustomResourceDefinition{})
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This changes the short name of the ClusterTopologyBinding CRD to ctb and the crd-upgrader will try to delete the legacy ClusterTopology CRD.

#### Which issue(s) this PR fixes:

Fixes #801

#### Special notes for your reviewer:

Tested alpha.8 -> alpha.12 -> this version upgrade route. I saw the issue upgradgin to alpha.12 and it being fixed when upgrading to this version. I believe adding this kind of specific e2e upgrade test is not helpful, but the current upgrade tests in the repo would have caught a similar bug in the future.

#### Does this PR introduce a API change?
#### Additional documentation e.g., enhancement proposals, usage docs, etc.:
